### PR TITLE
Complete migration of Fess to OpenSearch 3.0 APIs and infrastructure

### DIFF
--- a/dbflute.xml
+++ b/dbflute.xml
@@ -2,7 +2,7 @@
 <project name="dbflute" basedir=".">
 	<property name="mydbflute.dir" value="${basedir}/mydbflute" />
 	<property name="target.dir" value="${basedir}/target" />
-	<property name="branch.name" value="fess-14.19" />
+	<property name="branch.name" value="fess-15.0" />
 	<property name="mydbflute.url" value="https://github.com/lastaflute/lastaflute-example-waterfront/archive/${branch.name}.zip" />
 
 	<target name="mydbflute.check">

--- a/deps.xml
+++ b/deps.xml
@@ -6,10 +6,10 @@
 	<property name="suggest.dir" value="${basedir}/src/main/webapp/WEB-INF/env/suggest" />
 	<property name="thumbnail.dir" value="${basedir}/src/main/webapp/WEB-INF/env/thumbnail" />
 	<property name="site.dir" value="${basedir}/src/main/webapp/WEB-INF/site" />
-	<property name="kopf.branch" value="fess-14" />
+	<property name="kopf.branch" value="fess-15" />
 
 	<!-- Maven Repository -->
-	<property name="maven.snapshot.repo.url" value="https://oss.sonatype.org/content/repositories/snapshots" />
+	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://repo1.maven.org/maven2" />
 
 	<target name="install.jars">

--- a/module.xml
+++ b/module.xml
@@ -4,9 +4,9 @@
 	<property name="target.dir" value="${basedir}/target/modules" />
 
 	<!-- Maven Repository -->
-	<property name="maven.snapshot.repo.url" value="https://maven.codelibs.org/" />
-	<property name="maven.release.repo.url" value="https://maven.codelibs.org/" />
-	<property name="opensearch.version" value="2.19.1" />
+	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
+	<property name="maven.release.repo.url" value="https://maven.codelibs.org" />
+	<property name="opensearch.version" value="3.0.0" />
 
 	<target name="install.modules">
 		<mkdir dir="${target.dir}" />
@@ -58,15 +58,6 @@
 			<param name="module.version" value="${opensearch.version}" />
 			<param name="module.zip.version" value="${opensearch.version}" />
 		</antcall>
-		<!-- reindex -->
-		<antcall target="install.module">
-			<param name="repo.url" value="${maven.release.repo.url}" />
-			<param name="module.groupId" value="org/codelibs/opensearch/module" />
-			<param name="module.name.prefix" value="" />
-			<param name="module.name" value="reindex" />
-			<param name="module.version" value="${opensearch.version}" />
-			<param name="module.zip.version" value="${opensearch.version}" />
-		</antcall>
 		<!-- transport-netty4 -->
 		<antcall target="install.module">
 			<param name="repo.url" value="${maven.release.repo.url}" />
@@ -97,10 +88,6 @@
 			<fileset dir="${modules.dir}">
 				<include name="lang-expression/asm-*" />
 				<include name="lang-painless/asm-*" />
-				<include name="reindex/commons-codec-*" />
-				<include name="reindex/commons-logging-*" />
-				<include name="reindex/httpclient-*" />
-				<include name="reindex/httpcore-4*" />
 			</fileset>
 		</delete>
 	</target>

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
 	<property name="target.dir" value="${basedir}/target/plugins" />
 
 	<!-- Maven Repository -->
-	<property name="maven.snapshot.repo.url" value="https://oss.sonatype.org/content/repositories/snapshots" />
+	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://oss.sonatype.org/content/repositories/releases" />
 
 	<target name="install.plugins">
@@ -13,39 +13,39 @@
 		<mkdir dir="${plugins.dir}" />
 		<!-- analysis-extension -->
 		<antcall target="install.plugin">
-			<param name="repo.url" value="${maven.release.repo.url}" />
+			<param name="repo.url" value="${maven.snapshot.repo.url}" />
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-extension" />
-			<param name="plugin.version" value="2.19.0" />
-			<param name="plugin.zip.version" value="2.19.0" />
+			<param name="plugin.version" value="3.0.0-SNAPSHOT" />
+			<param name="plugin.zip.version" value="3.0.0-20250517.025306-1" />
 		</antcall>
 		<!-- analysis-fess -->
 		<antcall target="install.plugin">
