### PR TITLE
Update EOL date for Fess 15.1.0

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -165,7 +165,7 @@ public class SystemHelper {
             logger.debug("Initialize {}", this.getClass().getSimpleName());
         }
         final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        cal.set(2026, 12 - 1, 1); // EOL Date
+        cal.set(2027, 1 - 1, 1); // EOL Date
         eolTime = cal.getTimeInMillis();
         if (isEoled()) {
             logger.error("Your system is out of support. See https://fess.codelibs.org/eol.html");


### PR DESCRIPTION
This pull request updates the end-of-life (EOL) date for Fess version 15.1.0 in the SystemHelper class.
The EOL date has been changed to January 1, 2027 to reflect the revised support policy.