### PR TITLE
Add missing errors.unauthorized_request message to all language resource files

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
@@ -32,7 +32,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Status */
     public static final String LABELS_AVAILABLE = "{labels.available}";
 
-    /** The key of the message: Created by */
+    /** The key of the message: Created By */
     public static final String LABELS_CREATED_BY = "{labels.createdBy}";
 
     /** The key of the message: Created Time */
@@ -41,16 +41,16 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Depth */
     public static final String LABELS_DEPTH = "{labels.depth}";
 
-    /** The key of the message: Excluded Paths For Crawling */
+    /** The key of the message: Excluded Paths for Crawling */
     public static final String LABELS_EXCLUDED_PATHS = "{labels.excludedPaths}";
 
-    /** The key of the message: Excluded URLs For Crawling */
+    /** The key of the message: Excluded URLs for Crawling */
     public static final String LABELS_EXCLUDED_URLS = "{labels.excludedUrls}";
 
-    /** The key of the message: Excluded Paths For Indexing */
+    /** The key of the message: Excluded Paths for Searching */
     public static final String LABELS_EXCLUDED_DOC_PATHS = "{labels.excludedDocPaths}";
 
-    /** The key of the message: Excluded URLs For Indexing */
+    /** The key of the message: Excluded URLs for Searching */
     public static final String LABELS_EXCLUDED_DOC_URLS = "{labels.excludedDocUrls}";
 
     /** The key of the message: Hostname */