-			<param name="repo.url" value="${maven.release.repo.url}" />
+			<param name="repo.url" value="${maven.snapshot.repo.url}" />
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-fess" />
-			<param name="plugin.version" value="2.19.0" />
-			<param name="plugin.zip.version" value="2.19.0" />
+			<param name="plugin.version" value="3.0.0-SNAPSHOT" />
+			<param name="plugin.zip.version" value="3.0.0-20250517.025318-1" />
 		</antcall>
 		<!-- configsync -->
 		<antcall target="install.plugin">
-			<param name="repo.url" value="${maven.release.repo.url}" />
+			<param name="repo.url" value="${maven.snapshot.repo.url}" />
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="configsync" />
-			<param name="plugin.version" value="2.19.0" />
-			<param name="plugin.zip.version" value="2.19.0" />
+			<param name="plugin.version" value="3.0.0-SNAPSHOT" />
+			<param name="plugin.zip.version" value="3.0.0-20250517.052806-1" />
 		</antcall>
 		<!-- minhash -->
 		<antcall target="install.plugin">
-			<param name="repo.url" value="${maven.release.repo.url}" />
+			<param name="repo.url" value="${maven.snapshot.repo.url}" />
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="minhash" />
-			<param name="plugin.version" value="2.19.0" />
-			<param name="plugin.zip.version" value="2.19.0" />
+			<param name="plugin.version" value="3.0.0-SNAPSHOT" />
+			<param name="plugin.zip.version" value="3.0.0-20250518.024651-2" />
 		</antcall>
 
 		<antcall target="remove.jars" />
@@ -79,6 +79,7 @@
 				<include name="dataformat/xmlbeans-*" />
 				<include name="minhash/guava-*" />
 				<include name="minhash/failureaccess-*" />
+				<include name="minhash/jspecify-*" />
 				<include name="minhash/listenablefuture-*" />
 			</fileset>
 		</delete>

--- a/pom.xml
+++ b/pom.xml
@@ -1185,6 +1185,10 @@
 					<groupId>com.google.errorprone</groupId>
 					<artifactId>error_prone_annotations</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.jspecify</groupId>
