### PR TITLE
fix(crawler): add fallback URL resolution for relative paths with special characters

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/transformer/FessXpathTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/FessXpathTransformer.java
@@ -1107,6 +1107,43 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
             final int pos = urlValue.indexOf(':');
             if (pos > 0 && pos < 10) {
                 u = encodeUrl(normalizeUrl(urlValue), encoding);
+            } else {
+                // Fallback: manually construct absolute URL for relative paths
+                final String scheme = uri.getScheme();
+                final String authority = uri.getAuthority();
+                if (scheme != null && authority != null) {
+                    final String fallbackUrl;
+                    if (urlValue.startsWith("//")) {
+                        fallbackUrl = scheme + ":" + urlValue;
+                    } else if (urlValue.startsWith("?") || urlValue.startsWith("#")) {
+                        fallbackUrl = uri.toString() + urlValue;
+                    } else if (urlValue.startsWith("/")) {
+                        String absPath = urlValue;
+                        while (absPath.startsWith("/../")) {
+                            absPath = absPath.substring(3);
+                        }
+                        if (!absPath.startsWith("/")) {
+                            absPath = "/" + absPath;
+                        }
+                        fallbackUrl = scheme + "://" + authority + absPath;
+                    } else {
+                        String basePath = uri.getRawPath();
+                        if (basePath == null) {
+                            basePath = "/";
+                        }
+                        final int lastSlash = basePath.lastIndexOf('/');
+                        final String parentPath = lastSlash >= 0 ? basePath.substring(0, lastSlash + 1) : "/";
+                        String resolvedPath = parentPath + urlValue;
+                        while (resolvedPath.startsWith("/../")) {
+                            resolvedPath = resolvedPath.substring(3);
+                        }
+                        if (!resolvedPath.startsWith("/")) {
+                            resolvedPath = "/" + resolvedPath;
+                        }
+                        fallbackUrl = scheme + "://" + authority + resolvedPath;
+                    }
+                    u = encodeUrl(normalizeUrl(fallbackUrl), encoding);
+                }
             }
         }
 

--- a/src/test/java/org/codelibs/fess/crawler/transformer/FessXpathTransformerTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/transformer/FessXpathTransformerTest.java
@@ -1143,6 +1143,120 @@ public class FessXpathTransformerTest extends UnitFessTestCase {
         assertTrue(result.contains("http://example.com/page1"));
     }
 
+    @Test
+    public void test_getAnchorList_relativeUrlWithSpace() throws Exception {
+        final String data = "<html><body><a href=\"page 2.html\">link</a></body></html>";
+        final Document document = getDocument(data);
+
+        final FessXpathTransformer transformer = createAnchorListTransformer();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/dir/test.html");
+        responseData.setCharSet("UTF-8");
+
+        final List<String> result = transformer.getAnchorList(document, responseData);
+        assertEquals(1, result.size());
+        assertEquals("http://example.com/dir/page%202.html", result.get(0));
+    }
+
+    @Test
+    public void test_getAnchorList_absolutePathWithSpace() throws Exception {
+        final String data = "<html><body><a href=\"/path with space/page.html\">link</a></body></html>";
+        final Document document = getDocument(data);
+
+        final FessXpathTransformer transformer = createAnchorListTransformer();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/dir/test.html");
+        responseData.setCharSet("UTF-8");
+
+        final List<String> result = transformer.getAnchorList(document, responseData);
+        assertEquals(1, result.size());
+        assertEquals("http://example.com/path%20with%20space/page.html", result.get(0));
+    }
+
+    @Test
+    public void test_getAnchorList_protocolRelativeWithSpace() throws Exception {
+        final String data = "<html><body><a href=\"//cdn.example.com/a b.js\">link</a></body></html>";
+        final Document document = getDocument(data);
+
+        final FessXpathTransformer transformer = createAnchorListTransformer();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/test.html");
+        responseData.setCharSet("UTF-8");
+
+        final List<String> result = transformer.getAnchorList(document, responseData);
+        assertEquals(1, result.size());
+        assertEquals("http://cdn.example.com/a%20b.js", result.get(0));
+    }
+
+    @Test
+    public void test_getAnchorList_parentTraversalWithSpace() throws Exception {
+        final String data = "<html><body><a href=\"../page 2.html\">link</a></body></html>";
+        final Document document = getDocument(data);
+
+        final FessXpathTransformer transformer = createAnchorListTransformer();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/dir/sub/test.html");
+        responseData.setCharSet("UTF-8");
+
+        final List<String> result = transformer.getAnchorList(document, responseData);
+        assertEquals(1, result.size());
+        assertEquals("http://example.com/dir/page%202.html", result.get(0));
+    }
+
+    @Test
+    public void test_getAnchorList_parentTraversalAboveRootWithSpace() throws Exception {
+        final String data = "<html><body><a href=\"/../page 2.html\">link</a></body></html>";
+        final Document document = getDocument(data);
+
+        final FessXpathTransformer transformer = createAnchorListTransformer();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/test.html");
+        responseData.setCharSet("UTF-8");
+
+        final List<String> result = transformer.getAnchorList(document, responseData);
+        assertEquals(1, result.size());
+        assertEquals("http://example.com/page%202.html", result.get(0));
+    }
+
+    @Test
+    public void test_getAnchorList_parentTraversalFromRootWithSpace() throws Exception {
+        final String data = "<html><body><a href=\"../page 2.html\">link</a></body></html>";
+        final Document document = getDocument(data);
+
+        final FessXpathTransformer transformer = createAnchorListTransformer();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/test.html");
+        responseData.setCharSet("UTF-8");
+
+        final List<String> result = transformer.getAnchorList(document, responseData);
+        assertEquals(1, result.size());
+        assertEquals("http://example.com/page%202.html", result.get(0));
+    }
+
     private FessXpathTransformer createAnchorListTransformer() {
         final FessXpathTransformer transformer = new FessXpathTransformer() {
             @Override


### PR DESCRIPTION
## Summary

- Adds a fallback URL resolution mechanism in `FessXpathTransformer` for relative URLs that `URI.resolve()` cannot handle (e.g., paths containing spaces or other characters that prevent scheme detection)
- Covers four relative URL forms: protocol-relative (`//host/path`), query/fragment-only (`?q=...`, `#anchor`), root-absolute (`/path`), and relative (`../path`, `./path`)

## Changes Made

- **`FessXpathTransformer.java`**: Added `else` branch after the existing absolute-URL check (`pos > 0 && pos < 10`). When the URL value has no detectable scheme, the fallback manually constructs the absolute URL from the base URI's scheme and authority, handling `/../` normalization at the root boundary.
- **`FessXpathTransformerTest.java`**: Added 6 new test cases covering the fallback paths:
  - Relative path with space (`page 2.html`)
  - Absolute path with space (`/path with space/page.html`)
  - Protocol-relative URL with space (`//cdn.example.com/a b.js`)
  - Parent traversal with space (`../page 2.html`)
  - Parent traversal above root (`/../page 2.html`)
  - Parent traversal from root (`../page 2.html` with root base URL)

## Testing

- All new tests assert correct percent-encoded absolute URLs are produced
- Existing tests remain unaffected (fallback only activates when the original path has no scheme)

## Breaking Changes

None — the fallback only runs when the existing code path produces no result.

## Additional Notes

- The `/../` stripping loop mirrors the existing pattern used in `XpathTransformer` base class
- URLs that already resolve correctly via `URI.resolve()` (absolute URLs, normal relative paths) are unaffected