### PR TITLE
#813: Add search options

### DIFF
--- a/src/main/java/org/codelibs/fess/app/pager/DataConfigPager.java
+++ b/src/main/java/org/codelibs/fess/app/pager/DataConfigPager.java
@@ -60,6 +60,8 @@ public class DataConfigPager implements Serializable {
 
     public String versionNo;
 
+    public String description;
+
     public void clear() {
         allRecordCount = 0;
         allPageCount = 0;
@@ -77,6 +79,7 @@ public class DataConfigPager implements Serializable {
         createdBy = null;
         createdTime = null;
         versionNo = null;
+        description = null;
 
     }
 

--- a/src/main/java/org/codelibs/fess/app/pager/FileConfigPager.java
+++ b/src/main/java/org/codelibs/fess/app/pager/FileConfigPager.java
@@ -64,6 +64,8 @@ public class FileConfigPager implements Serializable {
 
     public String versionNo;
 
+    public String description;
+
     public void clear() {
         allRecordCount = 0;
         allPageCount = 0;
@@ -83,6 +85,7 @@ public class FileConfigPager implements Serializable {
         createdBy = null;
         createdTime = null;
         versionNo = null;
+        description = null;
 
     }
 

--- a/src/main/java/org/codelibs/fess/app/pager/RelatedContentPager.java
+++ b/src/main/java/org/codelibs/fess/app/pager/RelatedContentPager.java
@@ -44,7 +44,7 @@ public class RelatedContentPager implements Serializable {
 
     public String term;
 
-    public String queries;
+    public String content;
 
     public String createdBy;
 
@@ -62,7 +62,7 @@ public class RelatedContentPager implements Serializable {
 
         id = null;
         term = null;
-        queries = null;
+        content = null;
         createdBy = null;
         createdTime = null;
         versionNo = null;

--- a/src/main/java/org/codelibs/fess/app/service/BoostDocumentRuleService.java
+++ b/src/main/java/org/codelibs/fess/app/service/BoostDocumentRuleService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.BoostDocPager;
 import org.codelibs.fess.es.config.cbean.BoostDocumentRuleCB;
@@ -69,8 +70,11 @@ public class BoostDocumentRuleService {
     }
 
     protected void setupListCondition(final BoostDocumentRuleCB cb, final BoostDocPager boostDocumentRulePager) {
-        if (boostDocumentRulePager.id != null) {
-            cb.query().docMeta().setId_Equal(boostDocumentRulePager.id);
+        if (StringUtil.isNotBlank(boostDocumentRulePager.urlExpr)) {
+            cb.query().setUrlExpr_Wildcard(boostDocumentRulePager.urlExpr);
+        }
+        if (StringUtil.isNotBlank(boostDocumentRulePager.boostExpr)) {
+            cb.query().setBoostExpr_Wildcard(boostDocumentRulePager.boostExpr);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/service/DataConfigService.java
+++ b/src/main/java/org/codelibs/fess/app/service/DataConfigService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.DataConfigPager;
 import org.codelibs.fess.es.config.cbean.DataConfigCB;
@@ -74,8 +75,14 @@ public class DataConfigService {
     }
 
     protected void setupListCondition(final DataConfigCB cb, final DataConfigPager dataConfigPager) {
-        if (dataConfigPager.id != null) {
-            cb.query().docMeta().setId_Equal(dataConfigPager.id);
+        if (StringUtil.isNotBlank(dataConfigPager.name)) {
+            cb.query().setName_Wildcard(dataConfigPager.name);
+        }
+        if (StringUtil.isNotBlank(dataConfigPager.handlerName)) {
+            cb.query().setHandlerName_Wildcard(dataConfigPager.handlerName);
+        }
+        if (StringUtil.isNotBlank(dataConfigPager.description)) {
+            cb.query().setDescription_Wildcard(dataConfigPager.description);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/service/DuplicateHostService.java
+++ b/src/main/java/org/codelibs/fess/app/service/DuplicateHostService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.DuplicateHostPager;
 import org.codelibs.fess.es.config.cbean.DuplicateHostCB;
@@ -84,8 +85,11 @@ public class DuplicateHostService {
     }
 
     protected void setupListCondition(final DuplicateHostCB cb, final DuplicateHostPager duplicateHostPager) {
-        if (duplicateHostPager.id != null) {
-            cb.query().docMeta().setId_Equal(duplicateHostPager.id);
+        if (StringUtil.isNotBlank(duplicateHostPager.regularName)) {
+            cb.query().setRegularName_Wildcard(duplicateHostPager.regularName);
+        }
+        if (StringUtil.isNotBlank(duplicateHostPager.duplicateHostName)) {
+            cb.query().setDuplicateHostName_Wildcard(duplicateHostPager.duplicateHostName);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/service/FileConfigService.java
+++ b/src/main/java/org/codelibs/fess/app/service/FileConfigService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.FileConfigPager;
 import org.codelibs.fess.es.config.cbean.FileConfigCB;
@@ -83,8 +84,14 @@ public class FileConfigService {
     }
 
     protected void setupListCondition(final FileConfigCB cb, final FileConfigPager fileConfigPager) {
-        if (fileConfigPager.id != null) {
-            cb.query().docMeta().setId_Equal(fileConfigPager.id);
+        if (StringUtil.isNotBlank(fileConfigPager.name)) {
+            cb.query().setName_Wildcard(fileConfigPager.name);
+        }
+        if (StringUtil.isNotBlank(fileConfigPager.paths)) {
+            cb.query().setPaths_Wildcard(fileConfigPager.paths);
+        }
+        if (StringUtil.isNotBlank(fileConfigPager.description)) {
+            cb.query().setDescription_Wildcard(fileConfigPager.description);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/service/KeyMatchService.java
+++ b/src/main/java/org/codelibs/fess/app/service/KeyMatchService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.KeyMatchPager;
 import org.codelibs.fess.es.config.cbean.KeyMatchCB;
@@ -74,8 +75,11 @@ public class KeyMatchService {
     }
 
     protected void setupListCondition(final KeyMatchCB cb, final KeyMatchPager keyMatchPager) {
-        if (keyMatchPager.id != null) {
-            cb.query().docMeta().setId_Equal(keyMatchPager.id);
+        if (StringUtil.isNotBlank(keyMatchPager.term)) {
+            cb.query().setTerm_Wildcard(keyMatchPager.term);
+        }
+        if (StringUtil.isNotBlank(keyMatchPager.query)) {
+            cb.query().setQuery_Wildcard(keyMatchPager.query);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/service/LabelTypeService.java
+++ b/src/main/java/org/codelibs/fess/app/service/LabelTypeService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.LabelTypePager;
 import org.codelibs.fess.es.config.cbean.LabelTypeCB;
@@ -68,8 +69,11 @@ public class LabelTypeService {
     }
 
     protected void setupListCondition(final LabelTypeCB cb, final LabelTypePager labelTypePager) {
-        if (labelTypePager.id != null) {
-            cb.query().docMeta().setId_Equal(labelTypePager.id);
+        if (StringUtil.isNotBlank(labelTypePager.name)) {
+            cb.query().setName_Wildcard(labelTypePager.name);
+        }
+        if (StringUtil.isNotBlank(labelTypePager.value)) {
+            cb.query().setValue_Wildcard(labelTypePager.value);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/service/PathMappingService.java
+++ b/src/main/java/org/codelibs/fess/app/service/PathMappingService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.PathMapPager;
 import org.codelibs.fess.es.config.cbean.PathMappingCB;
@@ -87,8 +88,11 @@ public class PathMappingService {
     }
 
     protected void setupListCondition(final PathMappingCB cb, final PathMapPager pathMappingPager) {
-        if (pathMappingPager.id != null) {
-            cb.query().docMeta().setId_Equal(pathMappingPager.id);
+        if (StringUtil.isNotBlank(pathMappingPager.regex)) {
+            cb.query().setRegex_Wildcard(pathMappingPager.regex);
+        }
+        if (StringUtil.isNotBlank(pathMappingPager.replacement)) {
+            cb.query().setReplacement_Wildcard(pathMappingPager.replacement);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/service/RelatedContentService.java
+++ b/src/main/java/org/codelibs/fess/app/service/RelatedContentService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.RelatedContentPager;
 import org.codelibs.fess.es.config.cbean.RelatedContentCB;
@@ -70,8 +71,11 @@ public class RelatedContentService {
     }
 
     protected void setupListCondition(final RelatedContentCB cb, final RelatedContentPager relatedContentPager) {
-        if (relatedContentPager.id != null) {
-            cb.query().docMeta().setId_Equal(relatedContentPager.id);
+        if (StringUtil.isNotBlank(relatedContentPager.term)) {
+            cb.query().setTerm_Wildcard(relatedContentPager.term);
+        }
+        if (StringUtil.isNotBlank(relatedContentPager.content)) {
+            cb.query().setContent_Wildcard(relatedContentPager.content);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/service/RelatedQueryService.java
+++ b/src/main/java/org/codelibs/fess/app/service/RelatedQueryService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.Resource;
 
 import org.codelibs.core.beans.util.BeanUtil;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.RelatedQueryPager;
 import org.codelibs.fess.es.config.cbean.RelatedQueryCB;
@@ -70,8 +71,11 @@ public class RelatedQueryService {
     }
 
     protected void setupListCondition(final RelatedQueryCB cb, final RelatedQueryPager relatedQueryPager) {
-        if (relatedQueryPager.id != null) {
-            cb.query().docMeta().setId_Equal(relatedQueryPager.id);
+        if (StringUtil.isNotBlank(relatedQueryPager.term)) {
+            cb.query().setTerm_Wildcard(relatedQueryPager.term);
+        }
+        if (StringUtil.isNotBlank(relatedQueryPager.queries)) {
+            cb.query().setQueries_Wildcard(relatedQueryPager.queries);
         }
         // TODO Long, Integer, String supported only.
 

--- a/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/AdminBoostdocAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/AdminBoostdocAction.java
@@ -96,7 +96,7 @@ public class AdminBoostdocAction extends FessAdminAction {
         RenderDataUtil.register(data, "boostDocumentRuleItems", boostDocumentRuleService.getBoostDocumentRuleList(boostDocPager)); // page navi
 
         // restore from pager
-        copyBeanToBean(boostDocPager, form, op -> op.include("id"));
+        copyBeanToBean(boostDocPager, form, op -> op.include("urlExpr", "boostExpr"));
     }
 
     // ===================================================================================
@@ -279,7 +279,7 @@ public class AdminBoostdocAction extends FessAdminAction {
             RenderDataUtil.register(data, "boostDocumentRuleItems", boostDocumentRuleService.getBoostDocumentRuleList(boostDocPager));
         }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(boostDocPager, form, op -> op.include("id"));
+                copyBeanToBean(boostDocPager, form, op -> op.include("urlExpr", "boostExpr"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/SearchForm.java
@@ -21,6 +21,8 @@ package org.codelibs.fess.app.web.admin.boostdoc;
  */
 public class SearchForm {
 
-    public String id;
+    public String urlExpr;
+
+    public String boostExpr;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/dataconfig/AdminDataconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dataconfig/AdminDataconfigAction.java
@@ -112,9 +112,10 @@ public class AdminDataconfigAction extends FessAdminAction {
 
     protected void searchPaging(final RenderData data, final SearchForm form) {
         RenderDataUtil.register(data, "dataConfigItems", dataConfigService.getDataConfigList(dataConfigPager)); // page navi
+        registerHandlerNames(data);
 
         // restore from pager
-        copyBeanToBean(dataConfigPager, form, op -> op.include("id"));
+        copyBeanToBean(dataConfigPager, form, op -> op.include("name", "handlerName", "description"));
     }
 
     // ===================================================================================
@@ -352,9 +353,10 @@ public class AdminDataconfigAction extends FessAdminAction {
     private HtmlResponse asListHtml() {
         return asHtml(path_AdminDataconfig_AdminDataconfigJsp).renderWith(data -> {
             RenderDataUtil.register(data, "dataConfigItems", dataConfigService.getDataConfigList(dataConfigPager));
+            registerHandlerNames(data);
         }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(dataConfigPager, form, op -> op.include("id"));
+                copyBeanToBean(dataConfigPager, form, op -> op.include("name", "handlerName", "description"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/dataconfig/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dataconfig/SearchForm.java
@@ -21,5 +21,10 @@ package org.codelibs.fess.app.web.admin.dataconfig;
  */
 public class SearchForm {
 
-    public String id;
+    public String name;
+
+    public String handlerName;
+
+    public String description;
+
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/duplicatehost/AdminDuplicatehostAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/duplicatehost/AdminDuplicatehostAction.java
@@ -96,7 +96,7 @@ public class AdminDuplicatehostAction extends FessAdminAction {
         RenderDataUtil.register(data, "duplicateHostItems", duplicateHostService.getDuplicateHostList(duplicateHostPager)); // page navi
 
         // restore from pager
-        copyBeanToBean(duplicateHostPager, form, op -> op.include("id"));
+        copyBeanToBean(duplicateHostPager, form, op -> op.include("regularName", "duplicateHostName"));
     }
 
     // ===================================================================================
@@ -278,7 +278,7 @@ public class AdminDuplicatehostAction extends FessAdminAction {
             RenderDataUtil.register(data, "duplicateHostItems", duplicateHostService.getDuplicateHostList(duplicateHostPager)); // page navi
             }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(duplicateHostPager, form, op -> op.include("id"));
+                copyBeanToBean(duplicateHostPager, form, op -> op.include("regularName", "duplicateHostName"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/duplicatehost/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/duplicatehost/SearchForm.java
@@ -21,5 +21,8 @@ package org.codelibs.fess.app.web.admin.duplicatehost;
  */
 public class SearchForm {
 
-    public String id;
+    public String regularName;
+
+    public String duplicateHostName;
+
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/fileconfig/AdminFileconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/fileconfig/AdminFileconfigAction.java
@@ -110,7 +110,7 @@ public class AdminFileconfigAction extends FessAdminAction {
         RenderDataUtil.register(data, "fileConfigItems", fileConfigService.getFileConfigList(fileConfigPager)); // page navi
 
         // restore from pager
-        copyBeanToBean(fileConfigPager, form, op -> op.include("id"));
+        copyBeanToBean(fileConfigPager, form, op -> op.include("name", "paths", "description"));
     }
 
     // ===================================================================================
@@ -339,7 +339,7 @@ public class AdminFileconfigAction extends FessAdminAction {
             RenderDataUtil.register(data, "fileConfigItems", fileConfigService.getFileConfigList(fileConfigPager)); // page navi
             }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(fileConfigPager, form, op -> op.include("id"));
+                copyBeanToBean(fileConfigPager, form, op -> op.include("name", "paths", "description"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/fileconfig/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/fileconfig/SearchForm.java
@@ -21,5 +21,10 @@ package org.codelibs.fess.app.web.admin.fileconfig;
  */
 public class SearchForm {
 
-    public String id;
+    public String name;
+
+    public String paths;
+
+    public String description;
+
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/keymatch/AdminKeymatchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/keymatch/AdminKeymatchAction.java
@@ -103,7 +103,7 @@ public class AdminKeymatchAction extends FessAdminAction {
         RenderDataUtil.register(data, "keyMatchItems", keyMatchService.getKeyMatchList(keyMatchPager)); // page navi
 
         // restore from pager
-        copyBeanToBean(keyMatchPager, form, op -> op.include("id"));
+        copyBeanToBean(keyMatchPager, form, op -> op.include("term", "query"));
     }
 
     // ===================================================================================
@@ -293,7 +293,7 @@ public class AdminKeymatchAction extends FessAdminAction {
             RenderDataUtil.register(data, "keyMatchItems", keyMatchService.getKeyMatchList(keyMatchPager)); // page navi
             }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(keyMatchPager, form, op -> op.include("id"));
+                copyBeanToBean(keyMatchPager, form, op -> op.include("term", "query"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/keymatch/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/keymatch/SearchForm.java
@@ -21,5 +21,8 @@ package org.codelibs.fess.app.web.admin.keymatch;
  */
 public class SearchForm {
 
-    public String id;
+    public String term;
+
+    public String query;
+
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/labeltype/AdminLabeltypeAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/labeltype/AdminLabeltypeAction.java
@@ -108,7 +108,7 @@ public class AdminLabeltypeAction extends FessAdminAction {
         RenderDataUtil.register(data, "labelTypeItems", labelTypeService.getLabelTypeList(labelTypePager)); // page navi
 
         // restore from pager
-        copyBeanToBean(labelTypePager, form, op -> op.include("id"));
+        copyBeanToBean(labelTypePager, form, op -> op.include("name", "value"));
     }
 
     // ===================================================================================
@@ -330,7 +330,7 @@ public class AdminLabeltypeAction extends FessAdminAction {
             RenderDataUtil.register(data, "labelTypeItems", labelTypeService.getLabelTypeList(labelTypePager)); // page navi
             }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(labelTypePager, form, op -> op.include("id"));
+                copyBeanToBean(labelTypePager, form, op -> op.include("name", "value"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/labeltype/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/labeltype/SearchForm.java
@@ -21,5 +21,8 @@ package org.codelibs.fess.app.web.admin.labeltype;
  */
 public class SearchForm {
 
-    public String id;
+    public String name;
+
+    public String value;
+
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/pathmap/AdminPathmapAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/pathmap/AdminPathmapAction.java
@@ -97,7 +97,7 @@ public class AdminPathmapAction extends FessAdminAction {
         RenderDataUtil.register(data, "pathMappingItems", pathMappingService.getPathMappingList(pathMapPager)); // page navi
 
         // restore from pager
-        copyBeanToBean(pathMapPager, form, op -> op.include("id"));
+        copyBeanToBean(pathMapPager, form, op -> op.include("regex", "replacement"));
     }
 
     // ===================================================================================
@@ -279,7 +279,7 @@ public class AdminPathmapAction extends FessAdminAction {
             RenderDataUtil.register(data, "pathMappingItems", pathMappingService.getPathMappingList(pathMapPager)); // page navi
             }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(pathMapPager, form, op -> op.include("id"));
+                copyBeanToBean(pathMapPager, form, op -> op.include("regex", "replacement"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/pathmap/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/pathmap/SearchForm.java
@@ -21,5 +21,8 @@ package org.codelibs.fess.app.web.admin.pathmap;
  */
 public class SearchForm {
 
-    public String id;
+    public String regex;
+
+    public String replacement;
+
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/relatedcontent/AdminRelatedcontentAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/relatedcontent/AdminRelatedcontentAction.java
@@ -96,7 +96,7 @@ public class AdminRelatedcontentAction extends FessAdminAction {
         RenderDataUtil.register(data, "relatedContentItems", relatedContentService.getRelatedContentList(relatedContentPager)); // page navi
 
         // restore from pager
-        copyBeanToBean(relatedContentPager, form, op -> op.include("id"));
+        copyBeanToBean(relatedContentPager, form, op -> op.include("term", "content"));
     }
 
     // ===================================================================================
@@ -279,7 +279,7 @@ public class AdminRelatedcontentAction extends FessAdminAction {
             RenderDataUtil.register(data, "relatedContentItems", relatedContentService.getRelatedContentList(relatedContentPager));
         }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(relatedContentPager, form, op -> op.include("id"));
+                copyBeanToBean(relatedContentPager, form, op -> op.include("term", "content"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/relatedcontent/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/relatedcontent/SearchForm.java
@@ -20,6 +20,8 @@ package org.codelibs.fess.app.web.admin.relatedcontent;
  */
 public class SearchForm {
 
-    public String id;
+    public String term;
+
+    public String content;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/relatedquery/AdminRelatedqueryAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/relatedquery/AdminRelatedqueryAction.java
@@ -103,7 +103,7 @@ public class AdminRelatedqueryAction extends FessAdminAction {
         RenderDataUtil.register(data, "relatedQueryItems", relatedQueryService.getRelatedQueryList(relatedQueryPager)); // page navi
 
         // restore from pager
-        copyBeanToBean(relatedQueryPager, form, op -> op.include("id"));
+        copyBeanToBean(relatedQueryPager, form, op -> op.include("term", "queries"));
     }
 
     // ===================================================================================
@@ -311,7 +311,7 @@ public class AdminRelatedqueryAction extends FessAdminAction {
             RenderDataUtil.register(data, "relatedQueryItems", relatedQueryService.getRelatedQueryList(relatedQueryPager));
         }).useForm(SearchForm.class, setup -> {
             setup.setup(form -> {
-                copyBeanToBean(relatedQueryPager, form, op -> op.include("id"));
+                copyBeanToBean(relatedQueryPager, form, op -> op.include("term", "queries"));
             });
         });
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/relatedquery/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/relatedquery/SearchForm.java
@@ -20,6 +20,8 @@ package org.codelibs.fess.app.web.admin.relatedquery;
  */
 public class SearchForm {
 
-    public String id;
+    public String term;
+
+    public String queries;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/SearchBody.java
@@ -18,6 +18,9 @@ package org.codelibs.fess.app.web.api.admin.boostdoc;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String urlExpr;
+
+    public String boostExpr;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/SearchBody.java
@@ -18,6 +18,11 @@ package org.codelibs.fess.app.web.api.admin.dataconfig;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String name;
+
+    public String handlerName;
+
+    public String description;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/SearchBody.java
@@ -18,6 +18,9 @@ package org.codelibs.fess.app.web.api.admin.duplicatehost;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String regularName;
+
+    public String duplicateHostName;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/SearchBody.java
@@ -18,6 +18,11 @@ package org.codelibs.fess.app.web.api.admin.fileconfig;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String name;
+
+    public String paths;
+
+    public String description;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/SearchBody.java
@@ -18,6 +18,9 @@ package org.codelibs.fess.app.web.api.admin.keymatch;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String term;
+
+    public String query;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/SearchBody.java
@@ -18,6 +18,9 @@ package org.codelibs.fess.app.web.api.admin.labeltype;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String name;
+
+    public String value;
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/SearchBody.java
@@ -18,5 +18,9 @@ package org.codelibs.fess.app.web.api.admin.pathmap;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String regex;
+
+    public String replacement;
+
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/SearchBody.java
@@ -18,5 +18,9 @@ package org.codelibs.fess.app.web.api.admin.relatedcontent;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String term;
+
+    public String content;
+
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/SearchBody.java
@@ -18,5 +18,9 @@ package org.codelibs.fess.app.web.api.admin.relatedquery;
 import org.codelibs.fess.app.web.api.admin.BaseSearchBody;
 
 public class SearchBody extends BaseSearchBody {
-    public String id;
+
+    public String term;
+
+    public String queries;
+
 }

--- a/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc.jsp
@@ -36,6 +36,37 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/boostdoc/"
+										 styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="urlExpr" class="col-sm-2 control-label"><la:message
+												key="labels.boost_document_rule_url_expr" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="urlExpr" property="urlExpr" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="boostExpr" class="col-sm-2 control-label"><la:message
+												key="labels.boost_document_rule_boost_expr" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="boostExpr" property="boostExpr" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${boostDocPager.allRecordCount == 0}">
 									<div class="row top10">

--- a/src/main/webapp/WEB-INF/view/admin/dataconfig/admin_dataconfig.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dataconfig/admin_dataconfig.jsp
@@ -36,6 +36,52 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/dataconfig/"
+										 styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="name" class="col-sm-2 control-label"><la:message
+												key="labels.name" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="name" property="name" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="handlerName" class="col-sm-2 control-label"><la:message
+												key="labels.handler_name" /></label>
+										<div class="col-sm-10">
+											<la:errors property="handlerName" />
+											<la:select styleId="handlerName" property="handlerName" size="1"
+													   styleClass="form-control">
+												<la:option value="" />
+												<c:forEach var="hn" varStatus="s"
+														   items="${handlerNameItems}">
+													<la:option value="${f:u(hn.value)}">${f:h(hn.label)}</la:option>
+												</c:forEach>
+											</la:select>
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="description" class="col-sm-2 control-label"><la:message
+												key="labels.description" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="description" property="description" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${dataConfigPager.allRecordCount == 0}">
 									<div class="row top10">

--- a/src/main/webapp/WEB-INF/view/admin/duplicatehost/admin_duplicatehost.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/duplicatehost/admin_duplicatehost.jsp
@@ -36,6 +36,37 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/duplicatehost/"
+										 styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="regularName" class="col-sm-2 control-label"><la:message
+												key="labels.regular_name" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="regularName" property="regularName" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="duplicateHostName" class="col-sm-2 control-label"><la:message
+												key="labels.duplicate_name" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="duplicateHostName" property="duplicateHostName" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${duplicateHostPager.allRecordCount == 0}">
 									<div class="row top10">

--- a/src/main/webapp/WEB-INF/view/admin/fileconfig/admin_fileconfig.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/fileconfig/admin_fileconfig.jsp
@@ -38,6 +38,44 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/fileconfig/"
+									styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="name" class="col-sm-2 control-label"><la:message
+												key="labels.name" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="name" property="name" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="paths" class="col-sm-2 control-label"><la:message
+												key="labels.paths" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="paths" property="paths" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="description" class="col-sm-2 control-label"><la:message
+												key="labels.description" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="description" property="description" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${fileConfigPager.allRecordCount == 0}">
 									<div class="row top10">

--- a/src/main/webapp/WEB-INF/view/admin/keymatch/admin_keymatch.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/keymatch/admin_keymatch.jsp
@@ -36,6 +36,37 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/keymatch/"
+										 styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="term" class="col-sm-2 control-label"><la:message
+												key="labels.key_match_term" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="term" property="term" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="query" class="col-sm-2 control-label"><la:message
+												key="labels.key_match_query" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="query" property="query" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${keyMatchPager.allRecordCount == 0}">
 									<div class="row top10">

--- a/src/main/webapp/WEB-INF/view/admin/labeltype/admin_labeltype.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/labeltype/admin_labeltype.jsp
@@ -36,6 +36,37 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/labeltype/"
+										 styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="name" class="col-sm-2 control-label"><la:message
+												key="labels.labeltype_name" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="name" property="name" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="value" class="col-sm-2 control-label"><la:message
+												key="labels.labeltype_value" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="value" property="value" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${labelTypePager.allRecordCount == 0}">
 									<div class="row top10">

--- a/src/main/webapp/WEB-INF/view/admin/pathmap/admin_pathmap.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/pathmap/admin_pathmap.jsp
@@ -36,6 +36,37 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/pathmap/"
+										 styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="regex" class="col-sm-2 control-label"><la:message
+												key="labels.regex" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="regex" property="regex" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="replacement" class="col-sm-2 control-label"><la:message
+												key="labels.replacement" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="replacement" property="replacement" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${pathMapPager.allRecordCount == 0}">
 									<div class="row top10">

--- a/src/main/webapp/WEB-INF/view/admin/relatedcontent/admin_relatedcontent.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/relatedcontent/admin_relatedcontent.jsp
@@ -36,6 +36,37 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/relatedcontent/"
+										 styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="term" class="col-sm-2 control-label"><la:message
+												key="labels.related_content_term" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="term" property="term" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="content" class="col-sm-2 control-label"><la:message
+												key="labels.related_content_content" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="content" property="content" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${relatedContentPager.allRecordCount == 0}">
 									<div class="row top10">

--- a/src/main/webapp/WEB-INF/view/admin/relatedquery/admin_relatedquery.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/relatedquery/admin_relatedquery.jsp
@@ -36,6 +36,37 @@
 									</la:info>
 									<la:errors />
 								</div>
+								<la:form action="/admin/relatedquery/"
+										 styleClass="form-horizontal">
+									<div class="form-group">
+										<label for="term" class="col-sm-2 control-label"><la:message
+												key="labels.related_query_term" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="term" property="term" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<label for="queries" class="col-sm-2 control-label"><la:message
+												key="labels.related_query_queries" /></label>
+										<div class="col-sm-10">
+											<la:text styleId="queries" property="queries" styleClass="form-control" />
+										</div>
+									</div>
+									<div class="form-group">
+										<div class="col-sm-offset-2 col-sm-10">
+											<button type="submit" class="btn btn-primary" id="submit"
+													name="search"
+													value="<la:message key="labels.crud_button_search" />">
+												<em class="fa fa-search"></em>
+												<la:message key="labels.crud_button_search" />
+											</button>
+											<button type="submit" class="btn btn-default" name="reset"
+													value="<la:message key="labels.crud_button_reset" />">
+												<la:message key="labels.crud_button_reset" />
+											</button>
+										</div>
+									</div>
+								</la:form>
 								<%-- List --%>
 								<c:if test="${relatedQueryPager.allRecordCount == 0}">
 									<div class="row top10">


### PR DESCRIPTION
Add search options for

* [webconfig](https://github.com/codelibs/fess/pull/2326) (name, urls, description)
* fileconfig (name, handlerName, description)
* dataconfig (name, handlerName, description)
* labeltype (name, value)
* keymatch (term, query)
* boostdoc (urlExpr, boostExpr)
* relatedcontent (term, content)
* relatedquery (term, queries)
* pathmap (regex, replacement)
* duplicatehost (regularName, duplicateHostName)