### PR TITLE
Finalize fess-parent version to 15.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0-SNAPSHOT</version>
+		<version>15.1.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
This pull request updates the parent POM version in the fess project’s pom.xml from 15.1.0-SNAPSHOT to the released 15.1.0 version. This change is part of the version finalization process across the Fess ecosystem to prepare for the official release.
