### PR TITLE
refactor(llm): extract constant and add resolveErrorCode in AbstractLlmClient

### DIFF
--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -58,6 +58,9 @@ public abstract class AbstractLlmClient implements LlmClient {
     /** Shared ObjectMapper instance for JSON processing. */
     protected static final ObjectMapper objectMapper = new ObjectMapper();
 
+    /** Buffer size reserved when truncating context to fit within max chars limit. */
+    protected static final int CONTEXT_TRUNCATION_BUFFER = 100;
+
     /** The HTTP client used for API communication. */
     protected CloseableHttpClient httpClient;
 
@@ -760,7 +763,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
             if (totalChars + docContext.length() > maxChars) {
                 // Truncate content to fit
-                final int remaining = maxChars - totalChars - 100;
+                final int remaining = maxChars - totalChars - CONTEXT_TRUNCATION_BUFFER;
                 if (remaining > 0 && docContext.length() > remaining) {
                     docContext.setLength(remaining);
                     docContext.append("...\n\n");
@@ -1032,6 +1035,27 @@ public abstract class AbstractLlmClient implements LlmClient {
             }
         }
         return Collections.emptyList();
+    }
+
+    // --- Error handling ---
+
+    /**
+     * Resolves an HTTP status code to an LlmException error code.
+     *
+     * @param statusCode the HTTP status code
+     * @return the corresponding error code
+     */
+    protected String resolveErrorCode(final int statusCode) {
+        if (statusCode == 429) {
+            return LlmException.ERROR_RATE_LIMIT;
+        }
+        if (statusCode == 401 || statusCode == 403) {
+            return LlmException.ERROR_AUTH;
+        }
+        if (statusCode == 502 || statusCode == 503) {
+            return LlmException.ERROR_SERVICE_UNAVAILABLE;
+        }
+        return LlmException.ERROR_UNKNOWN;
     }
 
     // --- Utility methods ---


### PR DESCRIPTION
## Summary

- Replace the magic number `100` used in context truncation with a named constant `CONTEXT_TRUNCATION_BUFFER` for clarity
- Add a `resolveErrorCode(int statusCode)` helper method that maps HTTP status codes (429, 401/403, 502/503) to their corresponding `LlmException` error codes

## Changes Made

- `AbstractLlmClient.java`: Added `CONTEXT_TRUNCATION_BUFFER = 100` constant and replaced inline magic number usage
- `AbstractLlmClient.java`: Added `resolveErrorCode(int)` protected method with mappings for rate-limit, auth, service-unavailable, and unknown error codes

## Testing

- Existing unit tests should cover the unchanged behavior
- The new `resolveErrorCode` method is straightforward branch logic and can be unit-tested independently

## Breaking Changes

None — both changes are backward-compatible (constant replaces inline literal, new method added without modifying existing signatures).

## Additional Notes

The `resolveErrorCode` method is intended for use by subclasses when handling HTTP error responses from LLM provider APIs, providing a consistent mapping across all client implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)