### PR TITLE
fix(build): Update Maven repository URL to Maven Central

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
 
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
-	<property name="maven.release.repo.url" value="https://oss.sonatype.org/content/repositories/releases" />
+	<property name="maven.release.repo.url" value="https://repo1.maven.org/maven2" />
 
 	<target name="install.plugins">
 		<mkdir dir="${target.dir}" />


### PR DESCRIPTION
## Summary
I updated the Maven release repository URL in `plugin.xml` from the deprecated Sonatype OSS URL to the current Maven Central repository URL. This ensures proper dependency resolution and compatibility with Maven Central's current infrastructure.

## Changes Made
- Updated `maven.release.repo.url` property in `plugin.xml`
- Changed from `https://oss.sonatype.org/content/repositories/releases` to `https://repo1.maven.org/maven2`

## Motivation
The old Sonatype OSS URL has been deprecated. Maven Central now uses `repo1.maven.org/maven2` as the canonical repository URL. This change ensures:
- Reliable dependency resolution
- Compatibility with current Maven Central infrastructure
- Alignment with Maven best practices

## Testing
- Verified the URL is the correct Maven Central repository endpoint
- This is a configuration-only change that affects build-time dependency resolution

## Breaking Changes
None. This is a transparent fix that maintains the same functionality with an updated repository URL.