### PR TITLE
feat(rag): add custom highlight tags and improve evaluation content processing

### DIFF
--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -799,7 +799,10 @@ public class ChatClient {
 
         @Override
         public HighlightInfo getHighlightInfo() {
-            return ComponentUtil.getViewHelper().createHighlightInfo();
+            return new HighlightInfo().fragmentSize(Integer.parseInt(fessConfig.getOrDefault("rag.chat.highlight.fragment.size", "500")))
+                    .numOfFragments(Integer.parseInt(fessConfig.getOrDefault("rag.chat.highlight.number.of.fragments", "3")))
+                    .preTags(StringUtil.EMPTY)
+                    .postTags(StringUtil.EMPTY);
         }
 
         @Override

--- a/src/main/java/org/codelibs/fess/entity/HighlightInfo.java
+++ b/src/main/java/org/codelibs/fess/entity/HighlightInfo.java
@@ -32,6 +32,10 @@ public class HighlightInfo {
     private int numOfFragments;
     /** The offset for fragment positioning. */
     private int fragmentOffset;
+    /** Custom pre-tags for highlighting (null uses OpenSearch defaults). */
+    private String[] preTags;
+    /** Custom post-tags for highlighting (null uses OpenSearch defaults). */
+    private String[] postTags;
 
     /**
      * Default constructor that initializes highlighting settings from Fess configuration.
@@ -122,6 +126,46 @@ public class HighlightInfo {
      */
     public HighlightInfo fragmentOffset(final int fragmentOffset) {
         this.fragmentOffset = fragmentOffset;
+        return this;
+    }
+
+    /**
+     * Gets the custom pre-tags for highlighting.
+     *
+     * @return the pre-tags array, or null if using defaults
+     */
+    public String[] getPreTags() {
+        return preTags;
+    }
+
+    /**
+     * Sets the custom pre-tags for highlighting with fluent interface.
+     *
+     * @param preTags the pre-tags to set
+     * @return this HighlightInfo instance for method chaining
+     */
+    public HighlightInfo preTags(final String... preTags) {
+        this.preTags = preTags;
+        return this;
+    }
+
+    /**
+     * Gets the custom post-tags for highlighting.
+     *
+     * @return the post-tags array, or null if using defaults
+     */
+    public String[] getPostTags() {
+        return postTags;
+    }
+
+    /**
+     * Sets the custom post-tags for highlighting with fluent interface.
+     *
+     * @param postTags the post-tags to set
+     * @return this HighlightInfo instance for method chaining
+     */
+    public HighlightInfo postTags(final String... postTags) {
+        this.postTags = postTags;
         return this;
     }
 }

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -336,6 +336,13 @@ public abstract class AbstractLlmClient implements LlmClient {
      */
     protected abstract int getEvaluationMaxRelevantDocs();
 
+    /**
+     * Gets the maximum number of characters for evaluation description.
+     *
+     * @return the maximum number of characters
+     */
+    protected abstract int getEvaluationDescriptionMaxChars();
+
     // --- Per-prompt-type parameter application ---
 
     /**
@@ -677,18 +684,39 @@ public abstract class AbstractLlmClient implements LlmClient {
      */
     protected String buildEvaluationPrompt(final String userMessage, final String query, final List<Map<String, Object>> searchResults) {
         // Build search results formatted text
+        final int maxChars = getEvaluationDescriptionMaxChars();
         final StringBuilder searchResultsText = new StringBuilder();
         for (int i = 0; i < searchResults.size(); i++) {
             final Map<String, Object> doc = searchResults.get(i);
             searchResultsText.append("[").append(i + 1).append("] ");
             searchResultsText.append("Title: ").append(getStringValue(doc, "title")).append("\n");
-            searchResultsText.append("Description: ").append(getStringValue(doc, "content_description")).append("\n\n");
+            final String content = getStringValue(doc, "content");
+            final String description = getStringValue(doc, "content_description");
+            String descText = StringUtil.isNotBlank(content) ? content : description;
+            descText = stripHtmlTags(descText);
+            if (descText != null && descText.length() > maxChars) {
+                descText = descText.substring(0, maxChars);
+            }
+            searchResultsText.append("Description: ").append(descText != null ? descText : "").append("\n\n");
         }
 
         return getEvaluationPrompt().replace("{{maxRelevantDocs}}", String.valueOf(getEvaluationMaxRelevantDocs()))
                 .replace("{{userMessage}}", userMessage)
                 .replace("{{query}}", query)
                 .replace("{{searchResults}}", searchResultsText.toString());
+    }
+
+    /**
+     * Strips HTML tags from the given text.
+     *
+     * @param text the text to strip HTML tags from
+     * @return the text without HTML tags
+     */
+    protected String stripHtmlTags(final String text) {
+        if (StringUtil.isBlank(text)) {
+            return text;
+        }
+        return text.replaceAll("<[^>]+>", "");
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -2035,6 +2035,14 @@ public class SearchEngineClient implements Client {
             final int phraseLimit = fessConfig.getQueryHighlightPhraseLimitAsInteger();
             final String encoder = fessConfig.getQueryHighlightEncoder();
             final HighlightBuilder highlightBuilder = new HighlightBuilder();
+            final String[] preTags = highlightInfo.getPreTags();
+            final String[] postTags = highlightInfo.getPostTags();
+            if (preTags != null) {
+                highlightBuilder.preTags(preTags);
+            }
+            if (postTags != null) {
+                highlightBuilder.postTags(postTags);
+            }
             queryFieldConfig.highlightedFields(
                     stream -> stream.forEach(hf -> highlightBuilder.field(new HighlightBuilder.Field(hf).highlighterType(highlighterType)
                             .fragmentSize(fragmentSize)


### PR DESCRIPTION
## Summary

Enhances the RAG (Retrieval-Augmented Generation) feature with configurable highlight tags and improved evaluation content processing.

## Changes Made

- **HighlightInfo**: Added `preTags` and `postTags` fields with fluent setters (`preTags(String...)`, `postTags(String...)`) and getters, allowing callers to override the default OpenSearch highlight tags
- **SearchEngineClient**: Reads `preTags`/`postTags` from `HighlightInfo` and applies them to the `HighlightBuilder` when set, enabling tag-free or custom-tagged highlight results
- **ChatClient**: RAG chat highlight now uses empty pre/post tags (no HTML markup in fragments) and configures fragment size/count via `fessConfig` properties (`rag.chat.highlight.fragment.size`, `rag.chat.highlight.number.of.fragments`)
- **AbstractLlmClient**: 
  - Added abstract method `getEvaluationDescriptionMaxChars()` for subclasses to define max content length
  - Evaluation prompt now prefers `content` field over `content_description`, strips HTML tags via new `stripHtmlTags()` helper, and truncates to max chars

## Testing

- Verify RAG chat search returns highlight fragments without HTML tags
- Verify custom fragment size/count are respected via fessConfig properties
- Verify evaluation prompt uses clean, truncated content text

## Breaking Changes

- `AbstractLlmClient` subclasses must implement the new abstract method `getEvaluationDescriptionMaxChars()`

## Additional Notes

- The `stripHtmlTags()` method in `AbstractLlmClient` is `protected` so subclasses can override if needed
- Default highlight tags behavior is preserved for non-RAG search flows (preTags/postTags are null by default)