@@ -59,16 +59,16 @@ public class FessLabels extends UserMessages {
     /** The key of the message: ID */
     public static final String LABELS_ID = "{labels.id}";
 
-    /** The key of the message: Included Paths For Crawling */
+    /** The key of the message: Included Paths for Crawling */
     public static final String LABELS_INCLUDED_PATHS = "{labels.includedPaths}";
 
-    /** The key of the message: Included URLs For Crawling */
+    /** The key of the message: Included URLs for Crawling */
     public static final String LABELS_INCLUDED_URLS = "{labels.includedUrls}";
 
-    /** The key of the message: Included Paths For Indexing */
+    /** The key of the message: Included Paths for Searching */
     public static final String LABELS_INCLUDED_DOC_PATHS = "{labels.includedDocPaths}";
 
-    /** The key of the message: Included URLs For Indexing */
+    /** The key of the message: Included URLs for Searching */
     public static final String LABELS_INCLUDED_DOC_URLS = "{labels.includedDocUrls}";
 
     /** The key of the message: Max Access Count */
@@ -77,10 +77,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Name */
     public static final String LABELS_NAME = "{labels.name}";
 
-    /** The key of the message: Num of Thread */
+    /** The key of the message: Number of Threads */
     public static final String LABELS_NUM_OF_THREAD = "{labels.numOfThread}";
 
-    /** The key of the message: Duplicate Name */
+    /** The key of the message: Duplicate Host Name */
     public static final String LABELS_DUPLICATE_HOST_NAME = "{labels.duplicateHostName}";
 
     /** The key of the message: Page Number */
@@ -95,7 +95,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Port */
     public static final String LABELS_PORT = "{labels.port}";
 
-    /** The key of the message: Regular Expression */
+    /** The key of the message: Regex */
     public static final String LABELS_REGEX = "{labels.regex}";
 
     /** The key of the message: Regular Name */
@@ -107,10 +107,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Session ID */
     public static final String LABELS_SESSION_ID = "{labels.sessionId}";
 
-    /** The key of the message: Display Order */
+    /** The key of the message: Sort Order */
     public static final String LABELS_SORT_ORDER = "{labels.sortOrder}";
 
-    /** The key of the message: Updated by */
+    /** The key of the message: Updated By */
     public static final String LABELS_UPDATED_BY = "{labels.updatedBy}";
 
     /** The key of the message: Updated Time */
@@ -128,16 +128,16 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Value */
     public static final String LABELS_VALUE = "{labels.value}";
 
-    /** The key of the message: Version No. */
+    /** The key of the message: Version No */
     public static final String LABELS_VERSION_NO = "{labels.versionNo}";
 
     /** The key of the message: Schedule */
     public static final String LABELS_CRON_EXPRESSION = "{labels.cronExpression}";
 
-    /** The key of the message: Remove Documents Before Days */
+    /** The key of the message: Delete documents older than specified days */
     public static final String LABELS_DAY_FOR_CLEANUP = "{labels.dayForCleanup}";
 
-    /** The key of the message: Simultaneous Crawler Config */
+    /** The key of the message: Concurrent Crawling Count */
     public static final String LABELS_CRAWLING_THREAD_COUNT = "{labels.crawlingThreadCount}";
 
     /** The key of the message: Boost */
@@ -146,7 +146,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Name */
     public static final String LABELS_CRAWLING_CONFIG_NAME = "{labels.crawlingConfigName}";
 
-    /** The key of the message: Crawling Path */
+    /** The key of the message: Path to Crawl */
     public static final String LABELS_CRAWLING_CONFIG_PATH = "{labels.crawlingConfigPath}";
 
     /** The key of the message: Process Type */
@@ -155,19 +155,19 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Parameters */
     public static final String LABELS_PARAMETERS = "{labels.parameters}";
 
-    /** The key of the message: Upload File */
+    /** The key of the message: File to Upload */
     public static final String LABELS_DESIGN_FILE = "{labels.designFile}";
 
     /** The key of the message: Bulk File */
     public static final String LABELS_BULK_FILE = "{labels.bulkFile}";
 
-    /** The key of the message: Additional Query Parameters */
+    /** The key of the message: Append Search Parameters */
     public static final String LABELS_APPEND_QUERY_PARAMETER = "{labels.appendQueryParameter}";
 
     /** The key of the message: Config ID */
     public static final String LABELS_CONFIG_ID = "{labels.configId}";
 
-    /** The key of the message: Config Parameters */
+    /** The key of the message: Config Parameter */
     public static final String LABELS_CONFIG_PARAMETER = "{labels.configParameter}";
 
     /** The key of the message: Content */
@@ -194,37 +194,37 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Error Name */
     public static final String LABELS_ERROR_NAME = "{labels.errorName}";
 
-    /** The key of the message: Expired */
+    /** The key of the message: Expired Time */
     public static final String LABELS_EXPIRED_TIME = "{labels.expiredTime}";
 
-    /** The key of the message: Expired */
+    /** The key of the message: Expires */
     public static final String LABELS_EXPIRES = "{labels.expires}";
 
     /** The key of the message: Failure Count */
     public static final String LABELS_FAILURE_COUNT_THRESHOLD = "{labels.failureCountThreshold}";
 
-    /** The key of the message: File System Config Name */
+    /** The key of the message: File Crawl Config Name */
     public static final String LABELS_FILE_CONFIG_NAME = "{labels.fileConfigName}";
 
-    /** The key of the message: File name */
+    /** The key of the message: File Name */
     public static final String LABELS_FILE_NAME = "{labels.fileName}";
 
     /** The key of the message: Handler Name */
     public static final String LABELS_HANDLER_NAME = "{labels.handlerName}";
 
-    /** The key of the message: Parameters */
+    /** The key of the message: Parameter */
     public static final String LABELS_HANDLER_PARAMETER = "{labels.handlerParameter}";
 
-    /** The key of the message: Scripts */
+    /** The key of the message: Script */
     public static final String LABELS_HANDLER_SCRIPT = "{labels.handlerScript}";
 
-    /** The key of the message: Popular words */
+    /** The key of the message: Popular Word */
     public static final String LABELS_POPULAR_WORD = "{labels.popularWord}";
 
     /** The key of the message: Ignored Failure Type */
     public static final String LABELS_IGNORE_FAILURE_TYPE = "{labels.ignoreFailureType}";
 
-    /** The key of the message: Last Accessed */
+    /** The key of the message: Last Access Time */
     public static final String LABELS_LAST_ACCESS_TIME = "{labels.lastAccessTime}";
 
     /** The key of the message: Notification To */
@@ -239,7 +239,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Scheme */
     public static final String LABELS_PROTOCOL_SCHEME = "{labels.protocolScheme}";
 
-    /** The key of the message: Purge By Bots */
+    /** The key of the message: Purge Bots */
     public static final String LABELS_PURGE_BY_BOTS = "{labels.purgeByBots}";
 
     /** The key of the message: Log Level */
@@ -263,13 +263,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Sort */
     public static final String LABELS_SORT = "{labels.sort}";
 
-    /** The key of the message: Start Pos */
+    /** The key of the message: Start */
     public static final String LABELS_START = "{labels.start}";
 
     /** The key of the message: Login Required */
     public static final String LABELS_LOGIN_REQUIRED = "{labels.loginRequired}";
 
-    /** The key of the message: Login Link */
+    /** The key of the message: Show Login Link */
     public static final String LABELS_LOGIN_LINK = "{labels.loginLink}";
 
     /** The key of the message: Thread Name */
@@ -287,7 +287,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: JSON Response */
     public static final String LABELS_WEB_API_JSON = "{labels.webApiJson}";
 
-    /** The key of the message: Web Config Name */
+    /** The key of the message: Web Crawl Config Name */
     public static final String LABELS_WEB_CONFIG_NAME = "{labels.webConfigName}";
 
     /** The key of the message: All Languages */
@@ -305,7 +305,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: hq */
     public static final String LABELS_HQ = "{labels.hq}";
 
-    /** The key of the message: Source */
+    /** The key of the message: Inputs */
     public static final String LABELS_INPUTS = "{labels.inputs}";
 
     /** The key of the message: Logging */
@@ -320,25 +320,25 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Labels */
     public static final String LABELS_LABEL_TYPE_IDS = "{labels.labelTypeIds}";
 
-    /** The key of the message: lang */
+    /** The key of the message: Language */
     public static final String LABELS_LANG = "{labels.lang}";
 
-    /** The key of the message: Target */
+    /** The key of the message: Outputs */
     public static final String LABELS_OUTPUTS = "{labels.outputs}";
 
-    /** The key of the message: POS */
+    /** The key of the message: Part-of-speech */
     public static final String LABELS_POS = "{labels.pos}";
 
-    /** The key of the message: Purge Job Log Before */
+    /** The key of the message: Delete old job logs */
     public static final String LABELS_PURGE_JOB_LOG_DAY = "{labels.purgeJobLogDay}";
 
-    /** The key of the message: Purge User Before */
+    /** The key of the message: Delete old user logs */
     public static final String LABELS_PURGE_USER_INFO_DAY = "{labels.purgeUserInfoDay}";
 
     /** The key of the message: Reading */
     public static final String LABELS_READING = "{labels.reading}";
 
-    /** The key of the message: Role ID */
+    /** The key of the message: Role IDs */
     public static final String LABELS_ROLE_TYPE_IDS = "{labels.roleTypeIds}";
 
     /** The key of the message: Script */
@@ -347,7 +347,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Result */
     public static final String LABELS_SCRIPT_RESULT = "{labels.scriptResult}";
 
-    /** The key of the message: Executor */
+    /** The key of the message: Execution Method */
     public static final String LABELS_SCRIPT_TYPE = "{labels.scriptType}";
 
     /** The key of the message: Segmentation */
@@ -377,7 +377,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Protwords File */
     public static final String LABELS_PROTWORDS_FILE = "{labels.protwordsFile}";
 
-    /** The key of the message: Additional Word File */
+    /** The key of the message: Elevate Word File */
     public static final String LABELS_ELEVATE_WORD_FILE = "{labels.elevateWordFile}";
 
     /** The key of the message: Bad Word File */
@@ -386,7 +386,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Condition */
     public static final String LABELS_URL_EXPR = "{labels.urlExpr}";
 
-    /** The key of the message: Boost Expr */
+    /** The key of the message: Boost Expression */
     public static final String LABELS_BOOST_EXPR = "{labels.boostExpr}";
 
     /** The key of the message: Confirm */
@@ -395,7 +395,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Crawler */
     public static final String LABELS_CRAWLER = "{labels.crawler}";
 
-    /** The key of the message: mode */
+    /** The key of the message: Mode */
     public static final String LABELS_CRUD_MODE = "{labels.crudMode}";
 
     /** The key of the message: Max Error Count */
@@ -425,7 +425,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Order */
     public static final String LABELS_ORDER = "{labels.order}";
 
-    /** The key of the message: Purge Suggest Documents Before */
+    /** The key of the message: Delete old suggest info */
     public static final String LABELS_PURGE_SUGGEST_SEARCH_LOG_DAY = "{labels.purgeSuggestSearchLogDay}";
 
     /** The key of the message: Query */
@@ -452,37 +452,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Extended Query */
     public static final String LABELS_ex_q = "{labels.ex_q}";
 
-    /** The key of the message: LDAP URL */
-    public static final String LABELS_LDAP_PROVIDER_URL = "{labels.ldapProviderUrl}";
-
-    /** The key of the message: User DN */
-    public static final String LABELS_LDAP_SECURITY_PRINCIPAL = "{labels.ldapSecurityPrincipal}";
-
-    /** The key of the message: Bind DN */
-    public static final String LABELS_LDAP_ADMIN_SECURITY_PRINCIPAL = "{labels.ldapAdminSecurityPrincipal}";
-
-    /** The key of the message: Password */
-    public static final String LABELS_LDAP_ADMIN_SECURITY_CREDENTIALS = "{labels.ldapAdminSecurityCredentials}";
-
-    /** The key of the message: Base DN */
-    public static final String LABELS_LDAP_BASE_DN = "{labels.ldapBaseDn}";
-
-    /** The key of the message: Account Filter */
-    public static final String LABELS_LDAP_ACCOUNT_FILTER = "{labels.ldapAccountFilter}";
-
-    /** The key of the message: Group Filter */
-    public static final String LABELS_LDAP_GROUP_FILTER = "{labels.ldapGroupFilter}";
-
-    /** The key of the message: memberOf Attribute */
-    public static final String LABELS_LDAP_MEMBEROF_ATTRIBUTE = "{labels.ldapMemberofAttribute}";
-
     /** The key of the message: Current Password */
     public static final String LABELS_OLD_PASSWORD = "{labels.oldPassword}";
 
     /** The key of the message: New Password */
     public static final String LABELS_NEW_PASSWORD = "{labels.newPassword}";
 
-    /** The key of the message: New Password(Confirm) */
+    /** The key of the message: New Password (Confirm) */
     public static final String LABELS_CONFIRM_NEW_PASSWORD = "{labels.confirmNewPassword}";
 
     /** The key of the message: System */
@@ -527,7 +503,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Key Match */
     public static final String LABELS_menu_key_match = "{labels.menu_key_match}";
 
-    /** The key of the message: Doc Boost */
+    /** The key of the message: Document Boost */
     public static final String LABELS_menu_boost_document_rule = "{labels.menu_boost_document_rule}";
 
     /** The key of the message: Path Mapping */
@@ -560,7 +536,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Suggest Word */
     public static final String LABELS_menu_suggest_word = "{labels.menu_suggest_word}";
 
-    /** The key of the message: Additional Word */
+    /** The key of the message: Elevate Word */
     public static final String LABELS_menu_elevate_word = "{labels.menu_elevate_word}";
 
     /** The key of the message: Bad Word */
@@ -575,7 +551,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Crawling Info */
     public static final String LABELS_menu_crawling_info = "{labels.menu_crawling_info}";
 
-    /** The key of the message: Log Files */
+    /** The key of the message: Log File */
     public static final String LABELS_menu_log = "{labels.menu_log}";
 
     /** The key of the message: Job Log */
@@ -590,7 +566,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Search */
     public static final String LABELS_menu_search_list = "{labels.menu_search_list}";
 
-    /** The key of the message: Back Up */
+    /** The key of the message: Backup */
     public static final String LABELS_menu_backup = "{labels.menu_backup}";
 
     /** The key of the message: Access Token */
@@ -605,16 +581,16 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Related Query */
     public static final String LABELS_menu_related_query = "{labels.menu_related_query}";
 
+    /** The key of the message: Search... */
+    public static final String LABELS_SIDEBAR_placeholder_search = "{labels.sidebar.placeholder_search}";
+
     /** The key of the message: Plugin */
     public static final String LABELS_menu_plugin = "{labels.menu_plugin}";
 
     /** The key of the message: Storage */
     public static final String LABELS_menu_storage = "{labels.menu_storage}";
 
-    /** The key of the message: Search... */
-    public static final String LABELS_SIDEBAR_placeholder_search = "{labels.sidebar.placeholder_search}";
-
-    /** The key of the message: MENU */
+    /** The key of the message: Menu */
     public static final String LABELS_SIDEBAR_MENU = "{labels.sidebar.menu}";
 
     /** The key of the message: &amp;copy;2024 &lt;a href="https://github.com/codelibs"&gt;CodeLibs Project&lt;/a&gt;. */
@@ -623,16 +599,16 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Search */
     public static final String LABELS_SEARCH = "{labels.search}";
 
-    /** The key of the message: Similar results are displayed. */
+    /** The key of the message: Showing similar results. */
     public static final String LABELS_similar_doc_result_status = "{labels.similar_doc_result_status}";
 
-    /** The key of the message: Results &lt;b&gt;{2}&lt;/b&gt;&lt;span class="hidden-phone"&gt; -&lt;/span&gt; &lt;b&gt;{3}&lt;/b&gt; of &lt;b&gt;{1}&lt;/b&gt; for &lt;b&gt;{0}&lt;/b&gt; */
+    /** The key of the message: Results &lt;b&gt;{2}&lt;/b&gt; - &lt;b&gt;{3}&lt;/b&gt; of &lt;b&gt;{1}&lt;/b&gt; for &lt;b&gt;{0}&lt;/b&gt; */
     public static final String LABELS_search_result_status = "{labels.search_result_status}";
 
-    /** The key of the message: Results &lt;b&gt;{2}&lt;/b&gt;&lt;span class="hidden-phone"&gt; -&lt;/span&gt; &lt;b&gt;{3}&lt;/b&gt; of about &lt;b&gt;{1}&lt;/b&gt; for &lt;b&gt;{0}&lt;/b&gt; */
+    /** The key of the message: Results &lt;b&gt;{2}&lt;/b&gt; - &lt;b&gt;{3}&lt;/b&gt; of over &lt;b&gt;{1}&lt;/b&gt; for &lt;b&gt;{0}&lt;/b&gt; */
     public static final String LABELS_search_result_status_over = "{labels.search_result_status_over}";
 
-    /** The key of the message: ({0} sec) */
+    /** The key of the message: ({0} seconds) */
     public static final String LABELS_search_result_time = "{labels.search_result_time}";
 
     /** The key of the message: Prev */
@@ -650,52 +626,52 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Popular Words: */
     public static final String LABELS_search_popular_word_word = "{labels.search_popular_word_word}";
 
-    /** The key of the message: Related Words: */
+    /** The key of the message: Related Queries: */
     public static final String LABELS_search_related_queries = "{labels.search_related_queries}";
 
-    /** The key of the message: -- Sort -- */
+    /** The key of the message: -  Sort  - */
     public static final String LABELS_search_result_select_sort = "{labels.search_result_select_sort}";
 
-    /** The key of the message: -- Results per page -- */
+    /** The key of the message: - Display Count - */
     public static final String LABELS_search_result_select_num = "{labels.search_result_select_num}";
 
-    /** The key of the message: Score */
+    /** The key of the message: by Score */
     public static final String LABELS_search_result_sort_score_desc = "{labels.search_result_sort_score_desc}";
 
-    /** The key of the message: File Name (ascending) */
+    /** The key of the message: by Filename (asc) */
     public static final String LABELS_search_result_sort_filename_asc = "{labels.search_result_sort_filename_asc}";
 
-    /** The key of the message: File Name (descending) */
+    /** The key of the message: by Filename (desc) */
     public static final String LABELS_search_result_sort_filename_desc = "{labels.search_result_sort_filename_desc}";
 
-    /** The key of the message: Date (ascending) */
+    /** The key of the message: by Date (asc) */
     public static final String LABELS_search_result_sort_created_asc = "{labels.search_result_sort_created_asc}";
 
-    /** The key of the message: Date (descending) */
+    /** The key of the message: by Date (desc) */
     public static final String LABELS_search_result_sort_created_desc = "{labels.search_result_sort_created_desc}";
 
-    /** The key of the message: Size (ascending) */
+    /** The key of the message: by Size (asc) */
     public static final String LABELS_search_result_sort_content_length_asc = "{labels.search_result_sort_content_length_asc}";
 
-    /** The key of the message: Size (descending) */
+    /** The key of the message: by Size (desc) */
     public static final String LABELS_search_result_sort_content_length_desc = "{labels.search_result_sort_content_length_desc}";
 
-    /** The key of the message: Last Modified (ascending) */
+    /** The key of the message: by Last Modified (asc) */
     public static final String LABELS_search_result_sort_last_modified_asc = "{labels.search_result_sort_last_modified_asc}";
 
-    /** The key of the message: Last Modified (descending) */
+    /** The key of the message: by Last Modified (desc) */
     public static final String LABELS_search_result_sort_last_modified_desc = "{labels.search_result_sort_last_modified_desc}";
 
-    /** The key of the message: Click (ascending) */
+    /** The key of the message: by Click Count (asc) */
     public static final String LABELS_search_result_sort_click_count_asc = "{labels.search_result_sort_click_count_asc}";
 
-    /** The key of the message: Click (descending) */
+    /** The key of the message: by Click Count (desc) */
     public static final String LABELS_search_result_sort_click_count_desc = "{labels.search_result_sort_click_count_desc}";
 
-    /** The key of the message: Favorite (ascending) */
+    /** The key of the message: by Favorite Count (asc) */
     public static final String LABELS_search_result_sort_favorite_count_asc = "{labels.search_result_sort_favorite_count_asc}";
 
-    /** The key of the message: Favorite (descending) */
+    /** The key of the message: by Favorite Count (desc) */
     public static final String LABELS_search_result_sort_favorite_count_desc = "{labels.search_result_sort_favorite_count_desc}";
 
     /** The key of the message: Multiple */
@@ -704,7 +680,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: {0} bytes */
     public static final String LABELS_search_result_size = "{labels.search_result_size}";
 
-    /** The key of the message: Registered: */
+    /** The key of the message: Created: */
     public static final String LABELS_search_result_created = "{labels.search_result_created}";
 
     /** The key of the message: Last Modified: */
@@ -716,13 +692,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Liked */
     public static final String LABELS_search_result_favorited = "{labels.search_result_favorited}";
 
-    /** The key of the message: Viewed ({0}) */
+    /** The key of the message: Click Count ({0}) */
     public static final String LABELS_search_click_count = "{labels.search_click_count}";
 
     /** The key of the message: {0} views */
     public static final String LABELS_search_click_views = "{labels.search_click_views}";
 
-    /** The key of the message: more.. */
+    /** The key of the message: More.. */
     public static final String LABELS_search_result_more = "{labels.search_result_more}";
 
     /** The key of the message: Cache */
@@ -734,67 +710,67 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Label */
     public static final String LABELS_facet_label_title = "{labels.facet_label_title}";
 
-    /** The key of the message: Date Range */
+    /** The key of the message: Time */
     public static final String LABELS_facet_timestamp_title = "{labels.facet_timestamp_title}";
 
-    /** The key of the message: Past 24 Hours */
+    /** The key of the message: Within 24 hours */
     public static final String LABELS_facet_timestamp_1day = "{labels.facet_timestamp_1day}";
 
-    /** The key of the message: Past Week */
+    /** The key of the message: Within a week */
     public static final String LABELS_facet_timestamp_1week = "{labels.facet_timestamp_1week}";
 
-    /** The key of the message: Past Month */
+    /** The key of the message: Within a month */
     public static final String LABELS_facet_timestamp_1month = "{labels.facet_timestamp_1month}";
 
-    /** The key of the message: Past Year */
+    /** The key of the message: Within a year */
     public static final String LABELS_facet_timestamp_1year = "{labels.facet_timestamp_1year}";
 
-    /** The key of the message: Past 3 Months */
+    /** The key of the message: Within 3 months */
     public static final String LABELS_facet_timestamp_3month = "{labels.facet_timestamp_3month}";
 
-    /** The key of the message: Past 6 Months */
+    /** The key of the message: Within 6 months */
     public static final String LABELS_facet_timestamp_6month = "{labels.facet_timestamp_6month}";
 
-    /** The key of the message: Past 2 Years */
+    /** The key of the message: Within 2 years */
     public static final String LABELS_facet_timestamp_2year = "{labels.facet_timestamp_2year}";
 
-    /** The key of the message: Past 3 Years */
+    /** The key of the message: Within 3 years */
     public static final String LABELS_facet_timestamp_3year = "{labels.facet_timestamp_3year}";
 
     /** The key of the message: Size */
     public static final String LABELS_facet_contentLength_title = "{labels.facet_contentLength_title}";
 
-    /** The key of the message: &amp;nbsp; - 10kb */
+    /** The key of the message: &amp;nbsp; - 10KB */
     public static final String LABELS_facet_contentLength_10k = "{labels.facet_contentLength_10k}";
 
-    /** The key of the message: 10kb - 100kb */
+    /** The key of the message: 10KB - 100KB */
     public static final String LABELS_facet_contentLength_10kto100k = "{labels.facet_contentLength_10kto100k}";
 
-    /** The key of the message: 100kb - 500kb */
+    /** The key of the message: 100KB - 500KB */
     public static final String LABELS_facet_contentLength_100kto500k = "{labels.facet_contentLength_100kto500k}";
 
-    /** The key of the message: 500kb - 1mb */
+    /** The key of the message: 500KB - 1MB */
     public static final String LABELS_facet_contentLength_500kto1m = "{labels.facet_contentLength_500kto1m}";
 
-    /** The key of the message: 1mb - &amp;nbsp; */
+    /** The key of the message: 1MB - &amp;nbsp; */
     public static final String LABELS_facet_contentLength_1m = "{labels.facet_contentLength_1m}";
 
-    /** The key of the message: 10kb - 50kb */
+    /** The key of the message: 10KB - 50KB */
     public static final String LABELS_facet_contentLength_10kto50k = "{labels.facet_contentLength_10kto50k}";
 
-    /** The key of the message: 50kb - 100kb */
+    /** The key of the message: 50KB - 100KB */
     public static final String LABELS_facet_contentLength_50kto100k = "{labels.facet_contentLength_50kto100k}";
 
-    /** The key of the message: 100kb - 250kb */
+    /** The key of the message: 100KB - 250KB */
     public static final String LABELS_facet_contentLength_100kto250k = "{labels.facet_contentLength_100kto250k}";
 
-    /** The key of the message: 250kb - 500kb */
+    /** The key of the message: 250KB - 500KB */
     public static final String LABELS_facet_contentLength_250kto500k = "{labels.facet_contentLength_250kto500k}";
 
-    /** The key of the message: 1mb - 5mb */
+    /** The key of the message: 1MB - 5MB */
     public static final String LABELS_facet_contentLength_1mto5m = "{labels.facet_contentLength_1mto5m}";
 
-    /** The key of the message: 5mb - &amp;nbsp; */
+    /** The key of the message: 5MB - &amp;nbsp; */
     public static final String LABELS_facet_contentLength_5m = "{labels.facet_contentLength_5m}";
 
     /** The key of the message: File Type */
@@ -833,10 +809,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: iBooks */
     public static final String LABELS_facet_filetype_ibooks = "{labels.facet_filetype_ibooks}";
 
-    /** The key of the message: Plain Text */
+    /** The key of the message: Text */
     public static final String LABELS_facet_filetype_txt = "{labels.facet_filetype_txt}";
 
-    /** The key of the message: Rich Text Format */
+    /** The key of the message: Rich Text */
     public static final String LABELS_facet_filetype_rtf = "{labels.facet_filetype_rtf}";
 
     /** The key of the message: Compiled HTML Help */
@@ -848,10 +824,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: 7z Archive */
     public static final String LABELS_facet_filetype_7z = "{labels.facet_filetype_7z}";
 
-    /** The key of the message: Bz Archive */
+    /** The key of the message: BZIP Archive */
     public static final String LABELS_facet_filetype_bz = "{labels.facet_filetype_bz}";
 
-    /** The key of the message: Bz2 Archive */
+    /** The key of the message: BZIP2 Archive */
     public static final String LABELS_facet_filetype_bz2 = "{labels.facet_filetype_bz2}";
 
     /** The key of the message: TAR Archive */
@@ -980,7 +956,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: PHP */
     public static final String LABELS_facet_filetype_php = "{labels.facet_filetype_php}";
 
-    /** The key of the message: Properties */
+    /** The key of the message: Properties File */
     public static final String LABELS_facet_filetype_properties = "{labels.facet_filetype_properties}";
 
     /** The key of the message: Python */
@@ -1013,13 +989,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Sort */
     public static final String LABELS_searchoptions_menu_sort = "{labels.searchoptions_menu_sort}";
 
-    /** The key of the message: Result */
+    /** The key of the message: Num */
     public static final String LABELS_searchoptions_menu_num = "{labels.searchoptions_menu_num}";
 
     /** The key of the message: {0} results */
     public static final String LABELS_searchoptions_num = "{labels.searchoptions_num}";
 
-    /** The key of the message: Languages */
+    /** The key of the message: Language */
     public static final String LABELS_searchoptions_menu_lang = "{labels.searchoptions_menu_lang}";
 
     /** The key of the message: Labels */
@@ -1031,19 +1007,19 @@ public class FessLabels extends UserMessages {
     /** The key of the message: System Error */
     public static final String LABELS_system_error_title = "{labels.system_error_title}";
 
-    /** The key of the message: Contact the Site Administrator. */
+    /** The key of the message: Please contact your site administrator. */
     public static final String LABELS_contact_site_admin = "{labels.contact_site_admin}";
 
-    /** The key of the message: Bad Request */
+    /** The key of the message: Invalid Request Format. */
     public static final String LABELS_request_error_title = "{labels.request_error_title}";
 
-    /** The key of the message: Invalid request for the url. */
+    /** The key of the message: Your request to the URL is invalid. */
     public static final String LABELS_bad_request = "{labels.bad_request}";
 
-    /** The key of the message: Page Not Found */
+    /** The key of the message: Page Not Found. */
     public static final String LABELS_page_not_found_title = "{labels.page_not_found_title}";
 
-    /** The key of the message: Check the url. */
+    /** The key of the message: Please check the URL. */
     public static final String LABELS_check_url = "{labels.check_url}";
 
     /** The key of the message: Username */
@@ -1061,16 +1037,16 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Login */
     public static final String LABELS_LOGIN_TITLE = "{labels.login.title}";
 
-    /** The key of the message: Labels */
+    /** The key of the message: Label */
     public static final String LABELS_index_label = "{labels.index_label}";
 
-    /** The key of the message: Preferred Languages */
+    /** The key of the message: Preferred Language */
     public static final String LABELS_index_lang = "{labels.index_lang}";
 
     /** The key of the message: Sort */
     public static final String LABELS_index_sort = "{labels.index_sort}";
 
-    /** The key of the message: Results per page */
+    /** The key of the message: Display Count */
     public static final String LABELS_index_num = "{labels.index_num}";
 
     /** The key of the message: Logout */
@@ -1091,10 +1067,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Administration */
     public static final String LABELS_ADMINISTRATION = "{labels.administration}";
 
-    /** The key of the message: Profile */
+    /** The key of the message: Settings */
     public static final String LABELS_profile_button = "{labels.profile_button}";
 
-    /** The key of the message: Profile */
+    /** The key of the message: Settings */
     public static final String LABELS_PROFILE_TITLE = "{labels.profile.title}";
 
     /** The key of the message: Update */
@@ -1139,13 +1115,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Clear */
     public static final String LABELS_search_options_clear = "{labels.search_options_clear}";
 
-    /** The key of the message: This is a cache of {0}. It is a snapshot of the page at {1}. */
+    /** The key of the message: This is a cache of {0}. It is a snapshot of the page as it appeared on {1}. */
     public static final String LABELS_search_cache_msg = "{labels.search_cache_msg}";
 
     /** The key of the message: Unknown */
     public static final String LABELS_search_unknown = "{labels.search_unknown}";
 
-    /** The key of the message: Back to top */
+    /** The key of the message: Back to Top */
     public static final String LABELS_footer_back_to_top = "{labels.footer_back_to_top}";
 
     /** The key of the message: Fess */
@@ -1157,19 +1133,19 @@ public class FessLabels extends UserMessages {
     /** The key of the message: File Crawling */
     public static final String LABELS_file_crawling_configuration = "{labels.file_crawling_configuration}";
 
-    /** The key of the message: File Crawling Configuration */
+    /** The key of the message: File Crawling Config */
     public static final String LABELS_file_crawling_title_details = "{labels.file_crawling_title_details}";
 
-    /** The key of the message: Included Paths For Crawling */
+    /** The key of the message: Included Paths */
     public static final String LABELS_included_paths = "{labels.included_paths}";
 
-    /** The key of the message: Excluded Paths For Crawling */
+    /** The key of the message: Excluded Paths */
     public static final String LABELS_excluded_paths = "{labels.excluded_paths}";
 
-    /** The key of the message: Included Paths For Indexing */
+    /** The key of the message: Included Doc Paths */
     public static final String LABELS_included_doc_paths = "{labels.included_doc_paths}";
 
-    /** The key of the message: Excluded Paths For Indexing */
+    /** The key of the message: Excluded Doc Paths */
     public static final String LABELS_excluded_doc_paths = "{labels.excluded_doc_paths}";
 
     /** The key of the message: Config Parameters */
@@ -1178,13 +1154,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Max Access Count */
     public static final String LABELS_max_access_count = "{labels.max_access_count}";
 
-    /** The key of the message: The number of Thread */
+    /** The key of the message: Number of Threads */
     public static final String LABELS_number_of_thread = "{labels.number_of_thread}";
 
-    /** The key of the message: Interval time */
+    /** The key of the message: Interval */
     public static final String LABELS_interval_time = "{labels.interval_time}";
 
-    /** The key of the message: ms */
+    /** The key of the message: msec */
     public static final String LABELS_MILLISEC = "{labels.millisec}";
 
     /** The key of the message: Permissions */
@@ -1202,25 +1178,25 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Create */
     public static final String LABELS_file_crawling_button_create = "{labels.file_crawling_button_create}";
 
-    /** The key of the message: Create new job */
+    /** The key of the message: Create New Job */
     public static final String LABELS_file_crawling_button_create_job = "{labels.file_crawling_button_create_job}";
 
     /** The key of the message: Web Crawling */
     public static final String LABELS_web_crawling_configuration = "{labels.web_crawling_configuration}";
 
-    /** The key of the message: Web Crawling Configuration */
+    /** The key of the message: Web Crawling Config */
     public static final String LABELS_web_crawling_title_details = "{labels.web_crawling_title_details}";
 
-    /** The key of the message: Included URLs For Crawling */
+    /** The key of the message: Included URLs */
     public static final String LABELS_included_urls = "{labels.included_urls}";
 
-    /** The key of the message: Excluded URLs For Crawling */
+    /** The key of the message: Excluded URLs */
     public static final String LABELS_excluded_urls = "{labels.excluded_urls}";
 
-    /** The key of the message: Included URLs For Indexing */
+    /** The key of the message: Included Doc URLs */
     public static final String LABELS_included_doc_urls = "{labels.included_doc_urls}";
 
-    /** The key of the message: Excluded URLs For Indexing */
+    /** The key of the message: Excluded Doc URLs */
     public static final String LABELS_excluded_doc_urls = "{labels.excluded_doc_urls}";
 
     /** The key of the message: User Agent */
@@ -1229,13 +1205,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Create */
     public static final String LABELS_web_crawling_button_create = "{labels.web_crawling_button_create}";
 
-    /** The key of the message: Create new job */
+    /** The key of the message: Create New Job */
     public static final String LABELS_web_crawling_button_create_job = "{labels.web_crawling_button_create_job}";
 
-    /** The key of the message: General Configuration */
+    /** The key of the message: General Config */
     public static final String LABELS_crawler_configuration = "{labels.crawler_configuration}";
 
-    /** The key of the message: General Configuration */
+    /** The key of the message: General Config */
     public static final String LABELS_crawler_title_edit = "{labels.crawler_title_edit}";
 
     /** The key of the message: Schedule */
@@ -1244,10 +1220,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Enabled */
     public static final String LABELS_ENABLED = "{labels.enabled}";
 
-    /** The key of the message: Remove Documents Before */
+    /** The key of the message: Delete old documents */
     public static final String LABELS_day_for_cleanup = "{labels.day_for_cleanup}";
 
-    /** The key of the message: Day(s) */
+    /** The key of the message: days */
     public static final String LABELS_DAY = "{labels.day}";
 
     /** The key of the message: Update */
@@ -1256,25 +1232,25 @@ public class FessLabels extends UserMessages {
     /** The key of the message: None */
     public static final String LABELS_NONE = "{labels.none}";
 
-    /** The key of the message: Simultaneous Crawler Config */
+    /** The key of the message: Concurrent Crawler Config */
     public static final String LABELS_crawling_thread_count = "{labels.crawling_thread_count}";
 
     /** The key of the message: Check Last Modified */
     public static final String LABELS_incremental_crawling = "{labels.incremental_crawling}";
 
-    /** The key of the message: Search Logging */
+    /** The key of the message: Search Log */
     public static final String LABELS_search_log_enabled = "{labels.search_log_enabled}";
 
-    /** The key of the message: User Logging */
+    /** The key of the message: User Log */
     public static final String LABELS_user_info_enabled = "{labels.user_info_enabled}";
 
-    /** The key of the message: Favorite Logging */
+    /** The key of the message: Favorite Log */
     public static final String LABELS_user_favorite_enabled = "{labels.user_favorite_enabled}";
 
     /** The key of the message: JSON Response */
     public static final String LABELS_web_api_json_enabled = "{labels.web_api_json_enabled}";
 
-    /** The key of the message: System Properties */
+    /** The key of the message: System Property */
     public static final String LABELS_app_value = "{labels.app_value}";
 
     /** The key of the message: Default Label Value */
@@ -1283,25 +1259,25 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Default Sort Value */
     public static final String LABELS_default_sort_value = "{labels.default_sort_value}";
 
-    /** The key of the message: Virtual Hosts */
+    /** The key of the message: Virtual Host */
     public static final String LABELS_virtual_host_value = "{labels.virtual_host_value}";
 
-    /** The key of the message: Append Params to URL */
+    /** The key of the message: Append Search Parameters */
     public static final String LABELS_append_query_param_enabled = "{labels.append_query_param_enabled}";
 
     /** The key of the message: Login Required */
     public static final String LABELS_login_required = "{labels.login_required}";
 
-    /** The key of the message: Similar Result Collapsed */
+    /** The key of the message: Collapse Duplicate Results */
     public static final String LABELS_result_collapsed = "{labels.result_collapsed}";
 
-    /** The key of the message: Login Link */
+    /** The key of the message: Show Login Link */
     public static final String LABELS_login_link = "{labels.login_link}";
 
-    /** The key of the message: Thumbnail View */
+    /** The key of the message: Show Thumbnail */
     public static final String LABELS_THUMBNAIL = "{labels.thumbnail}";
 
-    /** The key of the message: Excluded Failure Type */
+    /** The key of the message: Ignore Failure Types */
     public static final String LABELS_ignore_failure_type = "{labels.ignore_failure_type}";
 
     /** The key of the message: Failure Count Threshold */
@@ -1313,28 +1289,28 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Web */
     public static final String LABELS_supported_search_web = "{labels.supported_search_web}";
 
-    /** The key of the message: Not Available */
+    /** The key of the message: Unavailable */
     public static final String LABELS_supported_search_none = "{labels.supported_search_none}";
 
-    /** The key of the message: Purge Search Log Before */
+    /** The key of the message: Delete old search logs */
     public static final String LABELS_purge_search_log_day = "{labels.purge_search_log_day}";
 
-    /** The key of the message: Purge Job Log Before */
+    /** The key of the message: Delete old job logs */
     public static final String LABELS_purge_job_log_day = "{labels.purge_job_log_day}";
 
-    /** The key of the message: Purge User Before */
+    /** The key of the message: Delete old user logs */
     public static final String LABELS_purge_user_info_day = "{labels.purge_user_info_day}";
 
-    /** The key of the message: Bots Name For Purge */
+    /** The key of the message: Bot names to delete logs */
     public static final String LABELS_purge_by_bots = "{labels.purge_by_bots}";
 
     /** The key of the message: Log Level */
     public static final String LABELS_log_level = "{labels.log_level}";
 
-    /** The key of the message: Encoding for CSV */
+    /** The key of the message: CSV File Encoding */
     public static final String LABELS_csv_file_encoding = "{labels.csv_file_encoding}";
 
-    /** The key of the message: Notification Email */
+    /** The key of the message: Notification Mail */
     public static final String LABELS_notification_to = "{labels.notification_to}";
 
     /** The key of the message: Path Mapping */
@@ -1355,7 +1331,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Crawling/Displaying */
     public static final String LABELS_pathmap_pt_both = "{labels.pathmap_pt_both}";
 
-    /** The key of the message: Stored URLs */
+    /** The key of the message: Stored URL */
     public static final String LABELS_pathmap_pt_stored = "{labels.pathmap_pt_stored}";
 
     /** The key of the message: Regular Name */
@@ -1370,22 +1346,22 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Duplicate Host */
     public static final String LABELS_duplicate_host_title_details = "{labels.duplicate_host_title_details}";
 
-    /** The key of the message: System Configuration */
+    /** The key of the message: System Config */
     public static final String LABELS_dashboard_title_configuration = "{labels.dashboard_title_configuration}";
 
-    /** The key of the message: Suggest from Search Words */
+    /** The key of the message: Suggest from Search Terms */
     public static final String LABELS_suggest_search_log_enabled = "{labels.suggest_search_log_enabled}";
 
     /** The key of the message: Suggest from Documents */
     public static final String LABELS_suggest_documents_enabled = "{labels.suggest_documents_enabled}";
 
-    /** The key of the message: Purge Suggest Documents Before */
+    /** The key of the message: Delete old suggest info */
     public static final String LABELS_purge_suggest_search_log_day = "{labels.purge_suggest_search_log_day}";
 
-    /** The key of the message: Crawling Information */
+    /** The key of the message: Crawling Info */
     public static final String LABELS_crawling_info_title = "{labels.crawling_info_title}";
 
-    /** The key of the message: Crawling Information */
+    /** The key of the message: Crawling Info */
     public static final String LABELS_crawling_info_title_confirm = "{labels.crawling_info_title_confirm}";
 
     /** The key of the message: Back */
@@ -1403,7 +1379,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Reset */
     public static final String LABELS_crawling_info_reset = "{labels.crawling_info_reset}";
 
-    /** The key of the message: Crawling Information */
+    /** The key of the message: Crawling Info */
     public static final String LABELS_crawling_info_link_top = "{labels.crawling_info_link_top}";
 
     /** The key of the message: Details */
@@ -1421,7 +1397,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Delete All */
     public static final String LABELS_crawling_info_delete_all_link = "{labels.crawling_info_delete_all_link}";
 
-    /** The key of the message: Do you really want to delete all? */
+    /** The key of the message: Are you sure you want to delete all? */
     public static final String LABELS_crawling_info_delete_all_confirmation = "{labels.crawling_info_delete_all_confirmation}";
 
     /** The key of the message: Cancel */
@@ -1430,46 +1406,46 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Thread Dump */
     public static final String LABELS_crawling_info_thread_dump = "{labels.crawling_info_thread_dump}";
 
-    /** The key of the message: Crawler start time */
+    /** The key of the message: Crawler Start Time */
     public static final String LABELS_crawling_info_CrawlerStartTime = "{labels.crawling_info_CrawlerStartTime}";
 
-    /** The key of the message: Crawler end time */
+    /** The key of the message: Crawler End Time */
     public static final String LABELS_crawling_info_CrawlerEndTime = "{labels.crawling_info_CrawlerEndTime}";
 
-    /** The key of the message: Crawler exec time */
+    /** The key of the message: Crawler Execution Time */
     public static final String LABELS_crawling_info_CrawlerExecTime = "{labels.crawling_info_CrawlerExecTime}";
 
-    /** The key of the message: Crawler status */
+    /** The key of the message: Crawler Status */
     public static final String LABELS_crawling_info_CrawlerStatus = "{labels.crawling_info_CrawlerStatus}";
 
-    /** The key of the message: Crawl exec time (Web/File system) */
+    /** The key of the message: Crawl Execution Time (Web/File) */
     public static final String LABELS_crawling_info_WebFsCrawlExecTime = "{labels.crawling_info_WebFsCrawlExecTime}";
 
-    /** The key of the message: Crawl start time (Web/File system) */
+    /** The key of the message: Crawl Start Time (Web/File) */
     public static final String LABELS_crawling_info_WebFsCrawlStartTime = "{labels.crawling_info_WebFsCrawlStartTime}";
 
-    /** The key of the message: Crawl end time (Web/File system) */
+    /** The key of the message: Crawl End Time (Web/File) */
     public static final String LABELS_crawling_info_WebFsCrawlEndTime = "{labels.crawling_info_WebFsCrawlEndTime}";
 
-    /** The key of the message: Indexing exec time (Web/File system) */
+    /** The key of the message: Indexing Execution Time (Web/File) */
     public static final String LABELS_crawling_info_WebFsIndexExecTime = "{labels.crawling_info_WebFsIndexExecTime}";
 
-    /** The key of the message: Index size (Web/File system) */
+    /** The key of the message: Index Size (Web/File) */
     public static final String LABELS_crawling_info_WebFsIndexSize = "{labels.crawling_info_WebFsIndexSize}";
 
-    /** The key of the message: Crawl exec time (Data store) */
+    /** The key of the message: Crawl Execution Time (Data Store) */
     public static final String LABELS_crawling_info_DataCrawlExecTime = "{labels.crawling_info_DataCrawlExecTime}";
 
-    /** The key of the message: Crawl start time (Data store) */
+    /** The key of the message: Crawl Start Time (Data Store) */
     public static final String LABELS_crawling_info_DataCrawlStartTime = "{labels.crawling_info_DataCrawlStartTime}";
 
-    /** The key of the message: Crawl end time (Data store) */
+    /** The key of the message: Crawl End Time (Data Store) */
     public static final String LABELS_crawling_info_DataCrawlEndTime = "{labels.crawling_info_DataCrawlEndTime}";
 
-    /** The key of the message: Indexing exec time (Data store) */
+    /** The key of the message: Indexing Execution Time (Data Store) */
     public static final String LABELS_crawling_info_DataIndexExecTime = "{labels.crawling_info_DataIndexExecTime}";
 
-    /** The key of the message: Index size (Data store) */
+    /** The key of the message: Index Size (Data Store) */
     public static final String LABELS_crawling_info_DataIndexSize = "{labels.crawling_info_DataIndexSize}";
 
     /** The key of the message: Web Authentication */
@@ -1610,7 +1586,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Boost */
     public static final String LABELS_key_match_boost = "{labels.key_match_boost}";
 
-    /** The key of the message: Urls */
+    /** The key of the message: URLs */
     public static final String LABELS_key_match_urls = "{labels.key_match_urls}";
 
     /** The key of the message: Key Match */
@@ -1619,7 +1595,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Page Design */
     public static final String LABELS_design_configuration = "{labels.design_configuration}";
 
-    /** The key of the message: File Upload */
+    /** The key of the message: File to Upload */
     public static final String LABELS_design_title_file_upload = "{labels.design_title_file_upload}";
 
     /** The key of the message: File Manager */
@@ -1628,13 +1604,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Upload File */
     public static final String LABELS_design_file = "{labels.design_file}";
 
-    /** The key of the message: File Name (Optional) */
+    /** The key of the message: File Name (optional) */
     public static final String LABELS_design_file_name = "{labels.design_file_name}";
 
     /** The key of the message: Upload */
     public static final String LABELS_design_button_upload = "{labels.design_button_upload}";
 
-    /** The key of the message: JSP Files */
+    /** The key of the message: View Page File */
     public static final String LABELS_design_file_title_edit = "{labels.design_file_title_edit}";
 
     /** The key of the message: Edit */
@@ -1649,7 +1625,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Use Default */
     public static final String LABELS_design_use_default_button = "{labels.design_use_default_button}";
 
-    /** The key of the message: Edit JSP File */
+    /** The key of the message: View Edit Page File */
     public static final String LABELS_design_title_edit_content = "{labels.design_title_edit_content}";
 
     /** The key of the message: Update */
@@ -1661,13 +1637,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Data Store Crawling */
     public static final String LABELS_data_crawling_configuration = "{labels.data_crawling_configuration}";
 
-    /** The key of the message: Data Store Crawling Configuration */
+    /** The key of the message: Data Store Crawling Config */
     public static final String LABELS_data_crawling_title_details = "{labels.data_crawling_title_details}";
 
     /** The key of the message: Handler Name */
     public static final String LABELS_handler_name = "{labels.handler_name}";
 
-    /** The key of the message: Parameter */
+    /** The key of the message: Parameters */
     public static final String LABELS_handler_parameter = "{labels.handler_parameter}";
 
     /** The key of the message: Script */
@@ -1676,40 +1652,40 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Create */
     public static final String LABELS_data_crawling_button_create = "{labels.data_crawling_button_create}";
 
-    /** The key of the message: Create new job */
+    /** The key of the message: Create New Job */
     public static final String LABELS_data_crawling_button_create_job = "{labels.data_crawling_button_create_job}";
 
     /** The key of the message: Configuration Wizard */
     public static final String LABELS_wizard_title_configuration = "{labels.wizard_title_configuration}";
 
-    /** The key of the message: Quick Setup */
+    /** The key of the message: Easy Setup */
     public static final String LABELS_wizard_start_title = "{labels.wizard_start_title}";
 
-    /** The key of the message: Using Configuration Wizard, you can create crawling settings easily. */
+    /** The key of the message: You can create a crawl setting easily by using Configuration Wizard. */
     public static final String LABELS_wizard_start_desc = "{labels.wizard_start_desc}";
 
-    /** The key of the message: Start Configuration */
+    /** The key of the message: Start Setup */
     public static final String LABELS_wizard_start_button = "{labels.wizard_start_button}";
 
     /** The key of the message: Cancel */
     public static final String LABELS_wizard_button_cancel = "{labels.wizard_button_cancel}";
 
-    /** The key of the message: Crawling Configuration */
+    /** The key of the message: Crawl Config */
     public static final String LABELS_wizard_crawling_config_title = "{labels.wizard_crawling_config_title}";
 
-    /** The key of the message: Crawling Settings */
+    /** The key of the message: Crawl Setting */
     public static final String LABELS_wizard_crawling_setting_title = "{labels.wizard_crawling_setting_title}";
 
     /** The key of the message: Name */
     public static final String LABELS_wizard_crawling_config_name = "{labels.wizard_crawling_config_name}";
 
-    /** The key of the message: Crawling Path */
+    /** The key of the message: Crawl Path */
     public static final String LABELS_wizard_crawling_config_path = "{labels.wizard_crawling_config_path}";
 
-    /** The key of the message: Create again */
+    /** The key of the message: Create Continuously */
     public static final String LABELS_wizard_button_register_again = "{labels.wizard_button_register_again}";
 
-    /** The key of the message: Create and Next */
+    /** The key of the message: Create */
     public static final String LABELS_wizard_button_register_next = "{labels.wizard_button_register_next}";
 
     /** The key of the message: Start Crawling */
@@ -1718,7 +1694,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Crawler */
     public static final String LABELS_wizard_start_crawler_title = "{labels.wizard_start_crawler_title}";
 
-    /** The key of the message: To click "Start Crawling" button, you can start a crawling now. */
+    /** The key of the message: You can start crawling now by clicking "Start Crawling" button. */
     public static final String LABELS_wizard_start_crawling_desc = "{labels.wizard_start_crawling_desc}";
 
     /** The key of the message: Start Crawling */
@@ -1733,13 +1709,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Delete */
     public static final String LABELS_search_list_button_delete = "{labels.search_list_button_delete}";
 
-    /** The key of the message: Do you really want to delete? */
+    /** The key of the message: Are you sure you want to delete? */
     public static final String LABELS_search_list_delete_confirmation = "{labels.search_list_delete_confirmation}";
 
-    /** The key of the message: Delete all with this query */
+    /** The key of the message: Delete All by this Query */
     public static final String LABELS_search_list_button_delete_all = "{labels.search_list_button_delete_all}";
 
-    /** The key of the message: Do you really want to delete all with this query? */
+    /** The key of the message: Are you sure you want to delete all by this query? */
     public static final String LABELS_search_list_delete_all_confirmation = "{labels.search_list_delete_all_confirmation}";
 
     /** The key of the message: Cancel */
@@ -1760,7 +1736,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: URL */
     public static final String LABELS_failure_url_url = "{labels.failure_url_url}";
 
-    /** The key of the message: Last Access */
+    /** The key of the message: Last Access Time */
     public static final String LABELS_failure_url_last_access_time = "{labels.failure_url_last_access_time}";
 
     /** The key of the message: List */
@@ -1775,7 +1751,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Delete All */
     public static final String LABELS_failure_url_delete_all_link = "{labels.failure_url_delete_all_link}";
 
-    /** The key of the message: Do you really want to delete all? */
+    /** The key of the message: Are you sure you want to delete all? */
     public static final String LABELS_failure_url_delete_all_confirmation = "{labels.failure_url_delete_all_confirmation}";
 
     /** The key of the message: Cancel */
@@ -1799,25 +1775,25 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Log */
     public static final String LABELS_failure_url_error_log = "{labels.failure_url_error_log}";
 
-    /** The key of the message: Web Crawling Configuration */
+    /** The key of the message: Web Crawl Config */
     public static final String LABELS_failure_url_web_config_name = "{labels.failure_url_web_config_name}";
 
-    /** The key of the message: File Crawling Configuration */
+    /** The key of the message: File Crawl Config */
     public static final String LABELS_failure_url_file_config_name = "{labels.failure_url_file_config_name}";
 
     /** The key of the message: System Info */
     public static final String LABELS_system_info_configuration = "{labels.system_info_configuration}";
 
-    /** The key of the message: Env Properties */
+    /** The key of the message: Environment Variable Properties */
     public static final String LABELS_system_info_env_title = "{labels.system_info_env_title}";
 
     /** The key of the message: System Properties */
     public static final String LABELS_system_info_prop_title = "{labels.system_info_prop_title}";
 
-    /** The key of the message: Fess Properties */
+    /** The key of the message: App Properties */
     public static final String LABELS_system_info_fess_prop_title = "{labels.system_info_fess_prop_title}";
 
-    /** The key of the message: Properties for Bug Report */
+    /** The key of the message: Bug Report Properties */
     public static final String LABELS_system_info_bug_report_title = "{labels.system_info_bug_report_title}";
 
     /** The key of the message: system.properties does not exist. Default values are applied. */
@@ -1836,7 +1812,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Any */
     public static final String LABELS_file_auth_any = "{labels.file_auth_any}";
 
-    /** The key of the message: Create New File Config */
+    /** The key of the message: Create New File Crawl Config */
     public static final String LABELS_file_auth_create_file_config = "{labels.file_auth_create_file_config}";
 
     /** The key of the message: File Authentication */
@@ -1860,7 +1836,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Parameters */
     public static final String LABELS_file_auth_parameters = "{labels.file_auth_parameters}";
 
-    /** The key of the message: File System Config */
+    /** The key of the message: File Crawl Config */
     public static final String LABELS_file_auth_file_crawling_config = "{labels.file_auth_file_crawling_config}";
 
     /** The key of the message: Samba */
@@ -1872,13 +1848,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: {0}/{1} ({2} items) */
     public static final String LABELS_pagination_page_guide_msg = "{labels.pagination_page_guide_msg}";
 
-    /** The key of the message: No data. */
+    /** The key of the message: Not registered. */
     public static final String LABELS_list_could_not_find_crud_table = "{labels.list_could_not_find_crud_table}";
 
     /** The key of the message: Job Scheduler */
     public static final String LABELS_scheduledjob_configuration = "{labels.scheduledjob_configuration}";
 
-    /** The key of the message: Jobs */
+    /** The key of the message: Job */
     public static final String LABELS_scheduledjob_title_details = "{labels.scheduledjob_title_details}";
 
     /** The key of the message: Name */
@@ -1893,7 +1869,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Schedule */
     public static final String LABELS_scheduledjob_cronExpression = "{labels.scheduledjob_cronExpression}";
 
-    /** The key of the message: Executor */
+    /** The key of the message: Execution Method */
     public static final String LABELS_scheduledjob_scriptType = "{labels.scheduledjob_scriptType}";
 
     /** The key of the message: Script */
@@ -1911,10 +1887,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Active */
     public static final String LABELS_scheduledjob_active = "{labels.scheduledjob_active}";
 
-    /** The key of the message: Inactive */
+    /** The key of the message: Disabled */
     public static final String LABELS_scheduledjob_nojob = "{labels.scheduledjob_nojob}";
 
-    /** The key of the message: Start now */
+    /** The key of the message: Start Now */
     public static final String LABELS_scheduledjob_button_start = "{labels.scheduledjob_button_start}";
 
     /** The key of the message: Stop */
@@ -1938,10 +1914,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Status */
     public static final String LABELS_joblog_jobStatus = "{labels.joblog_jobStatus}";
 
-    /** The key of the message: Ok */
+    /** The key of the message: OK */
     public static final String LABELS_joblog_status_ok = "{labels.joblog_status_ok}";
 
-    /** The key of the message: Failed */
+    /** The key of the message: Fail */
     public static final String LABELS_joblog_status_fail = "{labels.joblog_status_fail}";
 
     /** The key of the message: Running */
@@ -1959,7 +1935,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Result */
     public static final String LABELS_joblog_scriptResult = "{labels.joblog_scriptResult}";
 
-    /** The key of the message: Executor */
+    /** The key of the message: Execution Method */
     public static final String LABELS_joblog_scriptType = "{labels.joblog_scriptType}";
 
     /** The key of the message: Start Time */
@@ -1974,7 +1950,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Delete All */
     public static final String LABELS_joblog_delete_all_link = "{labels.joblog_delete_all_link}";
 
-    /** The key of the message: Do you really want to delete all? */
+    /** The key of the message: Are you sure you want to delete all? */
     public static final String LABELS_joblog_delete_all_confirmation = "{labels.joblog_delete_all_confirmation}";
 
     /** The key of the message: Cancel */
@@ -1986,7 +1962,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Dictionary List */
     public static final String LABELS_dict_list_title = "{labels.dict_list_title}";
 
-    /** The key of the message: Dictionaries */
+    /** The key of the message: Dictionary */
     public static final String LABELS_dict_list_link = "{labels.dict_list_link}";
 
     /** The key of the message: Name */
@@ -2079,10 +2055,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Stemmer Override File */
     public static final String LABELS_dict_stemmeroverride_file = "{labels.dict_stemmeroverride_file}";
 
-    /** The key of the message: Mapping List */
+    /** The key of the message: Mapping Dictionary */
     public static final String LABELS_dict_mapping_configuration = "{labels.dict_mapping_configuration}";
 
-    /** The key of the message: Mapping List */
+    /** The key of the message: Mapping Dictionary */
     public static final String LABELS_dict_mapping_title = "{labels.dict_mapping_title}";
 
     /** The key of the message: List */
@@ -2121,10 +2097,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Mapping File */
     public static final String LABELS_dict_mapping_file = "{labels.dict_mapping_file}";
 
-    /** The key of the message: Kuromoji List */
+    /** The key of the message: Kuromoji Word List */
     public static final String LABELS_dict_kuromoji_configuration = "{labels.dict_kuromoji_configuration}";
 
-    /** The key of the message: Kuromoji List */
+    /** The key of the message: Kuromoji Word List */
     public static final String LABELS_dict_kuromoji_title = "{labels.dict_kuromoji_title}";
 
     /** The key of the message: List */
@@ -2157,7 +2133,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Reading */
     public static final String LABELS_dict_kuromoji_reading = "{labels.dict_kuromoji_reading}";
 
-    /** The key of the message: POS */
+    /** The key of the message: Part-of-speech */
     public static final String LABELS_dict_kuromoji_pos = "{labels.dict_kuromoji_pos}";
 
     /** The key of the message: Download */
@@ -2169,10 +2145,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Kuromoji File */
     public static final String LABELS_dict_kuromoji_file = "{labels.dict_kuromoji_file}";
 
-    /** The key of the message: Protwords List */
+    /** The key of the message: Protwords Word List */
     public static final String LABELS_dict_protwords_configuration = "{labels.dict_protwords_configuration}";
 
-    /** The key of the message: Protwords List */
+    /** The key of the message: Protwords Word List */
     public static final String LABELS_dict_protwords_title = "{labels.dict_protwords_title}";
 
     /** The key of the message: List */
@@ -2196,7 +2172,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Upload */
     public static final String LABELS_dict_protwords_link_upload = "{labels.dict_protwords_link_upload}";
 
-    /** The key of the message: Source */
+    /** The key of the message: Word Info */
     public static final String LABELS_dict_protwords_source = "{labels.dict_protwords_source}";
 
     /** The key of the message: Download */
@@ -2208,10 +2184,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Protwords File */
     public static final String LABELS_dict_protwords_file = "{labels.dict_protwords_file}";
 
-    /** The key of the message: Stopwords List */
+    /** The key of the message: Stopwords Word List */
     public static final String LABELS_dict_stopwords_configuration = "{labels.dict_stopwords_configuration}";
 
-    /** The key of the message: Stopwords List */
+    /** The key of the message: Stopwords Word List */
     public static final String LABELS_dict_stopwords_title = "{labels.dict_stopwords_title}";
 
     /** The key of the message: List */
@@ -2235,7 +2211,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Upload */
     public static final String LABELS_dict_stopwords_link_upload = "{labels.dict_stopwords_link_upload}";
 
-    /** The key of the message: Source */
+    /** The key of the message: Word Info */
     public static final String LABELS_dict_stopwords_source = "{labels.dict_stopwords_source}";
 
     /** The key of the message: Download */
@@ -2247,10 +2223,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Stopwords File */
     public static final String LABELS_dict_stopwords_file = "{labels.dict_stopwords_file}";
 
-    /** The key of the message: Doc Boost */
+    /** The key of the message: Document Boost */
     public static final String LABELS_boost_document_rule_configuration = "{labels.boost_document_rule_configuration}";
 
-    /** The key of the message: Doc Boost */
+    /** The key of the message: Document Boost */
     public static final String LABELS_boost_document_rule_title_details = "{labels.boost_document_rule_title_details}";
 
     /** The key of the message: Condition */
@@ -2259,7 +2235,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Condition */
     public static final String LABELS_boost_document_rule_url_expr = "{labels.boost_document_rule_url_expr}";
 
-    /** The key of the message: Boost Expr */
+    /** The key of the message: Boost Expression */
     public static final String LABELS_boost_document_rule_boost_expr = "{labels.boost_document_rule_boost_expr}";
 
     /** The key of the message: Sort Order */
@@ -2280,13 +2256,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Token */
     public static final String LABELS_access_token_token = "{labels.access_token_token}";
 
-    /** The key of the message: Expired */
+    /** The key of the message: Expires */
     public static final String LABELS_access_token_expires = "{labels.access_token_expires}";
 
     /** The key of the message: Parameter Name */
     public static final String LABELS_access_token_parameter_name = "{labels.access_token_parameter_name}";
 
-    /** The key of the message: Created */
+    /** The key of the message: Created Date */
     public static final String LABELS_access_token_updated_time = "{labels.access_token_updated_time}";
 
     /** The key of the message: Suggest Word */
@@ -2298,7 +2274,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Word Type */
     public static final String LABELS_suggest_word_type = "{labels.suggest_word_type}";
 
-    /** The key of the message: Word Count */
+    /** The key of the message: Number of Words */
     public static final String LABELS_suggest_word_number = "{labels.suggest_word_number}";
 
     /** The key of the message: All */
@@ -2310,10 +2286,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Query */
     public static final String LABELS_suggest_word_type_query = "{labels.suggest_word_type_query}";
 
-    /** The key of the message: Additional Word */
+    /** The key of the message: Elevate Word */
     public static final String LABELS_elevate_word_configuration = "{labels.elevate_word_configuration}";
 
-    /** The key of the message: Additional Word */
+    /** The key of the message: Elevate Word */
     public static final String LABELS_elevate_word_title_details = "{labels.elevate_word_title_details}";
 
     /** The key of the message: List */
@@ -2358,7 +2334,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Boost */
     public static final String LABELS_elevate_word_boost = "{labels.elevate_word_boost}";
 
-    /** The key of the message: Additional Word File */
+    /** The key of the message: Elevate Word File */
     public static final String LABELS_elevate_word_file = "{labels.elevate_word_file}";
 
     /** The key of the message: Bad Word */
@@ -2412,7 +2388,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Password */
     public static final String LABELS_user_password = "{labels.user_password}";
 
-    /** The key of the message: Confirm */
+    /** The key of the message: Password (Confirm) */
     public static final String LABELS_user_confirm_password = "{labels.user_confirm_password}";
 
     /** The key of the message: User */
@@ -2520,13 +2496,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Edit */
     public static final String LABELS_crud_title_edit = "{labels.crud_title_edit}";
 
-    /** The key of the message: Confirm to delete */
+    /** The key of the message: Confirm Delete */
     public static final String LABELS_crud_title_delete = "{labels.crud_title_delete}";
 
     /** The key of the message: Details */
     public static final String LABELS_crud_title_details = "{labels.crud_title_details}";
 
-    /** The key of the message: Do you really want to delete it? */
+    /** The key of the message: Are you sure you want to delete? */
     public static final String LABELS_crud_delete_confirmation = "{labels.crud_delete_confirmation}";
 
     /** The key of the message: Fess */
@@ -2535,7 +2511,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Dashboard */
     public static final String LABELS_admin_dashboard_title = "{labels.admin_dashboard_title}";
 
-    /** The key of the message: Toggle navigation */
+    /** The key of the message: Toggle Navigation */
     public static final String LABELS_admin_toggle_navi = "{labels.admin_toggle_navi}";
 
     /** The key of the message: System */
@@ -2560,6 +2536,21 @@ public class FessLabels extends UserMessages {
     public static final String LABELS_general_storage = "{labels.general_storage}";
 
     /** The key of the message: LDAP URL */
+    public static final String LABELS_LDAP_PROVIDER_URL = "{labels.ldapProviderUrl}";
+
+    /** The key of the message: User DN */
+    public static final String LABELS_LDAP_SECURITY_PRINCIPAL = "{labels.ldapSecurityPrincipal}";
+
+    /** The key of the message: Bind DN */
+    public static final String LABELS_LDAP_ADMIN_SECURITY_PRINCIPAL = "{labels.ldapAdminSecurityPrincipal}";
+
+    /** The key of the message: Password */
+    public static final String LABELS_LDAP_ADMIN_SECURITY_CREDENTIALS = "{labels.ldapAdminSecurityCredentials}";
+
+    /** The key of the message: Base DN */
+    public static final String LABELS_LDAP_BASE_DN = "{labels.ldapBaseDn}";
+
+    /** The key of the message: LDAP URL */
     public static final String LABELS_ldap_provider_url = "{labels.ldap_provider_url}";
 
     /** The key of the message: User DN */
@@ -2575,6 +2566,15 @@ public class FessLabels extends UserMessages {
     public static final String LABELS_ldap_base_dn = "{labels.ldap_base_dn}";
 
     /** The key of the message: Account Filter */
+    public static final String LABELS_LDAP_ACCOUNT_FILTER = "{labels.ldapAccountFilter}";
+
+    /** The key of the message: Group Filter */
+    public static final String LABELS_LDAP_GROUP_FILTER = "{labels.ldapGroupFilter}";
+
+    /** The key of the message: memberOf Attribute */
+    public static final String LABELS_LDAP_MEMBEROF_ATTRIBUTE = "{labels.ldapMemberofAttribute}";
+
+    /** The key of the message: Account Filter */
     public static final String LABELS_ldap_account_filter = "{labels.ldap_account_filter}";
 
     /** The key of the message: Group Filter */
@@ -2583,10 +2583,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: memberOf Attribute */
     public static final String LABELS_ldap_memberof_attribute = "{labels.ldap_memberof_attribute}";
 
-    /** The key of the message: Login page */
+    /** The key of the message: Login Page */
     public static final String LABELS_notification_login = "{labels.notification_login}";
 
-    /** The key of the message: Search top page */
+    /** The key of the message: Search Top Page */
     public static final String LABELS_notification_search_top = "{labels.notification_search_top}";
 
     /** The key of the message: Endpoint */
@@ -2601,10 +2601,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Bucket */
     public static final String LABELS_storage_bucket = "{labels.storage_bucket}";
 
-    /** The key of the message: Send TestMail */
+    /** The key of the message: Send Test Mail */
     public static final String LABELS_send_testmail = "{labels.send_testmail}";
 
-    /** The key of the message: Back Up */
+    /** The key of the message: Backup */
     public static final String LABELS_backup_configuration = "{labels.backup_configuration}";
 
     /** The key of the message: Name */
@@ -2616,25 +2616,25 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Upload */
     public static final String LABELS_backup_button_upload = "{labels.backup_button_upload}";
 
-    /** The key of the message: The limit of a search time was exceeded. The partial result might be displayed. */
+    /** The key of the message: The search processing time has exceeded the limit. The displayed results may be partial. */
     public static final String LABELS_process_time_is_exceeded = "{labels.process_time_is_exceeded}";
 
-    /** The key of the message: First Name */
+    /** The key of the message: Given Name */
     public static final String LABELS_user_given_name = "{labels.user_given_name}";
 
-    /** The key of the message: First Name */
+    /** The key of the message: Given Name */
     public static final String LABELS_GIVEN_NAME = "{labels.givenName}";
 
-    /** The key of the message: Last Name */
+    /** The key of the message: Surname */
     public static final String LABELS_user_surname = "{labels.user_surname}";
 
-    /** The key of the message: Last Name */
+    /** The key of the message: Surname */
     public static final String LABELS_SURAME = "{labels.surame}";
 
-    /** The key of the message: E-mail */
+    /** The key of the message: Mail */
     public static final String LABELS_user_mail = "{labels.user_mail}";
 
-    /** The key of the message: E-mail */
+    /** The key of the message: Mail */
     public static final String LABELS_MAIL = "{labels.mail}";
 
     /** The key of the message: Employee Number */
@@ -2703,10 +2703,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Postal Code */
     public static final String LABELS_POSTAL_CODE = "{labels.postalCode}";
 
-    /** The key of the message: Physical Delivery Office Name */
+    /** The key of the message: Office */
     public static final String LABELS_user_physicalDeliveryOfficeName = "{labels.user_physicalDeliveryOfficeName}";
 
-    /** The key of the message: Physical Delivery Office Name */
+    /** The key of the message: Office */
     public static final String LABELS_PHYSICAL_DELIVERY_OFFICE_NAME = "{labels.physicalDeliveryOfficeName}";
 
     /** The key of the message: Destination Indicator */
@@ -2781,10 +2781,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Teletex Terminal Identifier */
     public static final String LABELS_TELETEX_TERMINAL_IDENTIFIER = "{labels.teletexTerminalIdentifier}";
 
-    /** The key of the message: X121 Address */
+    /** The key of the message: x121Address */
     public static final String LABELS_user_x121Address = "{labels.user_x121Address}";
 
-    /** The key of the message: X121 Address */
+    /** The key of the message: x121Address */
     public static final String LABELS_X121_ADDRESS = "{labels.x121Address}";
 
     /** The key of the message: Business Category */
@@ -2844,13 +2844,13 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Data Migration */
     public static final String LABELS_upgrade_data_migration = "{labels.upgrade_data_migration}";
 
-    /** The key of the message: Reindex */
+    /** The key of the message: Re-indexing */
     public static final String LABELS_upgrade_reindex = "{labels.upgrade_reindex}";
 
     /** The key of the message: Start */
     public static final String LABELS_upgrade_start_button = "{labels.upgrade_start_button}";
 
-    /** The key of the message: Update Aliases */
+    /** The key of the message: Replace Aliases */
     public static final String LABELS_replace_aliases = "{labels.replace_aliases}";
 
     /** The key of the message: Reset Dictionaries */
@@ -2859,10 +2859,10 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Start */
     public static final String LABELS_reindex_start_button = "{labels.reindex_start_button}";
 
-    /** The key of the message: Version */
+    /** The key of the message: Target Version */
     public static final String LABELS_TARGET_VERSION = "{labels.targetVersion}";
 
-    /** The key of the message: Version From */
+    /** The key of the message: Target Version */
     public static final String LABELS_target_version = "{labels.target_version}";
 
     /** The key of the message: Request to OpenSearch */
@@ -2877,19 +2877,19 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Send */
     public static final String LABELS_sereq_button_upload = "{labels.sereq_button_upload}";
 
-    /** The key of the message: No match */
+    /** The key of the message: Not found */
     public static final String LABELS_facet_is_not_found = "{labels.facet_is_not_found}";
 
     /** The key of the message: Score: */
     public static final String LABELS_doc_score = "{labels.doc_score}";
 
-    /** The key of the message: Running as Development mode. For production use, please install a standalone OpenSearch server. */
+    /** The key of the message: Fess is running in development mode. Please install OpenSearch separately in a production environment. */
     public static final String LABELS_development_mode_warning = "{labels.development_mode_warning}";
 
-    /** The key of the message: Your system is out of support. See EOL page. */
+    /** The key of the message: The system you are using is no longer supported. Please refer to the product support lifecycle page and upgrade. */
     public static final String LABELS_eol_error = "{labels.eol_error}";
 
-    /** The key of the message: Search View */
+    /** The key of the message: Search Screen */
     public static final String LABELS_tooltip_search_view = "{labels.tooltip_search_view}";
 
     /** The key of the message: Run Crawler */
@@ -2904,28 +2904,28 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Logout */
     public static final String LABELS_tooltip_logout = "{labels.tooltip_logout}";
 
-    /** The key of the message: Advance */
+    /** The key of the message: Advanced Search */
     public static final String LABELS_ADVANCE = "{labels.advance}";
 
     /** The key of the message: Advanced Search */
     public static final String LABELS_advance_search_title = "{labels.advance_search_title}";
 
-    /** The key of the message: All these words */
+    /** The key of the message: with all of the words */
     public static final String LABELS_advance_search_must_queries = "{labels.advance_search_must_queries}";
 
-    /** The key of the message: Phrase search of these words */
+    /** The key of the message: with the exact phrase */
     public static final String LABELS_advance_search_phrase_query = "{labels.advance_search_phrase_query}";
 
-    /** The key of the message: Any of these words */
+    /** The key of the message: with at least one of the words */
     public static final String LABELS_advance_search_should_queries = "{labels.advance_search_should_queries}";
 
-    /** The key of the message: None of these words */
+    /** The key of the message: without the words */
     public static final String LABELS_advance_search_not_queries = "{labels.advance_search_not_queries}";
 
-    /** The key of the message: File Type */
+    /** The key of the message: File type */
     public static final String LABELS_advance_search_filetype = "{labels.advance_search_filetype}";
 
-    /** The key of the message: All Type */
+    /** The key of the message: Any format */
     public static final String LABELS_advance_search_filetype_default = "{labels.advance_search_filetype_default}";
 
     /** The key of the message: HTML */
@@ -2943,16 +2943,16 @@ public class FessLabels extends UserMessages {
     /** The key of the message: MS PowerPoint */
     public static final String LABELS_advance_search_filetype_powerpoint = "{labels.advance_search_filetype_powerpoint}";
 
-    /** The key of the message: Terms appearing */
+    /** The key of the message: Occurence */
     public static final String LABELS_advance_search_occt = "{labels.advance_search_occt}";
 
-    /** The key of the message: anywhere in the page */
+    /** The key of the message: Anywhere in the page */
     public static final String LABELS_advance_search_occt_default = "{labels.advance_search_occt_default}";
 
     /** The key of the message: in the title of the page */
     public static final String LABELS_advance_search_occt_allintitle = "{labels.advance_search_occt_allintitle}";
 
-    /** The key of the message: in the url of the page */
+    /** The key of the message: in the URL of the page */
     public static final String LABELS_advance_search_occt_allinurl = "{labels.advance_search_occt_allinurl}";
 
     /** The key of the message: Site or domain */
@@ -2961,19 +2961,19 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Last update */
     public static final String LABELS_advance_search_timestamp = "{labels.advance_search_timestamp}";
 
-    /** The key of the message: anytime */
+    /** The key of the message: Anytime */
     public static final String LABELS_advance_search_timestamp_default = "{labels.advance_search_timestamp_default}";
 
-    /** The key of the message: past 24 hours */
+    /** The key of the message: Past 24 hours */
     public static final String LABELS_advance_search_timestamp_pastday = "{labels.advance_search_timestamp_pastday}";
 
-    /** The key of the message: past week */
+    /** The key of the message: Past week */
     public static final String LABELS_advance_search_timestamp_pastweek = "{labels.advance_search_timestamp_pastweek}";
 
-    /** The key of the message: past month */
+    /** The key of the message: Past month */
     public static final String LABELS_advance_search_timestamp_pastmonth = "{labels.advance_search_timestamp_pastmonth}";
 
-    /** The key of the message: past year */
+    /** The key of the message: Past year */
     public static final String LABELS_advance_search_timestamp_pastyear = "{labels.advance_search_timestamp_pastyear}";
 
     /** The key of the message: Search Log */
@@ -2994,34 +2994,34 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Favorite Log */
     public static final String LABELS_searchlog_log_type_favorite = "{labels.searchlog_log_type_favorite}";
 
-    /** The key of the message: User Information */
+    /** The key of the message: User Log */
     public static final String LABELS_searchlog_log_type_user_info = "{labels.searchlog_log_type_user_info}";
 
-    /** The key of the message: Keywords */
+    /** The key of the message: Keyword Count */
     public static final String LABELS_searchlog_log_type_search_keyword = "{labels.searchlog_log_type_search_keyword}";
 
-    /** The key of the message: Zero Hits */
+    /** The key of the message: Zero Hit Count */
     public static final String LABELS_searchlog_log_type_search_zerohit = "{labels.searchlog_log_type_search_zerohit}";
 
-    /** The key of the message: Zero Clicks */
+    /** The key of the message: Zero Click Count */
     public static final String LABELS_searchlog_log_type_search_zeroclick = "{labels.searchlog_log_type_search_zeroclick}";
 
-    /** The key of the message: Keyword by Hour */
+    /** The key of the message: Search Count/Hour */
     public static final String LABELS_searchlog_log_type_search_count_hour = "{labels.searchlog_log_type_search_count_hour}";
 
-    /** The key of the message: Keyword by Day */
+    /** The key of the message: Search Count/Day */
     public static final String LABELS_searchlog_log_type_search_count_day = "{labels.searchlog_log_type_search_count_day}";
 
-    /** The key of the message: User by Hour */
+    /** The key of the message: User Count/Hour */
     public static final String LABELS_searchlog_log_type_search_user_hour = "{labels.searchlog_log_type_search_user_hour}";
 
-    /** The key of the message: User by Day */
+    /** The key of the message: User Count/Day */
     public static final String LABELS_searchlog_log_type_search_user_day = "{labels.searchlog_log_type_search_user_day}";
 
-    /** The key of the message: Request Time Avg. by Hour */
+    /** The key of the message: Request Average Time/Hour */
     public static final String LABELS_searchlog_log_type_search_reqtimeavg_hour = "{labels.searchlog_log_type_search_reqtimeavg_hour}";
 
-    /** The key of the message: Request Time Avg. by Day */
+    /** The key of the message: Request Average Time/Day */
     public static final String LABELS_searchlog_log_type_search_reqtimeavg_day = "{labels.searchlog_log_type_search_reqtimeavg_day}";
 
     /** The key of the message: Click Count */
@@ -3075,25 +3075,25 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Maintenance */
     public static final String LABELS_maintenance_title_configuration = "{labels.maintenance_title_configuration}";
 
-    /** The key of the message: The number of shards */
+    /** The key of the message: Number of Shards */
     public static final String LABELS_number_of_shards_for_doc = "{labels.number_of_shards_for_doc}";
 
-    /** The key of the message: Auto expand replicas */
+    /** The key of the message: Auto-expand Replicas */
     public static final String LABELS_auto_expand_replicas_for_doc = "{labels.auto_expand_replicas_for_doc}";
 
-    /** The key of the message: Crawler Indices */
+    /** The key of the message: Crawler Index */
     public static final String LABELS_clear_crawler_index = "{labels.clear_crawler_index}";
 
-    /** The key of the message: Clear Crawler Indices */
+    /** The key of the message: Delete Crawler Index */
     public static final String LABELS_clear_crawler_index_button = "{labels.clear_crawler_index_button}";
 
-    /** The key of the message: Diagnostic */
+    /** The key of the message: Diagnostics */
     public static final String LABELS_diagnostic_logs = "{labels.diagnostic_logs}";
 
     /** The key of the message: Download Logs */
     public static final String LABELS_download_diagnostic_logs_button = "{labels.download_diagnostic_logs_button}";
 
-    /** The key of the message: Reload Doc Index */
+    /** The key of the message: Reload Document Index */
     public static final String LABELS_reload_doc_index = "{labels.reload_doc_index}";
 
     /** The key of the message: Reload */
@@ -3177,7 +3177,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Tag Value */
     public static final String LABELS_storage_tag_value = "{labels.storage_tag_value}";
 
-    /** The key of the message: Your password needs to be updated. */
+    /** The key of the message: You need to update your password */
     public static final String LABELS_LOGIN_NEWPASSWORD = "{labels.login.newpassword}";
 
     /** The key of the message: New Password */

--- a/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
@@ -56,16 +56,16 @@ public class FessMessages extends FessLabels {
     /** The key of the message: {item} must be true. */
     public static final String CONSTRAINTS_AssertTrue_MESSAGE = "{constraints.AssertTrue.message}";
 
-    /** The key of the message: {item} must be less than ${inclusive == true ? 'or equal to ' : ''}{value}. */
+    /** The key of the message: {item} must be less than {value}. */
     public static final String CONSTRAINTS_DecimalMax_MESSAGE = "{constraints.DecimalMax.message}";
 
-    /** The key of the message: {item} must be greater than ${inclusive == true ? 'or equal to ' : ''}{value}. */
+    /** The key of the message: {item} must be greater than {value}. */
     public static final String CONSTRAINTS_DecimalMin_MESSAGE = "{constraints.DecimalMin.message}";
 
-    /** The key of the message: {item} is numeric value out of bounds (&lt;{integer} digits&gt;.&lt;{fraction} digits&gt; expected). */
+    /** The key of the message: {item} must be a number. (expected: &lt;number&gt;.&lt;number&gt;) */
     public static final String CONSTRAINTS_Digits_MESSAGE = "{constraints.Digits.message}";
 
-    /** The key of the message: {item} must be in the future. */
+    /** The key of the message: {item} must be a future value. */
     public static final String CONSTRAINTS_Future_MESSAGE = "{constraints.Future.message}";
 
     /** The key of the message: {item} must be less than or equal to {value}. */
@@ -74,112 +74,112 @@ public class FessMessages extends FessLabels {
     /** The key of the message: {item} must be greater than or equal to {value}. */
     public static final String CONSTRAINTS_Min_MESSAGE = "{constraints.Min.message}";
 
-    /** The key of the message: {item} may not be null. */
+    /** The key of the message: {item} is required. */
     public static final String CONSTRAINTS_NotNull_MESSAGE = "{constraints.NotNull.message}";
 
     /** The key of the message: {item} must be null. */
     public static final String CONSTRAINTS_Null_MESSAGE = "{constraints.Null.message}";
 
-    /** The key of the message: {item} must be in the past. */
+    /** The key of the message: {item} must be a past value. */
     public static final String CONSTRAINTS_Past_MESSAGE = "{constraints.Past.message}";
 
-    /** The key of the message: {item} must match "{regexp}". */
+    /** The key of the message: {item} does not match "{regexp}". */
     public static final String CONSTRAINTS_Pattern_MESSAGE = "{constraints.Pattern.message}";
 
-    /** The key of the message: Size of {item} must be between {min} and {max}. */
+    /** The key of the message: The size of {item} must be between {min} and {max}. */
     public static final String CONSTRAINTS_Size_MESSAGE = "{constraints.Size.message}";
 
-    /** The key of the message: {item} is invalid credit card number. */
+    /** The key of the message: {item} is an invalid credit card number. */
     public static final String CONSTRAINTS_CreditCardNumber_MESSAGE = "{constraints.CreditCardNumber.message}";
 
-    /** The key of the message: {item} is invalid {type} barcode. */
+    /** The key of the message: {item} is an invalid {type} barcode. */
     public static final String CONSTRAINTS_EAN_MESSAGE = "{constraints.EAN.message}";
 
-    /** The key of the message: {item} is not a well-formed email address. */
+    /** The key of the message: {item} is not a valid email address. */
     public static final String CONSTRAINTS_Email_MESSAGE = "{constraints.Email.message}";
 
-    /** The key of the message: Length of {item} must be between {min} and {max}. */
+    /** The key of the message: The length of {item} must be between {min} and {max}. */
     public static final String CONSTRAINTS_Length_MESSAGE = "{constraints.Length.message}";
 
-    /** The key of the message: The check digit for ${value} is invalid, Luhn Modulo 10 checksum failed. */
+    /** The key of the message: The Luhn Modulo 11 checksum of {value} is incorrect. */
     public static final String CONSTRAINTS_LuhnCheck_MESSAGE = "{constraints.LuhnCheck.message}";
 
-    /** The key of the message: The check digit for ${value} is invalid, Modulo 10 checksum failed. */
+    /** The key of the message: The Modulo 10 checksum of {value} is incorrect. */
     public static final String CONSTRAINTS_Mod10Check_MESSAGE = "{constraints.Mod10Check.message}";
 
-    /** The key of the message: The check digit for ${value} is invalid, Modulo 11 checksum failed. */
+    /** The key of the message: The Modulo 11 checksum of {value} is incorrect. */
     public static final String CONSTRAINTS_Mod11Check_MESSAGE = "{constraints.Mod11Check.message}";
 
-    /** The key of the message: The check digit for ${value} is invalid, ${modType} checksum failed. */
+    /** The key of the message: The {modType} checksum of {value} is incorrect. */
     public static final String CONSTRAINTS_ModCheck_MESSAGE = "{constraints.ModCheck.message}";
 
-    /** The key of the message: {item} may not be empty. */
+    /** The key of the message: {item} is required. */
     public static final String CONSTRAINTS_NotBlank_MESSAGE = "{constraints.NotBlank.message}";
 
-    /** The key of the message: {item} may not be empty. */
+    /** The key of the message: {item} is required. */
     public static final String CONSTRAINTS_NotEmpty_MESSAGE = "{constraints.NotEmpty.message}";
 
-    /** The key of the message: script expression "{script}" didn't evaluate to true. */
+    /** The key of the message: The script expression "{script}" is not true. */
     public static final String CONSTRAINTS_ParametersScriptAssert_MESSAGE = "{constraints.ParametersScriptAssert.message}";
 
     /** The key of the message: {item} must be between {min} and {max}. */
     public static final String CONSTRAINTS_Range_MESSAGE = "{constraints.Range.message}";
 
-    /** The key of the message: {item} may have unsafe html content. */
+    /** The key of the message: {item} contains unsafe HTML content. */
     public static final String CONSTRAINTS_SafeHtml_MESSAGE = "{constraints.SafeHtml.message}";
 
-    /** The key of the message: script expression "{script}" didn't evaluate to true. */
+    /** The key of the message: The script expression "{script}" is not true. */
     public static final String CONSTRAINTS_ScriptAssert_MESSAGE = "{constraints.ScriptAssert.message}";
 
-    /** The key of the message: {item} must be a valid URL. */
+    /** The key of the message: {item} is not a valid URL. */
     public static final String CONSTRAINTS_URL_MESSAGE = "{constraints.URL.message}";
 
     /** The key of the message: {item} is required. */
     public static final String CONSTRAINTS_Required_MESSAGE = "{constraints.Required.message}";
 
-    /** The key of the message: {item} should be numeric. */
+    /** The key of the message: {item} must be a number. */
     public static final String CONSTRAINTS_TypeInteger_MESSAGE = "{constraints.TypeInteger.message}";
 
-    /** The key of the message: {item} should be numeric. */
+    /** The key of the message: {item} must be a number. */
     public static final String CONSTRAINTS_TypeLong_MESSAGE = "{constraints.TypeLong.message}";
 
-    /** The key of the message: {item} should be numeric. */
+    /** The key of the message: {item} must be a number. */
     public static final String CONSTRAINTS_TypeFloat_MESSAGE = "{constraints.TypeFloat.message}";
 
-    /** The key of the message: {item} should be numeric. */
+    /** The key of the message: {item} must be a number. */
     public static final String CONSTRAINTS_TypeDouble_MESSAGE = "{constraints.TypeDouble.message}";
 
-    /** The key of the message: {item} cannot convert as {propertyType}. */
+    /** The key of the message: {item} cannot be converted to {propertyType}. */
     public static final String CONSTRAINTS_TypeAny_MESSAGE = "{constraints.TypeAny.message}";
 
-    /** The key of the message: {item} has wrong URI. */
+    /** The key of the message: {item} has an unrecognized URI. */
     public static final String CONSTRAINTS_UriType_MESSAGE = "{constraints.UriType.message}";
 
-    /** The key of the message: {item} is invalid cron expression. */
+    /** The key of the message: {item} is not a valid CRON expression. */
     public static final String CONSTRAINTS_CronExpression_MESSAGE = "{constraints.CronExpression.message}";
 
     /** The key of the message: Login failed. */
     public static final String ERRORS_LOGIN_FAILURE = "{errors.login.failure}";
 
-    /** The key of the message: Please retry because of illegal transition. */
+    /** The key of the message: Illegal transition. Please try again. */
     public static final String ERRORS_APP_ILLEGAL_TRANSITION = "{errors.app.illegal.transition}";
 
-    /** The key of the message: others might be updated, so retry. */
+    /** The key of the message: It may have been deleted by another process. Please try again. */
     public static final String ERRORS_APP_DB_ALREADY_DELETED = "{errors.app.db.already.deleted}";
 
-    /** The key of the message: others might be updated, so retry. */
+    /** The key of the message: It may have been updated by another process. Please try again. */
     public static final String ERRORS_APP_DB_ALREADY_UPDATED = "{errors.app.db.already.updated}";
 
-    /** The key of the message: already existing data, so retry. */
+    /** The key of the message: The data already exists. Please try again. */
     public static final String ERRORS_APP_DB_ALREADY_EXISTS = "{errors.app.db.already.exists}";
 
-    /** The key of the message: Your request might have been processed before this request. Please check and retry it. */
+    /** The key of the message: It may have been processed before this request. Please try again. */
     public static final String ERRORS_APP_DOUBLE_SUBMIT_REQUEST = "{errors.app.double.submit.request}";
 
-    /** The key of the message: Username or Password is not correct. */
+    /** The key of the message: Invalid username or password. */
     public static final String ERRORS_login_error = "{errors.login_error}";
 
-    /** The key of the message: Failed to process SSO login. */
+    /** The key of the message: SSO login process failed. */
     public static final String ERRORS_sso_login_error = "{errors.sso_login_error}";
 
     /** The key of the message: Could not find {0}. */
@@ -191,7 +191,7 @@ public class FessMessages extends FessLabels {
     /** The key of the message: Invalid JSP file. */
     public static final String ERRORS_invalid_design_jsp_file_name = "{errors.invalid_design_jsp_file_name}";
 
-    /** The key of the message: JSP file does not exist. */
+    /** The key of the message: The JSP file does not exist. */
     public static final String ERRORS_design_jsp_file_does_not_exist = "{errors.design_jsp_file_does_not_exist}";
 
     /** The key of the message: The file name is not specified. */
@@ -200,190 +200,142 @@ public class FessMessages extends FessLabels {
     /** The key of the message: Failed to upload an image file. */
     public static final String ERRORS_failed_to_write_design_image_file = "{errors.failed_to_write_design_image_file}";
 
-    /** The key of the message: Failed to update a jsp file. */
+    /** The key of the message: Failed to update the JSP file. */
     public static final String ERRORS_failed_to_update_jsp_file = "{errors.failed_to_update_jsp_file}";
 
     /** The key of the message: The file name is invalid. */
     public static final String ERRORS_design_file_name_is_invalid = "{errors.design_file_name_is_invalid}";
 
-    /** The key of the message: The kind of file is unsupported. */
+    /** The key of the message: This file type is unsupported. */
     public static final String ERRORS_design_file_is_unsupported_type = "{errors.design_file_is_unsupported_type}";
 
-    /** The key of the message: Failed to create a crawling config. */
+    /** The key of the message: Failed to create a crawling config at a wizard. */
     public static final String ERRORS_failed_to_create_crawling_config_at_wizard = "{errors.failed_to_create_crawling_config_at_wizard}";
 
     /** The key of the message: This feature is disabled. */
     public static final String ERRORS_design_editor_disabled = "{errors.design_editor_disabled}";
 
-    /** The key of the message: Not Found: {0} */
+    /** The key of the message: Not found. Cause: {0} */
     public static final String ERRORS_not_found_on_file_system = "{errors.not_found_on_file_system}";
 
-    /** The key of the message: Could not open {0}. &lt;br/&gt;Please check if the file is associated with an application. */
+    /** The key of the message: Could not open {0}.&lt;br&gt;Please check if the file is associated with an application. */
     public static final String ERRORS_could_not_open_on_system = "{errors.could_not_open_on_system}";
 
-    /** The key of the message: No more results could be displayed. */
+    /** The key of the message: No more results can be displayed. */
     public static final String ERRORS_result_size_exceeded = "{errors.result_size_exceeded}";
 
-    /** The key of the message: {0} file does not exist. */
+    /** The key of the message: The file {0} does not exist. */
     public static final String ERRORS_target_file_does_not_exist = "{errors.target_file_does_not_exist}";
 
-    /** The key of the message: Failed to delete {0} file. */
+    /** The key of the message: Failed to delete the file {0}. */
     public static final String ERRORS_failed_to_delete_file = "{errors.failed_to_delete_file}";
 
-    /** The key of the message: Not found Doc ID:{0} */
+    /** The key of the message: Doc ID is not found. Cause: {0} */
     public static final String ERRORS_docid_not_found = "{errors.docid_not_found}";
 
-    /** The key of the message: Not found URL of Doc ID:{0} */
+    /** The key of the message: The URL for the document ID is not found. Cause: {0} */
     public static final String ERRORS_document_not_found = "{errors.document_not_found}";
 
-    /** The key of the message: Could not load from this server: {0} */
+    /** The key of the message: Could not load from this server. Cause: {0} */
     public static final String ERRORS_not_load_from_server = "{errors.not_load_from_server}";
 
-    /** The key of the message: Failed to start job {0}. */
+    /** The key of the message: Failed to start a job: {0}. */
     public static final String ERRORS_failed_to_start_job = "{errors.failed_to_start_job}";
 
-    /** The key of the message: Failed to stop job {0}. */
+    /** The key of the message: Failed to stop a job: {0}. */
     public static final String ERRORS_failed_to_stop_job = "{errors.failed_to_stop_job}";
 
-    /** The key of the message: Failed to download the Synonym file. */
+    /** The key of the message: Failed to download a synonym file. */
     public static final String ERRORS_failed_to_download_synonym_file = "{errors.failed_to_download_synonym_file}";
 
-    /** The key of the message: Failed to upload the Synonym file. */
+    /** The key of the message: Failed to upload a synonym file. */
     public static final String ERRORS_failed_to_upload_synonym_file = "{errors.failed_to_upload_synonym_file}";
 
-    /** The key of the message: Failed to download the Stemmer Override file. */
+    /** The key of the message: Failed to download a stemmer override file. */
     public static final String ERRORS_failed_to_download_stemmeroverride_file = "{errors.failed_to_download_stemmeroverride_file}";
 
-    /** The key of the message: Failed to upload the Stemmer Override file. */
+    /** The key of the message: Failed to upload a stemmer override file. */
     public static final String ERRORS_failed_to_upload_stemmeroverride_file = "{errors.failed_to_upload_stemmeroverride_file}";
 
-    /** The key of the message: Failed to download the Kuromoji file. */
+    /** The key of the message: Failed to download a Kuromoji file. */
     public static final String ERRORS_failed_to_download_kuromoji_file = "{errors.failed_to_download_kuromoji_file}";
 
-    /** The key of the message: Failed to upload the Kuromoji file. */
+    /** The key of the message: Failed to upload a Kuromoji file. */
     public static final String ERRORS_failed_to_upload_kuromoji_file = "{errors.failed_to_upload_kuromoji_file}";
 
-    /** The key of the message: Failed to download the Protwords file. */
+    /** The key of the message: Failed to download a protwords file. */
     public static final String ERRORS_failed_to_download_protwords_file = "{errors.failed_to_download_protwords_file}";
 
-    /** The key of the message: Failed to upload the Protwords file. */
+    /** The key of the message: Failed to upload a protwords file. */
     public static final String ERRORS_failed_to_upload_protwords_file = "{errors.failed_to_upload_protwords_file}";
 
-    /** The key of the message: Failed to download the Stopwords file. */
+    /** The key of the message: Failed to download a stopwords file. */
     public static final String ERRORS_failed_to_download_stopwords_file = "{errors.failed_to_download_stopwords_file}";
 
-    /** The key of the message: Failed to upload the Stopwords file. */
+    /** The key of the message: Failed to upload a stopwords file. */
     public static final String ERRORS_failed_to_upload_stopwords_file = "{errors.failed_to_upload_stopwords_file}";
 
-    /** The key of the message: Failed to download the Elevate file. */
+    /** The key of the message: Failed to download an elevate word file. */
     public static final String ERRORS_failed_to_download_elevate_file = "{errors.failed_to_download_elevate_file}";
 
-    /** The key of the message: Failed to upload the Elevate file. */
+    /** The key of the message: Failed to upload an elevate word file. */
     public static final String ERRORS_failed_to_upload_elevate_file = "{errors.failed_to_upload_elevate_file}";
 
-    /** The key of the message: Failed to download the Badword file. */
+    /** The key of the message: Failed to download a bad word file. */
     public static final String ERRORS_failed_to_download_badword_file = "{errors.failed_to_download_badword_file}";
 
-    /** The key of the message: Failed to upload the Badword file. */
+    /** The key of the message: Failed to upload a bad word file. */
     public static final String ERRORS_failed_to_upload_badword_file = "{errors.failed_to_upload_badword_file}";
 
-    /** The key of the message: Failed to download the Mapping file. */
+    /** The key of the message: Failed to download a mapping file. */
     public static final String ERRORS_failed_to_download_mapping_file = "{errors.failed_to_download_mapping_file}";
 
-    /** The key of the message: Failed to upload the Mapping file. */
+    /** The key of the message: Failed to upload a mapping file. */
     public static final String ERRORS_failed_to_upload_mapping_file = "{errors.failed_to_upload_mapping_file}";
 
-    /** The key of the message: {0} is invalid. */
+    /** The key of the message: {0} is invalid as a token. */
     public static final String ERRORS_invalid_kuromoji_token = "{errors.invalid_kuromoji_token}";
 
-    /** The key of the message: The number of segmentations {0} does not the match number of readings {1}. */
+    /** The key of the message: The number of segmentation for {0} and {1} is different. */
     public static final String ERRORS_invalid_kuromoji_segmentation = "{errors.invalid_kuromoji_segmentation}";
 
-    /** The key of the message: "{1}" in "{0}" is invalid. */
+    /** The key of the message: {1} is invalid for {0}. */
     public static final String ERRORS_invalid_str_is_included = "{errors.invalid_str_is_included}";
 
     /** The key of the message: Password is required. */
     public static final String ERRORS_blank_password = "{errors.blank_password}";
 
-    /** The key of the message: Confirm Password does not match. */
+    /** The key of the message: Does not match a confirmation password. */
     public static final String ERRORS_invalid_confirm_password = "{errors.invalid_confirm_password}";
 
-    /** The key of the message: Crawler is running. The document cannot be deleted. */
+    /** The key of the message: A crawler is running. You cannot delete documents. */
     public static final String ERRORS_cannot_delete_doc_because_of_running = "{errors.cannot_delete_doc_because_of_running}";
 
-    /** The key of the message: Failed to delete document. */
+    /** The key of the message: Failed to delete a document. */
     public static final String ERRORS_failed_to_delete_doc_in_admin = "{errors.failed_to_delete_doc_in_admin}";
 
-    /** The key of the message: Failed to send the test mail. */
+    /** The key of the message: Failed to send a test mail. */
     public static final String ERRORS_failed_to_send_testmail = "{errors.failed_to_send_testmail}";
 
-    /** The key of the message: Could not find index for backup. */
-    public static final String ERRORS_could_not_find_backup_index = "{errors.could_not_find_backup_index}";
-
-    /** The key of the message: The current password is incorrect. */
-    public static final String ERRORS_no_user_for_changing_password = "{errors.no_user_for_changing_password}";
-
-    /** The key of the message: Failed to change your password. */
-    public static final String ERRORS_failed_to_change_password = "{errors.failed_to_change_password}";
-
-    /** The key of the message: Unknown version information. */
-    public static final String ERRORS_unknown_version_for_upgrade = "{errors.unknown_version_for_upgrade}";
-
-    /** The key of the message: Failed to upgrade from {0}: {1} */
-    public static final String ERRORS_failed_to_upgrade_from = "{errors.failed_to_upgrade_from}";
-
-    /** The key of the message: Failed to start reindexing from {0} to {1} */
-    public static final String ERRORS_failed_to_reindex = "{errors.failed_to_reindex}";
-
-    /** The key of the message: Failed to read request file: {0} */
-    public static final String ERRORS_failed_to_read_request_file = "{errors.failed_to_read_request_file}";
-
-    /** The key of the message: Invalid header: {0} */
-    public static final String ERRORS_invalid_header_for_request_file = "{errors.invalid_header_for_request_file}";
-
-    /** The key of the message: Could not delete logged in user. */
-    public static final String ERRORS_could_not_delete_logged_in_user = "{errors.could_not_delete_logged_in_user}";
-
-    /** The key of the message: Unauthorized request. */
-    public static final String ERRORS_unauthorized_request = "{errors.unauthorized_request}";
-
-    /** The key of the message: Failed to print thread dump. */
-    public static final String ERRORS_failed_to_print_thread_dump = "{errors.failed_to_print_thread_dump}";
-
-    /** The key of the message: {0} is not supported. */
-    public static final String ERRORS_file_is_not_supported = "{errors.file_is_not_supported}";
-
-    /** The key of the message: {0} is not found. */
-    public static final String ERRORS_plugin_file_is_not_found = "{errors.plugin_file_is_not_found}";
-
-    /** The key of the message: Failed to install {0}. */
-    public static final String ERRORS_failed_to_install_plugin = "{errors.failed_to_install_plugin}";
-
-    /** The key of the message: Failed to access available plugins. */
-    public static final String ERRORS_failed_to_find_plugins = "{errors.failed_to_find_plugins}";
-
-    /** The key of the message: Failed to process the request: {0} */
-    public static final String ERRORS_failed_to_process_sso_request = "{errors.failed_to_process_sso_request}";
-
-    /** The key of the message: The given query has unknown condition. */
+    /** The key of the message: The specified query has an unknown condition. */
     public static final String ERRORS_invalid_query_unknown = "{errors.invalid_query_unknown}";
 
     /** The key of the message: The given query is invalid. */
     public static final String ERRORS_invalid_query_parse_error = "{errors.invalid_query_parse_error}";
 
-    /** The key of the message: The given sort ({0}) is invalid. */
+    /** The key of the message: The specified sort {0} is invalid. */
     public static final String ERRORS_invalid_query_sort_value = "{errors.invalid_query_sort_value}";
 
-    /** The key of the message: The given sort ({0}) is not supported. */
+    /** The key of the message: The specified sort {0} is unsupported. */
     public static final String ERRORS_invalid_query_unsupported_sort_field = "{errors.invalid_query_unsupported_sort_field}";
 
-    /** The key of the message: The given sort order ({0}) is not supported. */
+    /** The key of the message: The specified sort order {0} is unsupported. */
     public static final String ERRORS_invalid_query_unsupported_sort_order = "{errors.invalid_query_unsupported_sort_order}";
 
-    /** The key of the message: The given query could not be processed. */
+    /** The key of the message: Could not process the specified query. */
     public static final String ERRORS_invalid_query_cannot_process = "{errors.invalid_query_cannot_process}";
 
-    /** The key of the message: Invalid mode(expected value is {0}, but it's {1}). */
+    /** The key of the message: The mode is incorrect. (not {0}, but {1}) */
     public static final String ERRORS_crud_invalid_mode = "{errors.crud_invalid_mode}";
 
     /** The key of the message: Failed to create a new data. */
@@ -398,52 +350,100 @@ public class FessMessages extends FessLabels {
     /** The key of the message: Failed to delete the data. ({0}) */
     public static final String ERRORS_crud_failed_to_delete_crud_table = "{errors.crud_failed_to_delete_crud_table}";
 
-    /** The key of the message: Could not find the data({0}). */
+    /** The key of the message: The data {0} is not found. */
     public static final String ERRORS_crud_could_not_find_crud_table = "{errors.crud_could_not_find_crud_table}";
+
+    /** The key of the message: Could not find any backup index. */
+    public static final String ERRORS_could_not_find_backup_index = "{errors.could_not_find_backup_index}";
+
+    /** The key of the message: The current password is not correct. */
+    public static final String ERRORS_no_user_for_changing_password = "{errors.no_user_for_changing_password}";
+
+    /** The key of the message: Failed to change your password. */
+    public static final String ERRORS_failed_to_change_password = "{errors.failed_to_change_password}";
+
+    /** The key of the message: Unknown version for upgrade. */
+    public static final String ERRORS_unknown_version_for_upgrade = "{errors.unknown_version_for_upgrade}";
+
+    /** The key of the message: Failed to upgrade from {0}. */
+    public static final String ERRORS_failed_to_upgrade_from = "{errors.failed_to_upgrade_from}";
+
+    /** The key of the message: Failed to start re-indexing from {0} to {1}. */
+    public static final String ERRORS_failed_to_reindex = "{errors.failed_to_reindex}";
+
+    /** The key of the message: Failed to read a request file: {0} */
+    public static final String ERRORS_failed_to_read_request_file = "{errors.failed_to_read_request_file}";
+
+    /** The key of the message: Invalid header line: {0} */
+    public static final String ERRORS_invalid_header_for_request_file = "{errors.invalid_header_for_request_file}";
+
+    /** The key of the message: You cannot delete a user who is logged in. */
+    public static final String ERRORS_could_not_delete_logged_in_user = "{errors.could_not_delete_logged_in_user}";
+
+    /** The key of the message: Unauthorized request. */
+    public static final String ERRORS_unauthorized_request = "{errors.unauthorized_request}";
+
+    /** The key of the message: Failed to print a thread dump. */
+    public static final String ERRORS_failed_to_print_thread_dump = "{errors.failed_to_print_thread_dump}";
+
+    /** The key of the message: {0} is not supported. */
+    public static final String ERRORS_file_is_not_supported = "{errors.file_is_not_supported}";
+
+    /** The key of the message: {0} is not found. */
+    public static final String ERRORS_plugin_file_is_not_found = "{errors.plugin_file_is_not_found}";
+
+    /** The key of the message: Failed to install {0}. */
+    public static final String ERRORS_failed_to_install_plugin = "{errors.failed_to_install_plugin}";
+
+    /** The key of the message: Could not find available plugins. */
+    public static final String ERRORS_failed_to_find_plugins = "{errors.failed_to_find_plugins}";
+
+    /** The key of the message: Failed to process a request: {0} */
+    public static final String ERRORS_failed_to_process_sso_request = "{errors.failed_to_process_sso_request}";
 
     /** The key of the message: {0} is required. */
     public static final String ERRORS_property_required = "{errors.property_required}";
 
-    /** The key of the message: {0} should be numeric. */
+    /** The key of the message: {0} must be an integer. */
     public static final String ERRORS_property_type_integer = "{errors.property_type_integer}";
 
-    /** The key of the message: {0} should be numeric. */
+    /** The key of the message: {0} must be a long. */
     public static final String ERRORS_property_type_long = "{errors.property_type_long}";
 
-    /** The key of the message: {0} should be numeric. */
+    /** The key of the message: {0} must be a float. */
     public static final String ERRORS_property_type_float = "{errors.property_type_float}";
 
-    /** The key of the message: {0} should be numeric. */
+    /** The key of the message: {0} must be a double. */
     public static final String ERRORS_property_type_double = "{errors.property_type_double}";
 
-    /** The key of the message: {0} should be date. */
+    /** The key of the message: {0} must be a date. */
     public static final String ERRORS_property_type_date = "{errors.property_type_date}";
 
     /** The key of the message: Failed to upload {0}. */
     public static final String ERRORS_storage_file_upload_failure = "{errors.storage_file_upload_failure}";
 
-    /** The key of the message: The target file is not found in Storage. */
+    /** The key of the message: The target file does not exist in the storage. */
     public static final String ERRORS_storage_file_not_found = "{errors.storage_file_not_found}";
 
     /** The key of the message: Failed to download {0}. */
     public static final String ERRORS_storage_file_download_failure = "{errors.storage_file_download_failure}";
 
-    /** The key of the message: Storage access error: {0} */
+    /** The key of the message: Storage Access Error: {0} */
     public static final String ERRORS_storage_access_error = "{errors.storage_access_error}";
 
-    /** The key of the message: Upload file is required. */
+    /** The key of the message: Please specify a file to upload. */
     public static final String ERRORS_storage_no_upload_file = "{errors.storage_no_upload_file}";
 
-    /** The key of the message: Directory name is invalid. */
+    /** The key of the message: The directory name is invalid. */
     public static final String ERRORS_storage_directory_name_is_invalid = "{errors.storage_directory_name_is_invalid}";
 
-    /** The key of the message: Failed to update tags for {0} */
+    /** The key of the message: Failed to update tags of {0}. */
     public static final String ERRORS_storage_tags_update_failure = "{errors.storage_tags_update_failure}";
 
     /** The key of the message: Updated parameters. */
     public static final String SUCCESS_update_crawler_params = "{success.update_crawler_params}";
 
-    /** The key of the message: Started a process to delete the document from index. */
+    /** The key of the message: Started a process to delete documents from an index. */
     public static final String SUCCESS_delete_doc_from_index = "{success.delete_doc_from_index}";
 
     /** The key of the message: Deleted session data. */
@@ -452,52 +452,52 @@ public class FessMessages extends FessLabels {
     /** The key of the message: Started a crawl process. */
     public static final String SUCCESS_start_crawl_process = "{success.start_crawl_process}";
 
-    /** The key of the message: Uploaded {0}. */
+    /** The key of the message: Updated {0}. */
     public static final String SUCCESS_upload_design_file = "{success.upload_design_file}";
 
     /** The key of the message: Updated {0}. */
     public static final String SUCCESS_update_design_jsp_file = "{success.update_design_jsp_file}";
 
-    /** The key of the message: Created a crawling config ({0}). */
+    /** The key of the message: Created a crawling config {0}. */
     public static final String SUCCESS_create_crawling_config_at_wizard = "{success.create_crawling_config_at_wizard}";
 
-    /** The key of the message: Deleted failure urls. */
+    /** The key of the message: Deleted failure URLs. */
     public static final String SUCCESS_failure_url_delete_all = "{success.failure_url_delete_all}";
 
     /** The key of the message: Deleted {0} file. */
     public static final String SUCCESS_delete_file = "{success.delete_file}";
 
-    /** The key of the message: Started job {0}. */
+    /** The key of the message: Started a job: {0}. */
     public static final String SUCCESS_job_started = "{success.job_started}";
 
-    /** The key of the message: Stopped job {0}. */
+    /** The key of the message: Stopped a job: {0}. */
     public static final String SUCCESS_job_stopped = "{success.job_stopped}";
 
-    /** The key of the message: Uploaded Synonym file. */
+    /** The key of the message: Uploaded a synonym file. */
     public static final String SUCCESS_upload_synonym_file = "{success.upload_synonym_file}";
 
-    /** The key of the message: Uploaded Protwords file. */
+    /** The key of the message: Uploaded a protwords file. */
     public static final String SUCCESS_upload_protwords_file = "{success.upload_protwords_file}";
 
-    /** The key of the message: Uploaded Stopwords file. */
+    /** The key of the message: Uploaded a stopwords file. */
     public static final String SUCCESS_upload_stopwords_file = "{success.upload_stopwords_file}";
 
-    /** The key of the message: Uploaded Stemmer Override file. */
+    /** The key of the message: Uploaded a stemmer override file. */
     public static final String SUCCESS_upload_stemmeroverride_file = "{success.upload_stemmeroverride_file}";
 
-    /** The key of the message: Uploaded Kuromoji file. */
+    /** The key of the message: Uploaded a Kuromoji file. */
     public static final String SUCCESS_upload_kuromoji_file = "{success.upload_kuromoji_file}";
 
-    /** The key of the message: Uploaded Additional Word file. */
+    /** The key of the message: Uploaded an elevate word file. */
     public static final String SUCCESS_upload_elevate_word = "{success.upload_elevate_word}";
 
-    /** The key of the message: Uploaded Bad Word file. */
+    /** The key of the message: Uploaded a bad word file. */
     public static final String SUCCESS_upload_bad_word = "{success.upload_bad_word}";
 
-    /** The key of the message: Uploaded Mapping file. */
+    /** The key of the message: Uploaded a mapping file. */
     public static final String SUCCESS_upload_mapping_file = "{success.upload_mapping_file}";
 
-    /** The key of the message: Sent the test mail. */
+    /** The key of the message: Sent a test mail. */
     public static final String SUCCESS_send_testmail = "{success.send_testmail}";
 
     /** The key of the message: Deleted job logs. */
@@ -506,40 +506,40 @@ public class FessMessages extends FessLabels {
     /** The key of the message: Changed your password. */
     public static final String SUCCESS_changed_password = "{success.changed_password}";
 
-    /** The key of the message: Started data update process. */
+    /** The key of the message: Started a data update process. */
     public static final String SUCCESS_started_data_update = "{success.started_data_update}";
 
-    /** The key of the message: Started reindexing. */
+    /** The key of the message: Started re-indexing. */
     public static final String SUCCESS_reindex_started = "{success.reindex_started}";
 
-    /** The key of the message: Bulk process is started. */
+    /** The key of the message: Started a bulk process. */
     public static final String SUCCESS_bulk_process_started = "{success.bulk_process_started}";
 
-    /** The key of the message: Printed thread dump to log file. */
+    /** The key of the message: Printed a thread dump to a log file. */
     public static final String SUCCESS_print_thread_dump = "{success.print_thread_dump}";
 
-    /** The key of the message: Installing {0} plugin. */
+    /** The key of the message: Installing plugin {0}. */
     public static final String SUCCESS_install_plugin = "{success.install_plugin}";
 
-    /** The key of the message: Deleting {0} plugin. */
+    /** The key of the message: Deleting plugin {0}. */
     public static final String SUCCESS_delete_plugin = "{success.delete_plugin}";
 
-    /** The key of the message: Uploaded {0} */
+    /** The key of the message: Uploaded {0}. */
     public static final String SUCCESS_upload_file_to_storage = "{success.upload_file_to_storage}";
 
-    /** The key of the message: Logged out. */
+    /** The key of the message: You have been logged out. */
     public static final String SUCCESS_sso_logout = "{success.sso_logout}";
 
-    /** The key of the message: Updated tags for {0}. */
+    /** The key of the message: Updated tags of {0}. */
     public static final String SUCCESS_update_storage_tags = "{success.update_storage_tags}";
 
-    /** The key of the message: Created data. */
+    /** The key of the message: Created the data. */
     public static final String SUCCESS_crud_create_crud_table = "{success.crud_create_crud_table}";
 
-    /** The key of the message: Updated data. */
+    /** The key of the message: Updated the data. */
     public static final String SUCCESS_crud_update_crud_table = "{success.crud_update_crud_table}";
 
-    /** The key of the message: Deleted data. */
+    /** The key of the message: Deleted the data. */
     public static final String SUCCESS_crud_delete_crud_table = "{success.crud_delete_crud_table}";
 
     /**
@@ -685,7 +685,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.DecimalMax.message' with parameters.
      * <pre>
-     * message: {item} must be less than ${inclusive == true ? 'or equal to ' : ''}{value}.
+     * message: {item} must be less than {value}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param value The parameter value for message. (NotNull)
@@ -700,7 +700,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.DecimalMin.message' with parameters.
      * <pre>
-     * message: {item} must be greater than ${inclusive == true ? 'or equal to ' : ''}{value}.
+     * message: {item} must be greater than {value}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param value The parameter value for message. (NotNull)
@@ -715,23 +715,21 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.Digits.message' with parameters.
      * <pre>
-     * message: {item} is numeric value out of bounds (&lt;{integer} digits&gt;.&lt;{fraction} digits&gt; expected).
+     * message: {item} must be a number. (expected: &lt;number&gt;.&lt;number&gt;)
      * </pre>
      * @param property The property name for the message. (NotNull)
-     * @param fraction The parameter fraction for message. (NotNull)
-     * @param integer The parameter integer for message. (NotNull)
      * @return this. (NotNull)
      */
-    public FessMessages addConstraintsDigitsMessage(String property, String fraction, String integer) {
+    public FessMessages addConstraintsDigitsMessage(String property) {
         assertPropertyNotNull(property);
-        add(property, new UserMessage(CONSTRAINTS_Digits_MESSAGE, fraction, integer));
+        add(property, new UserMessage(CONSTRAINTS_Digits_MESSAGE));
         return this;
     }
 
     /**
      * Add the created action message for the key 'constraints.Future.message' with parameters.
      * <pre>
-     * message: {item} must be in the future.
+     * message: {item} must be a future value.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -775,7 +773,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.NotNull.message' with parameters.
      * <pre>
-     * message: {item} may not be null.
+     * message: {item} is required.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -803,7 +801,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.Past.message' with parameters.
      * <pre>
-     * message: {item} must be in the past.
+     * message: {item} must be a past value.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -817,7 +815,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.Pattern.message' with parameters.
      * <pre>
-     * message: {item} must match "{regexp}".
+     * message: {item} does not match "{regexp}".
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param regexp The parameter regexp for message. (NotNull)
@@ -832,7 +830,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.Size.message' with parameters.
      * <pre>
-     * message: Size of {item} must be between {min} and {max}.
+     * message: The size of {item} must be between {min} and {max}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param min The parameter min for message. (NotNull)
@@ -848,7 +846,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.CreditCardNumber.message' with parameters.
      * <pre>
-     * message: {item} is invalid credit card number.
+     * message: {item} is an invalid credit card number.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -862,7 +860,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.EAN.message' with parameters.
      * <pre>
-     * message: {item} is invalid {type} barcode.
+     * message: {item} is an invalid {type} barcode.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param type The parameter type for message. (NotNull)
@@ -877,7 +875,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.Email.message' with parameters.
      * <pre>
-     * message: {item} is not a well-formed email address.
+     * message: {item} is not a valid email address.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -891,7 +889,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.Length.message' with parameters.
      * <pre>
-     * message: Length of {item} must be between {min} and {max}.
+     * message: The length of {item} must be between {min} and {max}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param min The parameter min for message. (NotNull)
@@ -907,7 +905,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.LuhnCheck.message' with parameters.
      * <pre>
-     * message: The check digit for ${value} is invalid, Luhn Modulo 10 checksum failed.
+     * message: The Luhn Modulo 11 checksum of {value} is incorrect.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param value The parameter value for message. (NotNull)
@@ -922,7 +920,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.Mod10Check.message' with parameters.
      * <pre>
-     * message: The check digit for ${value} is invalid, Modulo 10 checksum failed.
+     * message: The Modulo 10 checksum of {value} is incorrect.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param value The parameter value for message. (NotNull)
@@ -937,7 +935,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.Mod11Check.message' with parameters.
      * <pre>
-     * message: The check digit for ${value} is invalid, Modulo 11 checksum failed.
+     * message: The Modulo 11 checksum of {value} is incorrect.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param value The parameter value for message. (NotNull)
@@ -952,7 +950,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.ModCheck.message' with parameters.
      * <pre>
-     * message: The check digit for ${value} is invalid, ${modType} checksum failed.
+     * message: The {modType} checksum of {value} is incorrect.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param modType The parameter modType for message. (NotNull)
@@ -968,7 +966,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.NotBlank.message' with parameters.
      * <pre>
-     * message: {item} may not be empty.
+     * message: {item} is required.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -982,7 +980,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.NotEmpty.message' with parameters.
      * <pre>
-     * message: {item} may not be empty.
+     * message: {item} is required.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -996,7 +994,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.ParametersScriptAssert.message' with parameters.
      * <pre>
-     * message: script expression "{script}" didn't evaluate to true.
+     * message: The script expression "{script}" is not true.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param script The parameter script for message. (NotNull)
@@ -1027,7 +1025,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.SafeHtml.message' with parameters.
      * <pre>
-     * message: {item} may have unsafe html content.
+     * message: {item} contains unsafe HTML content.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1041,7 +1039,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.ScriptAssert.message' with parameters.
      * <pre>
-     * message: script expression "{script}" didn't evaluate to true.
+     * message: The script expression "{script}" is not true.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param script The parameter script for message. (NotNull)
@@ -1056,7 +1054,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.URL.message' with parameters.
      * <pre>
-     * message: {item} must be a valid URL.
+     * message: {item} is not a valid URL.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1084,7 +1082,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.TypeInteger.message' with parameters.
      * <pre>
-     * message: {item} should be numeric.
+     * message: {item} must be a number.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1098,7 +1096,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.TypeLong.message' with parameters.
      * <pre>
-     * message: {item} should be numeric.
+     * message: {item} must be a number.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1112,7 +1110,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.TypeFloat.message' with parameters.
      * <pre>
-     * message: {item} should be numeric.
+     * message: {item} must be a number.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1126,7 +1124,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.TypeDouble.message' with parameters.
      * <pre>
-     * message: {item} should be numeric.
+     * message: {item} must be a number.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1140,7 +1138,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.TypeAny.message' with parameters.
      * <pre>
-     * message: {item} cannot convert as {propertyType}.
+     * message: {item} cannot be converted to {propertyType}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param propertyType The parameter propertyType for message. (NotNull)
@@ -1155,7 +1153,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.UriType.message' with parameters.
      * <pre>
-     * message: {item} has wrong URI.
+     * message: {item} has an unrecognized URI.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1169,7 +1167,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'constraints.CronExpression.message' with parameters.
      * <pre>
-     * message: {item} is invalid cron expression.
+     * message: {item} is not a valid CRON expression.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1201,7 +1199,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.app.illegal.transition' with parameters.
      * <pre>
-     * message: Please retry because of illegal transition.
+     * message: Illegal transition. Please try again.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1215,7 +1213,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.app.db.already.deleted' with parameters.
      * <pre>
-     * message: others might be updated, so retry.
+     * message: It may have been deleted by another process. Please try again.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1229,7 +1227,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.app.db.already.updated' with parameters.
      * <pre>
-     * message: others might be updated, so retry.
+     * message: It may have been updated by another process. Please try again.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1243,7 +1241,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.app.db.already.exists' with parameters.
      * <pre>
-     * message: already existing data, so retry.
+     * message: The data already exists. Please try again.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1257,7 +1255,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.app.double.submit.request' with parameters.
      * <pre>
-     * message: Your request might have been processed before this request. Please check and retry it.
+     * message: It may have been processed before this request. Please try again.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1271,7 +1269,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.login_error' with parameters.
      * <pre>
-     * message: Username or Password is not correct.
+     * message: Invalid username or password.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1285,7 +1283,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.sso_login_error' with parameters.
      * <pre>
-     * message: Failed to process SSO login.
+     * message: SSO login process failed.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1342,7 +1340,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.design_jsp_file_does_not_exist' with parameters.
      * <pre>
-     * message: JSP file does not exist.
+     * message: The JSP file does not exist.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1384,7 +1382,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_update_jsp_file' with parameters.
      * <pre>
-     * message: Failed to update a jsp file.
+     * message: Failed to update the JSP file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1412,7 +1410,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.design_file_is_unsupported_type' with parameters.
      * <pre>
-     * message: The kind of file is unsupported.
+     * message: This file type is unsupported.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1426,7 +1424,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_create_crawling_config_at_wizard' with parameters.
      * <pre>
-     * message: Failed to create a crawling config.
+     * message: Failed to create a crawling config at a wizard.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1454,7 +1452,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.not_found_on_file_system' with parameters.
      * <pre>
-     * message: Not Found: {0}
+     * message: Not found. Cause: {0}
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1469,7 +1467,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.could_not_open_on_system' with parameters.
      * <pre>
-     * message: Could not open {0}. &lt;br/&gt;Please check if the file is associated with an application.
+     * message: Could not open {0}.&lt;br&gt;Please check if the file is associated with an application.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1484,7 +1482,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.result_size_exceeded' with parameters.
      * <pre>
-     * message: No more results could be displayed.
+     * message: No more results can be displayed.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1498,7 +1496,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.target_file_does_not_exist' with parameters.
      * <pre>
-     * message: {0} file does not exist.
+     * message: The file {0} does not exist.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1513,7 +1511,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_delete_file' with parameters.
      * <pre>
-     * message: Failed to delete {0} file.
+     * message: Failed to delete the file {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1528,7 +1526,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.docid_not_found' with parameters.
      * <pre>
-     * message: Not found Doc ID:{0}
+     * message: Doc ID is not found. Cause: {0}
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1543,7 +1541,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.document_not_found' with parameters.
      * <pre>
-     * message: Not found URL of Doc ID:{0}
+     * message: The URL for the document ID is not found. Cause: {0}
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1558,7 +1556,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.not_load_from_server' with parameters.
      * <pre>
-     * message: Could not load from this server: {0}
+     * message: Could not load from this server. Cause: {0}
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1573,7 +1571,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_start_job' with parameters.
      * <pre>
-     * message: Failed to start job {0}.
+     * message: Failed to start a job: {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1588,7 +1586,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_stop_job' with parameters.
      * <pre>
-     * message: Failed to stop job {0}.
+     * message: Failed to stop a job: {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1603,7 +1601,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_download_synonym_file' with parameters.
      * <pre>
-     * message: Failed to download the Synonym file.
+     * message: Failed to download a synonym file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1617,7 +1615,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_upload_synonym_file' with parameters.
      * <pre>
-     * message: Failed to upload the Synonym file.
+     * message: Failed to upload a synonym file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1631,7 +1629,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_download_stemmeroverride_file' with parameters.
      * <pre>
-     * message: Failed to download the Stemmer Override file.
+     * message: Failed to download a stemmer override file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1645,7 +1643,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_upload_stemmeroverride_file' with parameters.
      * <pre>
-     * message: Failed to upload the Stemmer Override file.
+     * message: Failed to upload a stemmer override file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1659,7 +1657,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_download_kuromoji_file' with parameters.
      * <pre>
-     * message: Failed to download the Kuromoji file.
+     * message: Failed to download a Kuromoji file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1673,7 +1671,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_upload_kuromoji_file' with parameters.
      * <pre>
-     * message: Failed to upload the Kuromoji file.
+     * message: Failed to upload a Kuromoji file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1687,7 +1685,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_download_protwords_file' with parameters.
      * <pre>
-     * message: Failed to download the Protwords file.
+     * message: Failed to download a protwords file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1701,7 +1699,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_upload_protwords_file' with parameters.
      * <pre>
-     * message: Failed to upload the Protwords file.
+     * message: Failed to upload a protwords file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1715,7 +1713,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_download_stopwords_file' with parameters.
      * <pre>
-     * message: Failed to download the Stopwords file.
+     * message: Failed to download a stopwords file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1729,7 +1727,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_upload_stopwords_file' with parameters.
      * <pre>
-     * message: Failed to upload the Stopwords file.
+     * message: Failed to upload a stopwords file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1743,7 +1741,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_download_elevate_file' with parameters.
      * <pre>
-     * message: Failed to download the Elevate file.
+     * message: Failed to download an elevate word file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1757,7 +1755,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_upload_elevate_file' with parameters.
      * <pre>
-     * message: Failed to upload the Elevate file.
+     * message: Failed to upload an elevate word file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1771,7 +1769,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_download_badword_file' with parameters.
      * <pre>
-     * message: Failed to download the Badword file.
+     * message: Failed to download a bad word file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1785,7 +1783,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_upload_badword_file' with parameters.
      * <pre>
-     * message: Failed to upload the Badword file.
+     * message: Failed to upload a bad word file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1799,7 +1797,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_download_mapping_file' with parameters.
      * <pre>
-     * message: Failed to download the Mapping file.
+     * message: Failed to download a mapping file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1813,7 +1811,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_upload_mapping_file' with parameters.
      * <pre>
-     * message: Failed to upload the Mapping file.
+     * message: Failed to upload a mapping file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1827,7 +1825,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.invalid_kuromoji_token' with parameters.
      * <pre>
-     * message: {0} is invalid.
+     * message: {0} is invalid as a token.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1842,7 +1840,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.invalid_kuromoji_segmentation' with parameters.
      * <pre>
-     * message: The number of segmentations {0} does not the match number of readings {1}.
+     * message: The number of segmentation for {0} and {1} is different.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1858,7 +1856,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.invalid_str_is_included' with parameters.
      * <pre>
-     * message: "{1}" in "{0}" is invalid.
+     * message: {1} is invalid for {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -1888,7 +1886,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.invalid_confirm_password' with parameters.
      * <pre>
-     * message: Confirm Password does not match.
+     * message: Does not match a confirmation password.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1902,7 +1900,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.cannot_delete_doc_because_of_running' with parameters.
      * <pre>
-     * message: Crawler is running. The document cannot be deleted.
+     * message: A crawler is running. You cannot delete documents.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1916,7 +1914,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_delete_doc_in_admin' with parameters.
      * <pre>
-     * message: Failed to delete document.
+     * message: Failed to delete a document.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1930,7 +1928,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.failed_to_send_testmail' with parameters.
      * <pre>
-     * message: Failed to send the test mail.
+     * message: Failed to send a test mail.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -1942,243 +1940,9 @@ public class FessMessages extends FessLabels {
     }
 
     /**
-     * Add the created action message for the key 'errors.could_not_find_backup_index' with parameters.
-     * <pre>
-     * message: Could not find index for backup.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsCouldNotFindBackupIndex(String property) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_could_not_find_backup_index));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.no_user_for_changing_password' with parameters.
-     * <pre>
-     * message: The current password is incorrect.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsNoUserForChangingPassword(String property) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_no_user_for_changing_password));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.failed_to_change_password' with parameters.
-     * <pre>
-     * message: Failed to change your password.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFailedToChangePassword(String property) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_failed_to_change_password));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.unknown_version_for_upgrade' with parameters.
-     * <pre>
-     * message: Unknown version information.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsUnknownVersionForUpgrade(String property) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_unknown_version_for_upgrade));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.failed_to_upgrade_from' with parameters.
-     * <pre>
-     * message: Failed to upgrade from {0}: {1}
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @param arg0 The parameter arg0 for message. (NotNull)
-     * @param arg1 The parameter arg1 for message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFailedToUpgradeFrom(String property, String arg0, String arg1) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_failed_to_upgrade_from, arg0, arg1));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.failed_to_reindex' with parameters.
-     * <pre>
-     * message: Failed to start reindexing from {0} to {1}
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @param arg0 The parameter arg0 for message. (NotNull)
-     * @param arg1 The parameter arg1 for message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFailedToReindex(String property, String arg0, String arg1) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_failed_to_reindex, arg0, arg1));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.failed_to_read_request_file' with parameters.
-     * <pre>
-     * message: Failed to read request file: {0}
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @param arg0 The parameter arg0 for message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFailedToReadRequestFile(String property, String arg0) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_failed_to_read_request_file, arg0));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.invalid_header_for_request_file' with parameters.
-     * <pre>
-     * message: Invalid header: {0}
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @param arg0 The parameter arg0 for message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsInvalidHeaderForRequestFile(String property, String arg0) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_invalid_header_for_request_file, arg0));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.could_not_delete_logged_in_user' with parameters.
-     * <pre>
-     * message: Could not delete logged in user.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsCouldNotDeleteLoggedInUser(String property) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_could_not_delete_logged_in_user));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.unauthorized_request' with parameters.
-     * <pre>
-     * message: Unauthorized request.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsUnauthorizedRequest(String property) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_unauthorized_request));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.failed_to_print_thread_dump' with parameters.
-     * <pre>
-     * message: Failed to print thread dump.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFailedToPrintThreadDump(String property) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_failed_to_print_thread_dump));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.file_is_not_supported' with parameters.
-     * <pre>
-     * message: {0} is not supported.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @param arg0 The parameter arg0 for message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFileIsNotSupported(String property, String arg0) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_file_is_not_supported, arg0));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.plugin_file_is_not_found' with parameters.
-     * <pre>
-     * message: {0} is not found.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @param arg0 The parameter arg0 for message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsPluginFileIsNotFound(String property, String arg0) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_plugin_file_is_not_found, arg0));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.failed_to_install_plugin' with parameters.
-     * <pre>
-     * message: Failed to install {0}.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @param arg0 The parameter arg0 for message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFailedToInstallPlugin(String property, String arg0) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_failed_to_install_plugin, arg0));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.failed_to_find_plugins' with parameters.
-     * <pre>
-     * message: Failed to access available plugins.
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFailedToFindPlugins(String property) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_failed_to_find_plugins));
-        return this;
-    }
-
-    /**
-     * Add the created action message for the key 'errors.failed_to_process_sso_request' with parameters.
-     * <pre>
-     * message: Failed to process the request: {0}
-     * </pre>
-     * @param property The property name for the message. (NotNull)
-     * @param arg0 The parameter arg0 for message. (NotNull)
-     * @return this. (NotNull)
-     */
-    public FessMessages addErrorsFailedToProcessSsoRequest(String property, String arg0) {
-        assertPropertyNotNull(property);
-        add(property, new UserMessage(ERRORS_failed_to_process_sso_request, arg0));
-        return this;
-    }
-
-    /**
      * Add the created action message for the key 'errors.invalid_query_unknown' with parameters.
      * <pre>
-     * message: The given query has unknown condition.
+     * message: The specified query has an unknown condition.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2206,7 +1970,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.invalid_query_sort_value' with parameters.
      * <pre>
-     * message: The given sort ({0}) is invalid.
+     * message: The specified sort {0} is invalid.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2221,7 +1985,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.invalid_query_unsupported_sort_field' with parameters.
      * <pre>
-     * message: The given sort ({0}) is not supported.
+     * message: The specified sort {0} is unsupported.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2236,7 +2000,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.invalid_query_unsupported_sort_order' with parameters.
      * <pre>
-     * message: The given sort order ({0}) is not supported.
+     * message: The specified sort order {0} is unsupported.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2251,7 +2015,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.invalid_query_cannot_process' with parameters.
      * <pre>
-     * message: The given query could not be processed.
+     * message: Could not process the specified query.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2265,7 +2029,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.crud_invalid_mode' with parameters.
      * <pre>
-     * message: Invalid mode(expected value is {0}, but it's {1}).
+     * message: The mode is incorrect. (not {0}, but {1})
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2340,7 +2104,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.crud_could_not_find_crud_table' with parameters.
      * <pre>
-     * message: Could not find the data({0}).
+     * message: The data {0} is not found.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2349,6 +2113,239 @@ public class FessMessages extends FessLabels {
     public FessMessages addErrorsCrudCouldNotFindCrudTable(String property, String arg0) {
         assertPropertyNotNull(property);
         add(property, new UserMessage(ERRORS_crud_could_not_find_crud_table, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.could_not_find_backup_index' with parameters.
+     * <pre>
+     * message: Could not find any backup index.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsCouldNotFindBackupIndex(String property) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_could_not_find_backup_index));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.no_user_for_changing_password' with parameters.
+     * <pre>
+     * message: The current password is not correct.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsNoUserForChangingPassword(String property) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_no_user_for_changing_password));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.failed_to_change_password' with parameters.
+     * <pre>
+     * message: Failed to change your password.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFailedToChangePassword(String property) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_failed_to_change_password));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.unknown_version_for_upgrade' with parameters.
+     * <pre>
+     * message: Unknown version for upgrade.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsUnknownVersionForUpgrade(String property) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_unknown_version_for_upgrade));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.failed_to_upgrade_from' with parameters.
+     * <pre>
+     * message: Failed to upgrade from {0}.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFailedToUpgradeFrom(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_failed_to_upgrade_from, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.failed_to_reindex' with parameters.
+     * <pre>
+     * message: Failed to start re-indexing from {0} to {1}.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @param arg1 The parameter arg1 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFailedToReindex(String property, String arg0, String arg1) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_failed_to_reindex, arg0, arg1));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.failed_to_read_request_file' with parameters.
+     * <pre>
+     * message: Failed to read a request file: {0}
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFailedToReadRequestFile(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_failed_to_read_request_file, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.invalid_header_for_request_file' with parameters.
+     * <pre>
+     * message: Invalid header line: {0}
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsInvalidHeaderForRequestFile(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_invalid_header_for_request_file, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.could_not_delete_logged_in_user' with parameters.
+     * <pre>
+     * message: You cannot delete a user who is logged in.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsCouldNotDeleteLoggedInUser(String property) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_could_not_delete_logged_in_user));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.unauthorized_request' with parameters.
+     * <pre>
+     * message: Unauthorized request.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsUnauthorizedRequest(String property) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_unauthorized_request));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.failed_to_print_thread_dump' with parameters.
+     * <pre>
+     * message: Failed to print a thread dump.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFailedToPrintThreadDump(String property) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_failed_to_print_thread_dump));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.file_is_not_supported' with parameters.
+     * <pre>
+     * message: {0} is not supported.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFileIsNotSupported(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_file_is_not_supported, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.plugin_file_is_not_found' with parameters.
+     * <pre>
+     * message: {0} is not found.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsPluginFileIsNotFound(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_plugin_file_is_not_found, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.failed_to_install_plugin' with parameters.
+     * <pre>
+     * message: Failed to install {0}.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFailedToInstallPlugin(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_failed_to_install_plugin, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.failed_to_find_plugins' with parameters.
+     * <pre>
+     * message: Could not find available plugins.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFailedToFindPlugins(String property) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_failed_to_find_plugins));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.failed_to_process_sso_request' with parameters.
+     * <pre>
+     * message: Failed to process a request: {0}
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsFailedToProcessSsoRequest(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_failed_to_process_sso_request, arg0));
         return this;
     }
 
@@ -2370,7 +2367,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.property_type_integer' with parameters.
      * <pre>
-     * message: {0} should be numeric.
+     * message: {0} must be an integer.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2385,7 +2382,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.property_type_long' with parameters.
      * <pre>
-     * message: {0} should be numeric.
+     * message: {0} must be a long.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2400,7 +2397,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.property_type_float' with parameters.
      * <pre>
-     * message: {0} should be numeric.
+     * message: {0} must be a float.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2415,7 +2412,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.property_type_double' with parameters.
      * <pre>
-     * message: {0} should be numeric.
+     * message: {0} must be a double.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2430,7 +2427,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.property_type_date' with parameters.
      * <pre>
-     * message: {0} should be date.
+     * message: {0} must be a date.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2460,7 +2457,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.storage_file_not_found' with parameters.
      * <pre>
-     * message: The target file is not found in Storage.
+     * message: The target file does not exist in the storage.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2489,7 +2486,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.storage_access_error' with parameters.
      * <pre>
-     * message: Storage access error: {0}
+     * message: Storage Access Error: {0}
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2504,7 +2501,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.storage_no_upload_file' with parameters.
      * <pre>
-     * message: Upload file is required.
+     * message: Please specify a file to upload.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2518,7 +2515,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.storage_directory_name_is_invalid' with parameters.
      * <pre>
-     * message: Directory name is invalid.
+     * message: The directory name is invalid.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2532,7 +2529,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'errors.storage_tags_update_failure' with parameters.
      * <pre>
-     * message: Failed to update tags for {0}
+     * message: Failed to update tags of {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2561,7 +2558,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.delete_doc_from_index' with parameters.
      * <pre>
-     * message: Started a process to delete the document from index.
+     * message: Started a process to delete documents from an index.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2603,7 +2600,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_design_file' with parameters.
      * <pre>
-     * message: Uploaded {0}.
+     * message: Updated {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2633,7 +2630,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.create_crawling_config_at_wizard' with parameters.
      * <pre>
-     * message: Created a crawling config ({0}).
+     * message: Created a crawling config {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2648,7 +2645,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.failure_url_delete_all' with parameters.
      * <pre>
-     * message: Deleted failure urls.
+     * message: Deleted failure URLs.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2677,7 +2674,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.job_started' with parameters.
      * <pre>
-     * message: Started job {0}.
+     * message: Started a job: {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2692,7 +2689,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.job_stopped' with parameters.
      * <pre>
-     * message: Stopped job {0}.
+     * message: Stopped a job: {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2707,7 +2704,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_synonym_file' with parameters.
      * <pre>
-     * message: Uploaded Synonym file.
+     * message: Uploaded a synonym file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2721,7 +2718,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_protwords_file' with parameters.
      * <pre>
-     * message: Uploaded Protwords file.
+     * message: Uploaded a protwords file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2735,7 +2732,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_stopwords_file' with parameters.
      * <pre>
-     * message: Uploaded Stopwords file.
+     * message: Uploaded a stopwords file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2749,7 +2746,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_stemmeroverride_file' with parameters.
      * <pre>
-     * message: Uploaded Stemmer Override file.
+     * message: Uploaded a stemmer override file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2763,7 +2760,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_kuromoji_file' with parameters.
      * <pre>
-     * message: Uploaded Kuromoji file.
+     * message: Uploaded a Kuromoji file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2777,7 +2774,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_elevate_word' with parameters.
      * <pre>
-     * message: Uploaded Additional Word file.
+     * message: Uploaded an elevate word file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2791,7 +2788,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_bad_word' with parameters.
      * <pre>
-     * message: Uploaded Bad Word file.
+     * message: Uploaded a bad word file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2805,7 +2802,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_mapping_file' with parameters.
      * <pre>
-     * message: Uploaded Mapping file.
+     * message: Uploaded a mapping file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2819,7 +2816,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.send_testmail' with parameters.
      * <pre>
-     * message: Sent the test mail.
+     * message: Sent a test mail.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2861,7 +2858,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.started_data_update' with parameters.
      * <pre>
-     * message: Started data update process.
+     * message: Started a data update process.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2875,7 +2872,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.reindex_started' with parameters.
      * <pre>
-     * message: Started reindexing.
+     * message: Started re-indexing.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2889,7 +2886,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.bulk_process_started' with parameters.
      * <pre>
-     * message: Bulk process is started.
+     * message: Started a bulk process.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2903,7 +2900,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.print_thread_dump' with parameters.
      * <pre>
-     * message: Printed thread dump to log file.
+     * message: Printed a thread dump to a log file.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2917,7 +2914,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.install_plugin' with parameters.
      * <pre>
-     * message: Installing {0} plugin.
+     * message: Installing plugin {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2932,7 +2929,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.delete_plugin' with parameters.
      * <pre>
-     * message: Deleting {0} plugin.
+     * message: Deleting plugin {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2947,7 +2944,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.upload_file_to_storage' with parameters.
      * <pre>
-     * message: Uploaded {0}
+     * message: Uploaded {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2962,7 +2959,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.sso_logout' with parameters.
      * <pre>
-     * message: Logged out.
+     * message: You have been logged out.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -2976,7 +2973,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.update_storage_tags' with parameters.
      * <pre>
-     * message: Updated tags for {0}.
+     * message: Updated tags of {0}.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @param arg0 The parameter arg0 for message. (NotNull)
@@ -2991,7 +2988,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.crud_create_crud_table' with parameters.
      * <pre>
-     * message: Created data.
+     * message: Created the data.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -3005,7 +3002,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.crud_update_crud_table' with parameters.
      * <pre>
-     * message: Updated data.
+     * message: Updated the data.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)
@@ -3019,7 +3016,7 @@ public class FessMessages extends FessLabels {
     /**
      * Add the created action message for the key 'success.crud_delete_crud_table' with parameters.
      * <pre>
-     * message: Deleted data.
+     * message: Deleted the data.
      * </pre>
      * @param property The property name for the message. (NotNull)
      * @return this. (NotNull)

--- a/src/main/resources/fess_message.properties
+++ b/src/main/resources/fess_message.properties
@@ -144,6 +144,7 @@ errors.failed_to_reindex=Failed to start re-indexing from {0} to {1}.
 errors.failed_to_read_request_file=Failed to read a request file: {0}
 errors.invalid_header_for_request_file=Invalid header line: {0}
 errors.could_not_delete_logged_in_user=You cannot delete a user who is logged in.
+errors.unauthorized_request=Unauthorized request.
 errors.failed_to_print_thread_dump=Failed to print a thread dump.
 errors.file_is_not_supported={0} is not supported.
 errors.plugin_file_is_not_found={0} is not found.

--- a/src/main/resources/fess_message_de.properties
+++ b/src/main/resources/fess_message_de.properties
@@ -140,6 +140,7 @@ errors.failed_to_reindex=Fehler beim Starten der Neuindizierung von {0} nach {1}
 errors.failed_to_read_request_file=Fehler beim Lesen einer Anforderungsdatei: {0}
 errors.invalid_header_for_request_file=Ungültige Header-Zeile: {0}
 errors.could_not_delete_logged_in_user=Sie können keinen angemeldeten Benutzer löschen.
+errors.unauthorized_request=Unautorisierte Anfrage.
 errors.failed_to_print_thread_dump=Fehler beim Drucken eines Thread-Dumps.
 errors.file_is_not_supported={0} wird nicht unterstützt.
 errors.plugin_file_is_not_found={0} wurde nicht gefunden.

--- a/src/main/resources/fess_message_en.properties
+++ b/src/main/resources/fess_message_en.properties
@@ -140,6 +140,7 @@ errors.failed_to_reindex=Failed to start re-indexing from {0} to {1}.
 errors.failed_to_read_request_file=Failed to read a request file: {0}
 errors.invalid_header_for_request_file=Invalid header line: {0}
 errors.could_not_delete_logged_in_user=You cannot delete a user who is logged in.
+errors.unauthorized_request=Unauthorized request.
 errors.failed_to_print_thread_dump=Failed to print a thread dump.
 errors.file_is_not_supported={0} is not supported.
 errors.plugin_file_is_not_found={0} is not found.

--- a/src/main/resources/fess_message_fr.properties
+++ b/src/main/resources/fess_message_fr.properties
@@ -140,6 +140,7 @@ errors.failed_to_reindex=Échec du démarrage de la réindexation de {0} à {1}.
 errors.failed_to_read_request_file=Échec de la lecture d'un fichier de requête : {0}
 errors.invalid_header_for_request_file=Ligne d'en-tête non valide : {0}
 errors.could_not_delete_logged_in_user=Vous ne pouvez pas supprimer un utilisateur connecté.
+errors.unauthorized_request=Requête non autorisée.
 errors.failed_to_print_thread_dump=Échec de l'impression d'un vidage de thread.
 errors.file_is_not_supported={0} n'est pas pris en charge.
 errors.plugin_file_is_not_found={0} est introuvable.

--- a/src/main/resources/fess_message_ko.properties
+++ b/src/main/resources/fess_message_ko.properties
@@ -140,6 +140,7 @@ errors.failed_to_reindex={0}에서 {1}(으)로 다시 색인화하지 못했습�
 errors.failed_to_read_request_file=요청 파일을 읽지 못했습니다: {0}
 errors.invalid_header_for_request_file=잘못된 헤더 줄: {0}
 errors.could_not_delete_logged_in_user=로그인한 사용자는 삭제할 수 없습니다.
+errors.unauthorized_request=권한이 없는 요청입니다.
 errors.failed_to_print_thread_dump=스레드 덤프를 인쇄하지 못했습니다.
 errors.file_is_not_supported={0}은(는) 지원되지 않습니다.
 errors.plugin_file_is_not_found={0}을(를) 찾을 수 없습니다.

--- a/src/main/resources/fess_message_ru.properties
+++ b/src/main/resources/fess_message_ru.properties
@@ -140,6 +140,7 @@ errors.failed_to_reindex=Не удалось начать переиндекса
 errors.failed_to_read_request_file=Не удалось прочитать файл запроса: {0}
 errors.invalid_header_for_request_file=Неверная строка заголовка: {0}
 errors.could_not_delete_logged_in_user=Вы не можете удалить пользователя, который вошел в систему.
+errors.unauthorized_request=Несанкционированный запрос.
 errors.failed_to_print_thread_dump=Не удалось распечатать дамп потока.
 errors.file_is_not_supported={0} не поддерживается.
 errors.plugin_file_is_not_found={0} не найден.


### PR DESCRIPTION
This pull request adds the missing errors.unauthorized_request message to all supported language resource files (fess_message.properties, fess_message_en.properties, fess_message_de.properties, fess_message_fr.properties, fess_message_ko.properties, and fess_message_ru.properties). This ensures consistent error message handling for unauthorized request scenarios across different locales.
