### PR TITLE
Refactor HTTP method usage for admin APIs to follow RESTful conventions

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/api/admin/accesstoken/ApiAdminAccesstokenAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/accesstoken/ApiAdminAccesstokenAction.java
@@ -57,7 +57,7 @@ public class ApiAdminAccesstokenAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/accesstoken
-    // POST /api/admin/accesstoken
+    // PUT /api/admin/accesstoken
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -76,9 +76,9 @@ public class ApiAdminAccesstokenAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/accesstoken/setting
+    // POST /api/admin/accesstoken/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final AccessToken accessToken = getAccessToken(body).map(entity -> {
@@ -97,9 +97,9 @@ public class ApiAdminAccesstokenAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(accessToken.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/accesstoken/setting
+    // PUT /api/admin/accesstoken/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final AccessToken accessToken = getAccessToken(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/badword/ApiAdminBadwordAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/badword/ApiAdminBadwordAction.java
@@ -61,7 +61,7 @@ public class ApiAdminBadwordAction extends FessApiAdminAction {
     protected SuggestHelper suggestHelper;
 
     // GET /api/admin/badword/settings
-    // POST /api/admin/badword/settings
+    // PUT /api/admin/badword/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -85,9 +85,9 @@ public class ApiAdminBadwordAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiConfigResponse().setting(body).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/badword/setting
+    // POST /api/admin/badword/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final BadWord entity = getBadWord(body).orElseGet(() -> {
@@ -106,9 +106,9 @@ public class ApiAdminBadwordAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(entity.getId()).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/user/setting
+    // PUT /api/admin/user/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final BadWord badWord = getBadWord(body).map(entity -> {
@@ -151,9 +151,9 @@ public class ApiAdminBadwordAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(id).created(false).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/badword/upload
+    // PUT /api/admin/badword/upload
     @Execute
-    public JsonResponse<ApiResult> post$upload(final UploadForm body) {
+    public JsonResponse<ApiResult> put$upload(final UploadForm body) {
         validateApi(body, messages -> {});
         CommonPoolUtil.execute(() -> {
             try (Reader reader = new BufferedReader(new InputStreamReader(body.badWordFile.getInputStream(), getCsvEncoding()))) {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/ApiAdminBoostdocAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/ApiAdminBoostdocAction.java
@@ -57,7 +57,7 @@ public class ApiAdminBoostdocAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/boostdoc
-    // POST /api/admin/boostdoc
+    // PUT /api/admin/boostdoc
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -77,9 +77,9 @@ public class ApiAdminBoostdocAction extends FessApiAdminAction {
                 })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/boostdoc/setting
+    // POST /api/admin/boostdoc/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final BoostDocumentRule boostDoc = getBoostDocumentRule(body).map(entity -> {
@@ -97,9 +97,9 @@ public class ApiAdminBoostdocAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(boostDoc.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/boostdoc/setting
+    // PUT /api/admin/boostdoc/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final BoostDocumentRule boostDoc = getBoostDocumentRule(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/crawlinginfo/ApiAdminCrawlinginfoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/crawlinginfo/ApiAdminCrawlinginfoAction.java
@@ -54,7 +54,7 @@ public class ApiAdminCrawlinginfoAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/crawlinginfo/logs
-    // POST /api/admin/crawlinginfo/logs
+    // PUT /api/admin/crawlinginfo/logs
     @Execute
     public JsonResponse<ApiResult> logs(final SearchBody body) {
         validateApi(body, messages -> {});

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/ApiAdminDataconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/ApiAdminDataconfigAction.java
@@ -60,7 +60,7 @@ public class ApiAdminDataconfigAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/dataconfig/settings
-    // POST /api/admin/dataconfig/settings
+    // PUT /api/admin/dataconfig/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -80,9 +80,9 @@ public class ApiAdminDataconfigAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/dataconfig/setting
+    // POST /api/admin/dataconfig/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final DataConfig dataConfig = getDataConfig(body).map(entity -> {
@@ -101,9 +101,9 @@ public class ApiAdminDataconfigAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(dataConfig.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/dataconfig/setting
+    // PUT /api/admin/dataconfig/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final DataConfig dataConfig = getDataConfig(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
@@ -67,9 +67,9 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
                 })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/dict/kuromoji/setting/{dictId}
+    // POST /api/admin/dict/kuromoji/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> put$setting(final String dictId, final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final String dictId, final CreateBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
@@ -85,9 +85,9 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/kuromoji/setting/{dictId}
+    // PUT /api/admin/dict/kuromoji/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$setting(final String dictId, final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final String dictId, final EditBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
@@ -115,9 +115,9 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(String.valueOf(id)).created(false).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/kuromoji/upload/{dictId}
+    // PUT /api/admin/dict/kuromoji/upload/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$upload(final String dictId, final UploadForm form) {
+    public JsonResponse<ApiResult> put$upload(final String dictId, final UploadForm form) {
         form.dictId = dictId;
         validateApi(form, messages -> {});
         final KuromojiFile file = kuromojiService.getKuromojiFile(form.dictId).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/ApiAdminDictMappingAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/ApiAdminDictMappingAction.java
@@ -67,9 +67,9 @@ public class ApiAdminDictMappingAction extends FessApiAdminAction {
                 })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/dict/mapping/setting/{dictId}
+    // POST /api/admin/dict/mapping/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> put$setting(final String dictId, final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final String dictId, final CreateBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
@@ -85,9 +85,9 @@ public class ApiAdminDictMappingAction extends FessApiAdminAction {
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/mapping/setting/{dictId}
+    // PUT /api/admin/dict/mapping/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$setting(final String dictId, final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final String dictId, final EditBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
@@ -115,9 +115,9 @@ public class ApiAdminDictMappingAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(String.valueOf(id)).created(false).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/mapping/upload/{dictId}
+    // PUT /api/admin/dict/mapping/upload/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$upload(final String dictId, final UploadForm form) {
+    public JsonResponse<ApiResult> put$upload(final String dictId, final UploadForm form) {
         form.dictId = dictId;
         validateApi(form, messages -> {});
         final CharMappingFile file = charMappingService.getCharMappingFile(form.dictId).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/ApiAdminDictProtwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/ApiAdminDictProtwordsAction.java
@@ -67,9 +67,9 @@ public class ApiAdminDictProtwordsAction extends FessApiAdminAction {
                 })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/dict/protwords/setting/{dictId}
+    // POST /api/admin/dict/protwords/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> put$setting(final String dictId, final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final String dictId, final CreateBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
@@ -85,9 +85,9 @@ public class ApiAdminDictProtwordsAction extends FessApiAdminAction {
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/protwords/setting/{dictId}
+    // PUT /api/admin/dict/protwords/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$setting(final String dictId, final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final String dictId, final EditBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
@@ -115,9 +115,9 @@ public class ApiAdminDictProtwordsAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(String.valueOf(id)).created(false).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/protwords/upload/{dictId}
+    // PUT /api/admin/dict/protwords/upload/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$upload(final String dictId, final UploadForm form) {
+    public JsonResponse<ApiResult> put$upload(final String dictId, final UploadForm form) {
         form.dictId = dictId;
         validateApi(form, messages -> {});
         final ProtwordsFile file = protwordsService.getProtwordsFile(form.dictId).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/ApiAdminDictStemmeroverrideAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/ApiAdminDictStemmeroverrideAction.java
@@ -67,9 +67,9 @@ public class ApiAdminDictStemmeroverrideAction extends FessApiAdminAction {
                 })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/dict/stemmerOverride/setting/{dictId}
+    // POST /api/admin/dict/stemmerOverride/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> put$setting(final String dictId, final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final String dictId, final CreateBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
@@ -85,9 +85,9 @@ public class ApiAdminDictStemmeroverrideAction extends FessApiAdminAction {
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/stemmerOverride/setting/{dictId}
+    // PUT /api/admin/dict/stemmerOverride/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$setting(final String dictId, final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final String dictId, final EditBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
@@ -115,9 +115,9 @@ public class ApiAdminDictStemmeroverrideAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(String.valueOf(id)).created(false).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/stemmerOverride/upload/{dictId}
+    // PUT /api/admin/dict/stemmerOverride/upload/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$upload(final String dictId, final UploadForm form) {
+    public JsonResponse<ApiResult> put$upload(final String dictId, final UploadForm form) {
         form.dictId = dictId;
         validateApi(form, messages -> {});
         final StemmerOverrideFile file = stemmerOverrideService.getStemmerOverrideFile(form.dictId).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/ApiAdminDictStopwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/ApiAdminDictStopwordsAction.java
@@ -67,9 +67,9 @@ public class ApiAdminDictStopwordsAction extends FessApiAdminAction {
                 })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/dict/stopwords/setting/{dictId}
+    // POST /api/admin/dict/stopwords/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> put$setting(final String dictId, final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final String dictId, final CreateBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
@@ -85,9 +85,9 @@ public class ApiAdminDictStopwordsAction extends FessApiAdminAction {
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/stopwords/setting/{dictId}
+    // PUT /api/admin/dict/stopwords/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$setting(final String dictId, final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final String dictId, final EditBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
@@ -115,9 +115,9 @@ public class ApiAdminDictStopwordsAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(String.valueOf(id)).created(false).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/stopwords/upload/{dictId}
+    // PUT /api/admin/dict/stopwords/upload/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$upload(final String dictId, final UploadForm form) {
+    public JsonResponse<ApiResult> put$upload(final String dictId, final UploadForm form) {
         form.dictId = dictId;
         validateApi(form, messages -> {});
         final StopwordsFile file = stopwordsService.getStopwordsFile(form.dictId).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/ApiAdminDictSynonymAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/ApiAdminDictSynonymAction.java
@@ -67,9 +67,9 @@ public class ApiAdminDictSynonymAction extends FessApiAdminAction {
                 })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/dict/synonym/setting/{dictId}
+    // POST /api/admin/dict/synonym/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> put$setting(final String dictId, final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final String dictId, final CreateBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
@@ -85,9 +85,9 @@ public class ApiAdminDictSynonymAction extends FessApiAdminAction {
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/synonym/setting/{dictId}
+    // PUT /api/admin/dict/synonym/setting/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$setting(final String dictId, final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final String dictId, final EditBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
@@ -115,9 +115,9 @@ public class ApiAdminDictSynonymAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(String.valueOf(id)).created(false).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/dict/synonym/upload/{dictId}
+    // PUT /api/admin/dict/synonym/upload/{dictId}
     @Execute
-    public JsonResponse<ApiResult> post$upload(final String dictId, final UploadForm form) {
+    public JsonResponse<ApiResult> put$upload(final String dictId, final UploadForm form) {
         form.dictId = dictId;
         validateApi(form, messages -> {});
         final SynonymFile file = synonymService.getSynonymFile(form.dictId).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/documents/ApiAdminDocumentsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/documents/ApiAdminDocumentsAction.java
@@ -57,9 +57,9 @@ public class ApiAdminDocumentsAction extends FessApiAdminAction {
     // Search Execute
     //
 
-    // POST /api/admin/documents/bulk
+    // PUT /api/admin/documents/bulk
     @Execute
-    public JsonResponse<ApiResult> post$bulk(final BulkBody body) {
+    public JsonResponse<ApiResult> put$bulk(final BulkBody body) {
         validateApi(body, messages -> {});
         if (body.documents == null) {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, "documents is required."));

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/ApiAdminDuplicatehostAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/ApiAdminDuplicatehostAction.java
@@ -55,7 +55,7 @@ public class ApiAdminDuplicatehostAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/duplicatehost/settings
-    // POST /api/admin/duplicatehost/settings
+    // PUT /api/admin/duplicatehost/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -75,9 +75,9 @@ public class ApiAdminDuplicatehostAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/duplicatehost/setting
+    // POST /api/admin/duplicatehost/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final DuplicateHost duplicateHost = getDuplicateHost(body).map(entity -> {
@@ -96,9 +96,9 @@ public class ApiAdminDuplicatehostAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(duplicateHost.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/duplicatehost/setting
+    // PUT /api/admin/duplicatehost/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final DuplicateHost duplicateHost = getDuplicateHost(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/ApiAdminElevatewordAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/ApiAdminElevatewordAction.java
@@ -65,7 +65,7 @@ public class ApiAdminElevatewordAction extends FessApiAdminAction {
     protected SuggestHelper suggestHelper;
 
     // GET /api/admin/elevateword
-    // POST /api/admin/elevateword
+    // PUT /api/admin/elevateword
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -92,9 +92,9 @@ public class ApiAdminElevatewordAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiConfigResponse().setting(body).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/elevateword/setting
+    // POST /api/admin/elevateword/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final ElevateWord entity = getElevateWord(body).orElseGet(() -> {
@@ -114,9 +114,9 @@ public class ApiAdminElevatewordAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(entity.getId()).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/elevateword/setting
+    // PUT /api/admin/elevateword/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final ElevateWord elevateWord = getElevateWord(body).map(entity -> {
@@ -160,9 +160,9 @@ public class ApiAdminElevatewordAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(id).created(false).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/elevateword/upload
+    // PUT /api/admin/elevateword/upload
     @Execute
-    public JsonResponse<ApiResult> post$upload(final UploadForm body) {
+    public JsonResponse<ApiResult> put$upload(final UploadForm body) {
         validateApi(body, messages -> {});
         CommonPoolUtil.execute(() -> {
             try (Reader reader = new BufferedReader(new InputStreamReader(body.elevateWordFile.getInputStream(), getCsvEncoding()))) {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/failureurl/ApiAdminFailureurlAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/failureurl/ApiAdminFailureurlAction.java
@@ -56,7 +56,7 @@ public class ApiAdminFailureurlAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/failureurl/logs
-    // POST /api/admin/failureurl/logs
+    // PUT /api/admin/failureurl/logs
     @Execute
     public JsonResponse<ApiResult> logs(final SearchBody body) {
         validateApi(body, messages -> {});

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileauth/ApiAdminFileauthAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileauth/ApiAdminFileauthAction.java
@@ -59,7 +59,7 @@ public class ApiAdminFileauthAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/fileauth/settings
-    // POST /api/admin/fileauth/settings
+    // PUT /api/admin/fileauth/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -79,9 +79,9 @@ public class ApiAdminFileauthAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/fileauth/setting
+    // POST /api/admin/fileauth/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         if (!isValidFileConfigId(body.fileConfigId)) {
             return asJson(new ApiErrorResponse().message("invalid fileConfigId").status(Status.BAD_REQUEST).result());
@@ -104,9 +104,9 @@ public class ApiAdminFileauthAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(fileAuth.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/fileauth/setting
+    // PUT /api/admin/fileauth/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final FileAuthentication fileAuth = getFileAuthentication(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/ApiAdminFileconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/ApiAdminFileconfigAction.java
@@ -60,7 +60,7 @@ public class ApiAdminFileconfigAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/fileconfig/settings
-    // POST /api/admin/fileconfig/settings
+    // PUT /api/admin/fileconfig/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -80,9 +80,9 @@ public class ApiAdminFileconfigAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/fileconfig/setting
+    // POST /api/admin/fileconfig/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final FileConfig fileConfig = getFileConfig(body).map(entity -> {
@@ -101,9 +101,9 @@ public class ApiAdminFileconfigAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(fileConfig.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/fileconfig/setting
+    // PUT /api/admin/fileconfig/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final FileConfig fileConfig = getFileConfig(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/general/ApiAdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/general/ApiAdminGeneralAction.java
@@ -52,9 +52,9 @@ public class ApiAdminGeneralAction extends FessApiAdminAction {
         return asJson(new ApiConfigResponse().setting(form).status(Status.OK).result());
     }
 
-    // POST /api/admin/general
+    // PUT /api/admin/general
     @Execute
-    public JsonResponse<ApiResult> post$index(final EditBody body) {
+    public JsonResponse<ApiResult> put$index(final EditBody body) {
         validateApi(body, messages -> {});
         final EditBody newBody = new EditBody();
         AdminGeneralAction.updateForm(fessConfig, newBody);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/group/ApiAdminGroupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/group/ApiAdminGroupAction.java
@@ -43,7 +43,7 @@ public class ApiAdminGroupAction extends FessApiAdminAction {
     private GroupService groupService;
 
     // GET /api/admin/group
-    // POST /api/admin/group
+    // PUT /api/admin/group
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -63,9 +63,9 @@ public class ApiAdminGroupAction extends FessApiAdminAction {
         })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/group/setting
+    // POST /api/admin/group/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         validateAttributes(body.attributes, this::throwValidationErrorApi);
         body.crudMode = CrudMode.CREATE;
@@ -85,9 +85,9 @@ public class ApiAdminGroupAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(entity.getId()).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/group/setting
+    // PUT /api/admin/group/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         validateAttributes(body.attributes, this::throwValidationErrorApi);
         body.crudMode = CrudMode.EDIT;

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/ApiAdminKeymatchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/ApiAdminKeymatchAction.java
@@ -55,7 +55,7 @@ public class ApiAdminKeymatchAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/keymatch/settings
-    // POST /api/admin/keymatch/settings
+    // PUT /api/admin/keymatch/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -75,9 +75,9 @@ public class ApiAdminKeymatchAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/keymatch/setting
+    // POST /api/admin/keymatch/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final KeyMatch keyMatch = getKeyMatch(body).map(entity -> {
@@ -96,9 +96,9 @@ public class ApiAdminKeymatchAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(keyMatch.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/keymatch/setting
+    // PUT /api/admin/keymatch/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final KeyMatch keyMatch = getKeyMatch(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/ApiAdminLabeltypeAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/ApiAdminLabeltypeAction.java
@@ -60,7 +60,7 @@ public class ApiAdminLabeltypeAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/labeltype/settings
-    // POST /api/admin/labeltype/settings
+    // PUT /api/admin/labeltype/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -80,9 +80,9 @@ public class ApiAdminLabeltypeAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/labeltype/setting
+    // POST /api/admin/labeltype/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final LabelType labelType = getLabelType(body).map(entity -> {
@@ -101,9 +101,9 @@ public class ApiAdminLabeltypeAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(labelType.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/labeltype/setting
+    // PUT /api/admin/labeltype/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final LabelType labelType = getLabelType(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/ApiAdminPathmapAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/ApiAdminPathmapAction.java
@@ -42,7 +42,7 @@ public class ApiAdminPathmapAction extends FessApiAdminAction {
     private PathMappingService pathMappingService;
 
     // GET /api/admin/pathmap
-    // POST /api/admin/pathmap
+    // PUT /api/admin/pathmap
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -63,9 +63,9 @@ public class ApiAdminPathmapAction extends FessApiAdminAction {
                 })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/pathmap/setting
+    // POST /api/admin/pathmap/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final PathMapping entity = getPathMapping(body).orElseGet(() -> {
@@ -84,9 +84,9 @@ public class ApiAdminPathmapAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(entity.getId()).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/pathmap/setting
+    // PUT /api/admin/pathmap/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final PathMapping entity = getPathMapping(body).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/plugin/ApiAdminPluginAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/plugin/ApiAdminPluginAction.java
@@ -46,9 +46,9 @@ public class ApiAdminPluginAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiPluginResponse().plugins(list).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/plugin
+    // POST /api/admin/plugin
     @Execute
-    public JsonResponse<ApiResult> put$index(final InstallBody body) {
+    public JsonResponse<ApiResult> post$index(final InstallBody body) {
         validateApi(body, messages -> {});
         final Artifact artifact = ComponentUtil.getPluginHelper().getArtifact(body.name, body.version);
         if (artifact == null) {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/ApiAdminRelatedcontentAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/ApiAdminRelatedcontentAction.java
@@ -52,7 +52,7 @@ public class ApiAdminRelatedcontentAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/relatedcontent/settings
-    // POST /api/admin/relatedcontent/settings
+    // PUT /api/admin/relatedcontent/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -73,9 +73,9 @@ public class ApiAdminRelatedcontentAction extends FessApiAdminAction {
                 })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/relatedcontent/setting
+    // POST /api/admin/relatedcontent/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final RelatedContent relatedContent = getRelatedContent(body).map(entity -> {
@@ -94,9 +94,9 @@ public class ApiAdminRelatedcontentAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(relatedContent.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/relatedcontent/setting
+    // PUT /api/admin/relatedcontent/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final RelatedContent relatedContent = getRelatedContent(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/ApiAdminRelatedqueryAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/ApiAdminRelatedqueryAction.java
@@ -55,7 +55,7 @@ public class ApiAdminRelatedqueryAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/relatedquery/settings
-    // POST /api/admin/relatedquery/settings
+    // PUT /api/admin/relatedquery/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -75,9 +75,9 @@ public class ApiAdminRelatedqueryAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/relatedquery/setting
+    // POST /api/admin/relatedquery/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final RelatedQuery relatedQuery = getRelatedQuery(body).map(entity -> {
@@ -96,9 +96,9 @@ public class ApiAdminRelatedqueryAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(relatedQuery.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/relatedquery/setting
+    // PUT /api/admin/relatedquery/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final RelatedQuery relatedQuery = getRelatedQuery(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/reqheader/ApiAdminReqheaderAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/reqheader/ApiAdminReqheaderAction.java
@@ -59,7 +59,7 @@ public class ApiAdminReqheaderAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/reqheader/settings
-    // POST /api/admin/reqheader/settings
+    // PUT /api/admin/reqheader/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -79,9 +79,9 @@ public class ApiAdminReqheaderAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/reqheader/setting
+    // POST /api/admin/reqheader/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         if (!isValidWebConfigId(body.webConfigId)) {
             return asJson(new ApiErrorResponse().message("invalid webConfigId").status(Status.BAD_REQUEST).result());
@@ -104,9 +104,9 @@ public class ApiAdminReqheaderAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(reqHeader.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/reqheader/setting
+    // PUT /api/admin/reqheader/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final RequestHeader reqHeader = getRequestHeader(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/role/ApiAdminRoleAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/role/ApiAdminRoleAction.java
@@ -41,7 +41,7 @@ public class ApiAdminRoleAction extends FessApiAdminAction {
     private RoleService roleService;
 
     // GET /api/admin/role/settings
-    // POST /api/admin/role/settings
+    // PUT /api/admin/role/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -61,9 +61,9 @@ public class ApiAdminRoleAction extends FessApiAdminAction {
         })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/role/setting
+    // POST /api/admin/role/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final Role entity = getRole(body).orElseGet(() -> {
@@ -81,9 +81,9 @@ public class ApiAdminRoleAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(entity.getId()).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/role/setting
+    // PUT /api/admin/role/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final Role entity = getRole(body).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/ApiAdminSchedulerAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/ApiAdminSchedulerAction.java
@@ -49,9 +49,9 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
         throw new UnsupportedOperationException();
     }
 
-    // POST /api/admin/scheduler/{id}/start
+    // PUT /api/admin/scheduler/{id}/start
     @Execute(urlPattern = "{}/@word")
-    public JsonResponse<ApiResult> post$start(final String id) {
+    public JsonResponse<ApiResult> put$start(final String id) {
         scheduledJobService.getScheduledJob(id).ifPresent(entity -> {
             if (!entity.isEnabled() || entity.isRunning()) {
                 throwValidationErrorApi(messages -> {
@@ -73,9 +73,9 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
         return asJson(new ApiResponse().status(Status.OK).result());
     }
 
-    // POST /api/admin/scheduler/{id}/stop
+    // PUT /api/admin/scheduler/{id}/stop
     @Execute(urlPattern = "{}/@word")
-    public JsonResponse<ApiResult> post$stop(final String id) {
+    public JsonResponse<ApiResult> put$stop(final String id) {
         scheduledJobService.getScheduledJob(id).ifPresent(entity -> {
             try {
                 entity.stop();
@@ -94,7 +94,7 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
     }
 
     // GET /api/admin/scheduler
-    // POST /api/admin/scheduler
+    // PUT /api/admin/scheduler
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -115,9 +115,9 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
                 })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/scheduler/setting
+    // POST /api/admin/scheduler/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final ScheduledJob entity = getScheduledJob(body).orElseGet(() -> {
@@ -136,9 +136,9 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(entity.getId()).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/scheduler/setting
+    // PUT /api/admin/scheduler/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final ScheduledJob entity = getScheduledJob(body).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/ApiAdminSearchlistAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/ApiAdminSearchlistAction.java
@@ -70,7 +70,7 @@ public class ApiAdminSearchlistAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/searchlist/docs
-    // POST /api/admin/searchlist/docs
+    // PUT /api/admin/searchlist/docs
     @Execute
     public JsonResponse<ApiResult> docs(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -113,9 +113,9 @@ public class ApiAdminSearchlistAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/searchlist/doc
+    // POST /api/admin/searchlist/doc
     @Execute
-    public JsonResponse<ApiResult> put$doc(final CreateBody body) {
+    public JsonResponse<ApiResult> post$doc(final CreateBody body) {
         validateApi(body, messages -> {});
         if (body.doc == null) {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, "doc is required"));
@@ -145,9 +145,9 @@ public class ApiAdminSearchlistAction extends FessApiAdminAction {
                 new ApiUpdateResponse().id(doc.get(fessConfig.getIndexFieldDocId()).toString()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/searchlist/doc
+    // PUT /api/admin/searchlist/doc
     @Execute
-    public JsonResponse<ApiResult> post$doc(final EditBody body) {
+    public JsonResponse<ApiResult> put$doc(final EditBody body) {
         validateApi(body, messages -> {});
         if (body.doc == null) {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, "doc is required"));

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/storage/ApiAdminStorageAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/storage/ApiAdminStorageAction.java
@@ -44,7 +44,7 @@ public class ApiAdminStorageAction extends FessApiAdminAction {
     private static final Logger logger = LogManager.getLogger(ApiAdminStorageAction.class);
 
     // GET /api/admin/storage/list/{id}
-    // POST /api/admin/storage/list/{id}
+    // PUT /api/admin/storage/list/{id}
     @Execute
     public JsonResponse<ApiResult> list(final OptionalThing<String> id) {
         final List<Map<String, Object>> list = getFileItems(id.isPresent() ? decodePath(id.get()) : null);
@@ -97,9 +97,9 @@ public class ApiAdminStorageAction extends FessApiAdminAction {
     }
 
     // curl -XPOST -H "Authorization: CHANGEME" localhost:8080/api/admin/storage/upload/ -F path=/ -F file=@...
-    // POST /api/admin/storage/upload/{pathId}/
+    // PUT /api/admin/storage/upload/{pathId}/
     @Execute
-    public JsonResponse<ApiResult> post$upload(final UploadForm form) {
+    public JsonResponse<ApiResult> put$upload(final UploadForm form) {
         validateApi(form, messages -> {});
         if (form.file == null) {
             throwValidationErrorApi(messages -> messages.addErrorsStorageNoUploadFile(GLOBAL));

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/user/ApiAdminUserAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/user/ApiAdminUserAction.java
@@ -42,7 +42,7 @@ public class ApiAdminUserAction extends FessApiAdminAction {
     private UserService userService;
 
     // GET /api/admin/user/settings
-    // POST /api/admin/user/settings
+    // PUT /api/admin/user/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -62,9 +62,9 @@ public class ApiAdminUserAction extends FessApiAdminAction {
         })).status(ApiResult.Status.OK).result());
     }
 
-    // PUT /api/admin/user/setting
+    // POST /api/admin/user/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final User entity = getUser(body).orElseGet(() -> {
@@ -83,9 +83,9 @@ public class ApiAdminUserAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiUpdateResponse().id(entity.getId()).created(true).status(ApiResult.Status.OK).result());
     }
 
-    // POST /api/admin/user/setting
+    // PUT /api/admin/user/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         validateAttributes(body.attributes, this::throwValidationErrorApi);
         body.crudMode = CrudMode.EDIT;

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/webauth/ApiAdminWebauthAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/webauth/ApiAdminWebauthAction.java
@@ -59,7 +59,7 @@ public class ApiAdminWebauthAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/webauth/settings
-    // POST /api/admin/webauth/settings
+    // PUT /api/admin/webauth/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -79,9 +79,9 @@ public class ApiAdminWebauthAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/webauth/setting
+    // POST /api/admin/webauth/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         if (!isValidWebConfigId(body.webConfigId)) {
             return asJson(new ApiErrorResponse().message("invalid webConfigId").status(Status.BAD_REQUEST).result());
@@ -104,9 +104,9 @@ public class ApiAdminWebauthAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(webAuth.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/webauth/setting
+    // PUT /api/admin/webauth/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final WebAuthentication webAuth = getWebAuthentication(body).map(entity -> {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/webconfig/ApiAdminWebconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/webconfig/ApiAdminWebconfigAction.java
@@ -60,7 +60,7 @@ public class ApiAdminWebconfigAction extends FessApiAdminAction {
     //                                                                      ==============
 
     // GET /api/admin/webconfig/settings
-    // POST /api/admin/webconfig/settings
+    // PUT /api/admin/webconfig/settings
     @Execute
     public JsonResponse<ApiResult> settings(final SearchBody body) {
         validateApi(body, messages -> {});
@@ -80,9 +80,9 @@ public class ApiAdminWebconfigAction extends FessApiAdminAction {
         })).status(Status.OK).result());
     }
 
-    // PUT /api/admin/webconfig/setting
+    // POST /api/admin/webconfig/setting
     @Execute
-    public JsonResponse<ApiResult> put$setting(final CreateBody body) {
+    public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.CREATE;
         final WebConfig webConfig = getWebConfig(body).map(entity -> {
@@ -101,9 +101,9 @@ public class ApiAdminWebconfigAction extends FessApiAdminAction {
         return asJson(new ApiUpdateResponse().id(webConfig.getId()).created(true).status(Status.OK).result());
     }
 
-    // POST /api/admin/webconfig/setting
+    // PUT /api/admin/webconfig/setting
     @Execute
-    public JsonResponse<ApiResult> post$setting(final EditBody body) {
+    public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         body.crudMode = CrudMode.EDIT;
         final WebConfig webConfig = getWebConfig(body).map(entity -> {

--- a/src/test/java/org/codelibs/fess/it/CrawlTestBase.java
+++ b/src/test/java/org/codelibs/fess/it/CrawlTestBase.java
@@ -39,7 +39,7 @@ public class CrawlTestBase extends ITBase {
     private static final String DOC_INDEX_NAME = "fess.search";
 
     protected static void createJob(final Map<String, Object> requestBody) {
-        checkMethodBase(requestBody).put("/api/admin/scheduler/setting").then().body("response.created", equalTo(true))
+        checkMethodBase(requestBody).post("/api/admin/scheduler/setting").then().body("response.created", equalTo(true))
                 .body("response.status", equalTo(0));
     }
 
@@ -47,7 +47,7 @@ public class CrawlTestBase extends ITBase {
         for (int i = 0; i < 30; i++) {
             final Map<String, Object> requestBody = new HashMap<>();
             final String schedulerId = getSchedulerIds(namePrefix).get(0);
-            final Response response = checkMethodBase(requestBody).post("/api/admin/scheduler/" + schedulerId + "/start");
+            final Response response = checkMethodBase(requestBody).put("/api/admin/scheduler/" + schedulerId + "/start");
             if (response.getBody().jsonPath().getInt("response.status") == 0) {
                 logger.info("Start scheduler \"{}\"", schedulerId);
                 return;
@@ -93,7 +93,7 @@ public class CrawlTestBase extends ITBase {
     }
 
     protected static String createWebConfig(final Map<String, Object> requestBody) {
-        String response = checkMethodBase(requestBody).put("/api/admin/webconfig/setting").asString();
+        String response = checkMethodBase(requestBody).post("/api/admin/webconfig/setting").asString();
         JsonPath jsonPath = JsonPath.from(response);
         assertTrue(jsonPath.getBoolean("response.created"));
         assertEquals(0, jsonPath.getInt("response.status"));
@@ -107,7 +107,7 @@ public class CrawlTestBase extends ITBase {
     }
 
     protected static String createFileConfig(final Map<String, Object> requestBody) {
-        String response = checkMethodBase(requestBody).put("/api/admin/fileconfig/setting").asString();
+        String response = checkMethodBase(requestBody).post("/api/admin/fileconfig/setting").asString();
         JsonPath jsonPath = JsonPath.from(response);
         assertTrue(jsonPath.getBoolean("response.created"));
         assertEquals(0, jsonPath.getInt("response.status"));

--- a/src/test/java/org/codelibs/fess/it/CrudTestBase.java
+++ b/src/test/java/org/codelibs/fess/it/CrudTestBase.java
@@ -105,7 +105,7 @@ public abstract class CrudTestBase extends ITBase {
         // Test: create setting api.
         for (int i = 0; i < NUM; i++) {
             final Map<String, Object> requestBody = createTestParam(i);
-            checkPutMethod(requestBody, getItemEndpointSuffix()).then().body("response.created", equalTo(true)).body("response.status",
+            checkPostMethod(requestBody, getItemEndpointSuffix()).then().body("response.created", equalTo(true)).body("response.status",
                     equalTo(0));
 
             //logger.info("create {}{}", i, checkPutMethod(requestBody, getItemEndpointSuffix()).asString()); // for debugging
@@ -168,7 +168,7 @@ public abstract class CrudTestBase extends ITBase {
                 }
             }
 
-            checkPostMethod(requestBody, getItemEndpointSuffix()).then().body("response.status", equalTo(0));
+            checkPutMethod(requestBody, getItemEndpointSuffix()).then().body("response.status", equalTo(0));
             refresh();
         }
 
@@ -212,14 +212,14 @@ public abstract class CrudTestBase extends ITBase {
         return response;
     }
 
-    protected Response checkPutMethod(final Map<String, Object> body, final String path) {
-        Response response = checkMethodBase(body).put(getApiPath() + "/" + path);
+    protected Response checkPostMethod(final Map<String, Object> body, final String path) {
+        Response response = checkMethodBase(body).post(getApiPath() + "/" + path);
         // logger.debug(response.asString());
         return response;
     }
 
-    protected Response checkPostMethod(final Map<String, Object> body, final String path) {
-        Response response = checkMethodBase(body).post(getApiPath() + "/" + path);
+    protected Response checkPutMethod(final Map<String, Object> body, final String path) {
+        Response response = checkMethodBase(body).put(getApiPath() + "/" + path);
         // logger.debug(response.asString());
         return response;
     }

--- a/src/test/java/org/codelibs/fess/it/admin/AccessTokenTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/AccessTokenTests.java
@@ -94,7 +94,7 @@ public class AccessTokenTests extends CrudTestBase {
         final Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", name);
         requestBody.put("permissions", "Radmin-api");
-        String response = checkPutMethod(requestBody, ITEM_ENDPOINT_SUFFIX).asString();
+        String response = checkPostMethod(requestBody, ITEM_ENDPOINT_SUFFIX).asString();
 
         // Test: access admin api using a new token
         String id = JsonPath.from(response).get("response.id");

--- a/src/test/java/org/codelibs/fess/it/admin/FileAuthTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/FileAuthTests.java
@@ -74,7 +74,7 @@ public class FileAuthTests extends CrudTestBase {
         requestBody.put("boost", 100.0);
         requestBody.put("available", true);
         requestBody.put("sort_order", 1);
-        checkMethodBase(requestBody).put("/api/admin/fileconfig/setting").then().body("response.created", equalTo(true))
+        checkMethodBase(requestBody).post("/api/admin/fileconfig/setting").then().body("response.created", equalTo(true))
                 .body("response.status", equalTo(0));
     }
 

--- a/src/test/java/org/codelibs/fess/it/admin/PluginTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/PluginTests.java
@@ -121,7 +121,7 @@ public class PluginTests extends CrudTestBase {
 
     @Test
     void testInstall_ng() {
-        checkPutMethod(Collections.emptyMap(), getInstallEndpointSuffix()).then().body("response.status", equalTo(1));
+        checkPostMethod(Collections.emptyMap(), getInstallEndpointSuffix()).then().body("response.status", equalTo(1));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class PluginTests extends CrudTestBase {
 
         // Install
         {
-            checkPutMethod(targetMap, getInstallEndpointSuffix()).then().body("response.status", equalTo(0));
+            checkPostMethod(targetMap, getInstallEndpointSuffix()).then().body("response.status", equalTo(0));
 
             boolean done = false;
             for (int i = 0; i < 60; i++) {

--- a/src/test/java/org/codelibs/fess/it/admin/ReqHeaderTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/ReqHeaderTests.java
@@ -75,7 +75,7 @@ public class ReqHeaderTests extends CrudTestBase {
         requestBody.put("boost", 100.0);
         requestBody.put("available", true);
         requestBody.put("sort_order", 1);
-        checkMethodBase(requestBody).put("/api/admin/webconfig/setting").then().body("response.created", equalTo(true))
+        checkMethodBase(requestBody).post("/api/admin/webconfig/setting").then().body("response.created", equalTo(true))
                 .body("response.status", equalTo(0));
     }
 

--- a/src/test/java/org/codelibs/fess/it/admin/SearchListTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/SearchListTests.java
@@ -123,7 +123,7 @@ public class SearchListTests extends CrudTestBase {
             //            doc.put("click_count", 100);  // Validation Error
             requestBody.put("doc", doc);
 
-            checkPostMethod(requestBody, getItemEndpointSuffix()).then().body("response.status", equalTo(0));
+            checkPutMethod(requestBody, getItemEndpointSuffix()).then().body("response.status", equalTo(0));
             refresh();
         }
 

--- a/src/test/java/org/codelibs/fess/it/admin/WebAuthTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/WebAuthTests.java
@@ -75,7 +75,7 @@ public class WebAuthTests extends CrudTestBase {
         requestBody.put("boost", 100.0);
         requestBody.put("available", true);
         requestBody.put("sort_order", 1);
-        checkMethodBase(requestBody).put("/api/admin/webconfig/setting").then().body("response.created", equalTo(true))
+        checkMethodBase(requestBody).post("/api/admin/webconfig/setting").then().body("response.created", equalTo(true))
                 .body("response.status", equalTo(0));
     }
 

--- a/src/test/java/org/codelibs/fess/it/search/SearchApiTests.java
+++ b/src/test/java/org/codelibs/fess/it/search/SearchApiTests.java
@@ -415,7 +415,7 @@ public class SearchApiTests extends CrawlTestBase {
         labelBody.put("name", TEST_LABEL);
         labelBody.put("value", TEST_LABEL);
         labelBody.put("included_paths", ".*tools.*");
-        Response response = checkMethodBase(labelBody).put("/api/admin/labeltype/setting");
+        Response response = checkMethodBase(labelBody).post("/api/admin/labeltype/setting");
         JsonPath jsonPath = JsonPath.from(response.asString());
         assertTrue(jsonPath.getBoolean("response.created"));
         assertEquals(0, jsonPath.getInt("response.status"));
@@ -427,7 +427,7 @@ public class SearchApiTests extends CrawlTestBase {
         labelBody.put("name", CRAWL_LABEL);
         labelBody.put("value", CRAWL_LABEL);
         labelBody.put("included_paths", ".*");
-        Response response = checkMethodBase(labelBody).put("/api/admin/labeltype/setting");
+        Response response = checkMethodBase(labelBody).post("/api/admin/labeltype/setting");
         JsonPath jsonPath = JsonPath.from(response.asString());
         assertTrue(jsonPath.getBoolean("response.created"));
         assertEquals(0, jsonPath.getInt("response.status"));


### PR DESCRIPTION
This pull request updates HTTP method annotations and corresponding method names in various admin API controllers to align with RESTful standards:
- Changed method annotations from POST to PUT for update operations.
- Changed method annotations from PUT to POST for create operations.
- Updated method names (e.g., post$setting, put$setting, etc.) to match the new annotations.

These changes improve clarity and consistency in the API’s RESTful design.