### PR TITLE
fix(llm): handle empty content with length finish reason for reasoning models

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/chat/ChatAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/chat/ChatAction.java
@@ -98,6 +98,12 @@ public class ChatAction extends FessSearchAction {
         return redirect(getClass());
     }
 
+    /**
+     * Returns the user ID for the current session. If the user is authenticated, returns the username;
+     * otherwise, returns the guest user code.
+     *
+     * @return the user ID
+     */
     protected String getUserId() {
         final String username = systemHelper.getUsername();
         if (!Constants.GUEST_USER.equals(username)) {

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -541,6 +541,12 @@ public abstract class AbstractLlmClient implements LlmClient {
             applyPromptTypeParams(request, "intent");
 
             final LlmChatResponse response = chatWithConcurrencyControl(request);
+            if (isEmptyContentWithLengthFinish(response)) {
+                logger.warn(
+                        "[RAG:INTENT] Empty content with finish_reason=length detected (possible reasoning model token exhaustion). Falling back to search. userMessage={}",
+                        userMessage);
+                return IntentDetectionResult.fallbackSearch(userMessage);
+            }
             final IntentDetectionResult result = parseIntentResponse(response.getContent(), userMessage);
 
             if (logger.isDebugEnabled()) {
@@ -576,6 +582,12 @@ public abstract class AbstractLlmClient implements LlmClient {
             applyPromptTypeParams(request, "intent");
 
             final LlmChatResponse response = chatWithConcurrencyControl(request);
+            if (isEmptyContentWithLengthFinish(response)) {
+                logger.warn(
+                        "[RAG:INTENT] Empty content with finish_reason=length detected (possible reasoning model token exhaustion). Falling back to search. userMessage={}",
+                        userMessage);
+                return IntentDetectionResult.fallbackSearch(userMessage);
+            }
             final IntentDetectionResult result = parseIntentResponse(response.getContent(), userMessage);
 
             if (logger.isDebugEnabled()) {
@@ -616,6 +628,16 @@ public abstract class AbstractLlmClient implements LlmClient {
             applyPromptTypeParams(request, "evaluation");
 
             final LlmChatResponse response = chatWithConcurrencyControl(request);
+            if (isEmptyContentWithLengthFinish(response)) {
+                logger.warn(
+                        "[RAG:EVAL] Empty content with finish_reason=length detected (possible reasoning model token exhaustion). Falling back to all relevant. userMessage={}",
+                        userMessage);
+                final List<String> allDocIds = searchResults.stream()
+                        .map(doc -> getStringValue(doc, "doc_id"))
+                        .filter(StringUtil::isNotBlank)
+                        .collect(Collectors.toList());
+                return RelevanceEvaluationResult.fallbackAllRelevant(allDocIds);
+            }
             final RelevanceEvaluationResult result = parseEvaluationResponse(response.getContent(), searchResults);
 
             if (logger.isDebugEnabled()) {
@@ -1314,6 +1336,18 @@ public abstract class AbstractLlmClient implements LlmClient {
     }
 
     // --- Utility methods ---
+
+    /**
+     * Checks if the LLM response has empty/blank content with a "length" finish reason.
+     * This typically indicates that a reasoning model consumed all tokens for internal
+     * reasoning, leaving no tokens for actual output content.
+     *
+     * @param response the LLM chat response
+     * @return true if content is empty/blank and finish reason is "length"
+     */
+    protected boolean isEmptyContentWithLengthFinish(final LlmChatResponse response) {
+        return StringUtil.isBlank(response.getContent()) && "length".equals(response.getFinishReason());
+    }
 
     /**
      * Gets a string value from a map.


### PR DESCRIPTION
## Summary

Handle the edge case where LLM reasoning models return empty/blank content with `finish_reason=length`, which occurs when the model exhausts its token budget entirely on internal chain-of-thought reasoning, leaving no tokens for the actual output.

## Changes Made

- **`AbstractLlmClient`**: Added `isEmptyContentWithLengthFinish()` utility method to detect the empty-content-with-length-finish pattern
- **`AbstractLlmClient`**: Applied fallback to intent detection paths — returns `IntentDetectionResult.fallbackSearch(userMessage)` when token exhaustion is detected
- **`AbstractLlmClient`**: Applied fallback to relevance evaluation — returns `RelevanceEvaluationResult.fallbackAllRelevant(allDocIds)` when token exhaustion is detected
- **`ChatAction`**: Added Javadoc to `getUserId()` for clarity

## Testing

- The fallbacks degrade gracefully: intent detection falls back to a standard search, and relevance evaluation treats all documents as relevant rather than failing

## Breaking Changes

None. The changes add fallback behavior for an edge case that previously would have led to empty/null content being parsed.

## Additional Notes

This issue is specific to reasoning models (e.g., o1, o3, DeepSeek R1) that use tokens for internal reasoning steps. When `finish_reason=length` is combined with blank content, it's a reliable signal that the reasoning consumed all available tokens with no room for the final answer.