### PR TITLE
Update opensearch-analysis-fess plugin to version 3.0.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,8 +26,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-fess" />
-			<param name="plugin.version" value="3.0.0" />
-			<param name="plugin.zip.version" value="3.0.0" />
+			<param name="plugin.version" value="3.0.1" />
+			<param name="plugin.zip.version" value="3.0.1" />
 		</antcall>
 		<!-- configsync -->
 		<antcall target="install.plugin">


### PR DESCRIPTION
This update replaces the opensearch-analysis-fess plugin version from 3.0.0 to 3.0.1 in plugin.xml. It ensures compatibility with the latest plugin release and incorporates any bug fixes or improvements provided in the newer version.
