### PR TITLE
chore(release): Update version to 15.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.3.0-SNAPSHOT</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
This pull request updates the project version in the `pom.xml` file to use the latest stable release instead of a snapshot version.

* Upgraded the parent project version from `15.3.0-SNAPSHOT` to `15.3.0` in `pom.xml`, ensuring the build uses the stable release.Update parent version from 15.3.0-SNAPSHOT to 15.3.0 for release preparation.