### PR TITLE
Preserve and Restore Search Parameters Using Cookies in SSO Flow

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/FessSearchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/FessSearchAction.java
@@ -233,6 +233,7 @@ public abstract class FessSearchAction extends FessBaseAction {
     }
 
     protected HtmlResponse redirectToLogin() {
+        searchHelper.storeSearchParameters();
         return systemHelper.getRedirectResponseToLogin(redirect(SsoAction.class));
     }
 

--- a/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
@@ -21,12 +21,15 @@ import org.codelibs.fess.app.web.RootAction;
 import org.codelibs.fess.app.web.base.FessLoginAction;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.app.web.login.LoginAction;
+import org.codelibs.fess.app.web.search.SearchAction;
+import org.codelibs.fess.entity.RequestParameter;
 import org.codelibs.fess.exception.SsoMessageException;
 import org.codelibs.fess.sso.SsoManager;
 import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
 import org.lastaflute.web.Execute;
+import org.lastaflute.web.UrlChain;
 import org.lastaflute.web.login.credential.LoginCredential;
 import org.lastaflute.web.login.exception.LoginFailureException;
 import org.lastaflute.web.response.ActionResponse;
@@ -44,6 +47,17 @@ public class SsoAction extends FessLoginAction {
     @Execute
     public ActionResponse index() {
         if (fessLoginAssist.getSavedUserBean().isPresent()) {
+            final RequestParameter[] searchParameters = searchHelper.getSearchParameters();
+            if (searchParameters.length > 0) {
+                final UrlChain chain = new UrlChain(this);
+                for (final RequestParameter param : searchParameters) {
+                    for (final String value : param.getValues()) {
+                        chain.params(param.getName(), value);
+                    }
+                }
+                return redirectWith(SearchAction.class, chain);
+
+            }
             return redirect(RootAction.class);
         }
         final SsoManager ssoManager = ComponentUtil.getSsoManager();

--- a/src/main/java/org/codelibs/fess/entity/RequestParameter.java
+++ b/src/main/java/org/codelibs/fess/entity/RequestParameter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.entity;
+
+import java.util.Arrays;
+
+public class RequestParameter {
+
+    private final String name;
+
+    private final String[] values;
+
+    public RequestParameter(final String name, final String[] values) {
+        this.name = name;
+        this.values = values;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String[] getValues() {
+        return values;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + name + ", " + Arrays.toString(values) + "]";
+    }
+}

--- a/src/main/java/org/codelibs/fess/helper/SearchHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SearchHelper.java
@@ -15,8 +15,14 @@
  */
 package org.codelibs.fess.helper;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,17 +34,23 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.exception.InterruptedRuntimeException;
 import org.codelibs.core.lang.StringUtil;
+import org.codelibs.core.stream.StreamUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.QueryContext;
+import org.codelibs.fess.entity.RequestParameter;
 import org.codelibs.fess.entity.SearchRenderData;
 import org.codelibs.fess.entity.SearchRequestParams;
 import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.exception.InvalidQueryException;
+import org.codelibs.fess.exception.SearchQueryException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.client.SearchEngineClient.SearchConditionBuilder;
@@ -53,6 +65,7 @@ import org.dbflute.optional.OptionalThing;
 import org.dbflute.util.DfTypeUtil;
 import org.lastaflute.taglib.function.LaFunctions;
 import org.lastaflute.web.util.LaRequestUtil;
+import org.lastaflute.web.util.LaResponseUtil;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteResponse.Result;
 import org.opensearch.action.bulk.BulkRequestBuilder;
@@ -63,6 +76,9 @@ import org.opensearch.common.document.DocumentField;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class SearchHelper {
@@ -376,6 +392,175 @@ public class SearchHelper {
     public void addRewriter(final SearchRequestParamsRewriter rewriter) {
         searchRequestParamsRewriters = Arrays.copyOf(searchRequestParamsRewriters, searchRequestParamsRewriters.length + 1);
         searchRequestParamsRewriters[searchRequestParamsRewriters.length - 1] = rewriter;
+    }
+
+    public void storeSearchParameters() {
+        LaRequestUtil.getOptionalRequest().ifPresent(req -> {
+            final FessConfig fessConfig = ComponentUtil.getFessConfig();
+            final String requiredKeysStr = fessConfig.getCookieSearchParameterRequiredKeys();
+            if (StringUtil.isNotBlank(requiredKeysStr) && StreamUtil.split(requiredKeysStr, ",")
+                    .get(stream -> stream.map(String::trim).filter(StringUtil::isNotEmpty).anyMatch(name -> {
+                        final String[] values = req.getParameterValues(name);
+                        if (values == null || values.length == 0 || StringUtil.isEmpty(values[0])) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Required parameter '{}' is missing or empty. Skip storing search parameters.", name);
+                            }
+                            return true;
+                        }
+                        return false;
+                    }))) {
+                return;
+            }
+            final String keysStr = fessConfig.getCookieSearchParameterKeys();
+            if (StringUtil.isNotBlank(keysStr)) {
+                final RequestParameter[] parameters = StreamUtil.split(keysStr, ",").get(stream -> stream.map(String::trim).map(s -> {
+                    if (StringUtil.isEmpty(s)) {
+                        return null;
+                    }
+                    final String[] values = req.getParameterValues(s);
+                    if (values == null || values.length == 0) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Parameter '{}' is not present or has no value.", s);
+                        }
+                        return null;
+                    }
+                    return new RequestParameter(s, values);
+                }).filter(o -> o != null).toArray(n -> new RequestParameter[n]));
+                if (parameters.length == 0) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("No valid parameters found in request. Nothing to store.");
+                    }
+                    return;
+                }
+                try {
+                    final String encoded = serializeParameters(parameters);
+                    if (encoded.length() > fessConfig.getCookieSearchParameterMaxLengthAsInteger()) {
+                        logger.warn("Encoded search parameters exceed the maximum cookie length: {} > {}. Skipping cookie storage.",
+                                encoded.length(), fessConfig.getCookieSearchParameterMaxLengthAsInteger());
+                        return;
+                    }
+                    LaResponseUtil.getOptionalResponse().ifPresent(res -> {
+                        final Cookie cookie = new Cookie(fessConfig.getCookieSearchParameterName(), encoded);
+                        cookie.setHttpOnly(Constants.TRUE.equalsIgnoreCase(fessConfig.getCookieSearchParameterHttpOnly()));
+                        final String secure = fessConfig.getCookieSearchParameterSecure();
+                        if (StringUtil.isBlank(secure)) {
+                            final String forwardedProto = req.getHeader("X-Forwarded-Proto");
+                            if ("https".equalsIgnoreCase(forwardedProto)) {
+                                cookie.setSecure(true);
+                            } else {
+                                cookie.setSecure(req.isSecure());
+                            }
+                        } else {
+                            cookie.setSecure(Constants.TRUE.equalsIgnoreCase(secure));
+                        }
+                        final String domain = fessConfig.getCookieSearchParameterDomain();
+                        if (StringUtil.isNotBlank(domain)) {
+                            cookie.setDomain(domain);
+                        }
+                        final String path = fessConfig.getCookieSearchParameterPath();
+                        if (StringUtil.isNotBlank(path)) {
+                            cookie.setPath(path);
+                        }
+                        cookie.setMaxAge(fessConfig.getCookieSearchParameterMaxAgeAsInteger());
+                        cookie.setAttribute("SameSite", fessConfig.getCookieSearchParameterSameSite());
+                        res.addCookie(cookie);
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Stored search parameters in cookie: name={}, size={}, maxAge={}, path={}, domain={}, secure={}, httpOnly={}, sameSite={}",
+                                    cookie.getName(), encoded.length(), cookie.getMaxAge(), cookie.getPath(), cookie.getDomain(),
+                                    cookie.getSecure(), cookie.isHttpOnly(), fessConfig.getCookieSearchParameterSameSite());
+                        }
+                    });
+                } catch (final Exception e) {
+                    logger.warn("Failed to store search parameters in cookie.", e);
+                }
+            }
+        });
+    }
+
+    protected String serializeParameters(final RequestParameter[] parameters) {
+        final ObjectMapper mapper = new ObjectMapper();
+        final List<Object[]> compactList = new ArrayList<>();
+        for (final RequestParameter p : parameters) {
+            compactList.add(new Object[] { p.getName(), p.getValues() });
+        }
+        try {
+            final String json = mapper.writeValueAsString(compactList);
+            final byte[] compressed = gzipCompress(json.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(compressed);
+        } catch (final Exception e) {
+            throw new SearchQueryException("Failed to serialize a query: " + Arrays.toString(parameters), e);
+        }
+    }
+
+    protected byte[] gzipCompress(final byte[] data) {
+        try (final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            try (final GZIPOutputStream gzipOut = new GZIPOutputStream(bos)) {
+                gzipOut.write(data);
+            }
+            return bos.toByteArray();
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+    }
+
+    public RequestParameter[] getSearchParameters() {
+        return LaRequestUtil.getOptionalRequest().map(req -> {
+            final FessConfig fessConfig = ComponentUtil.getFessConfig();
+            final String cookieName = fessConfig.getCookieSearchParameterName();
+            final Cookie[] cookies = req.getCookies();
+            if (cookies != null) {
+                for (final Cookie cookie : cookies) {
+                    if (cookieName.equals(cookie.getName())) {
+                        try {
+                            final String encoded = cookie.getValue();
+                            final byte[] compressed = Base64.getUrlDecoder().decode(encoded);
+                            final byte[] jsonBytes = gzipDecompress(compressed);
+                            final ObjectMapper mapper = new ObjectMapper();
+                            final List<?> list = mapper.readValue(jsonBytes, List.class);
+
+                            final List<RequestParameter> result = new ArrayList<>();
+                            for (Object item : list) {
+                                if (item instanceof List<?> pair) {
+                                    if (pair.size() == 2 && pair.get(0) instanceof String name
+                                            && pair.get(1) instanceof List<?> valueList) {
+                                        final String[] values =
+                                                valueList.stream().filter(v -> v instanceof String).toArray(n -> new String[n]);
+                                        result.add(new RequestParameter(name, values));
+                                    }
+                                }
+                            }
+                            LaResponseUtil.getOptionalResponse().ifPresent(res -> {
+                                final Cookie invalidCookie = new Cookie(fessConfig.getCookieSearchParameterName(), StringUtil.EMPTY);
+                                invalidCookie.setPath(fessConfig.getCookieSearchParameterPath());
+                                invalidCookie.setMaxAge(0);
+                                res.addCookie(invalidCookie);
+                            });
+                            return result.toArray(n -> new RequestParameter[n]);
+                        } catch (final Exception e) {
+                            logger.warn("Failed to deserialize search parameters from cookie.", e);
+                            return new RequestParameter[0];
+                        }
+                    }
+                }
+            }
+            return new RequestParameter[0];
+        }).orElse(new RequestParameter[0]);
+    }
+
+    protected byte[] gzipDecompress(final byte[] compressed) {
+        try (final ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
+                final GZIPInputStream gzipIn = new GZIPInputStream(bis);
+                final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            final byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gzipIn.read(buffer)) > 0) {
+                bos.write(buffer, 0, len);
+            }
+            return bos.toByteArray();
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
     }
 
     public interface SearchRequestParamsRewriter {

--- a/src/main/java/org/codelibs/fess/helper/SearchHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SearchHelper.java
@@ -95,6 +95,8 @@ public class SearchHelper {
 
     protected SearchRequestParamsRewriter[] searchRequestParamsRewriters = {};
 
+    protected ObjectMapper mapper = new ObjectMapper();;
+
     // ===================================================================================
     //                                                                              Method
     //                                                                      ==============
@@ -479,7 +481,6 @@ public class SearchHelper {
     }
 
     protected String serializeParameters(final RequestParameter[] parameters) {
-        final ObjectMapper mapper = new ObjectMapper();
         final List<Object[]> compactList = new ArrayList<>();
         for (final RequestParameter p : parameters) {
             compactList.add(new Object[] { p.getName(), p.getValues() });
@@ -516,7 +517,6 @@ public class SearchHelper {
                             final String encoded = cookie.getValue();
                             final byte[] compressed = Base64.getUrlDecoder().decode(encoded);
                             final byte[] jsonBytes = gzipDecompress(compressed);
-                            final ObjectMapper mapper = new ObjectMapper();
                             final List<?> list = mapper.readValue(jsonBytes, List.class);
 
                             final List<RequestParameter> result = new ArrayList<>();

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -1275,6 +1275,36 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. cookie */
     String SESSION_TRACKING_MODES = "session.tracking.modes";
 
+    /** The key of the configuration. e.g. q,num,sort */
+    String COOKIE_SEARCH_PARAMETER_KEYS = "cookie.search.parameter.keys";
+
+    /** The key of the configuration. e.g. q */
+    String COOKIE_SEARCH_PARAMETER_required_keys = "cookie.search.parameter.required_keys";
+
+    /** The key of the configuration. e.g. 1000 */
+    String COOKIE_SEARCH_PARAMETER_MAX_LENGTH = "cookie.search.parameter.max.length";
+
+    /** The key of the configuration. e.g. fsrp */
+    String COOKIE_SEARCH_PARAMETER_NAME = "cookie.search.parameter.name";
+
+    /** The key of the configuration. e.g. true */
+    String COOKIE_SEARCH_PARAMETER_http_only = "cookie.search.parameter.http_only";
+
+    /** The key of the configuration. e.g.  */
+    String COOKIE_SEARCH_PARAMETER_SECURE = "cookie.search.parameter.secure";
+
+    /** The key of the configuration. e.g. 60 */
+    String COOKIE_SEARCH_PARAMETER_max_age = "cookie.search.parameter.max_age";
+
+    /** The key of the configuration. e.g.  */
+    String COOKIE_SEARCH_PARAMETER_DOMAIN = "cookie.search.parameter.domain";
+
+    /** The key of the configuration. e.g. / */
+    String COOKIE_SEARCH_PARAMETER_PATH = "cookie.search.parameter.path";
+
+    /** The key of the configuration. e.g. Lax */
+    String COOKIE_SEARCH_PARAMETER_same_site = "cookie.search.parameter.same_site";
+
     /** The key of the configuration. e.g. 25 */
     String PAGING_PAGE_SIZE = "paging.page.size";
 
@@ -6368,6 +6398,130 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     String getSessionTrackingModes();
 
     /**
+     * Get the value for the key 'cookie.search.parameter.keys'. <br>
+     * The value is, e.g. q,num,sort <br>
+     * comment: Comma-separated list of request parameter keys to store in cookies before SSO login.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterKeys();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.required_keys'. <br>
+     * The value is, e.g. q <br>
+     * comment: Comma-separated list of required parameter keys that must be present to store in cookies.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterRequiredKeys();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.max.length'. <br>
+     * The value is, e.g. 1000 <br>
+     * comment: Maximum length of the encoded search parameters stored in cookies.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterMaxLength();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.max.length' as {@link Integer}. <br>
+     * The value is, e.g. 1000 <br>
+     * comment: Maximum length of the encoded search parameters stored in cookies.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getCookieSearchParameterMaxLengthAsInteger();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.name'. <br>
+     * The value is, e.g. fsrp <br>
+     * comment: Cookie name used to store encoded search parameters before SSO login.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterName();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.http_only'. <br>
+     * The value is, e.g. true <br>
+     * comment: Whether to set HttpOnly attribute to the search parameter cookie.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterHttpOnly();
+
+    /**
+     * Is the property for the key 'cookie.search.parameter.http_only' true? <br>
+     * The value is, e.g. true <br>
+     * comment: Whether to set HttpOnly attribute to the search parameter cookie.
+     * @return The determination, true or false. (if not found, exception but basically no way)
+     */
+    boolean isCookieSearchParameterHttpOnly();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.secure'. <br>
+     * The value is, e.g.  <br>
+     * comment: Whether to set Secure attribute to the search parameter cookie. Should be true in production environments using HTTPS.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterSecure();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.secure' as {@link Integer}. <br>
+     * The value is, e.g.  <br>
+     * comment: Whether to set Secure attribute to the search parameter cookie. Should be true in production environments using HTTPS.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getCookieSearchParameterSecureAsInteger();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.max_age'. <br>
+     * The value is, e.g. 60 <br>
+     * comment: Max-Age (in seconds) for the search parameter cookie. Use -1 for session-only cookies.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterMaxAge();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.max_age' as {@link Integer}. <br>
+     * The value is, e.g. 60 <br>
+     * comment: Max-Age (in seconds) for the search parameter cookie. Use -1 for session-only cookies.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getCookieSearchParameterMaxAgeAsInteger();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.domain'. <br>
+     * The value is, e.g.  <br>
+     * comment: Domain attribute for the search parameter cookie. Set to the domain scope you want the cookie to be available on (e.g., example.com).
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterDomain();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.domain' as {@link Integer}. <br>
+     * The value is, e.g.  <br>
+     * comment: Domain attribute for the search parameter cookie. Set to the domain scope you want the cookie to be available on (e.g., example.com).
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getCookieSearchParameterDomainAsInteger();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.path'. <br>
+     * The value is, e.g. / <br>
+     * comment: Path attribute for the search parameter cookie. Typically set to "/" or the context path of the app.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterPath();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.same_site'. <br>
+     * The value is, e.g. Lax <br>
+     * comment: SameSite attribute for the search parameter cookie. Valid values: Lax, Strict, None
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterSameSite();
+
+    /**
      * Get the value for the key 'paging.page.size'. <br>
      * The value is, e.g. 25 <br>
      * comment: The size of one page for paging
@@ -10732,6 +10886,66 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return get(FessConfig.SESSION_TRACKING_MODES);
         }
 
+        public String getCookieSearchParameterKeys() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_KEYS);
+        }
+
+        public String getCookieSearchParameterRequiredKeys() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_required_keys);
+        }
+
+        public String getCookieSearchParameterMaxLength() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_LENGTH);
+        }
+
+        public Integer getCookieSearchParameterMaxLengthAsInteger() {
+            return getAsInteger(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_LENGTH);
+        }
+
+        public String getCookieSearchParameterName() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_NAME);
+        }
+
+        public String getCookieSearchParameterHttpOnly() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_http_only);
+        }
+
+        public boolean isCookieSearchParameterHttpOnly() {
+            return is(FessConfig.COOKIE_SEARCH_PARAMETER_http_only);
+        }
+
+        public String getCookieSearchParameterSecure() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_SECURE);
+        }
+
+        public Integer getCookieSearchParameterSecureAsInteger() {
+            return getAsInteger(FessConfig.COOKIE_SEARCH_PARAMETER_SECURE);
+        }
+
+        public String getCookieSearchParameterMaxAge() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_max_age);
+        }
+
+        public Integer getCookieSearchParameterMaxAgeAsInteger() {
+            return getAsInteger(FessConfig.COOKIE_SEARCH_PARAMETER_max_age);
+        }
+
+        public String getCookieSearchParameterDomain() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_DOMAIN);
+        }
+
+        public Integer getCookieSearchParameterDomainAsInteger() {
+            return getAsInteger(FessConfig.COOKIE_SEARCH_PARAMETER_DOMAIN);
+        }
+
+        public String getCookieSearchParameterPath() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_PATH);
+        }
+
+        public String getCookieSearchParameterSameSite() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_same_site);
+        }
+
         public String getPagingPageSize() {
             return get(FessConfig.PAGING_PAGE_SIZE);
         }
@@ -12206,6 +12420,16 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.COOKIE_DEFAULT_PATH, "/");
             defaultMap.put(FessConfig.COOKIE_DEFAULT_EXPIRE, "3600");
             defaultMap.put(FessConfig.SESSION_TRACKING_MODES, "cookie");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_KEYS, "q,num,sort");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_required_keys, "q");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_LENGTH, "1000");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_NAME, "fsrp");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_http_only, "true");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_SECURE, "");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_max_age, "60");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_DOMAIN, "");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_PATH, "/");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_same_site, "Lax");
             defaultMap.put(FessConfig.PAGING_PAGE_SIZE, "25");
             defaultMap.put(FessConfig.PAGING_PAGE_RANGE_SIZE, "5");
             defaultMap.put(FessConfig.PAGING_PAGE_RANGE_FILL_LIMIT, "true");

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1036,6 +1036,27 @@ cookie.default.expire = 3600
 # Session tracking modes
 session.tracking.modes=cookie
 
+# Comma-separated list of request parameter keys to store in cookies before SSO login.
+cookie.search.parameter.keys=q,num,sort
+# Comma-separated list of required parameter keys that must be present to store in cookies.
+cookie.search.parameter.required_keys=q
+# Maximum length of the encoded search parameters stored in cookies.
+cookie.search.parameter.max.length=1000
+# Cookie name used to store encoded search parameters before SSO login.
+cookie.search.parameter.name=fsrp
+# Whether to set HttpOnly attribute to the search parameter cookie.
+cookie.search.parameter.http_only=true
+# Whether to set Secure attribute to the search parameter cookie. Should be true in production environments using HTTPS.
+cookie.search.parameter.secure=
+# Max-Age (in seconds) for the search parameter cookie. Use -1 for session-only cookies.
+cookie.search.parameter.max_age=60
+# Domain attribute for the search parameter cookie. Set to the domain scope you want the cookie to be available on (e.g., example.com).
+cookie.search.parameter.domain=
+# Path attribute for the search parameter cookie. Typically set to "/" or the context path of the app.
+cookie.search.parameter.path=/
+# SameSite attribute for the search parameter cookie. Valid values: Lax, Strict, None
+cookie.search.parameter.same_site=Lax
+
 # ----------------------------------------------------------
 #                                                     Paging
 #                                                     ------

--- a/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codelibs.fess.helper;
+
+import java.util.Base64;
+
+import org.codelibs.fess.entity.RequestParameter;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+
+import jakarta.servlet.http.Cookie;
+
+public class SearchHelperTest extends UnitFessTestCase {
+    private SearchHelper searchHelper;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        searchHelper = new SearchHelper();
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getCookieSearchParameterRequiredKeys() {
+                return "";
+            }
+
+            @Override
+            public String getCookieSearchParameterKeys() {
+                return "q,lang";
+            }
+
+            @Override
+            public Integer getCookieSearchParameterMaxLengthAsInteger() {
+                return 4096;
+            }
+
+            @Override
+            public String getCookieSearchParameterName() {
+                return "FESS_SEARCH_PARAM";
+            }
+
+            @Override
+            public String getCookieSearchParameterHttpOnly() {
+                return "true";
+            }
+
+            @Override
+            public String getCookieSearchParameterSecure() {
+                return "";
+            }
+
+            @Override
+            public String getCookieSearchParameterDomain() {
+                return "";
+            }
+
+            @Override
+            public String getCookieSearchParameterPath() {
+                return "/";
+            }
+
+            @Override
+            public Integer getCookieSearchParameterMaxAgeAsInteger() {
+                return 3600;
+            }
+
+            @Override
+            public String getCookieSearchParameterSameSite() {
+                return "Lax";
+            }
+        });
+    }
+
+    public void test_serializeParameters() {
+        RequestParameter[] params = new RequestParameter[] { new RequestParameter("q", new String[] { "test" }),
+                new RequestParameter("lang", new String[] { "en", "ja" }) };
+        String encoded = searchHelper.serializeParameters(params);
+        assertNotNull(encoded);
+        byte[] compressed = Base64.getUrlDecoder().decode(encoded);
+        byte[] jsonBytes = searchHelper.gzipDecompress(compressed);
+        String json = new String(jsonBytes);
+        assertTrue(json.contains("q"));
+        assertTrue(json.contains("lang"));
+    }
+
+    public void test_store_and_getSearchParameters() {
+        getMockRequest().setParameter("q", "test");
+        getMockRequest().setParameter("lang", new String[] { "en", "ja" });
+        searchHelper.storeSearchParameters();
+        Cookie[] cookies = getMockResponse().getCookies();
+        boolean found = false;
+        for (Cookie cookie : cookies) {
+            if ("FESS_SEARCH_PARAM".equals(cookie.getName())) {
+                found = true;
+                assertNotNull(cookie.getValue());
+            }
+        }
+        assertTrue(found);
+        // CookieをリクエストにセットしてgetSearchParametersをテスト
+        getMockRequest().addCookie(cookies[0]);
+        RequestParameter[] result = searchHelper.getSearchParameters();
+        assertEquals(2, result.length);
+        assertEquals("q", result[0].getName());
+        assertEquals("test", result[0].getValues()[0]);
+        assertEquals("lang", result[1].getName());
+        assertEquals("en", result[1].getValues()[0]);
+        assertEquals("ja", result[1].getValues()[1]);
+    }
+}

--- a/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
@@ -111,7 +111,6 @@ public class SearchHelperTest extends UnitFessTestCase {
             }
         }
         assertTrue(found);
-        // CookieをリクエストにセットしてgetSearchParametersをテスト
         getMockRequest().addCookie(cookies[0]);
         RequestParameter[] result = searchHelper.getSearchParameters();
         assertEquals(2, result.length);


### PR DESCRIPTION
This pull request enhances the SSO login flow by introducing functionality to store and restore search parameters using cookies. Key additions include:

- SearchHelper now serializes selected request parameters into a compressed and encoded cookie before redirecting to login.
- On successful login, these parameters are retrieved and appended to the search redirect URL.
- New methods storeSearchParameters() and getSearchParameters() were implemented in SearchHelper.
- Configuration keys were added to FessConfig and fess_config.properties to support cookie attributes (e.g., name, max age, secure, SameSite).
- Adjustments in FessSearchAction and SsoAction to integrate the parameter preservation and restoration flow.

This improves user experience by maintaining their search context across SSO authentication.