### PR TITLE
Add null check for IdP Single Logout Service URL in SamlAuthenticator

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -237,6 +237,13 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 final SamlUser samlUser = (SamlUser) user.getFessUser();
                 try {
                     final Auth auth = new Auth(getSettings(), request, response);
+                    final Saml2Settings settings = auth.getSettings();
+                    if (settings.getIdpSingleLogoutServiceUrl() == null) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("IdP single logout service URL is not configured, skipping SLO for user: {}", samlUser);
+                        }
+                        return null;
+                    }
                     final LogoutRequestParams logoutRequestParams = new LogoutRequestParams(samlUser.getSessionIndex(), samlUser.getName(),
                             samlUser.getNameIdFormat(), samlUser.getNameidNameQualifier(), samlUser.getNameidSPNameQualifier());
                     return auth.logout(null, logoutRequestParams, true);


### PR DESCRIPTION
This PR adds a null check for the Identity Provider’s Single Logout (SLO) service URL in the SamlAuthenticator class. If the URL is not configured, the method logs a debug message and skips the logout process to prevent potential NullPointerException. This improves the robustness of the SAML logout handling.
