### PR TITLE
Remove redundant tearDown() overrides in test classes

### DIFF
--- a/src/test/java/org/codelibs/fess/crawler/transformer/FessFileTransformerTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/transformer/FessFileTransformerTest.java
@@ -35,12 +35,6 @@ public class FessFileTransformerTest extends UnitFessTestCase {
         ComponentUtil.register(new DataSerializer(), "dataSerializer");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     private String encodeUrl(final String url) {
         try {
             return URLEncoder.encode(url, Constants.UTF_8);

--- a/src/test/java/org/codelibs/fess/crawler/transformer/FessXpathTransformerTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/transformer/FessXpathTransformerTest.java
@@ -77,12 +77,6 @@ public class FessXpathTransformerTest extends UnitFessTestCase {
         ComponentUtil.register(new DataSerializer(), "dataSerializer");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_transform() throws Exception {
         String data = "<html><head><title>Test</title></head><body><h1>Header1</h1><p>This is a pen.</p></body></html>";
 

--- a/src/test/java/org/codelibs/fess/helper/CrawlerStatsHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/CrawlerStatsHelperTest.java
@@ -45,12 +45,6 @@ public class CrawlerStatsHelperTest extends UnitFessTestCase {
         crawlerStatsHelper.init();
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_beginDone() {
         String key = "test";
         crawlerStatsHelper.begin(key);

--- a/src/test/java/org/codelibs/fess/helper/CrawlingConfigHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/CrawlingConfigHelperTest.java
@@ -119,12 +119,6 @@ public class CrawlingConfigHelperTest extends UnitFessTestCase {
         }, DataConfigService.class.getCanonicalName());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_getConfigType() {
         assertNull(crawlingConfigHelper.getConfigType(null));
         assertNull(crawlingConfigHelper.getConfigType(""));

--- a/src/test/java/org/codelibs/fess/helper/IndexingHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/IndexingHelperTest.java
@@ -83,12 +83,6 @@ public class IndexingHelperTest extends UnitFessTestCase {
         }, WebConfigService.class.getCanonicalName());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_sendDocuments() {
         documentSizeByQuery = 0L;
         final AtomicReference<String> sentIndex = new AtomicReference<>();

--- a/src/test/java/org/codelibs/fess/helper/JobHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/JobHelperTest.java
@@ -37,12 +37,6 @@ public class JobHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockJobLogBhv(), JobLogBhv.class.getCanonicalName());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_register_with_null_scheduledJob() {
         try {
             jobHelper.register((ScheduledJob) null);

--- a/src/test/java/org/codelibs/fess/helper/KeyMatchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/KeyMatchHelperTest.java
@@ -42,12 +42,6 @@ public class KeyMatchHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new VirtualHostHelper(), "virtualHostHelper");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_init() {
         try {
             keyMatchHelper.init();

--- a/src/test/java/org/codelibs/fess/helper/LabelTypeHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/LabelTypeHelperTest.java
@@ -43,12 +43,6 @@ public class LabelTypeHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockRoleQueryHelper(), "roleQueryHelper");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_init() {
         try {
             labelTypeHelper.init();

--- a/src/test/java/org/codelibs/fess/helper/LanguageHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/LanguageHelperTest.java
@@ -39,12 +39,6 @@ public class LanguageHelperTest extends UnitFessTestCase {
         ComponentUtil.setFessConfig(new MockFessConfig());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_createScript() {
         Map<String, Object> doc = new HashMap<>();
         assertEquals("aaa", languageHelper.createScript(doc, "aaa").getIdOrCode());

--- a/src/test/java/org/codelibs/fess/helper/OsddHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/OsddHelperTest.java
@@ -29,12 +29,6 @@ import org.lastaflute.web.servlet.request.stream.WrittenStreamOut;
 
 public class OsddHelperTest extends UnitFessTestCase {
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_init_nofile() {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             @Override

--- a/src/test/java/org/codelibs/fess/helper/ProtocolHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ProtocolHelperTest.java
@@ -60,12 +60,6 @@ public class ProtocolHelperTest extends UnitFessTestCase {
         assertEquals(2, protocolHelper.getFileProtocols().length);
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_add_smbx() {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             @Override

--- a/src/test/java/org/codelibs/fess/helper/QueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/QueryHelperTest.java
@@ -107,12 +107,6 @@ public class QueryHelperTest extends UnitFessTestCase {
         new WildcardQueryCommand().register();
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     private void setQueryType(final String queryType) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {

--- a/src/test/java/org/codelibs/fess/helper/RelatedContentHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RelatedContentHelperTest.java
@@ -62,12 +62,6 @@ public class RelatedContentHelperTest extends UnitFessTestCase {
         inject(virtualHostHelper);
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_init() {
         // Setup test data
         List<RelatedContent> testData = new ArrayList<>();

--- a/src/test/java/org/codelibs/fess/helper/RelatedQueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RelatedQueryHelperTest.java
@@ -62,12 +62,6 @@ public class RelatedQueryHelperTest extends UnitFessTestCase {
         inject(virtualHostHelper);
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_init() {
         // Setup test data
         List<RelatedQuery> testData = new ArrayList<>();

--- a/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
@@ -52,12 +52,6 @@ public class RoleQueryHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockPermissionHelper(), "permissionHelper");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     private Set<String> buildByParameter(final RoleQueryHelper roleQueryHelperImpl, final HttpServletRequest request) {
         Set<String> roleSet = new HashSet<>();
         roleQueryHelperImpl.processParameter(request, roleSet);

--- a/src/test/java/org/codelibs/fess/helper/SambaHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SambaHelperTest.java
@@ -44,12 +44,6 @@ public class SambaHelperTest extends UnitFessTestCase {
         sambaHelper = new SambaHelper();
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_smb_account() throws SmbException {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             @Override

--- a/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
@@ -48,12 +48,6 @@ public class SearchHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockSystemHelper(), "systemHelper");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_serializeParameters() {
         RequestParameter[] params = new RequestParameter[] { new RequestParameter("q", new String[] { "test" }),
                 new RequestParameter("lang", new String[] { "en", "ja" }) };

--- a/src/test/java/org/codelibs/fess/helper/SearchLogHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SearchLogHelperTest.java
@@ -39,12 +39,6 @@ public class SearchLogHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockSystemHelper(), "systemHelper");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_init() {
         SearchLogHelper helper = new SearchLogHelper();
         helper.init();

--- a/src/test/java/org/codelibs/fess/helper/SuggestHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SuggestHelperTest.java
@@ -52,12 +52,6 @@ public class SuggestHelperTest extends UnitFessTestCase {
         ComponentUtil.register(new MockPopularWordHelper(), "popularWordHelper");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_init() {
         SuggestHelper helper = new SuggestHelper();
         try {

--- a/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
@@ -93,12 +93,6 @@ public class SystemHelperTest extends UnitFessTestCase {
         ComponentUtil.register(systemHelper, "systemHelper");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_getUsername() {
         assertEquals("guest", systemHelper.getUsername());
     }

--- a/src/test/java/org/codelibs/fess/helper/ThemeHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ThemeHelperTest.java
@@ -45,10 +45,10 @@ public class ThemeHelperTest extends UnitFessTestCase {
 
     @Override
     public void tearDown() throws Exception {
-        super.tearDown();
         if (tempDir != null && Files.exists(tempDir)) {
             deleteDirectory(tempDir);
         }
+        super.tearDown();
     }
 
     private void deleteDirectory(Path dir) throws IOException {

--- a/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
@@ -67,7 +67,6 @@ public class ViewHelperTest extends UnitFessTestCase {
     @Override
     public void tearDown() throws Exception {
         propertiesFile.delete();
-        ComponentUtil.setFessConfig(null);
         super.tearDown();
     }
 

--- a/src/test/java/org/codelibs/fess/helper/VirtualHostHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/VirtualHostHelperTest.java
@@ -32,12 +32,6 @@ public class VirtualHostHelperTest extends UnitFessTestCase {
         virtualHostHelper = new VirtualHostHelper();
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     public void test_getVirtualHostPath() {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             private static final long serialVersionUID = 1L;

--- a/src/test/java/org/codelibs/fess/query/TermQueryCommandTest.java
+++ b/src/test/java/org/codelibs/fess/query/TermQueryCommandTest.java
@@ -56,12 +56,6 @@ public class TermQueryCommandTest extends UnitFessTestCase {
         queryCommand = new TermQueryCommand();
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
-    }
-
     private void setQueryType(final String queryType) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {

--- a/src/test/java/org/codelibs/fess/util/ComponentUtilTest.java
+++ b/src/test/java/org/codelibs/fess/util/ComponentUtilTest.java
@@ -31,13 +31,11 @@ public class ComponentUtilTest extends UnitFessTestCase {
     }
 
     @Override
-    public void tearDown() throws Exception {
-        ComponentUtil.setFessConfig(null);
-        super.tearDown();
+    protected boolean isUseOneTimeContainer() {
+        return true;
     }
 
     public void test_setFessConfig_null() {
-        ComponentUtil.setFessConfig(null);
         assertTrue(FessProp.propMap.isEmpty());
     }
 
@@ -81,8 +79,6 @@ public class ComponentUtilTest extends UnitFessTestCase {
         List<String> results = new ArrayList<>();
         Runnable process = () -> results.add("executed");
 
-        ComponentUtil.setFessConfig(null);
-
         ComponentUtil.processAfterContainerInit(process);
 
         assertEquals(0, results.size());
@@ -91,7 +87,6 @@ public class ComponentUtilTest extends UnitFessTestCase {
     public void test_doInitProcesses() {
         List<String> executionOrder = new ArrayList<>();
 
-        ComponentUtil.setFessConfig(null);
         ComponentUtil.processAfterContainerInit(() -> executionOrder.add("first"));
         ComponentUtil.processAfterContainerInit(() -> executionOrder.add("second"));
 
@@ -114,8 +109,6 @@ public class ComponentUtilTest extends UnitFessTestCase {
     }
 
     public void test_available_withoutSystemHelper() {
-        ComponentUtil.setFessConfig(null);
-
         assertFalse(ComponentUtil.available());
     }
 


### PR DESCRIPTION
This update removes unnecessary tearDown() method overrides from multiple test classes across the codebase. These overrides previously called ComponentUtil.setFessConfig(null), which is no longer required due to improved container lifecycle handling or updated mocking behavior. The cleanup reduces test code redundancy and simplifies maintenance without affecting test behavior.
