### PR TITLE
Update AWS index settings and hide unsupported options for cloud/AWS in admin UI

### DIFF
--- a/src/main/resources/fess_indices/_aws/fess.json
+++ b/src/main/resources/fess_indices/_aws/fess.json
@@ -641,9 +641,9 @@
           "user_dictionary_rules": ["令和,令和,レイワ,名詞-固有名詞-一般", "日本経済新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞", "関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,テスト名詞", "朝青龍,朝青龍,アサショウリュウ,カスタム名詞"]
         },
         "korean_tokenizer": {
-            "type": "seunjeon_tokenizer",
-            "index_eojeol": false,
-            "user_words": ["덕후", "버카충", "낄끼빠빠" ]
+            "type": "nori_tokenizer",
+            "decompound_mode": "mixed",
+            "user_dictionary_rules": ["덕후", "버카충", "낄끼빠빠" ]
         },
         "simplified_chinese_tokenizer": {
             "type": "smartcn_tokenizer"

--- a/src/main/webapp/WEB-INF/view/admin/general/admin_general.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/general/admin_general.jsp
@@ -78,6 +78,7 @@
                                         </div>
                                     </div>
                                 </div>
+                                <c:if test="${fesenType!='cloud' and fesenType!='aws'}">
                                 <div class="form-group row">
                                     <span class="font-weight-bold col-sm-3 text-sm-right col-form-label"><la:message
                                             key="labels.result_collapsed"/></span>
@@ -91,6 +92,7 @@
                                         </div>
                                     </div>
                                 </div>
+                                </c:if>
                                 <div class="form-group row">
                                     <span class="font-weight-bold col-sm-3 text-sm-right col-form-label"><la:message
                                             key="labels.thumbnail"/></span>


### PR DESCRIPTION
This pull request updates the Korean tokenizer configuration in the AWS-specific index settings by switching from seunjeon_tokenizer to nori_tokenizer with appropriate settings to align with the current OpenSearch capabilities.
