### PR TITLE
refactor(i18n): rename chat title label to "AI Search Mode"

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
@@ -3444,7 +3444,7 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Update */
     public static final String LABELS_LOGIN_UPDATE = "{labels.login.update}";
 
-    /** The key of the message: AI Chat - Fess */
+    /** The key of the message: AI Search Mode - Fess */
     public static final String LABELS_chat_title = "{labels.chat_title}";
 
     /** The key of the message: New Chat */

--- a/src/main/resources/fess_label.properties
+++ b/src/main/resources/fess_label.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Confirm New Password
 labels.login.update=Update
 
 # Chat labels
-labels.chat_title=AI Chat - Fess
+labels.chat_title=AI Search Mode - Fess
 labels.chat_new_chat=New Chat
 labels.chat_input_placeholder=Ask a question...
 labels.chat_thinking=Thinking...

--- a/src/main/resources/fess_label_de.properties
+++ b/src/main/resources/fess_label_de.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Neues Passwort bestätigen
 labels.login.update=Aktualisieren
 
 # Chat labels
-labels.chat_title=KI-Chat - Fess
+labels.chat_title=KI-Suchmodus - Fess
 labels.chat_new_chat=Neuer Chat
 labels.chat_input_placeholder=Stellen Sie eine Frage...
 labels.chat_thinking=Denkt nach...

--- a/src/main/resources/fess_label_en.properties
+++ b/src/main/resources/fess_label_en.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Confirm New Password
 labels.login.update=Update
 
 # Chat labels
-labels.chat_title=AI Chat - Fess
+labels.chat_title=AI Search Mode - Fess
 labels.chat_new_chat=New Chat
 labels.chat_input_placeholder=Ask a question...
 labels.chat_thinking=Thinking...

--- a/src/main/resources/fess_label_es.properties
+++ b/src/main/resources/fess_label_es.properties
@@ -1139,7 +1139,7 @@ labels.login.placeholder_confirm_new_password=Confirmar nueva contraseña
 labels.login.update=Actualizar
 
 # Chat labels
-labels.chat_title=Chat IA - Fess
+labels.chat_title=Modo de búsqueda IA - Fess
 labels.chat_new_chat=Nueva conversación
 labels.chat_input_placeholder=Haz una pregunta...
 labels.chat_thinking=Pensando...

--- a/src/main/resources/fess_label_fr.properties
+++ b/src/main/resources/fess_label_fr.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Confirmer le nouveau mot de passe
 labels.login.update=Mettre à jour
 
 # Chat labels
-labels.chat_title=Chat IA - Fess
+labels.chat_title=Mode de recherche IA - Fess
 labels.chat_new_chat=Nouvelle conversation
 labels.chat_input_placeholder=Posez une question...
 labels.chat_thinking=Réflexion en cours...

--- a/src/main/resources/fess_label_hi.properties
+++ b/src/main/resources/fess_label_hi.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=नया पासवर्ड �
 labels.login.update=अपडेट
 
 # Chat labels
-labels.chat_title=AI चैट - Fess
+labels.chat_title=AI खोज मोड - Fess
 labels.chat_new_chat=नई चैट
 labels.chat_input_placeholder=एक प्रश्न पूछें...
 labels.chat_thinking=सोच रहा हूँ...

--- a/src/main/resources/fess_label_id.properties
+++ b/src/main/resources/fess_label_id.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Konfirmasi Kata Sandi Baru
 labels.login.update=Perbarui
 
 # Chat labels
-labels.chat_title=Obrolan AI - Fess
+labels.chat_title=Mode Pencarian AI - Fess
 labels.chat_new_chat=Obrolan Baru
 labels.chat_input_placeholder=Ajukan pertanyaan...
 labels.chat_thinking=Sedang berpikir...

--- a/src/main/resources/fess_label_it.properties
+++ b/src/main/resources/fess_label_it.properties
@@ -1133,7 +1133,7 @@ labels.login.placeholder_confirm_new_password=Conferma nuova password
 labels.login.update=Aggiorna
 
 # Chat labels
-labels.chat_title=Chat IA - Fess
+labels.chat_title=Modalità ricerca IA - Fess
 labels.chat_new_chat=Nuova chat
 labels.chat_input_placeholder=Fai una domanda...
 labels.chat_thinking=Sto pensando...

--- a/src/main/resources/fess_label_ja.properties
+++ b/src/main/resources/fess_label_ja.properties
@@ -1140,7 +1140,7 @@ labels.crawling_info_link_create=作成
 labels.failure_url_link_update=編集
 
 # Chat labels
-labels.chat_title=AIチャット - Fess
+labels.chat_title=AI検索モード - Fess
 labels.chat_new_chat=新規チャット
 labels.chat_input_placeholder=質問を入力してください...
 labels.chat_thinking=回答中...

--- a/src/main/resources/fess_label_ko.properties
+++ b/src/main/resources/fess_label_ko.properties
@@ -1133,7 +1133,7 @@ labels.login.placeholder_confirm_new_password=새 비밀번호 확인
 labels.login.update=갱신
 
 # Chat labels
-labels.chat_title=AI 채팅 - Fess
+labels.chat_title=AI 검색 모드 - Fess
 labels.chat_new_chat=새 채팅
 labels.chat_input_placeholder=질문을 입력하세요...
 labels.chat_thinking=생각 중...

