### PR TITLE
Update project and parent version to 15.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fess</artifactId>
-	<version>15.1.1-SNAPSHOT</version>
+	<version>15.2.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>Fess</name>
 	<description>Fess is Full tExt Search System.</description>
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0</version>
+		<version>15.2.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
This pull request updates the Maven project version of fess-suggest from 15.1.1-SNAPSHOT to 15.2.0-SNAPSHOT. Additionally, it updates the parent POM version from 15.1.0 to 15.2.0-SNAPSHOT to align with the new development cycle.
