### PR TITLE
Do not add fuzzy query for terms with double-quotes

### DIFF
--- a/src/test/java/org/codelibs/fess/query/TermQueryCommandTest.java
+++ b/src/test/java/org/codelibs/fess/query/TermQueryCommandTest.java
@@ -83,6 +83,14 @@ public class TermQueryCommandTest extends UnitFessTestCase {
                 "{\"prefix\":{\"site\":{\"value\":\"aaa\",\"boost\":1.0}}}", //
                 "site:aaa");
 
+        // assertion for fuzzy search
+        assertQueryBuilder(BoolQueryBuilder.class,
+                "{\"bool\":{\"should\":[{\"match_phrase\":{\"title\":{\"query\":\"helloworld\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":0.5}}},{\"match_phrase\":{\"content\":{\"query\":\"helloworld\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":0.05}}},{\"fuzzy\":{\"title\":{\"value\":\"helloworld\",\"fuzziness\":\"AUTO\",\"prefix_length\":0,\"max_expansions\":10,\"transpositions\":true,\"boost\":0.01}}},{\"fuzzy\":{\"content\":{\"value\":\"helloworld\",\"fuzziness\":\"AUTO\",\"prefix_length\":0,\"max_expansions\":10,\"transpositions\":true,\"boost\":0.005}}}],\"adjust_pure_negative\":true,\"boost\":1.0}}",
+                "helloworld");
+        assertQueryBuilder(BoolQueryBuilder.class,
+                "{\"bool\":{\"should\":[{\"match_phrase\":{\"title\":{\"query\":\"helloworld\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":0.5}}},{\"match_phrase\":{\"content\":{\"query\":\"helloworld\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":0.05}}}],\"adjust_pure_negative\":true,\"boost\":1.0}}",
+                "\"helloworld\"");
+
         assertQueryBuilder("{\"timestamp\":{\"order\":\"asc\"}}", "sort:timestamp");
         assertQueryBuilder("{\"timestamp\":{\"order\":\"asc\"}}", "sort:timestamp.asc");
         assertQueryBuilder("{\"timestamp\":{\"order\":\"desc\"}}", "sort:timestamp.desc");


### PR DESCRIPTION
## Background
By default, for single-phrase Term Queries, Fess adds fuzzy query (with a low boost value) to the default query builder, causing results with similar phrases to appear as well (see #2503).
(For example, searching "plawright" without quotes will also display results with "playwright")

However, there are no mechanisms for the user to indicates that they only want results with their specified term (as in, without fuzzy query results)

## Solution
This patch allows users to ignore fuzzy results by surrounding the exact-search terms with double quotes, or by using phrase search in Advanced search page