--- a/src/main/resources/fess_label_nl.properties
+++ b/src/main/resources/fess_label_nl.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Nieuw wachtwoord bevestigen
 labels.login.update=Bijwerken
 
 # Chat labels
-labels.chat_title=AI Chat - Fess
+labels.chat_title=AI-zoekmodus - Fess
 labels.chat_new_chat=Nieuwe chat
 labels.chat_input_placeholder=Stel een vraag...
 labels.chat_thinking=Aan het denken...

--- a/src/main/resources/fess_label_pl.properties
+++ b/src/main/resources/fess_label_pl.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Potwierdź nowe hasło
 labels.login.update=Aktualizuj
 
 # Chat labels
-labels.chat_title=Czat AI - Fess
+labels.chat_title=Tryb wyszukiwania AI - Fess
 labels.chat_new_chat=Nowy czat
 labels.chat_input_placeholder=Zadaj pytanie...
 labels.chat_thinking=Myślę...

--- a/src/main/resources/fess_label_pt_BR.properties
+++ b/src/main/resources/fess_label_pt_BR.properties
@@ -1139,7 +1139,7 @@ labels.login.placeholder_confirm_new_password=Confirmar nova senha
 labels.login.update=Atualizar
 
 # Chat labels
-labels.chat_title=Chat IA - Fess
+labels.chat_title=Modo de pesquisa IA - Fess
 labels.chat_new_chat=Nova conversa
 labels.chat_input_placeholder=Faça uma pergunta...
 labels.chat_thinking=Pensando...

--- a/src/main/resources/fess_label_ru.properties
+++ b/src/main/resources/fess_label_ru.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Подтвердите новый 
 labels.login.update=Обновить
 
 # Chat labels
-labels.chat_title=ИИ-чат - Fess
+labels.chat_title=Режим ИИ-поиска - Fess
 labels.chat_new_chat=Новый чат
 labels.chat_input_placeholder=Задайте вопрос...
 labels.chat_thinking=Думаю...

--- a/src/main/resources/fess_label_tr.properties
+++ b/src/main/resources/fess_label_tr.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=Yeni Şifreyi Onayla
 labels.login.update=Güncelle
 
 # Chat labels
-labels.chat_title=Yapay Zeka Sohbeti - Fess
+labels.chat_title=Yapay Zeka Arama Modu - Fess
 labels.chat_new_chat=Yeni Sohbet
 labels.chat_input_placeholder=Bir soru sorun...
 labels.chat_thinking=Düşünüyor...

--- a/src/main/resources/fess_label_zh_CN.properties
+++ b/src/main/resources/fess_label_zh_CN.properties
@@ -1133,7 +1133,7 @@ labels.login.placeholder_confirm_new_password=确认新密码
 labels.login.update=更新
 
 # Chat labels
-labels.chat_title=AI 聊天 - Fess
+labels.chat_title=AI 搜索模式 - Fess
 labels.chat_new_chat=新对话
 labels.chat_input_placeholder=请输入问题...
 labels.chat_thinking=思考中...

--- a/src/main/resources/fess_label_zh_TW.properties
+++ b/src/main/resources/fess_label_zh_TW.properties
@@ -1140,7 +1140,7 @@ labels.login.placeholder_confirm_new_password=確認新密碼
 labels.login.update=更新
 
 # Chat labels
-labels.chat_title=AI 聊天 - Fess
+labels.chat_title=AI 搜尋模式 - Fess
 labels.chat_new_chat=新對話
 labels.chat_input_placeholder=請輸入問題...
 labels.chat_thinking=思考中...


### PR DESCRIPTION
## Summary

Renames the `labels.chat_title` label from "AI Chat - Fess" to "AI Search Mode - Fess" across all supported languages to better reflect the nature of the feature.

## Changes Made

- Updated `labels.chat_title` in `FessLabels.java` (Java constant comment)
- Updated `fess_label.properties` and all 17 locale-specific label files:
  - `fess_label_de.properties` — KI-Chat → KI-Suchmodus
  - `fess_label_en.properties` — AI Chat → AI Search Mode
  - `fess_label_es.properties` — Chat IA → Modo de búsqueda IA
  - `fess_label_fr.properties` — Chat IA → Mode de recherche IA
  - `fess_label_hi.properties` — AI चैट → AI खोज मोड
  - `fess_label_id.properties` — Obrolan AI → Mode Pencarian AI
  - `fess_label_it.properties` — Chat IA → Modalità ricerca IA
  - `fess_label_ja.properties` — AIチャット → AI検索モード
  - `fess_label_ko.properties` — AI 채팅 → AI 검색 모드
  - `fess_label_nl.properties` — AI Chat → AI-zoekmodus
  - `fess_label_pl.properties` — Czat AI → Tryb wyszukiwania AI
  - `fess_label_pt_BR.properties` — Chat IA → Modo de pesquisa IA
  - `fess_label_ru.properties` — ИИ-чат → Режим ИИ-поиска
  - `fess_label_tr.properties`, `fess_label_zh_CN.properties`, `fess_label_zh_TW.properties` — equivalent renames

## Testing

- No logic changes; label-only update
- Visual verification: page title in browser should show "AI Search Mode - Fess" instead of "AI Chat - Fess"

## Additional Notes

This is a pure i18n label rename with no functional impact. All 18 files (Java constants + 17 properties files) have been updated consistently.