### PR TITLE
Improve GitBucketDataStore Crawler

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/transformer/FessTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/FessTransformer.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.crawler.transformer;
 
+import java.net.URI;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Collections;
@@ -184,17 +185,7 @@ public interface FessTransformer {
 
         String u = decodeUrlAsName(url, url.startsWith("file:"));
 
-        int idx = u.lastIndexOf('?');
-        if (idx >= 0) {
-            u = u.substring(0, idx);
-        }
-
-        idx = u.lastIndexOf('#');
-        if (idx >= 0) {
-            u = u.substring(0, idx);
-        }
-
-        idx = u.lastIndexOf('/');
+        int idx = u.lastIndexOf('/');
         if (idx >= 0) {
             if (u.length() > idx + 1) {
                 u = u.substring(idx + 1);
@@ -238,7 +229,9 @@ public interface FessTransformer {
 
         final String escapedUrl = escapePlus ? url.replace("+", "%2B") : url;
         try {
-            return URLDecoder.decode(escapedUrl, enc);
+            final URI u = new URI(escapedUrl);
+            final URI uri = new URI(u.getScheme(), u.getUserInfo(), u.getHost(), u.getPort(), u.getPath(), null, null);
+            return URLDecoder.decode(uri.toString(), enc);
         } catch (final Exception e) {
             return url;
         }

--- a/src/test/java/org/codelibs/fess/crawler/transformer/FessFileTransformerTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/transformer/FessFileTransformerTest.java
@@ -59,6 +59,10 @@ public class FessFileTransformerTest extends UnitFessTestCase {
         url = "file://C .doc";
         exp = "file://C .doc";
         assertEquals(exp, transformer.decodeUrlAsName(url, true));
+
+        url = "http://example.com/foo/" + encodeUrl("#") + "/@@bar/index.html#fragment?foo=bar";
+        exp = "http://example.com/foo/#/@@bar/index.html";
+        assertEquals(exp, transformer.decodeUrlAsName(url, false));
     }
 
     public void test_decodeUrl_null() throws Exception {
@@ -216,7 +220,7 @@ public class FessFileTransformerTest extends UnitFessTestCase {
         assertEquals(exp, transformer.getSiteOnFile(url, "UTF-8"));
 
         url = "file:///";
-        exp = "///";
+        exp = "/";
         assertEquals(exp, transformer.getSiteOnFile(url, "UTF-8"));
 
         url = "file://///";


### PR DESCRIPTION
The following problems remain in #1062. So I fixed it.

* URL encoding is not appropriate for a path containing a specific character. (Such as @ and space etc.)
* If the path contains `%23` (original letter is #), the URL is saved in the title tag.


**crawl log when including `@` in path** (origin path is `/node_modules/es5-ext/array/#/@@iterator`)
```
2017-05-29 04:46:41,918 [AVxNtQ7SteRxwqn425pe-1] WARN  Failed to access to http://127.0.0.1:8080/api/v3/repos/root/nodetest/contents/node_modules%2Fes5-ext%2Farray%2F%2523%2F%2540%2540iterator?ref=3d3cc5a17032b1d4c449e33480efcc31160f0ad5
org.codelibs.elasticsearch.runner.net.CurlException: The content does not exist.
        at org.codelibs.elasticsearch.runner.net.CurlResponse.getContentAsStream(CurlResponse.java:62) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:411) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:427) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:427) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:427) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:427) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:427) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.storeData(GitBucketDataStoreImpl.java:120) [classes/:?]
        at org.codelibs.fess.ds.impl.AbstractDataStoreImpl.store(AbstractDataStoreImpl.java:106) [classes/:?]
        at org.codelibs.fess.helper.DataIndexHelper$DataCrawlingThread.process(DataIndexHelper.java:236) [classes/:?]
        at org.codelibs.fess.helper.DataIndexHelper$DataCrawlingThread.run(DataIndexHelper.java:222) [classes/:?]
Caused by: java.io.FileNotFoundException: http://127.0.0.1:8080/api/v3/repos/root/nodetest/contents/node_modules%2Fes5-ext%2Farray%2F%2523%2F%2540%2540iterator?ref=3d3cc5a17032b1d4c449e33480efcc31160f0ad5
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_131]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:1.8.0_131]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_131]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1926) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1921) ~[?:1.8.0_131]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection.getChainedException(HttpURLConnection.java:1920) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1490) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474) ~[?:1.8.0_131]
        at org.codelibs.elasticsearch.runner.net.CurlRequest$1$1.open(CurlRequest.java:164) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest$1.writeContent(CurlRequest.java:194) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest$1.onResponse(CurlRequest.java:161) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest.execute(CurlRequest.java:143) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest.execute(CurlRequest.java:155) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:410) ~[classes/:?]
        ... 9 more
Caused by: java.io.FileNotFoundException: http://127.0.0.1:8080/api/v3/repos/root/nodetest/contents/node_modules%2Fes5-ext%2Farray%2F%2523%2F%2540%2540iterator?ref=3d3cc5a17032b1d4c449e33480efcc31160f0ad5
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1872) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474) ~[?:1.8.0_131]
        at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:480) ~[?:1.8.0_131]
        at org.codelibs.elasticsearch.runner.net.CurlRequest$1.onResponse(CurlRequest.java:160) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest.execute(CurlRequest.java:143) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest.execute(CurlRequest.java:155) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:410) ~[classes/:?]
        ... 9 more
```

**crawl log when including space in path** (origin path is `/Assets/Standard Assets`)
```
2017-05-29 04:46:22,889 [AVxNtQ7SteRxwqn425pe-1] WARN  Failed to access to http://127.0.0.1:8080/api/v3/repos/root/AudioTest/contents/Assets%2FStandard%2BAssets?ref=da974dfe451024ae6976acc3ea4e43462b7a7fa2
org.codelibs.elasticsearch.runner.net.CurlException: The content does not exist.
        at org.codelibs.elasticsearch.runner.net.CurlResponse.getContentAsStream(CurlResponse.java:62) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:411) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:427) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:427) [classes/:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.storeData(GitBucketDataStoreImpl.java:120) [classes/:?]
        at org.codelibs.fess.ds.impl.AbstractDataStoreImpl.store(AbstractDataStoreImpl.java:106) [classes/:?]
        at org.codelibs.fess.helper.DataIndexHelper$DataCrawlingThread.process(DataIndexHelper.java:236) [classes/:?]
        at org.codelibs.fess.helper.DataIndexHelper$DataCrawlingThread.run(DataIndexHelper.java:222) [classes/:?]
Caused by: java.io.FileNotFoundException: http://127.0.0.1:8080/api/v3/repos/root/AudioTest/contents/Assets%2FStandard%2BAssets?ref=da974dfe451024ae6976acc3ea4e43462b7a7fa2
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_131]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:1.8.0_131]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_131]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1926) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1921) ~[?:1.8.0_131]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection.getChainedException(HttpURLConnection.java:1920) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1490) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474) ~[?:1.8.0_131]
        at org.codelibs.elasticsearch.runner.net.CurlRequest$1$1.open(CurlRequest.java:164) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest$1.writeContent(CurlRequest.java:194) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest$1.onResponse(CurlRequest.java:161) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest.execute(CurlRequest.java:143) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest.execute(CurlRequest.java:155) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:410) ~[classes/:?]
        ... 6 more
Caused by: java.io.FileNotFoundException: http://127.0.0.1:8080/api/v3/repos/root/AudioTest/contents/Assets%2FStandard%2BAssets?ref=da974dfe451024ae6976acc3ea4e43462b7a7fa2
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1872) ~[?:1.8.0_131]
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474) ~[?:1.8.0_131]
        at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:480) ~[?:1.8.0_131]
        at org.codelibs.elasticsearch.runner.net.CurlRequest$1.onResponse(CurlRequest.java:160) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest.execute(CurlRequest.java:143) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.elasticsearch.runner.net.CurlRequest.execute(CurlRequest.java:155) ~[elasticsearch-cluster-runner-5.3.2.0.jar:?]
        at org.codelibs.fess.ds.impl.GitBucketDataStoreImpl.crawlFileContents(GitBucketDataStoreImpl.java:410) ~[classes/:?]
        ... 6 more
```

**URL is stored in title tag**
![fess-store](https://cloud.githubusercontent.com/assets/1295639/26534829/093d4444-4463-11e7-9fb7-310253bc1703.png)

