### PR TITLE
Update Fess and OpenSearch to version 15.1 and 3.1.0 respectively

### DIFF
--- a/dbflute.xml
+++ b/dbflute.xml
@@ -2,7 +2,7 @@
 <project name="dbflute" basedir=".">
 	<property name="mydbflute.dir" value="${basedir}/mydbflute" />
 	<property name="target.dir" value="${basedir}/target" />
-	<property name="branch.name" value="fess-15.0" />
+	<property name="branch.name" value="fess-15.1" />
 	<property name="mydbflute.url" value="https://github.com/lastaflute/lastaflute-example-waterfront/archive/${branch.name}.zip" />
 
 	<target name="mydbflute.check">

--- a/module.xml
+++ b/module.xml
@@ -6,7 +6,7 @@
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://maven.codelibs.org" />
-	<property name="opensearch.version" value="3.0.0" />
+	<property name="opensearch.version" value="3.1.0" />
 
 	<target name="install.modules">
 		<mkdir dir="${target.dir}" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,8 +17,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-extension" />
-			<param name="plugin.version" value="3.0.0" />
-			<param name="plugin.zip.version" value="3.0.0" />
+			<param name="plugin.version" value="3.1.0" />
+			<param name="plugin.zip.version" value="3.1.0" />
 		</antcall>
 		<!-- analysis-fess -->
 		<antcall target="install.plugin">
@@ -26,8 +26,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-fess" />
-			<param name="plugin.version" value="3.0.1" />
-			<param name="plugin.zip.version" value="3.0.1" />
+			<param name="plugin.version" value="3.1.0" />
+			<param name="plugin.zip.version" value="3.1.0" />
 		</antcall>
 		<!-- configsync -->
 		<antcall target="install.plugin">
@@ -35,8 +35,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="configsync" />
-			<param name="plugin.version" value="3.0.0" />
-			<param name="plugin.zip.version" value="3.0.0" />
+			<param name="plugin.version" value="3.1.0" />
+			<param name="plugin.zip.version" value="3.1.0" />
 		</antcall>
 		<!-- minhash -->
 		<antcall target="install.plugin">
@@ -44,8 +44,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="minhash" />
-			<param name="plugin.version" value="3.0.0" />
-			<param name="plugin.zip.version" value="3.0.0" />
+			<param name="plugin.version" value="3.1.0" />
+			<param name="plugin.zip.version" value="3.1.0" />
 		</antcall>
 
 		<antcall target="remove.jars" />

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fess</artifactId>
-	<version>15.0.1-SNAPSHOT</version>
+	<version>15.1.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>Fess</name>
 	<description>Fess is Full tExt Search System.</description>
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.0.0</version>
+		<version>15.1.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
This update includes the following changes:

- Upgraded branch.name in dbflute.xml from fess-15.0 to fess-15.1.
- Bumped opensearch.version in module.xml from 3.0.0 to 3.1.0.
- Updated multiple plugin versions in plugin.xml to 3.1.0, including:
  - analysis-extension
  - analysis-fess
  - configsync
  - minhash
- Updated pom.xml:
  - Changed project version from 15.0.1-SNAPSHOT to 15.1.0-SNAPSHOT.
  - Updated parent POM version to 15.1.0-SNAPSHOT.

These changes prepare the project for compatibility with the latest Fess 15.1 and OpenSearch 3.1.0 versions.