### PR TITLE
Set Referrer-Policy in search result

### DIFF
--- a/src/main/webapp/WEB-INF/orig/view/search.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/search.jsp
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="referrer" content="no-referrer">
 <title>${f:h(displayQuery)}-<la:message
 		key="labels.search_title" /></title>
 <c:if test="${osddLink}">

--- a/src/main/webapp/WEB-INF/view/search.jsp
+++ b/src/main/webapp/WEB-INF/view/search.jsp
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="referrer" content="no-referrer">
 <title>${f:h(displayQuery)}-<la:message
 		key="labels.search_title" /></title>
 <c:if test="${osddLink}">


### PR DESCRIPTION
Hi, developers. Thank you so much for your wonderful application!

I'm very new to Fess. The current Fess search result tells your search keywords to web servers you clicked. This PR makes Fess not to tell your search keywords to the web server by [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) and improve privacy.