### PR TITLE
JSON API responses contain geoInfo

### DIFF
--- a/src/main/java/org/codelibs/fess/api/json/JsonApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/json/JsonApiManager.java
@@ -153,6 +153,7 @@ public class JsonApiManager extends BaseApiManager {
             final String allPageCount = Integer.toString(data.getAllPageCount());
             final List<Map<String, Object>> documentItems = data.getDocumentItems();
             final FacetResponse facetResponse = data.getFacetResponse();
+            final GeoInfo geoInfo = params.getGeoInfo();
 
             buf.append("\"q\":");
             buf.append(escapeJson(query));
@@ -255,6 +256,18 @@ public class JsonApiManager extends BaseApiManager {
                     buf.append(']');
                 }
             }
+            // geo
+            if (geoInfo != null && StringUtil.isNotEmpty(geoInfo.distance)) {
+                buf.append(',');
+                buf.append("\"geo_distance\":{\"location\":[");
+                buf.append(geoInfo.latitude);
+                buf.append(',');
+                buf.append(geoInfo.longitude);
+                buf.append("],\"distance\":\"");
+                buf.append(geoInfo.distance);
+                buf.append("\"}");
+            }
+
         } catch (final Exception e) {
             status = 1;
             errMsg = e.getMessage();

--- a/src/main/java/org/codelibs/fess/entity/GeoInfo.java
+++ b/src/main/java/org/codelibs/fess/entity/GeoInfo.java
@@ -34,6 +34,9 @@ import org.lastaflute.core.message.UserMessages;
 
 public class GeoInfo {
 
+    public double latitude;
+    public double longitude;
+    public String distance;
     private QueryBuilder builder;
 
     public GeoInfo(final HttpServletRequest request) {
@@ -51,7 +54,7 @@ public class GeoInfo {
                             for (final String geoField : geoFields) {
                                 if (key.startsWith("geo." + geoField + ".")) {
                                     final String distanceKey = key.replaceFirst(".point$", ".distance");
-                                    final String distance = request.getParameter(distanceKey);
+                                    distance = request.getParameter(distanceKey);
                                     if (StringUtil.isNotBlank(distance)) {
                                         StreamUtil.of(e.getValue()).forEach(
                                                 pt -> {
@@ -63,10 +66,10 @@ public class GeoInfo {
                                                     final String[] values = pt.split(",");
                                                     if (values.length == 2) {
                                                         try {
-                                                            final double lat = Double.parseDouble(values[0]);
-                                                            final double lon = Double.parseDouble(values[1]);
-                                                            list.add(QueryBuilders.geoDistanceQuery(geoField).distance(distance).lat(lat)
-                                                                    .lon(lon));
+                                                            latitude = Double.parseDouble(values[0]);
+                                                            longitude = Double.parseDouble(values[1]);
+                                                            list.add(QueryBuilders.geoDistanceQuery(geoField).distance(distance)
+                                                                    .lat(latitude).lon(longitude));
                                                         } catch (final Exception ex) {
                                                             throw new InvalidQueryException(messages -> messages
                                                                     .addErrorsInvalidQueryUnknown(UserMessages.GLOBAL_PROPERTY_KEY), ex


### PR DESCRIPTION
If a query contains geo information, JSON response contains a `geo_distance` element.

e.g.)
`"geo_distance":{"location":[35.2,139.1],"distance":"10km"}`