### PR TITLE
refactor(llm): unify per-prompt-type parameter config and add extra params support

### DIFF
--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -36,10 +36,13 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.timer.TimeoutManager;
 import org.codelibs.core.timer.TimeoutTask;
 import org.codelibs.fess.util.ComponentUtil;
+import org.lastaflute.web.LastaWebKey;
 import org.lastaflute.web.util.LaRequestUtil;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpSession;
 
 /**
  * Abstract base class for LLM client implementations.
@@ -242,18 +245,12 @@ public abstract class AbstractLlmClient implements LlmClient {
     protected abstract String getLlmType();
 
     /**
-     * Gets the temperature parameter.
+     * Gets the configuration prefix for this provider.
+     * Used to look up per-prompt-type parameters from FessConfig.
      *
-     * @return the temperature
+     * @return the config prefix (e.g. "rag.llm.openai")
      */
-    protected abstract double getTemperature();
-
-    /**
-     * Gets the maximum tokens for the response.
-     *
-     * @return the maximum tokens
-     */
-    protected abstract int getMaxTokens();
+    protected abstract String getConfigPrefix();
 
     /**
      * Gets the base system prompt for RAG chat responses.
@@ -339,19 +336,35 @@ public abstract class AbstractLlmClient implements LlmClient {
      */
     protected abstract int getEvaluationMaxRelevantDocs();
 
-    /**
-     * Gets the maximum tokens for intent detection.
-     *
-     * @return the maximum tokens for intent detection
-     */
-    protected abstract int getIntentDetectionMaxTokens();
+    // --- Per-prompt-type parameter application ---
 
     /**
-     * Gets the maximum tokens for result evaluation.
+     * Applies per-prompt-type parameters to the request from configuration.
+     * Reads temperature, max.tokens, and thinking.budget from config using
+     * the pattern: {configPrefix}.{promptType}.{paramName}
      *
-     * @return the maximum tokens for result evaluation
+     * Subclasses can override to add provider-specific parameters (e.g. reasoning_effort, top_p).
+     *
+     * @param request the LLM chat request
+     * @param promptType the prompt type (e.g. "intent", "evaluation", "answer")
      */
-    protected abstract int getEvaluationMaxTokens();
+    protected void applyPromptTypeParams(final LlmChatRequest request, final String promptType) {
+        final String prefix = getConfigPrefix() + "." + promptType;
+        final var config = ComponentUtil.getFessConfig();
+
+        final String temp = config.getOrDefault(prefix + ".temperature", null);
+        if (temp != null) {
+            request.setTemperature(Double.parseDouble(temp));
+        }
+        final String maxTokens = config.getOrDefault(prefix + ".max.tokens", null);
+        if (maxTokens != null) {
+            request.setMaxTokens(Integer.parseInt(maxTokens));
+        }
+        final String thinkingBudget = config.getOrDefault(prefix + ".thinking.budget", null);
+        if (thinkingBudget != null) {
+            request.setThinkingBudget(Integer.parseInt(thinkingBudget));
+        }
+    }
 
     // --- Locale support methods ---
 
