### PR TITLE
Refactor Japanese tokenizer configuration in fess.json

### DIFF
--- a/src/main/resources/fess_indices/fess.json
+++ b/src/main/resources/fess_indices/fess.json
@@ -657,11 +657,10 @@
       },
       "tokenizer": {
         "japanese_tokenizer": {
-          "type": "fess_japanese_reloadable_tokenizer",
+          "type": "fess_japanese_tokenizer",
           "mode": "normal",
           "user_dictionary": "${fess.dictionary.path}ja/kuromoji.txt",
-          "discard_punctuation": false,
-          "reload_interval":"1m"
+          "discard_punctuation": false
         },
         "korean_tokenizer": {
             "type": "fess_korean_tokenizer",


### PR DESCRIPTION
This pull request updates the configuration for the Japanese tokenizer in the `fess.json` file to simplify its setup by removing the reloadable feature.

Tokenizer configuration changes:

* [`src/main/resources/fess_indices/fess.json`](diffhunk://#diff-177fdc6c8217b6866de849798156568f50371252d7f22e5cb29536e49cb2e2c9L660-R663): Changed the Japanese tokenizer type from `fess_japanese_reloadable_tokenizer` to `fess_japanese_tokenizer` and removed the `reload_interval` property.