### PR TITLE
Feature: UI extension to restrict the search query for the given path/URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ dbflute_fess/schema/project-lastadoc-fess.json
 src/main/resources/fess_indices/.fess_config.access_token/access_token.bulk
 src/main/resources/ga_client_secrets.p12
 src/main/webapp/WEB-INF/project.properties
+.factorypath
+.vscode/launch.json

--- a/src/main/resources/fess_indices/fess.json
+++ b/src/main/resources/fess_indices/fess.json
@@ -8,6 +8,12 @@
       "auto_expand_replicas": "${fess.index.auto_expand_replicas}"
     },
     "analysis": {
+      "normalizer": {
+        "useLowerCase": {
+          "type": "custom",
+          "filter": [ "lowercase" ]
+        }
+      },
       "char_filter": {
         "mapping_fa_filter": {
           "type": "mapping",

--- a/src/main/resources/fess_indices/fess/doc.json
+++ b/src/main/resources/fess_indices/fess/doc.json
@@ -584,7 +584,8 @@
         "type": "keyword"
       },
       "url": {
-        "type": "keyword"
+        "type": "keyword",
+        "normalizer": "useLowerCase"
       }
     }
 }

--- a/src/main/resources/fess_label_de.properties
+++ b/src/main/resources/fess_label_de.properties
@@ -320,6 +320,7 @@ labels.profile.placeholder_confirm_new_password=Neues Passwort (bestätigen)
 labels.top.search=Suche
 labels.index_title=Fess
 labels.index_form_search_btn=Suche
+labels.index_form_searchpath_btn=Pfad
 labels.index_osdd_title=Suche
 labels.index_form_option_btn=Optionen
 labels.index_help=Hilfe

--- a/src/main/resources/fess_label_en.properties
+++ b/src/main/resources/fess_label_en.properties
@@ -364,6 +364,7 @@ labels.profile.placeholder_confirm_new_password=Confirm New Password
 labels.top.search=Search
 labels.index_title=Fess
 labels.index_form_search_btn=Search
+labels.index_form_searchpath_btn=Path
 labels.index_osdd_title=Search
 labels.index_form_option_btn=Options
 labels.index_help=Help

--- a/src/main/webapp/WEB-INF/view/header.jsp
+++ b/src/main/webapp/WEB-INF/view/header.jsp
@@ -22,6 +22,14 @@
 								<em class="fa fa-search"></em>
 							</button>
 							<button type="button" class="btn btn-light"
+								data-toggle="control-search-path" data-target="#searchPath"
+								id="searchPathButton">
+								<i class="far fa-folder"></i> 
+								<span class="sr-only">
+									<la:message key="labels.index_form_searchpath_btn" />
+								</span>
+							</button>
+							<button type="button" class="btn btn-light"
 								data-toggle="control-options" data-target="#searchOptions"
 								id="searchOptionsButton">
 								<em class="fa fa-cog"></em> <span class="sr-only"><la:message
@@ -94,4 +102,22 @@
 			</div>
 		</div>
 	</div>
+
+	<div id="searchPath" class="control-search-path">
+		<div class="container">
+				<div class="input-group mb-3">
+						<div class="input-group-prepend">
+								<span class="input-group-text" id="basic-addon1"><i class="far fa-folder"></i></span>
+						</div>
+						<input type="text" class="form-control" placeholder="" aria-label="" aria-describedby="search path"
+								id="searchPathField" name="searchPath" value="${f:h(fe:join(searchPath))}">
+						<div class="input-group-append">
+								<button class="btn btn-outline-secondary" type="button" id="searchPathFieldClear">
+										<i class="fa fa-times-circle"></i>
+								</button>
+						</div>
+				</div>
+		</div>
+</div>
+
 </la:form>

--- a/src/main/webapp/WEB-INF/view/index.jsp
+++ b/src/main/webapp/WEB-INF/view/index.jsp
@@ -118,6 +118,22 @@
 									autocomplete="off" />
 							</div>
 						</div>
+						<div id="searchPath" class="control-search-path mx-auto col-10 col-sm-8 col-md-8 col-lg-6" style="margin-top:10px;">
+							<div class="container">
+								<div class="input-group mb-3">
+									<div class="input-group-prepend">
+										<span class="input-group-text" id="basic-addon1"><i class="far fa-folder"></i></span>
+									</div>
+									<input type="text" class="form-control" placeholder="" aria-label="" aria-describedby="search path"
+										id="searchPathField" name="searchPath" value="${f:h(fe:join(searchPath))}">
+									<div class="input-group-append">
+										<button class="btn btn-outline-secondary" type="button" id="searchPathFieldClear">
+											<i class="fa fa-times-circle"></i>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
 						<c:if test="${!empty popularWords}">
 							<div class="clearfix">
 								<p class="text-truncate">
@@ -142,6 +158,11 @@
 								<la:message key="labels.index_form_search_btn" />
 							</button>
 							<button type="button" class="btn btn-outline-secondary"