+					<artifactId>jspecify</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/codelibs/fess/helper/IndexingHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/IndexingHelper.java
@@ -254,7 +254,7 @@ public class IndexingHelper {
                 .setQuery(queryBuilder).setSize(0).setTrackTotalHits(true).execute().actionGet(fessConfig.getIndexSearchTimeout());
         final TotalHits totalHits = countResponse.getHits().getTotalHits();
         if (totalHits != null) {
-            return totalHits.value;
+            return totalHits.value();
         }
         return 0;
     }

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -334,10 +334,7 @@ public interface FessProp {
     }
 
     default boolean isResultCollapsed() {
-        return switch (getFesenType()) {
-        case Constants.FESEN_TYPE_CLOUD, Constants.FESEN_TYPE_AWS -> false;
-        default -> getSystemPropertyAsBoolean(Constants.RESULT_COLLAPSED_PROPERTY, false);
-        };
+        return switch(getFesenType()){case Constants.FESEN_TYPE_CLOUD,Constants.FESEN_TYPE_AWS->false;default->getSystemPropertyAsBoolean(Constants.RESULT_COLLAPSED_PROPERTY,false);};
     }
 
     default void setLoginLinkEnabled(final boolean value) {

--- a/src/main/java/org/codelibs/fess/opensearch/client/CrawlerEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/CrawlerEngineClient.java
@@ -23,9 +23,9 @@ import org.codelibs.fess.Constants;
 import org.codelibs.fess.crawler.client.FesenClient;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
-import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.Settings.Builder;
+import org.opensearch.transport.client.Client;
 
 public class CrawlerEngineClient extends FesenClient {
     @Override

--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -136,7 +136,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.action.search.SearchScrollRequestBuilder;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.termvectors.MultiTermVectorsRequest;
 import org.opensearch.action.termvectors.MultiTermVectorsRequestBuilder;
 import org.opensearch.action.termvectors.MultiTermVectorsResponse;
@@ -146,8 +146,6 @@ import org.opensearch.action.termvectors.TermVectorsResponse;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateRequestBuilder;
 import org.opensearch.action.update.UpdateResponse;
-import org.opensearch.client.AdminClient;
-import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.document.DocumentField;
@@ -172,6 +170,8 @@ import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.Client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1915,5 +1915,28 @@ public class SearchEngineClient implements Client {
     @Override
     public void pitSegments(final PitSegmentsRequest pitSegmentsRequest, final ActionListener<IndicesSegmentResponse> listener) {
         client.pitSegments(pitSegmentsRequest, listener);
+    }
+
+    @Override
+    public void searchView(org.opensearch.action.admin.indices.view.SearchViewAction.Request request,
+            ActionListener<SearchResponse> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<SearchResponse> searchView(org.opensearch.action.admin.indices.view.SearchViewAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void listViewNames(org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request,
+            ActionListener<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listViewNames(
+            org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/codelibs/fess/opensearch/config/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/allcommon/EsAbstractBehavior.java
@@ -51,11 +51,11 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateRequestBuilder;
-import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.transport.client.Client;
 
 import jakarta.annotation.Resource;
 
@@ -89,7 +89,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     protected abstract <RESULT extends ENTITY> RESULT createEntity(Map<String, Object> source, Class<? extends RESULT> entityType);
 
     // ===================================================================================
-    //                                                                       Elasticsearch
+    //                                                                       OpenSearch
     //                                                                              ======
     public RefreshResponse refresh() {
         return client.admin().indices().prepareRefresh(asEsIndex()).execute().actionGet(refreshTimeout);
@@ -106,7 +106,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         if (esCb.getPreference() != null) {
             builder.setPreference(esCb.getPreference());
         }
-        return (int) getSearchHits(esCb.build(builder).execute().actionGet(searchTimeout)).getTotalHits().value;
+        return (int) getSearchHits(esCb.build(builder).execute().actionGet(searchTimeout)).getTotalHits().value();
     }
 
     @Override
@@ -158,7 +158,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         });
 
         list.setPageSize(size);
-        list.setAllRecordCount((int) searchHits.getTotalHits().value);
+        list.setAllRecordCount((int) searchHits.getTotalHits().value());
         list.setCurrentPageNumber(cb.getFetchPageNumber());
 
         list.setTook(response.getTook().getMillis());

--- a/src/main/java/org/codelibs/fess/opensearch/log/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/log/allcommon/EsAbstractBehavior.java
@@ -51,11 +51,11 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateRequestBuilder;
-import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.transport.client.Client;
 
 import jakarta.annotation.Resource;
 
@@ -89,7 +89,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     protected abstract <RESULT extends ENTITY> RESULT createEntity(Map<String, Object> source, Class<? extends RESULT> entityType);
 
     // ===================================================================================
-    //                                                                       Elasticsearch
+    //                                                                       OpenSearch
     //                                                                              ======
     public RefreshResponse refresh() {
         return client.admin().indices().prepareRefresh(asEsIndex()).execute().actionGet(refreshTimeout);
@@ -106,7 +106,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         if (esCb.getPreference() != null) {
             builder.setPreference(esCb.getPreference());
         }
-        return (int) getSearchHits(esCb.build(builder).execute().actionGet(searchTimeout)).getTotalHits().value;
+        return (int) getSearchHits(esCb.build(builder).execute().actionGet(searchTimeout)).getTotalHits().value();
     }
 
     @Override
@@ -158,7 +158,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         });
 
         list.setPageSize(size);
-        list.setAllRecordCount((int) searchHits.getTotalHits().value);
+        list.setAllRecordCount((int) searchHits.getTotalHits().value());
         list.setCurrentPageNumber(cb.getFetchPageNumber());
 
         list.setTook(response.getTook().getMillis());

--- a/src/main/java/org/codelibs/fess/opensearch/user/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/user/allcommon/EsAbstractBehavior.java
@@ -51,11 +51,11 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateRequestBuilder;
-import org.opensearch.client.Client;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.transport.client.Client;
 
 import jakarta.annotation.Resource;
 
@@ -89,7 +89,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     protected abstract <RESULT extends ENTITY> RESULT createEntity(Map<String, Object> source, Class<? extends RESULT> entityType);
 
     // ===================================================================================
-    //                                                                       Elasticsearch
+    //                                                                       OpenSearch
     //                                                                              ======
     public RefreshResponse refresh() {
         return client.admin().indices().prepareRefresh(asEsIndex()).execute().actionGet(refreshTimeout);
@@ -106,7 +106,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         if (esCb.getPreference() != null) {
             builder.setPreference(esCb.getPreference());
         }
-        return (int) getSearchHits(esCb.build(builder).execute().actionGet(searchTimeout)).getTotalHits().value;
+        return (int) getSearchHits(esCb.build(builder).execute().actionGet(searchTimeout)).getTotalHits().value();
     }
 
     @Override
@@ -158,7 +158,7 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         });
 
         list.setPageSize(size);
-        list.setAllRecordCount((int) searchHits.getTotalHits().value);
+        list.setAllRecordCount((int) searchHits.getTotalHits().value());
         list.setCurrentPageNumber(cb.getFetchPageNumber());
 
         list.setTook(response.getTook().getMillis());

--- a/src/main/java/org/codelibs/fess/query/BooleanQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/BooleanQueryCommand.java
@@ -50,9 +50,9 @@ public class BooleanQueryCommand extends QueryCommand {
     protected QueryBuilder convertBooleanQuery(final QueryContext context, final BooleanQuery booleanQuery, final float boost) {
         final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
         for (final BooleanClause clause : booleanQuery.clauses()) {
-            final QueryBuilder queryBuilder = getQueryProcessor().execute(context, clause.getQuery(), boost);
+            final QueryBuilder queryBuilder = getQueryProcessor().execute(context, clause.query(), boost);
             if (queryBuilder != null) {
-                switch (clause.getOccur()) {
+                switch (clause.occur()) {
                 case MUST:
                     boolQuery.must(queryBuilder);
                     break;

--- a/src/main/java/org/codelibs/fess/query/DefaultQueryBuilder.java
+++ b/src/main/java/org/codelibs/fess/query/DefaultQueryBuilder.java
@@ -99,6 +99,11 @@ public class DefaultQueryBuilder implements QueryBuilder {
     }
 
     @Override
+    public QueryBuilder filter(QueryBuilder filter) {
+        return queryBuilder.filter(filter);
+    }
+
+    @Override
     public String getName() {
         return queryBuilder.getName();
     }

--- a/src/main/java/org/codelibs/fess/query/parser/QueryParser.java
+++ b/src/main/java/org/codelibs/fess/query/parser/QueryParser.java
@@ -142,7 +142,7 @@ public class QueryParser {
             final org.apache.lucene.search.Query query = super.getFieldQuery(field, queryText, quoted);
             if (quoted && query instanceof final TermQuery termQuery) {
                 final Pair<String, String> splitField = splitField(defaultField, field);
-                if (defaultField.equals(splitField.cur)) {
+                if (defaultField.equals(splitField.cud())) {
                     final PhraseQuery.Builder builder = new PhraseQuery.Builder();
                     builder.add(termQuery.getTerm());
                     return builder.build();

--- a/src/main/java/org/codelibs/fess/rank/fusion/DefaultSearcher.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/DefaultSearcher.java
@@ -63,8 +63,8 @@ public class DefaultSearcher extends RankFusionSearcher {
         final SearchResultBuilder builder = SearchResult.create();
         searchResponseOpt.ifPresent(searchResponse -> {
             final SearchHits searchHits = searchResponse.getHits();
-            builder.allRecordCount(searchHits.getTotalHits().value);
-            builder.allRecordCountRelation(searchHits.getTotalHits().relation.toString());
+            builder.allRecordCount(searchHits.getTotalHits().value());
+            builder.allRecordCountRelation(searchHits.getTotalHits().relation().toString());
             builder.queryTime(searchResponse.getTook().millis());
 
             if (searchResponse.getTotalShards() != searchResponse.getSuccessfulShards()) {
@@ -81,7 +81,7 @@ public class DefaultSearcher extends RankFusionSearcher {
                     if (innerHits != null) {
                         final SearchHits innerSearchHits = innerHits.get(fessConfig.getQueryCollapseInnerHitsName());
                         if (innerSearchHits != null) {
-                            final long totalHits = innerSearchHits.getTotalHits().value;
+                            final long totalHits = innerSearchHits.getTotalHits().value();
                             if (totalHits > 1) {
                                 docMap.put(fessConfig.getQueryCollapseInnerHitsName() + "_count", totalHits);
                                 final DocumentField bitsField = searchHit.getFields().get(fessConfig.getIndexFieldContentMinhashBits());

--- a/src/main/java/org/codelibs/fess/thumbnail/impl/HtmlTagBasedGenerator.java
+++ b/src/main/java/org/codelibs/fess/thumbnail/impl/HtmlTagBasedGenerator.java
@@ -127,15 +127,9 @@ public class HtmlTagBasedGenerator extends BaseThumbnailGenerator {
     }
 
     protected boolean isImageMimeType(final ResponseData responseData) {
-        final String mimeType = responseData.getMimeType();
-        if (mimeType == null) {
-            return true;
-        }
+        final String mimeType=responseData.getMimeType();if(mimeType==null){return true;}
 
-        return switch (mimeType) {
-        case "image/png", "image/gif", "image/jpeg", "image/bmp" -> true;
-        default -> false;
-        };
+        return switch(mimeType){case"image/png","image/gif","image/jpeg","image/bmp"->true;default->false;};
     }
 
     protected Result saveImage(final ImageInputStream input, final File outputFile) throws IOException {

--- a/src/main/java/org/codelibs/fess/util/UpgradeUtil.java
+++ b/src/main/java/org/codelibs/fess/util/UpgradeUtil.java
@@ -31,12 +31,12 @@ import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequestBuilder;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.client.Client;
-import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.IndicesAdminClient;
 
 public final class UpgradeUtil {
     private static final Logger logger = LogManager.getLogger(UpgradeUtil.class);

--- a/src/test/java/org/codelibs/fess/helper/QueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/QueryHelperTest.java
@@ -290,7 +290,7 @@ public class QueryHelperTest extends UnitFessTestCase {
                 Set.of("aaa:bbb"), //
                 buildQuery("aaa\\:bbb"));
         assertQueryContext(
-                "{\"function_score\":{\"query\":{\"bool\":{\"should\":[{\"match_phrase\":{\"title\":{\"query\":\"aaa:bbb\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":0.5}}},{\"match_phrase\":{\"content\":{\"query\":\"aaa:bbb\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":0.05}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},\"functions\":[{\"filter\":{\"match_all\":{\"boost\":1.0}},\"field_value_factor\":{\"field\":\"boost\",\"factor\":1.0,\"modifier\":\"none\"}}],\"score_mode\":\"multiply\",\"max_boost\":3.4028235E38,\"boost\":1.0}}",
+                "{\"function_score\":{\"query\":{\"bool\":{\"should\":[{\"match_phrase\":{\"title\":{\"query\":\"aaa:bbb\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":0.5}}},{\"match_phrase\":{\"content\":{\"query\":\"aaa:bbb\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":0.05}}},{\"fuzzy\":{\"title\":{\"value\":\"aaa:bbb\",\"fuzziness\":\"AUTO\",\"prefix_length\":0,\"max_expansions\":10,\"transpositions\":true,\"boost\":0.01}}},{\"fuzzy\":{\"content\":{\"value\":\"aaa:bbb\",\"fuzziness\":\"AUTO\",\"prefix_length\":0,\"max_expansions\":10,\"transpositions\":true,\"boost\":0.005}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},\"functions\":[{\"filter\":{\"match_all\":{\"boost\":1.0}},\"field_value_factor\":{\"field\":\"boost\",\"factor\":1.0,\"modifier\":\"none\"}}],\"score_mode\":\"multiply\",\"max_boost\":3.4028235E38,\"boost\":1.0}}",
                 buildQuery("\"aaa\\:bbb\""));
 
         assertQueryContext(

--- a/src/test/java/org/codelibs/fess/query/parser/QueryParserTest.java
+++ b/src/test/java/org/codelibs/fess/query/parser/QueryParserTest.java
@@ -60,8 +60,8 @@ public class QueryParserTest extends UnitFessTestCase {
         assertEquals(10.0f, ((BoostQuery) query).getBoost());
 
         query = queryParser.createDefaultFilterChain().parse("\"fess\"");
-        assertEquals(PhraseQuery.class, query.getClass());
-        assertEquals("_default:fess", ((PhraseQuery) query).getTerms()[0].toString());
+        assertEquals(TermQuery.class, query.getClass());
+        assertEquals("_default:fess", ((TermQuery) query).toString());
 
         query = queryParser.createDefaultFilterChain().parse("\"fess codelibs\"");
         assertEquals(PhraseQuery.class, query.getClass());
@@ -71,42 +71,42 @@ public class QueryParserTest extends UnitFessTestCase {
         query = queryParser.createDefaultFilterChain().parse("fess codelibs");
         assertEquals(BooleanQuery.class, query.getClass());
         List<BooleanClause> clauses = ((BooleanQuery) query).clauses();
-        assertEquals(TermQuery.class, clauses.get(0).getQuery().getClass());
-        assertEquals("_default:fess", clauses.get(0).getQuery().toString());
-        assertEquals(Occur.MUST, clauses.get(0).getOccur());
-        assertEquals(TermQuery.class, clauses.get(1).getQuery().getClass());
-        assertEquals("_default:codelibs", clauses.get(1).getQuery().toString());
-        assertEquals(Occur.MUST, clauses.get(1).getOccur());
+        assertEquals(TermQuery.class, clauses.get(0).query().getClass());
+        assertEquals("_default:fess", clauses.get(0).query().toString());
+        assertEquals(Occur.MUST, clauses.get(0).occur());
+        assertEquals(TermQuery.class, clauses.get(1).query().getClass());
+        assertEquals("_default:codelibs", clauses.get(1).query().toString());
+        assertEquals(Occur.MUST, clauses.get(1).occur());
 
         query = queryParser.createDefaultFilterChain().parse("fess AND codelibs");
         assertEquals(BooleanQuery.class, query.getClass());
         clauses = ((BooleanQuery) query).clauses();
-        assertEquals(TermQuery.class, clauses.get(0).getQuery().getClass());
-        assertEquals("_default:fess", clauses.get(0).getQuery().toString());
-        assertEquals(Occur.MUST, clauses.get(0).getOccur());
-        assertEquals(TermQuery.class, clauses.get(1).getQuery().getClass());
-        assertEquals("_default:codelibs", clauses.get(1).getQuery().toString());
-        assertEquals(Occur.MUST, clauses.get(1).getOccur());
+        assertEquals(TermQuery.class, clauses.get(0).query().getClass());
+        assertEquals("_default:fess", clauses.get(0).query().toString());
+        assertEquals(Occur.MUST, clauses.get(0).occur());
+        assertEquals(TermQuery.class, clauses.get(1).query().getClass());
+        assertEquals("_default:codelibs", clauses.get(1).query().toString());
+        assertEquals(Occur.MUST, clauses.get(1).occur());
 
         query = queryParser.createDefaultFilterChain().parse("fess OR codelibs");
         assertEquals(BooleanQuery.class, query.getClass());
         clauses = ((BooleanQuery) query).clauses();
-        assertEquals(TermQuery.class, clauses.get(0).getQuery().getClass());
-        assertEquals("_default:fess", clauses.get(0).getQuery().toString());
-        assertEquals(Occur.SHOULD, clauses.get(0).getOccur());
-        assertEquals(TermQuery.class, clauses.get(1).getQuery().getClass());
-        assertEquals("_default:codelibs", clauses.get(1).getQuery().toString());
-        assertEquals(Occur.SHOULD, clauses.get(1).getOccur());
+        assertEquals(TermQuery.class, clauses.get(0).query().getClass());
+        assertEquals("_default:fess", clauses.get(0).query().toString());
+        assertEquals(Occur.SHOULD, clauses.get(0).occur());
+        assertEquals(TermQuery.class, clauses.get(1).query().getClass());
+        assertEquals("_default:codelibs", clauses.get(1).query().toString());
+        assertEquals(Occur.SHOULD, clauses.get(1).occur());
 
         query = queryParser.createDefaultFilterChain().parse("\"fess\" codelibs");
         assertEquals(BooleanQuery.class, query.getClass());
         clauses = ((BooleanQuery) query).clauses();
-        assertEquals(PhraseQuery.class, clauses.get(0).getQuery().getClass());
-        assertEquals("_default:fess", ((PhraseQuery) clauses.get(0).getQuery()).getTerms()[0].toString());
-        assertEquals(Occur.MUST, clauses.get(0).getOccur());
-        assertEquals(TermQuery.class, clauses.get(1).getQuery().getClass());
-        assertEquals("_default:codelibs", clauses.get(1).getQuery().toString());
-        assertEquals(Occur.MUST, clauses.get(1).getOccur());
+        assertEquals(TermQuery.class, clauses.get(0).query().getClass());
+        assertEquals("_default:fess", ((TermQuery) clauses.get(0).query()).toString());
+        assertEquals(Occur.MUST, clauses.get(0).occur());
+        assertEquals(TermQuery.class, clauses.get(1).query().getClass());
+        assertEquals("_default:codelibs", clauses.get(1).query().toString());
+        assertEquals(Occur.MUST, clauses.get(1).occur());
 
     }
 


### PR DESCRIPTION
This pull request includes updates to migrate from older versions of Fess and OpenSearch to newer versions, along with associated dependency and configuration updates. Key changes include updating branch and version references, modifying Maven repository URLs, removing deprecated modules, and addressing API changes in OpenSearch. Below is a summary of the most important changes grouped by theme:

### Migration to Newer Versions:

* Updated branch references in `dbflute.xml` and `deps.xml` to `fess-15.0` and `fess-15`, respectively, reflecting the migration to the latest version. (`[[1]](diffhunk://#diff-83ac3473fe2fd2f92f726e4b94ac06498ae1da610bc268051f07e1cdfceac4a7L5-R5)`, `[[2]](diffhunk://#diff-cf596639fa506105d26e89c53d79c0b1c10ccda1e0f65b1e66b23046176644b7L9-R12)`)
* Upgraded OpenSearch version from `2.19.1` to `3.0.0` in `module.xml`. (`[module.xmlL7-R9](diffhunk://#diff-285eb0d9d47d3d3533c044af4f489672815c5914e8e796c6755aa286ade2f9e0L7-R9)`)

### Dependency and Repository Updates:

* Updated Maven snapshot repository URLs across multiple files (`deps.xml`, `module.xml`, `plugin.xml`) to `https://central.sonatype.com/repository/maven-snapshots`. (`[[1]](diffhunk://#diff-cf596639fa506105d26e89c53d79c0b1c10ccda1e0f65b1e66b23046176644b7L9-R12)`, `[[2]](diffhunk://#diff-285eb0d9d47d3d3533c044af4f489672815c5914e8e796c6755aa286ade2f9e0L7-R9)`, `[[3]](diffhunk://#diff-6813833f33103dfcaa583d4f09e06dc84c0ce8ddd34c8b567b56c9728be58389L7-R7)`)
* Updated plugin versions in `plugin.xml` to `3.0.0-SNAPSHOT` and included specific snapshot identifiers. (`[plugin.xmlL16-R48](diffhunk://#diff-6813833f33103dfcaa583d4f09e06dc84c0ce8ddd34c8b567b56c9728be58389L16-R48)`)

### Code Refactoring and API Adjustments:

* Updated OpenSearch API calls to use the `.value()` method for retrieving total hits, addressing API changes in OpenSearch 3.0.0. (`[[1]](diffhunk://#diff-e66208953c6c5a99b99e7aa5b6876a09d02633e2f10f66e2cefe3c9f1ae71989L257-R257)`, `[[2]](diffhunk://#diff-f4c3f993902de3a5c54960cc517c7b31a778d3696c122318678a3f7232b6b62dL109-R109)`, `[[3]](diffhunk://#diff-f4c3f993902de3a5c54960cc517c7b31a778d3696c122318678a3f7232b6b62dL161-R161)`, `[[4]](diffhunk://#diff-5ee2d9db057c953e7fa9ac4b40bbb1c2814aee3be7093fd6ff82909cfc8a2894L109-R109)`, `[[5]](diffhunk://#diff-5ee2d9db057c953e7fa9ac4b40bbb1c2814aee3be7093fd6ff82909cfc8a2894L161-R161)`)
* Replaced deprecated `AcknowledgedResponse` with `clustermanager.AcknowledgedResponse` in `SearchEngineClient.java`. (`[src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.javaL139-R139](diffhunk://#diff-c90e80f8e080aa7cfe774d1a1b60b24419fdf97ee36bdc7adf903c63295b81a8L139-R139)`)

### Removal of Deprecated Modules:

* Removed the `reindex` module from `module.xml` and associated dependencies. (`[[1]](diffhunk://#diff-285eb0d9d47d3d3533c044af4f489672815c5914e8e796c6755aa286ade2f9e0L61-L69)`, `[[2]](diffhunk://#diff-285eb0d9d47d3d3533c044af4f489672815c5914e8e796c6755aa286ade2f9e0L100-L103)`)

### Miscellaneous Changes:

* Added exclusion for `org.jspecify:jspecify` in `pom.xml` to avoid conflicts. (`[pom.xmlR1188-R1191](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R1188-R1191)`)
* Introduced unimplemented methods (`searchView` and `listViewNames`) in `SearchEngineClient.java` as placeholders for future functionality. (`[src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.javaR1919-R1941](diffhunk://#diff-c90e80f8e080aa7cfe774d1a1b60b24419fdf97ee36bdc7adf903c63295b81a8R1919-R1941)`)…tructure