### PR TITLE
Search by DocID instead of ID when deleting old documents

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/IndexingHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/IndexingHelper.java
@@ -121,8 +121,7 @@ public class IndexingHelper {
         }
         if (!docIdList.isEmpty()) {
             searchEngineClient.deleteByQuery(fessConfig.getIndexDocumentUpdateIndex(),
-                    QueryBuilders.idsQuery().addIds(docIdList.stream().toArray(n -> new String[n])));
-
+                    QueryBuilders.termsQuery(fessConfig.getIndexFieldDocId(), docIdList.stream().toArray(n -> new String[n])));
         }
     }
 
@@ -145,7 +144,7 @@ public class IndexingHelper {
     public long deleteDocumentsByDocId(final SearchEngineClient searchEngineClient, final List<String> docIdList) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         return searchEngineClient.deleteByQuery(fessConfig.getIndexDocumentUpdateIndex(),
-                QueryBuilders.idsQuery().addIds(docIdList.stream().toArray(n -> new String[n])));
+                QueryBuilders.termsQuery(fessConfig.getIndexFieldDocId(), docIdList.stream().toArray(n -> new String[n])));
     }
 
     public long deleteDocumentByQuery(final SearchEngineClient searchEngineClient, final QueryBuilder queryBuilder) {


### PR DESCRIPTION
## Background
When a crawler is re-executed with different permission settings, the crawler will create another set of results (with new permission settings).
But the older results (with old permission settings) are not properly removed.

## Reproduce
This is reproducible on Fess 14.12.0-SNAPSHOT (codelibs/fess@613c418)
- Create 2 users (user1 and user2)
- Create a crawler (can be either Web, Filesystem or Datastore) with permission `{user}user1`
- Create and start the crawler's scheduler
- Change the crawler's permission to:
```
{user}user1
{user}user2
```
- Re-run the crawler's scheduler

## Expected and actual behavior
Expected behavior: The older search results are removed and replaced with newer search results => searching by user1 only shows 1 result
Actual behavior: The newer search results are generated, but the older results still remain => searching by user1 shows 2 duplicated results

## Solution
The method `IndexingHelper#deleteOldDocuments()` is responsible for removing old search entries, and it seems that it can find these old entries correctly (the docIdList correctly contains old entries).
But the `deleteByQuery()` call seems to be searching the wrong column (with the default settings, it is searching by "_id" column instead of "doc_id")
This patch changes the QueryBuilder (used by `deleteByQuery()`) from querying by "_id" column to "doc_id" instead.

## Tested environment
- Fess 14.12.0-SNAPSHOT (codelibs/fess@613c418)