### PR TITLE
Remove unused execution block from maven-source-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,15 +101,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>source-jar</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>


### PR DESCRIPTION
This change removes the <executions> block from the maven-source-plugin configuration in the pom.xml. The removed configuration previously generated source JARs during the package phase, but it appears to be no longer required or is being handled elsewhere. This cleanup simplifies the build configuration.
