### PR TITLE
chore(deps): Update OpenSearch and plugins to latest versions

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -6,7 +6,7 @@
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://maven.codelibs.org" />
-	<property name="opensearch.version" value="3.3.0" />
+	<property name="opensearch.version" value="3.3.2" />
 
 	<target name="install.modules">
 		<mkdir dir="${target.dir}" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,8 +17,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-extension" />
-			<param name="plugin.version" value="3.3.0" />
-			<param name="plugin.zip.version" value="3.3.0" />
+			<param name="plugin.version" value="3.3.1" />
+			<param name="plugin.zip.version" value="3.3.1" />
 		</antcall>
 		<!-- analysis-fess -->
 		<antcall target="install.plugin">
@@ -26,8 +26,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-fess" />
-			<param name="plugin.version" value="3.3.0" />
-			<param name="plugin.zip.version" value="3.3.0" />
+			<param name="plugin.version" value="3.3.1" />
+			<param name="plugin.zip.version" value="3.3.1" />
 		</antcall>
 		<!-- configsync -->
 		<antcall target="install.plugin">
@@ -35,8 +35,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="configsync" />
-			<param name="plugin.version" value="3.3.0" />
-			<param name="plugin.zip.version" value="3.3.0" />
+			<param name="plugin.version" value="3.3.1" />
+			<param name="plugin.zip.version" value="3.3.1" />
 		</antcall>
 		<!-- minhash -->
 		<antcall target="install.plugin">
@@ -44,8 +44,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="minhash" />
-			<param name="plugin.version" value="3.3.0" />
-			<param name="plugin.zip.version" value="3.3.0" />
+			<param name="plugin.version" value="3.3.1" />
+			<param name="plugin.zip.version" value="3.3.1" />
 		</antcall>
 
 		<antcall target="remove.jars" />

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.3.0</version>
+		<version>15.3.1</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary

This PR updates OpenSearch core and related plugin dependencies to their latest versions to incorporate bug fixes and improvements.

## Changes Made

- Update OpenSearch core from 3.3.0 to 3.3.2
- Update OpenSearch analysis-extension plugin from 3.3.0 to 3.3.1
- Update OpenSearch analysis-fess plugin from 3.3.0 to 3.3.1
- Update OpenSearch configsync plugin from 3.3.0 to 3.3.1
- Update OpenSearch minhash plugin from 3.3.0 to 3.3.1
- Update Fess parent version from 15.3.0 to 15.3.1

## Modified Files

- `module.xml` - Updated OpenSearch core version
- `plugin.xml` - Updated all OpenSearch plugin versions
- `pom.xml` - Updated Fess parent version

## Testing

These are dependency version updates. Standard testing procedures should be followed:
- Build verification with `mvn package`
- Integration tests with OpenSearch 3.3.2
- Verify plugin compatibility

## Breaking Changes

None expected. These are minor version updates within the same major version.