### PR TITLE
Refactor SystemHelper and Standardize Test Teardown for FessConfig Cleanup

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -208,8 +208,11 @@ public class SystemHelper {
     }
 
     public String getUsername() {
-        final RequestManager requestManager = ComponentUtil.getRequestManager();
-        return requestManager.findUserBean(FessUserBean.class).map(FessUserBean::getUserId).orElse(Constants.GUEST_USER);
+        return getRequestManager().findUserBean(FessUserBean.class).map(FessUserBean::getUserId).orElse(Constants.GUEST_USER);
+    }
+
+    protected RequestManager getRequestManager() {
+        return ComponentUtil.getRequestManager();
     }
 
     public Date getCurrentTime() {

--- a/src/test/java/org/codelibs/fess/helper/ActivityHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ActivityHelperTest.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.app.web.base.login.FessCredential;
 import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.unit.UnitFessTestCase;

--- a/src/test/java/org/codelibs/fess/helper/CrawlerStatsHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/CrawlerStatsHelperTest.java
@@ -45,6 +45,12 @@ public class CrawlerStatsHelperTest extends UnitFessTestCase {
         crawlerStatsHelper.init();
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_beginDone() {
         String key = "test";
         crawlerStatsHelper.begin(key);

--- a/src/test/java/org/codelibs/fess/helper/CrawlingConfigHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/CrawlingConfigHelperTest.java
@@ -119,6 +119,12 @@ public class CrawlingConfigHelperTest extends UnitFessTestCase {
         }, DataConfigService.class.getCanonicalName());
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_getConfigType() {
         assertNull(crawlingConfigHelper.getConfigType(null));
         assertNull(crawlingConfigHelper.getConfigType(""));

--- a/src/test/java/org/codelibs/fess/helper/CrawlingInfoHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/CrawlingInfoHelperTest.java
@@ -28,8 +28,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.service.CrawlingInfoService;
 import org.codelibs.fess.exception.FessSystemException;
-import org.codelibs.fess.opensearch.config.exentity.CrawlingConfig;
-import org.codelibs.fess.opensearch.config.exentity.CrawlingConfig.ConfigName;
 import org.codelibs.fess.opensearch.config.exentity.CrawlingInfo;
 import org.codelibs.fess.opensearch.config.exentity.CrawlingInfoParam;
 import org.codelibs.fess.unit.UnitFessTestCase;

--- a/src/test/java/org/codelibs/fess/helper/CurlHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/CurlHelperTest.java
@@ -19,11 +19,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.util.Map;
 
 import javax.net.ssl.SSLSocketFactory;
 
@@ -33,7 +28,6 @@ import org.codelibs.fesen.client.node.NodeManager;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
-import org.codelibs.fess.util.ResourceUtil;
 
 public class CurlHelperTest extends UnitFessTestCase {
 

--- a/src/test/java/org/codelibs/fess/helper/DataIndexHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/DataIndexHelperTest.java
@@ -20,9 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.service.FailureUrlService;
 import org.codelibs.fess.ds.DataStore;
 import org.codelibs.fess.ds.DataStoreFactory;

--- a/src/test/java/org/codelibs/fess/helper/IndexingHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/IndexingHelperTest.java
@@ -83,6 +83,12 @@ public class IndexingHelperTest extends UnitFessTestCase {
         }, WebConfigService.class.getCanonicalName());
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_sendDocuments() {
         documentSizeByQuery = 0L;
         final AtomicReference<String> sentIndex = new AtomicReference<>();

--- a/src/test/java/org/codelibs/fess/helper/JobHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/JobHelperTest.java
@@ -37,6 +37,12 @@ public class JobHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockJobLogBhv(), JobLogBhv.class.getCanonicalName());
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_register_with_null_scheduledJob() {
         try {
             jobHelper.register((ScheduledJob) null);

--- a/src/test/java/org/codelibs/fess/helper/KeyMatchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/KeyMatchHelperTest.java
@@ -23,11 +23,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.codelibs.core.misc.Tuple3;
-import org.codelibs.fess.opensearch.config.exbhv.KeyMatchBhv;
 import org.codelibs.fess.opensearch.config.exentity.KeyMatch;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
-import org.dbflute.cbean.result.ListResultBean;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder.FilterFunctionBuilder;
 import org.opensearch.index.query.functionscore.ScoreFunctionBuilder;
@@ -42,16 +40,13 @@ public class KeyMatchHelperTest extends UnitFessTestCase {
         keyMatchHelper = new KeyMatchHelper();
         ComponentUtil.register(new SystemHelper(), "systemHelper");
         ComponentUtil.register(new VirtualHostHelper(), "virtualHostHelper");
-        // ComponentUtil.register(new MockSearchEngineClient(), "searchEngineClient");
-        // ComponentUtil.register(new MockKeyMatchBhv(), KeyMatchBhv.class);
     }
 
-    // public static class MockKeyMatchBhv extends KeyMatchBhv {
-    //     @Override
-    //     public ListResultBean<KeyMatch> selectList(org.dbflute.cbean.ConditionBean cb) {
-    //         return new ListResultBean<>();
-    //     }
-    // }
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
 
     public void test_init() {
         try {

--- a/src/test/java/org/codelibs/fess/helper/LabelTypeHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/LabelTypeHelperTest.java
@@ -16,15 +16,12 @@
 package org.codelibs.fess.helper;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.service.LabelTypeService;
 import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.helper.LabelTypeHelper.LabelTypePattern;
@@ -44,6 +41,12 @@ public class LabelTypeHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockLabelTypeService(), LabelTypeService.class.getCanonicalName());
         ComponentUtil.register(new MockVirtualHostHelper(), "virtualHostHelper");
         ComponentUtil.register(new MockRoleQueryHelper(), "roleQueryHelper");
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
     }
 
     public void test_init() {

--- a/src/test/java/org/codelibs/fess/helper/LanguageHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/LanguageHelperTest.java
@@ -39,6 +39,12 @@ public class LanguageHelperTest extends UnitFessTestCase {
         ComponentUtil.setFessConfig(new MockFessConfig());
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_createScript() {
         Map<String, Object> doc = new HashMap<>();
         assertEquals("aaa", languageHelper.createScript(doc, "aaa").getIdOrCode());

--- a/src/test/java/org/codelibs/fess/helper/OsddHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/OsddHelperTest.java
@@ -29,6 +29,12 @@ import org.lastaflute.web.servlet.request.stream.WrittenStreamOut;
 
 public class OsddHelperTest extends UnitFessTestCase {
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_init_nofile() {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             @Override

--- a/src/test/java/org/codelibs/fess/helper/PathMappingHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/PathMappingHelperTest.java
@@ -17,9 +17,9 @@ package org.codelibs.fess.helper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.function.BiFunction;
 
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.opensearch.config.exentity.PathMapping;

--- a/src/test/java/org/codelibs/fess/helper/PluginHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/PluginHelperTest.java
@@ -27,9 +27,6 @@ import org.codelibs.fess.exception.PluginException;
 import org.codelibs.fess.helper.PluginHelper.Artifact;
 import org.codelibs.fess.helper.PluginHelper.ArtifactType;
 import org.codelibs.fess.unit.UnitFessTestCase;
-import org.codelibs.fess.util.ComponentUtil;
-import org.codelibs.fess.mylasta.direction.FessConfig;
-import org.codelibs.curl.CurlRequest;
 import org.lastaflute.di.exception.IORuntimeException;
 
 public class PluginHelperTest extends UnitFessTestCase {

--- a/src/test/java/org/codelibs/fess/helper/PopularWordHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/PopularWordHelperTest.java
@@ -15,14 +15,10 @@
  */
 package org.codelibs.fess.helper;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
-import org.codelibs.fess.util.ComponentUtil;
 
 import com.google.common.cache.CacheBuilder;
 

--- a/src/test/java/org/codelibs/fess/helper/ProcessHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ProcessHelperTest.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.codelibs.fess.exception.JobNotFoundException;

--- a/src/test/java/org/codelibs/fess/helper/ProtocolHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ProtocolHelperTest.java
@@ -60,6 +60,12 @@ public class ProtocolHelperTest extends UnitFessTestCase {
         assertEquals(2, protocolHelper.getFileProtocols().length);
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_add_smbx() {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             @Override

--- a/src/test/java/org/codelibs/fess/helper/QueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/QueryHelperTest.java
@@ -107,6 +107,12 @@ public class QueryHelperTest extends UnitFessTestCase {
         new WildcardQueryCommand().register();
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     private void setQueryType(final String queryType) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {

--- a/src/test/java/org/codelibs/fess/helper/RelatedContentHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RelatedContentHelperTest.java
@@ -62,6 +62,12 @@ public class RelatedContentHelperTest extends UnitFessTestCase {
         inject(virtualHostHelper);
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_init() {
         // Setup test data
         List<RelatedContent> testData = new ArrayList<>();

--- a/src/test/java/org/codelibs/fess/helper/RelatedQueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RelatedQueryHelperTest.java
@@ -62,6 +62,12 @@ public class RelatedQueryHelperTest extends UnitFessTestCase {
         inject(virtualHostHelper);
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_init() {
         // Setup test data
         List<RelatedQuery> testData = new ArrayList<>();

--- a/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
@@ -25,8 +25,6 @@ import org.codelibs.core.crypto.CachedCipher;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
-import org.codelibs.fess.helper.PermissionHelper;
-import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
@@ -52,6 +50,12 @@ public class RoleQueryHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockFessConfig(), "fessConfig");
         ComponentUtil.register(new MockSystemHelper(), "systemHelper");
         ComponentUtil.register(new MockPermissionHelper(), "permissionHelper");
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
     }
 
     private Set<String> buildByParameter(final RoleQueryHelper roleQueryHelperImpl, final HttpServletRequest request) {

--- a/src/test/java/org/codelibs/fess/helper/SambaHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SambaHelperTest.java
@@ -16,7 +16,6 @@
 package org.codelibs.fess.helper;
 
 import java.io.File;
-import java.util.Locale;
 
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.misc.DynamicProperties;
@@ -43,6 +42,12 @@ public class SambaHelperTest extends UnitFessTestCase {
         ComponentUtil.register(systemProps, "systemProperties");
 
         sambaHelper = new SambaHelper();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
     }
 
     public void test_smb_account() throws SmbException {

--- a/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
@@ -15,42 +15,21 @@
  */
 package org.codelibs.fess.helper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Consumer;
 
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.FacetInfo;
-import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.entity.GeoInfo;
 import org.codelibs.fess.entity.HighlightInfo;
-import org.codelibs.fess.entity.QueryContext;
 import org.codelibs.fess.entity.RequestParameter;
-import org.codelibs.fess.entity.SearchRenderData;
 import org.codelibs.fess.entity.SearchRequestParams;
-import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
-import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
-import org.codelibs.fess.opensearch.client.SearchEngineClient;
-import org.codelibs.fess.util.QueryStringBuilder;
-import org.codelibs.fess.rank.fusion.RankFusionProcessor;
 import org.codelibs.fess.unit.UnitFessTestCase;
-import org.codelibs.fess.util.BooleanFunction;
 import org.codelibs.fess.util.ComponentUtil;
-import org.codelibs.fess.util.QueryResponseList;
-import org.dbflute.optional.OptionalEntity;
-import org.dbflute.optional.OptionalThing;
-import org.opensearch.action.bulk.BulkRequestBuilder;
-import org.opensearch.action.update.UpdateRequestBuilder;
-import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.QueryBuilders;
 
 import jakarta.servlet.http.Cookie;
 
@@ -67,6 +46,12 @@ public class SearchHelperTest extends UnitFessTestCase {
     private void setupMockComponents() {
         ComponentUtil.setFessConfig(new MockFessConfig());
         ComponentUtil.register(new MockSystemHelper(), "systemHelper");
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
     }
 
     public void test_serializeParameters() {

--- a/src/test/java/org/codelibs/fess/helper/SearchLogHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SearchLogHelperTest.java
@@ -39,6 +39,12 @@ public class SearchLogHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockSystemHelper(), "systemHelper");
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_init() {
         SearchLogHelper helper = new SearchLogHelper();
         helper.init();

--- a/src/test/java/org/codelibs/fess/helper/SuggestHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SuggestHelperTest.java
@@ -28,10 +28,6 @@ import org.codelibs.fess.opensearch.config.exentity.BadWord;
 import org.codelibs.fess.opensearch.config.exentity.ElevateWord;
 import org.codelibs.fess.opensearch.log.exbhv.SearchLogBhv;
 import org.codelibs.fess.opensearch.log.exentity.SearchLog;
-import org.codelibs.fess.suggest.Suggester;
-import org.codelibs.fess.suggest.index.contents.document.ESSourceReader;
-import org.codelibs.fess.suggest.index.SuggestDeleteResponse;
-import org.codelibs.fess.suggest.settings.SuggestSettings;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 
@@ -54,6 +50,12 @@ public class SuggestHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockBadWordBhv(), "badWordBhv");
         ComponentUtil.register(new MockSystemHelper(), "systemHelper");
         ComponentUtil.register(new MockPopularWordHelper(), "popularWordHelper");
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
     }
 
     public void test_init() {

--- a/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
@@ -37,7 +37,11 @@ import org.codelibs.fess.exception.FessSystemException;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
+import org.lastaflute.web.login.LoginManager;
 import org.lastaflute.web.response.HtmlResponse;
+import org.lastaflute.web.servlet.request.RequestManager;
+import org.lastaflute.web.servlet.request.SimpleRequestManager;
 
 public class SystemHelperTest extends UnitFessTestCase {
 
@@ -73,11 +77,26 @@ public class SystemHelperTest extends UnitFessTestCase {
             protected File getDesignJspFile(String path) {
                 return new File(desginJspRootFile, path);
             }
+
+            @Override
+            protected RequestManager getRequestManager() {
+                return new SimpleRequestManager() {
+                    public OptionalThing<LoginManager> findLoginManager(Class<?> userBeanType) {
+                        return OptionalThing.empty();
+                    }
+                };
+            }
         };
         envMap.clear();
         systemHelper.init();
         systemHelper.addShutdownHook(() -> {});
         ComponentUtil.register(systemHelper, "systemHelper");
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
     }
 
     public void test_getUsername() {

--- a/src/test/java/org/codelibs/fess/helper/ThemeHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ThemeHelperTest.java
@@ -15,8 +15,6 @@
  */
 package org.codelibs.fess.helper;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,9 +24,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.codelibs.fess.exception.ThemeException;
 import org.codelibs.fess.helper.PluginHelper.Artifact;
-import org.codelibs.fess.helper.PluginHelper.ArtifactType;
 import org.codelibs.fess.unit.UnitFessTestCase;
-import org.codelibs.fess.util.ResourceUtil;
 
 public class ThemeHelperTest extends UnitFessTestCase {
 
@@ -40,6 +36,11 @@ public class ThemeHelperTest extends UnitFessTestCase {
         super.setUp();
         themeHelper = new ThemeHelper();
         tempDir = Files.createTempDirectory("theme-test");
+        Files.createDirectories(Paths.get("target", "fess", "WEB-INF", "view"));
+        Files.createDirectories(Paths.get("target", "fess", "WEB-INF", "plugin"));
+        Files.createDirectories(Paths.get("target", "fess", "images"));
+        Files.createDirectories(Paths.get("target", "fess", "css"));
+        Files.createDirectories(Paths.get("target", "fess", "js"));
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
@@ -25,11 +25,9 @@ import java.util.Set;
 
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.misc.DynamicProperties;
-import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.FacetInfo;
 import org.codelibs.fess.entity.FacetQueryView;
 import org.codelibs.fess.entity.HighlightInfo;
-import org.codelibs.fess.helper.UserAgentHelper.UserAgentType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.config.exentity.PathMapping;
 import org.codelibs.fess.unit.UnitFessTestCase;
@@ -69,6 +67,7 @@ public class ViewHelperTest extends UnitFessTestCase {
     @Override
     public void tearDown() throws Exception {
         propertiesFile.delete();
+        ComponentUtil.setFessConfig(null);
         super.tearDown();
     }
 

--- a/src/test/java/org/codelibs/fess/helper/VirtualHostHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/VirtualHostHelperTest.java
@@ -32,6 +32,12 @@ public class VirtualHostHelperTest extends UnitFessTestCase {
         virtualHostHelper = new VirtualHostHelper();
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
     public void test_getVirtualHostPath() {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             private static final long serialVersionUID = 1L;


### PR DESCRIPTION
This pull request includes two main changes:

1. Refactoring in SystemHelper:
  - The getUsername() method now uses a protected getRequestManager() method. This refactor facilitates better testability and decoupling, enabling easier mocking or overriding of request handling behavior in test contexts.
2. Test Cleanup Enhancements:
  - Added or updated tearDown() methods across all test classes to explicitly reset FessConfig using ComponentUtil.setFessConfig(null).
  - This change ensures test isolation and prevents interference from shared static configuration states.
  - Additionally, redundant imports and commented-out legacy code in test classes were removed for clarity.

These changes improve the maintainability and reliability of the test suite and support more consistent unit test behavior.