### PR TITLE
Refactor cookie security logic using isSecureCookie method

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/UserInfoHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/UserInfoHelper.java
@@ -150,10 +150,22 @@ public class UserInfoHelper {
         if (StringUtil.isNotBlank(cookiePath)) {
             cookie.setPath(cookiePath);
         }
-        if (cookieSecure != null) {
-            cookie.setSecure(cookieSecure);
-        }
+        cookie.setSecure(isSecureCookie());
         LaResponseUtil.getResponse().addCookie(cookie);
+    }
+
+    protected boolean isSecureCookie() {
+        if (cookieSecure != null) {
+            return cookieSecure;
+        }
+
+        return LaRequestUtil.getOptionalRequest().map(req -> {
+            String forwardedProto = req.getHeader("X-Forwarded-Proto");
+            if ("https".equalsIgnoreCase(forwardedProto)) {
+                return true;
+            }
+            return req.isSecure();
+        }).orElse(false);
     }
 
     protected String getUserCodeFromCookie(final HttpServletRequest request) {

--- a/src/test/java/org/codelibs/fess/helper/UserInfoHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/UserInfoHelperTest.java
@@ -81,4 +81,31 @@ public class UserInfoHelperTest extends UnitFessTestCase {
         assertNull(userInfoHelper
                 .createUserCodeFromUserId("123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"));
     }
+
+    public void test_isSecureCookie_cookieSecureNotNull() {
+        UserInfoHelper userInfoHelper = new UserInfoHelper();
+
+        userInfoHelper.setCookieSecure(Boolean.TRUE);
+        assertTrue(userInfoHelper.isSecureCookie());
+
+        userInfoHelper.setCookieSecure(Boolean.FALSE);
+        assertFalse(userInfoHelper.isSecureCookie());
+    }
+
+    public void test_isSecureCookie_cookieSecureNull_xForwardedProto_https() {
+        UserInfoHelper userInfoHelper = new UserInfoHelper();
+        userInfoHelper.setCookieSecure(null);
+
+        MockletHttpServletRequest request = getMockRequest();
+        request.addHeader("X-Forwarded-Proto", "https");
+
+        assertTrue(userInfoHelper.isSecureCookie());
+    }
+
+    public void test_isSecureCookie_noRequest() {
+        UserInfoHelper userInfoHelper = new UserInfoHelper();
+        userInfoHelper.setCookieSecure(null);
+
+        assertFalse(userInfoHelper.isSecureCookie());
+    }
 }


### PR DESCRIPTION
This pull request enhances cookie security handling in the `UserInfoHelper` class and adds corresponding unit tests to ensure the functionality works as expected. The key changes include introducing a method to determine if cookies should be secure and updating the logic for setting cookie security attributes.

### Enhancements to cookie security handling:

* [`src/main/java/org/codelibs/fess/helper/UserInfoHelper.java`](diffhunk://#diff-80017b1a9f69f6c2e00337785023c31b86ca5c4739ea0423780d1c459c58cbbfR153-R168): Added a new method `isSecureCookie()` to determine if cookies should be marked as secure. The method checks the `cookieSecure` property and falls back to inspecting the `X-Forwarded-Proto` header or the request's security status. Updated the `updateCookie` method to use `isSecureCookie()` and ensure cookies are added to the response securely.

### Unit tests for secure cookie logic:

* [`src/test/java/org/codelibs/fess/helper/UserInfoHelperTest.java`](diffhunk://#diff-9bf641c7225362e6fe14fab925c2b2302846378b7e764474699f4919caf39842R84-R110): Added multiple test cases for the `isSecureCookie()` method to verify behavior when `cookieSecure` is explicitly set, when the `X-Forwarded-Proto` header indicates HTTPS, and when no request is available.