### PR TITLE
Fix Maven build warnings and minor code cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
 				<artifactId>formatter-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>net.alchim31.maven</groupId>
+				<groupId>com.github.hazendaz.maven</groupId>
 				<artifactId>yuicompressor-maven-plugin</artifactId>
 				<executions>
 					<execution>
@@ -204,6 +204,7 @@
 						<exclude>**/plugins/**/*.js</exclude>
 						<exclude>**/WEB-INF/site/**</exclude>
 					</excludes>
+					<sourceDirectory>src/main/webapp/js</sourceDirectory>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/webapp/js/search.js
+++ b/src/main/webapp/js/search.js
@@ -4,7 +4,10 @@ $(function() {
       $favorites = $(".favorite", $result),
       $searchButton = $("#searchButton"),
       contextPath = $("#contextPath").val(),
-      loadImage;
+      loadImage,
+      IMG_LOADING_DELAY = 200,
+      IMG_LOADING_MAX = 0,
+      clipboard;
 
   $("#searchForm").on("submit", function(e) {
     $searchButton.attr("disabled", true);
@@ -38,13 +41,13 @@ $(function() {
 
   $result.on("mousedown", "a.link", function(e) {
     var docId = $(this).attr("data-id"),
-      rt = $("#rt").val(),
-      queryId = $("#queryId").val(),
-      order = $(this).attr("data-order"),
-      url = $(this).attr("href"),
-      buf = [],
-      hashIndex,
-      hashStr;
+        rt = $("#rt").val(),
+        queryId = $("#queryId").val(),
+        order = $(this).attr("data-order"),
+        url = $(this).attr("href"),
+        buf = [],
+        hashIndex,
+        hashStr;
     buf.push(contextPath);
     buf.push("/go/?rt=");
     buf.push(rt);
@@ -67,11 +70,11 @@ $(function() {
 
   $result.on("mouseover", "a.link", function(e) {
     var docId = $(this).attr("data-id"),
-      rt = $("#rt").val(),
-      url = $(this).attr("href"),
-      buf = [],
-      hashIndex,
-      hashStr;
+        rt = $("#rt").val(),
+        url = $(this).attr("href"),
+        buf = [],
+        hashIndex,
+        hashStr;
     buf.push(contextPath);
     buf.push("/go/?rt=");
     buf.push(rt);
@@ -217,8 +220,6 @@ $(function() {
     });
   }
 
-  var IMG_LOADING_DELAY = 200;
-  var IMG_LOADING_MAX = 0;
   loadImage = function(img, url, limit) {
     var imgData = new Image();
     $(imgData).on("load", function() {
@@ -250,7 +251,7 @@ $(function() {
     loadImage(this, $(this).attr("data-src"), IMG_LOADING_MAX);
   });
   
-  var clipboard = new ClipboardJS(".url-copy");
+  clipboard = new ClipboardJS(".url-copy");
   clipboard.on("success", function(e) {
     e.trigger.classList.remove("url-copy");
     e.trigger.classList.remove("far");

--- a/src/test/java/org/codelibs/fess/it/admin/BackupTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/BackupTests.java
@@ -78,7 +78,7 @@ public class BackupTests extends CrudTestBase {
     protected void testRead() {
         final Map<String, Object> searchBody = new HashMap<>();
         final String response = checkMethodBase(searchBody).get(API_PATH + "/" + LIST_ENDPOINT_SUFFIX).asString();
-        assertEquals(new Integer(0), JsonPath.from(response).get("response.status"));
+        assertEquals(Integer.valueOf(0), JsonPath.from(response).get("response.status"));
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/it/admin/BoostDocTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/BoostDocTests.java
@@ -62,7 +62,7 @@ public class BoostDocTests extends CrudTestBase {
         final Map<String, Object> requestBody = new HashMap<>();
         final String keyProp = NAME_PREFIX + id;
         requestBody.put(KEY_PROPERTY, keyProp);
-        requestBody.put("boost_expr", new Integer(id).toString());
+        requestBody.put("boost_expr", Integer.valueOf(id).toString());
         requestBody.put("sort_order", id);
         return requestBody;
     }

--- a/src/test/java/org/codelibs/fess/it/admin/DuplicateHostTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/DuplicateHostTests.java
@@ -62,7 +62,7 @@ public class DuplicateHostTests extends CrudTestBase {
         final Map<String, Object> requestBody = new HashMap<>();
         final String keyProp = NAME_PREFIX + id;
         requestBody.put(KEY_PROPERTY, keyProp);
-        requestBody.put("duplicate_host_name", "duplicate_" + new Integer(id).toString());
+        requestBody.put("duplicate_host_name", "duplicate_" + Integer.valueOf(id).toString());
         requestBody.put("sort_order", id);
         return requestBody;
     }

--- a/src/test/java/org/codelibs/fess/it/admin/GeneralTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/GeneralTests.java
@@ -81,7 +81,7 @@ public class GeneralTests extends CrudTestBase {
         String response = checkGetMethod(searchBody, "").asString();
         final Map<String, Object> res = JsonPath.from(response).getMap("response.setting");
         assertTrue(!res.isEmpty());
-        assertEquals(new Integer(0), JsonPath.from(response).get("response.status"));
+        assertEquals(Integer.valueOf(0), JsonPath.from(response).get("response.status"));
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/it/admin/GroupTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/GroupTests.java
@@ -69,7 +69,7 @@ public class GroupTests extends CrudTestBase {
         final String keyProp = NAME_PREFIX + id;
         requestBody.put(KEY_PROPERTY, keyProp);
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("gidNumber", new Integer(id).toString());
+        attributes.put("gidNumber", Integer.valueOf(id).toString());
         requestBody.put("attributes", attributes);
 
         return requestBody;

--- a/src/test/java/org/codelibs/fess/it/admin/JobLogTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/JobLogTests.java
@@ -78,7 +78,7 @@ public class JobLogTests extends CrudTestBase {
     protected void testRead() {
         final Map<String, Object> searchBody = new HashMap<>();
         final String response = checkMethodBase(searchBody).get(API_PATH + "/" + LIST_ENDPOINT_SUFFIX).asString();
-        assertEquals(new Integer(0), JsonPath.from(response).get("response.status"));
+        assertEquals(Integer.valueOf(0), JsonPath.from(response).get("response.status"));
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/it/admin/KeyMatchTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/KeyMatchTests.java
@@ -64,7 +64,7 @@ public class KeyMatchTests extends CrudTestBase {
         requestBody.put(KEY_PROPERTY, keyProp);
         requestBody.put(KEY_PROPERTY, keyProp);
         requestBody.put("query", "query" + id);
-        requestBody.put("max_size", new Integer(id).toString());
+        requestBody.put("max_size", Integer.valueOf(id).toString());
         requestBody.put("boost", 100);
         return requestBody;
     }

--- a/src/test/java/org/codelibs/fess/it/admin/LabelTypeTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/LabelTypeTests.java
@@ -62,7 +62,7 @@ public class LabelTypeTests extends CrudTestBase {
         final Map<String, Object> requestBody = new HashMap<>();
         final String keyProp = NAME_PREFIX + id;
         requestBody.put(KEY_PROPERTY, keyProp);
-        requestBody.put("value", new Integer(id).toString());
+        requestBody.put("value", Integer.valueOf(id).toString());
         return requestBody;
     }
 

--- a/src/test/java/org/codelibs/fess/it/admin/LogTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/LogTests.java
@@ -78,7 +78,7 @@ public class LogTests extends CrudTestBase {
     protected void testRead() {
         final Map<String, Object> searchBody = new HashMap<>();
         final String response = checkMethodBase(searchBody).get(API_PATH + "/" + LIST_ENDPOINT_SUFFIX).asString();
-        assertEquals(new Integer(0), JsonPath.from(response).get("response.status"));
+        assertEquals(Integer.valueOf(0), JsonPath.from(response).get("response.status"));
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/it/admin/SuggestTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/SuggestTests.java
@@ -83,7 +83,7 @@ public class SuggestTests extends CrudTestBase {
         assertTrue(res.containsKey("total_words_num"));
         assertTrue(res.containsKey("document_words_num"));
         assertTrue(res.containsKey("query_words_num"));
-        assertEquals(new Integer(0), JsonPath.from(response).get("response.status"));
+        assertEquals(Integer.valueOf(0), JsonPath.from(response).get("response.status"));
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/it/admin/SystemInfoTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/SystemInfoTests.java
@@ -84,7 +84,7 @@ public class SystemInfoTests extends CrudTestBase {
         assertTrue(res.containsKey("system_props"));
         assertTrue(res.containsKey("fess_props"));
         assertTrue(res.containsKey("bug_report_props"));
-        assertEquals(new Integer(0), JsonPath.from(response).get("response.status"));
+        assertEquals(Integer.valueOf(0), JsonPath.from(response).get("response.status"));
     }
 
     @Override


### PR DESCRIPTION
This pull request addresses and resolves warnings that occurred during Maven builds. The following changes have been made:

- Updated the groupId of yuicompressor-maven-plugin to avoid plugin resolution warnings.
- Added sourceDirectory to the plugin configuration to explicitly specify JavaScript sources.
- Declared IMG_LOADING_DELAY, IMG_LOADING_MAX, and clipboard variables at the top of search.js to prevent hoisting-related issues and improve clarity.
- Replaced deprecated usage of new Integer(...) with Integer.valueOf(...) across various test classes to eliminate compiler warnings.

These updates improve build stability and align the code with modern Java best practices.