### PR TITLE
fix(system): Update EOL date to April 1, 2027

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -165,7 +165,7 @@ public class SystemHelper {
             logger.debug("Initialize {}", this.getClass().getSimpleName());
         }
         final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        cal.set(2027, 3 - 1, 1); // EOL Date
+        cal.set(2027, 4 - 1, 1); // EOL Date
         eolTime = cal.getTimeInMillis();
         if (isEoled()) {
             logger.error("Your system is out of support. See https://fess.codelibs.org/eol.html");


### PR DESCRIPTION
## Summary
This PR updates the End-of-Life (EOL) date in SystemHelper to April 1, 2027, extending the support period for the current version by one month.

## Changes Made
- Updated EOL date from March 1, 2027 to April 1, 2027 in `SystemHelper.java:168`
- The change affects the `eolTime` initialization in the system helper

## Testing
- Verified the date calculation is correct (April = month 4, adjusted to 4-1 for Calendar API)
- Confirmed no compilation errors

## Additional Notes
This is a simple configuration change to extend the support period. No breaking changes or functional modifications are included.