### PR TITLE
Fix: Update JCIFS library import paths

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/PermissionHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PermissionHelper.java
@@ -38,7 +38,7 @@ import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
 import jakarta.annotation.Resource;
-import jcifs.SID;
+import org.codelibs.jcifs.smb.SID;
 
 /**
  * Helper class for handling permission-related operations in Fess.
@@ -230,20 +230,20 @@ public class PermissionHelper {
                     logger.debug("smbUrl:{} roleType:{}", responseData.getUrl(), roleTypeList);
                 }
             } else if (responseData.getUrl().startsWith("smb1:")) {
-                final jcifs.smb1.smb1.SID[] allowedSids =
-                        (jcifs.smb1.smb1.SID[]) metaDataMap.get(org.codelibs.fess.crawler.client.smb1.SmbClient.SMB_ALLOWED_SID_ENTRIES);
+                final org.codelibs.jcifs.smb1.SID[] allowedSids = (org.codelibs.jcifs.smb1.SID[]) metaDataMap
+                        .get(org.codelibs.fess.crawler.client.smb1.SmbClient.SMB_ALLOWED_SID_ENTRIES);
                 if (allowedSids != null) {
-                    for (final jcifs.smb1.smb1.SID sid : allowedSids) {
+                    for (final org.codelibs.jcifs.smb1.SID sid : allowedSids) {
                         final String accountId = sambaHelper.getAccountId(sid);
                         if (accountId != null) {
                             roleTypeList.add(accountId);
                         }
                     }
                 }
-                final jcifs.smb1.smb1.SID[] deniedSids =
-                        (jcifs.smb1.smb1.SID[]) metaDataMap.get(org.codelibs.fess.crawler.client.smb1.SmbClient.SMB_DENIED_SID_ENTRIES);
+                final org.codelibs.jcifs.smb1.SID[] deniedSids = (org.codelibs.jcifs.smb1.SID[]) metaDataMap
+                        .get(org.codelibs.fess.crawler.client.smb1.SmbClient.SMB_DENIED_SID_ENTRIES);
                 if (deniedSids != null) {
-                    for (final jcifs.smb1.smb1.SID sid : deniedSids) {
+                    for (final org.codelibs.jcifs.smb1.SID sid : deniedSids) {
                         final String accountId = sambaHelper.getAccountId(sid);
                         if (accountId != null) {
                             roleTypeList.add(fessConfig.getRoleSearchDeniedPrefix() + accountId);

--- a/src/main/java/org/codelibs/fess/helper/SambaHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SambaHelper.java
@@ -23,7 +23,7 @@ import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
 import jakarta.annotation.PostConstruct;
-import jcifs.SID;
+import org.codelibs.jcifs.smb.SID;
 
 /**
  * Helper class for Samba-related operations.
@@ -129,7 +129,7 @@ public class SambaHelper {
      * @param sid The SID.
      * @return The account ID.
      */
-    public String getAccountId(final jcifs.smb1.smb1.SID sid) {
+    public String getAccountId(final org.codelibs.jcifs.smb1.SID sid) {
         final int type = sid.getType();
         if (logger.isDebugEnabled()) {
             try {

--- a/src/test/java/org/codelibs/fess/helper/SambaHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SambaHelperTest.java
@@ -23,8 +23,8 @@ import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 
-import jcifs.SID;
-import jcifs.smb.SmbException;
+import org.codelibs.jcifs.smb.SID;
+import org.codelibs.jcifs.smb.impl.SmbException;
 
 public class SambaHelperTest extends UnitFessTestCase {
 


### PR DESCRIPTION
## Summary
I've updated the JCIFS library import paths throughout the codebase to align with the new library structure from org.codelibs.jcifs.

## Changes Made
- Updated `PermissionHelper.java` to use `org.codelibs.jcifs.smb.SID` instead of `jcifs.SID`
- Updated SMB1 specific imports to use `org.codelibs.jcifs.smb1.SID` for legacy SMB1 compatibility
- Modified `SambaHelper.java` to use the new import paths
- Updated `SambaHelperTest.java` to import `org.codelibs.jcifs.smb.impl.SmbException` for proper exception handling

## Testing
- Verified that all import statements resolve correctly
- Ensured SID type handling remains consistent across both SMB and SMB1 protocols
- Checked that existing permission and Samba helper functionality is preserved

## Breaking Changes
None - This is an internal refactoring that maintains the same public API.

## Additional Notes
This change ensures compatibility with the updated JCIFS library version while maintaining backward compatibility with SMB1 protocol where needed.