@@ -361,11 +374,16 @@ public abstract class AbstractLlmClient implements LlmClient {
      * @return the user's locale, or default locale if not in request context
      */
     protected Locale getUserLocale() {
-        try {
-            return LaRequestUtil.getOptionalRequest().map(request -> request.getLocale()).orElse(Locale.getDefault());
-        } catch (final Exception e) {
-            return Locale.getDefault();
-        }
+        return LaRequestUtil.getOptionalRequest().map(request -> {
+            final HttpSession session = request.getSession(false);
+            if (session != null && session.getAttribute(LastaWebKey.USER_LOCALE_KEY) instanceof final Locale sessionLocale) {
+                return sessionLocale;
+            }
+            if (request.getAttribute(LastaWebKey.USER_LOCALE_KEY) instanceof final Locale requestLocale) {
+                return requestLocale;
+            }
+            return request.getLocale();
+        }).orElse(Locale.getDefault());
     }
 
     /**
@@ -415,9 +433,7 @@ public abstract class AbstractLlmClient implements LlmClient {
             }
             final LlmChatRequest request = new LlmChatRequest();
             request.addUserMessage(prompt);
-            request.setMaxTokens(getIntentDetectionMaxTokens());
-            request.setTemperature(0.3);
-            request.setThinkingBudget(0);
+            applyPromptTypeParams(request, "intent");
 
             final LlmChatResponse response = chat(request);
             final IntentDetectionResult result = parseIntentResponse(response.getContent());
@@ -451,9 +467,7 @@ public abstract class AbstractLlmClient implements LlmClient {
             }
             final LlmChatRequest request = new LlmChatRequest();
             request.addUserMessage(prompt);
-            request.setMaxTokens(getEvaluationMaxTokens());
-            request.setTemperature(0.3);
-            request.setThinkingBudget(0);
+            applyPromptTypeParams(request, "evaluation");
 
             final LlmChatResponse response = chat(request);
             final RelevanceEvaluationResult result = parseEvaluationResponse(response.getContent(), searchResults);
@@ -515,8 +529,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
         addHistory(request, history);
         request.addUserMessage(userMessage);
-        request.setMaxTokens(getMaxTokens());
-        request.setTemperature(getTemperature());
+        applyPromptTypeParams(request, "unclear");
         request.setStream(true);
 
         streamChat(request, callback);
@@ -535,8 +548,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
         addHistory(request, history);
         request.addUserMessage(userMessage);
-        request.setMaxTokens(getMaxTokens());
-        request.setTemperature(getTemperature());
+        applyPromptTypeParams(request, "noresults");
         request.setStream(true);
 
         streamChat(request, callback);
@@ -556,8 +568,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
         addHistory(request, history);
         request.addUserMessage(userMessage);
-        request.setMaxTokens(getMaxTokens());
-        request.setTemperature(getTemperature());
+        applyPromptTypeParams(request, "docnotfound");
         request.setStream(true);
 
         streamChat(request, callback);
@@ -596,8 +607,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
         addHistory(request, history);
         request.addUserMessage(userMessage);
-        request.setMaxTokens(getMaxTokens());
-        request.setTemperature(getTemperature());
+        applyPromptTypeParams(request, "summary");
         request.setStream(true);
 
         streamChat(request, callback);
@@ -619,8 +629,7 @@ public abstract class AbstractLlmClient implements LlmClient {
         request.addSystemMessage(resolvedPrompt);
         addHistory(request, history);
         request.addUserMessage(userMessage);
-        request.setMaxTokens(getMaxTokens());
-        request.setTemperature(getTemperature());
+        applyPromptTypeParams(request, "faq");
         request.setStream(true);
 
         streamChat(request, callback);
@@ -640,8 +649,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
         addHistory(request, history);
         request.addUserMessage(userMessage);
-        request.setMaxTokens(getMaxTokens());
-        request.setTemperature(getTemperature());
+        applyPromptTypeParams(request, "direct");
         request.setStream(true);
 
         streamChat(request, callback);
@@ -770,8 +778,7 @@ public abstract class AbstractLlmClient implements LlmClient {
         addHistory(request, history);
         request.addUserMessage(userMessage);
 
-        request.setMaxTokens(getMaxTokens());
-        request.setTemperature(getTemperature());
+        applyPromptTypeParams(request, "answer");
 
         return request;
     }

--- a/src/main/java/org/codelibs/fess/llm/LlmChatRequest.java
+++ b/src/main/java/org/codelibs/fess/llm/LlmChatRequest.java
@@ -16,7 +16,9 @@
 package org.codelibs.fess.llm;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Request object for LLM chat completion.
@@ -31,6 +33,7 @@ public class LlmChatRequest {
     private Double temperature;
     private boolean stream;
     private Integer thinkingBudget;
+    private Map<String, String> extraParams;
 
     /**
      * Default constructor.
@@ -200,5 +203,50 @@ public class LlmChatRequest {
     public LlmChatRequest setThinkingBudget(final Integer thinkingBudget) {
         this.thinkingBudget = thinkingBudget;
         return this;
+    }
+
+    /**
+     * Gets the extra parameters for provider-specific settings.
+     *
+     * @return the extra parameters map, or {@code null} if not set
+     */
+    public Map<String, String> getExtraParams() {
+        return extraParams;
+    }
+
+    /**
+     * Sets the extra parameters for provider-specific settings.
+     *
+     * @param extraParams the extra parameters map
+     * @return this request for method chaining
+     */
+    public LlmChatRequest setExtraParams(final Map<String, String> extraParams) {
+        this.extraParams = extraParams;
+        return this;
+    }
+
+    /**
+     * Adds a single extra parameter for provider-specific settings.
+     *
+     * @param key the parameter key
+     * @param value the parameter value
+     * @return this request for method chaining
+     */
+    public LlmChatRequest putExtraParam(final String key, final String value) {
+        if (extraParams == null) {
+            extraParams = new HashMap<>();
+        }
+        extraParams.put(key, value);
+        return this;
+    }
+
+    /**
+     * Gets a single extra parameter value.
+     *
+     * @param key the parameter key
+     * @return the parameter value, or {@code null} if not set
+     */
+    public String getExtraParam(final String key) {
+        return extraParams != null ? extraParams.get(key) : null;
     }
 }


### PR DESCRIPTION
## Summary

Replaces scattered abstract methods for LLM parameters with a unified, config-driven approach that supports per-prompt-type configuration for all providers.

## Changes Made

- **`AbstractLlmClient.java`**:
  - Replaced `getTemperature()`, `getMaxTokens()`, `getIntentDetectionMaxTokens()`, and `getEvaluationMaxTokens()` abstract methods with a single `getConfigPrefix()` abstract method
  - Added `applyPromptTypeParams(request, promptType)` that reads `temperature`, `max.tokens`, and `thinking.budget` from FessConfig using pattern `{configPrefix}.{promptType}.{paramName}`
  - All prompt handlers (`intent`, `evaluation`, `unclear`, `noresults`, `docnotfound`, `summary`, `faq`, `direct`, `answer`) now delegate parameter setup to `applyPromptTypeParams`
  - Improved `getUserLocale()` to check `LastaWebKey.USER_LOCALE_KEY` in session and request attributes before falling back to `request.getLocale()`

- **`LlmChatRequest.java`**:
  - Added `extraParams` field (`Map<String, String>`) for provider-specific parameters
  - Added `getExtraParams()`, `setExtraParams()`, `putExtraParam()`, and `getExtraParam()` methods

## Testing

- Existing unit tests should pass; per-prompt-type config keys are optional and fall back gracefully when not set

## Breaking Changes

- Subclasses of `AbstractLlmClient` must now implement `getConfigPrefix()` instead of `getTemperature()`, `getMaxTokens()`, `getIntentDetectionMaxTokens()`, and `getEvaluationMaxTokens()`

## Additional Notes

- This enables fine-grained configuration per prompt type (e.g., lower temperature for intent detection, higher token limits for answer generation) without code changes
- The `extraParams` map allows provider-specific parameters (e.g., `reasoning_effort` for OpenAI) to be passed through `applyPromptTypeParams` overrides in subclasses