### PR TITLE
Avoid adding blank highlight terms in WildcardQueryCommand

### DIFF
--- a/src/main/java/org/codelibs/fess/query/WildcardQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/WildcardQueryCommand.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.QueryContext;
 import org.codelibs.fess.exception.InvalidQueryException;
@@ -59,7 +60,10 @@ public class WildcardQueryCommand extends QueryCommand {
         if (Constants.DEFAULT_FIELD.equals(field)) {
             final String text = wildcardQuery.getTerm().text();
             context.addFieldLog(field, text);
-            context.addHighlightedQuery(StringUtils.strip(text, "*"));
+            final String highlightText = StringUtils.strip(text, "*");
+            if (StringUtil.isNotBlank(highlightText)) {
+                context.addHighlightedQuery(highlightText);
+            }
             return buildDefaultQueryBuilder(fessConfig, context,
                     (f, b) -> QueryBuilders.wildcardQuery(f, toLowercaseWildcard(text)).boost(b * boost));
         }
@@ -67,7 +71,10 @@ public class WildcardQueryCommand extends QueryCommand {
         if (isSearchField(field)) {
             final String text = wildcardQuery.getTerm().text();
             context.addFieldLog(field, text);
-            context.addHighlightedQuery(StringUtils.strip(text, "*"));
+            final String highlightText = StringUtils.strip(text, "*");
+            if (StringUtil.isNotBlank(highlightText)) {
+                context.addHighlightedQuery(highlightText);
+            }
             return QueryBuilders.wildcardQuery(field, toLowercaseWildcard(text)).boost(boost);
         }
 
@@ -82,7 +89,10 @@ public class WildcardQueryCommand extends QueryCommand {
         }
         final String origQuery = queryBuf.toString();
         context.addFieldLog(Constants.DEFAULT_FIELD, origQuery);
-        context.addHighlightedQuery(StringUtils.strip(query, "*"));
+        final String highlightText = StringUtils.strip(query, "*");
+        if (StringUtil.isNotBlank(highlightText)) {
+            context.addHighlightedQuery(highlightText);
+        }
         return buildDefaultQueryBuilder(fessConfig, context, (f, b) -> QueryBuilders.wildcardQuery(f, origQuery).boost(b * boost));
     }
 


### PR DESCRIPTION
This pull request improves the handling of highlighted queries in the `WildcardQueryCommand` class by introducing additional validation to ensure that only non-blank strings are added as highlighted queries. It also includes a minor import addition for utility functions.

### Improvements to highlighted query handling:

* Updated `convertWildcardQuery` method to validate that the stripped query text is not blank before adding it as a highlighted query. This ensures that empty or whitespace-only strings are not unnecessarily processed. (`src/main/java/org/codelibs/fess/query/WildcardQueryCommand.java`, [[1]](diffhunk://#diff-066544c963089e7b9c4fb6a17a363535e93003ea53f3e2aa76bb8603c9f0e3a2L62-R77) [[2]](diffhunk://#diff-066544c963089e7b9c4fb6a17a363535e93003ea53f3e2aa76bb8603c9f0e3a2L85-R95)

### Codebase enhancements:

* Added `StringUtil` import to leverage its `isNotBlank` utility method for improved readability and functionality. (`src/main/java/org/codelibs/fess/query/WildcardQueryCommand.java`, [src/main/java/org/codelibs/fess/query/WildcardQueryCommand.javaR25](diffhunk://#diff-066544c963089e7b9c4fb6a17a363535e93003ea53f3e2aa76bb8603c9f0e3a2R25))…ipping