+								data-toggle="control-search-path" data-target="#searchPath" id="searchPathButton">
+								<i class="far fa-folder"></i>
+								<la:message key="labels.index_form_searchpath_btn" />
+							</button>
+							<button type="button" class="btn btn-outline-secondary"
 								data-toggle="control-options" data-target="#searchOptions"
 								id="searchOptionsButton">
 								<em class="fa fa-cog"></em>
@@ -160,5 +181,6 @@
 	<script type="text/javascript" src="${fe:url('/js/bootstrap.min.js')}"></script>
 	<script type="text/javascript" src="${fe:url('/js/suggestor.js')}"></script>
 	<script type="text/javascript" src="${fe:url('/js/index.js')}"></script>
+	<script type="text/javascript" src="${fe:url('/js/searchpath.js')}"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/view/search.jsp
+++ b/src/main/webapp/WEB-INF/view/search.jsp
@@ -153,5 +153,6 @@
 	<script type="text/javascript" src="${fe:url('/js/bootstrap.min.js')}"></script>
 	<script type="text/javascript" src="${fe:url('/js/suggestor.js')}"></script>
 	<script type="text/javascript" src="${fe:url('/js/search.js')}"></script>
+	<script type="text/javascript" src="${fe:url('/js/searchpath.js')}"></script>
 </body>
 </html>

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -160,3 +160,7 @@ legend{
 		white-space: nowrap;
 	}
 }
+
+/* searchPath extension */
+#searchPath {display: none;}
+#searchPath.active {display: block;}

--- a/src/main/webapp/js/searchpath.js
+++ b/src/main/webapp/js/searchpath.js
@@ -1,0 +1,52 @@
+// Search Path extension
+$("[data-toggle='control-search-path']").click(function (e) {
+  e.preventDefault();
+  var target = $(this).attr("data-target") || $(this).attr("href");
+  if (target) {
+    $(target).toggleClass("active");
+  }
+});
+
+$('#searchPathFieldClear').click(function (e) {
+  $('#searchPathField').val('');
+});
+
+
+$(function () {
+  var query = (location.search.split('q' + '=')[1] || '').split('&')[0];
+  var searchPathTerms = [];
+
+  if (query.indexOf("inurl") > 0) {
+    var inurlEncodedMatches = query.match(/inurl%3A%22(.*?)%22/g) || [""];
+    inurlEncodedMatches.forEach(function (item, idx) {
+      var inurl = decodeURIComponent(item)
+      // console.log("In URL: " + inurl);
+
+      var searchPathTerm = (inurl.match("\\inurl:\"(.*?)\\\"") || [""])[1];
+      // console.log("Search Path Term: " + searchPathTerm);
+
+      //Replace inurl in query
+      $('#query').val($('#query').val().replace('inurl:\"' + searchPathTerm + '\"', '').trim())
+      searchPathTerms.push(searchPathTerm);
+    });
+
+    //Activate search path field
+    $('#searchPath').toggleClass("active", true);
+    $('#searchPathField').val(searchPathTerms.join(" "));
+  }
+});
+
+$('#searchForm').submit(function () {
+  var searchPath = $('#searchPathField').val();
+  if (searchPath != "") {
+    $('#query').css('color', 'white');
+    $('#contentQuery').css('color', 'white');
+    $('#searchPathField').css('color', 'white');
+
+    var searchPathTerms = searchPath.split(" ");
+    searchPathTerms.forEach(function (item, idx) {
+      $('#query').val($('#query').val() + " inurl:\"" + item + "\"");
+      $('#contentQuery').val($('#contentQuery').val() + " inurl:\"" + item + "\"");
+    })
+  }
+});


### PR DESCRIPTION
This is a simple UI extension to restrict the search query for a given file path or URL.

If the user wants to use such functionality, he has to use the `inurl:` syntax, which is not useful for non-power users.
This extension combines the `inurl:` syntax and hides the complexity with a simple and intuitive extra search path field.

## Screenshots

### Startpage
<img width="993" alt="Screenshot 2020-07-08 at 17 05 34" src="https://user-images.githubusercontent.com/1219881/86935701-6b903480-c13d-11ea-988f-ba131911579e.png">

### Startpage - activated path search
<img width="962" alt="Screenshot 2020-07-08 at 17 05 43" src="https://user-images.githubusercontent.com/1219881/86935721-71861580-c13d-11ea-9f3c-941139be9acb.png">
 
### Search page
<img width="1164" alt="Screenshot 2020-07-08 at 17 06 10" src="https://user-images.githubusercontent.com/1219881/86935985-b7db7480-c13d-11ea-9cea-48acaa85c519.png">

### Search page - activated path search
<img width="1185" alt="Screenshot 2020-07-08 at 17 06 17" src="https://user-images.githubusercontent.com/1219881/86936016-c033af80-c13d-11ea-9ee7-d3d1a70268e3.png">
