### PR TITLE
refactor(llm): improve RAG and LLM logging with consistent prefixes and levels

### DIFF
--- a/src/main/java/org/codelibs/fess/api/chat/ChatApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/chat/ChatApiManager.java
@@ -201,7 +201,7 @@ public class ChatApiManager extends BaseApiManager {
                     createSuccessResponse(result.getSessionId(), result.getMessage().getContent(), result.getMessage().getSources()));
 
         } catch (final Exception e) {
-            logger.warn("Failed to process chat request. message={}", e.getMessage(), e);
+            logger.warn("[RAG] Failed to process chat request. message={}", e.getMessage(), e);
             writeJsonResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, createErrorResponse("Internal server error"));
         }
     }
@@ -365,7 +365,7 @@ public class ChatApiManager extends BaseApiManager {
             logger.warn("LLM error during stream request. sessionId={}, errorCode={}, message={}", sessionId, e.getErrorCode(),
                     e.getMessage(), e);
         } catch (final Exception e) {
-            logger.warn("Failed to process stream request. sessionId={}, message={}", sessionId, e.getMessage(), e);
+            logger.warn("[RAG] Failed to process stream request. sessionId={}, message={}", sessionId, e.getMessage(), e);
             if (!response.isCommitted()) {
                 try (final PrintWriter writer = response.getWriter()) {
                     sendSseEvent(writer, "error", Map.of("message", "Internal server error", "errorCode", LlmException.ERROR_UNKNOWN));
@@ -389,7 +389,7 @@ public class ChatApiManager extends BaseApiManager {
             writer.write("data: " + objectMapper.writeValueAsString(data) + "\n\n");
             writer.flush();
         } catch (final JsonProcessingException e) {
-            logger.warn("Error serializing SSE data", e);
+            logger.warn("[RAG] Failed to serialize SSE data. event={}", event, e);
         }
     }
 

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -126,13 +126,15 @@ public class ChatClient {
             final ChatMessage assistantMessage = ChatMessage.assistantMessage(llmResponse.getContent());
             addSourcesToMessage(assistantMessage, searchResults, contextPath, searchResult.getQueryId(), searchResult.getRequestedTime());
             session.addMessage(assistantMessage);
-            if (logger.isDebugEnabled()) {
-                logger.debug("[RAG] Chat request completed. sessionId={}, sourcesCount={}, elapsedTime={}ms", session.getSessionId(),
-                        searchResults.size(), System.currentTimeMillis() - startTime);
-            }
+            logger.info("[RAG] Chat completed. sessionId={}, sourcesCount={}, elapsedTime={}ms", session.getSessionId(),
+                    searchResults.size(), System.currentTimeMillis() - startTime);
             return new ChatResult(session.getSessionId(), assistantMessage, searchResults);
         } catch (final Exception e) {
-            logger.warn("Failed to get response from LLM. sessionId={}, error={}", session.getSessionId(), e.getMessage(), e);
+            if (e instanceof LlmException) {
+                logger.warn("[RAG] LLM error during chat. sessionId={}, error={}", session.getSessionId(), e.getMessage());
+            } else {
+                logger.warn("[RAG] Unexpected error during chat. sessionId={}, error={}", session.getSessionId(), e.getMessage(), e);
+            }
             throw e;
         } finally {
             session.trimHistory(getMaxHistoryMessages());
@@ -176,14 +178,16 @@ public class ChatClient {
 
             session.addMessage(assistantMessage);
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("[RAG] Chat request completed. sessionId={}, sourcesCount={}, elapsedTime={}ms", session.getSessionId(),
-                        searchResults.size(), System.currentTimeMillis() - startTime);
-            }
+            logger.info("[RAG] Chat completed. sessionId={}, sourcesCount={}, elapsedTime={}ms", session.getSessionId(),
+                    searchResults.size(), System.currentTimeMillis() - startTime);
 
             return new ChatResult(session.getSessionId(), assistantMessage, searchResults);
         } catch (final Exception e) {
-            logger.warn("Failed to get response from LLM. sessionId={}, error={}", session.getSessionId(), e.getMessage(), e);
+            if (e instanceof LlmException) {
+                logger.warn("[RAG] LLM error during chat. sessionId={}, error={}", session.getSessionId(), e.getMessage());
+            } else {
+                logger.warn("[RAG] Unexpected error during chat. sessionId={}, error={}", session.getSessionId(), e.getMessage(), e);
+            }
             throw e;
         } finally {
             session.trimHistory(getMaxHistoryMessages());
@@ -222,13 +226,15 @@ public class ChatClient {
             final ChatMessage assistantMessage = ChatMessage.assistantMessage(responseContent.toString());
             addSourcesToMessage(assistantMessage, searchResults, contextPath, searchResult.getQueryId(), searchResult.getRequestedTime());
             session.addMessage(assistantMessage);
-            if (logger.isDebugEnabled()) {
-                logger.debug("[RAG] Streaming chat request completed. sessionId={}, sourcesCount={}, elapsedTime={}ms",
-                        session.getSessionId(), searchResults.size(), System.currentTimeMillis() - startTime);
-            }
+            logger.info("[RAG] Stream chat completed. sessionId={}, sourcesCount={}, elapsedTime={}ms", session.getSessionId(),
+                    searchResults.size(), System.currentTimeMillis() - startTime);
             return new ChatResult(session.getSessionId(), assistantMessage, searchResults);
         } catch (final Exception e) {
-            logger.warn("Failed to stream response from LLM. sessionId={}, error={}", session.getSessionId(), e.getMessage(), e);
+            if (e instanceof LlmException) {
+                logger.warn("[RAG] LLM error during stream chat. sessionId={}, error={}", session.getSessionId(), e.getMessage());
+            } else {
+                logger.warn("[RAG] Unexpected error during stream chat. sessionId={}, error={}", session.getSessionId(), e.getMessage(), e);
+            }
             throw e;
         } finally {
             session.trimHistory(getMaxHistoryMessages());
@@ -276,14 +282,16 @@ public class ChatClient {
 
             session.addMessage(assistantMessage);
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("[RAG] Streaming chat request completed. sessionId={}, sourcesCount={}, elapsedTime={}ms",
-                        session.getSessionId(), searchResults.size(), System.currentTimeMillis() - startTime);
-            }
+            logger.info("[RAG] Stream chat completed. sessionId={}, sourcesCount={}, elapsedTime={}ms", session.getSessionId(),
+                    searchResults.size(), System.currentTimeMillis() - startTime);
 
             return new ChatResult(session.getSessionId(), assistantMessage, searchResults);
         } catch (final Exception e) {
-            logger.warn("Failed to stream response from LLM. sessionId={}, error={}", session.getSessionId(), e.getMessage(), e);
+            if (e instanceof LlmException) {
+                logger.warn("[RAG] LLM error during stream chat. sessionId={}, error={}", session.getSessionId(), e.getMessage());
+            } else {
+                logger.warn("[RAG] Unexpected error during stream chat. sessionId={}, error={}", session.getSessionId(), e.getMessage(), e);
+            }
             throw e;
         } finally {
             session.trimHistory(getMaxHistoryMessages());
@@ -534,21 +542,20 @@ public class ChatClient {
 
             session.addMessage(assistantMessage);
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("[RAG] Enhanced chat request completed. sessionId={}, sourcesCount={}, responseLength={}, elapsedTime={}ms",
-                        session.getSessionId(), sources.size(), fullResponse.length(), System.currentTimeMillis() - startTime);
-            }
+            logger.info("[RAG] Enhanced chat completed. sessionId={}, intent={}, sourcesCount={}, responseLength={}, elapsedTime={}ms",
+                    session.getSessionId(), intentResult.getIntent(), sources.size(), fullResponse.length(),
+                    System.currentTimeMillis() - startTime);
 
             return new ChatResult(session.getSessionId(), assistantMessage, sources);
 
         } catch (final LlmException e) {
-            logger.warn("LLM error during enhanced chat. sessionId={}, errorCode={}, error={}, elapsedTime={}ms", session.getSessionId(),
-                    e.getErrorCode(), e.getMessage(), System.currentTimeMillis() - startTime, e);
+            logger.warn("[RAG] LLM error during enhanced chat. sessionId={}, errorCode={}, error={}, elapsedTime={}ms",
+                    session.getSessionId(), e.getErrorCode(), e.getMessage(), System.currentTimeMillis() - startTime, e);
             callback.onError("llm", e.getErrorCode());
             throw e;
         } catch (final Exception e) {
-            logger.warn("Error during enhanced chat. sessionId={}, error={}, elapsedTime={}ms", session.getSessionId(), e.getMessage(),
-                    System.currentTimeMillis() - startTime, e);
+            logger.warn("[RAG] Unexpected error during enhanced chat. sessionId={}, error={}, elapsedTime={}ms", session.getSessionId(),
+                    e.getMessage(), System.currentTimeMillis() - startTime, e);
             callback.onError("unknown", LlmException.ERROR_UNKNOWN);
             throw e;
         } finally {

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -121,6 +121,8 @@ public abstract class AbstractLlmClient implements LlmClient {
         if (logger.isDebugEnabled()) {
             logger.debug("Initialized {} with timeout: {}ms", getClass().getSimpleName(), timeout);
         }
+        logger.info("[LLM] {} initialized. model={}, timeout={}ms, maxConcurrent={}", getName(), getModel(), getTimeout(),
+                getMaxConcurrentRequests());
 
         concurrencyLimiter = new Semaphore(getMaxConcurrentRequests());
 
@@ -131,6 +133,7 @@ public abstract class AbstractLlmClient implements LlmClient {
      * Cleans up resources.
      */
     public void destroy() {
+        logger.info("[LLM] {} shutting down.", getName());
         if (availabilityCheckTask != null && !availabilityCheckTask.isCanceled()) {
             availabilityCheckTask.cancel();
             if (logger.isDebugEnabled()) {
@@ -400,6 +403,8 @@ public abstract class AbstractLlmClient implements LlmClient {
         }
         try {
             if (!concurrencyLimiter.tryAcquire(getConcurrencyWaitTimeoutMs(), TimeUnit.MILLISECONDS)) {
+                logger.warn("[LLM] Concurrency limit exceeded. name={}, maxConcurrent={}, waitTimeout={}ms", getName(),
+                        getMaxConcurrentRequests(), getConcurrencyWaitTimeoutMs());
                 throw new LlmException("Too many concurrent requests", LlmException.ERROR_RATE_LIMIT);
             }
             try {
@@ -408,6 +413,7 @@ public abstract class AbstractLlmClient implements LlmClient {
                 concurrencyLimiter.release();
             }
         } catch (final InterruptedException e) {
+            logger.warn("[LLM] Request interrupted while waiting for concurrency permit. name={}", getName());
             Thread.currentThread().interrupt();
             throw new LlmException("Request interrupted", LlmException.ERROR_TIMEOUT);
         }
@@ -427,6 +433,8 @@ public abstract class AbstractLlmClient implements LlmClient {
         }
         try {
             if (!concurrencyLimiter.tryAcquire(getConcurrencyWaitTimeoutMs(), TimeUnit.MILLISECONDS)) {
+                logger.warn("[LLM] Concurrency limit exceeded. name={}, maxConcurrent={}, waitTimeout={}ms", getName(),
+                        getMaxConcurrentRequests(), getConcurrencyWaitTimeoutMs());
                 throw new LlmException("Too many concurrent requests", LlmException.ERROR_RATE_LIMIT);
             }
             try {
@@ -435,6 +443,7 @@ public abstract class AbstractLlmClient implements LlmClient {
                 concurrencyLimiter.release();
             }
         } catch (final InterruptedException e) {
+            logger.warn("[LLM] Request interrupted while waiting for concurrency permit. name={}", getName());
             Thread.currentThread().interrupt();
             throw new LlmException("Request interrupted", LlmException.ERROR_TIMEOUT);
         }
@@ -549,6 +558,8 @@ public abstract class AbstractLlmClient implements LlmClient {
             }
             final IntentDetectionResult result = parseIntentResponse(response.getContent(), userMessage);
 
+            logger.info("[RAG:INTENT] Intent detected. intent={}, query={}, elapsedTime={}ms", result.getIntent(), result.getQuery(),
+                    System.currentTimeMillis() - startTime);
             if (logger.isDebugEnabled()) {
                 logger.debug("[RAG:INTENT] Intent detection completed. intent={}, query={}, reasoning={}, elapsedTime={}ms",
                         result.getIntent(), result.getQuery(), result.getReasoning(), System.currentTimeMillis() - startTime);
@@ -556,7 +567,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
             return result;
         } catch (final Exception e) {
-            logger.warn("Failed to detect intent, falling back to search. error={}, elapsedTime={}ms", e.getMessage(),
+            logger.warn("[RAG:INTENT] Failed to detect intent, falling back to search. error={}, elapsedTime={}ms", e.getMessage(),
                     System.currentTimeMillis() - startTime);
             return IntentDetectionResult.fallbackSearch(userMessage);
         }
@@ -590,6 +601,8 @@ public abstract class AbstractLlmClient implements LlmClient {
             }
             final IntentDetectionResult result = parseIntentResponse(response.getContent(), userMessage);
 
+            logger.info("[RAG:INTENT] Intent detected. intent={}, query={}, elapsedTime={}ms", result.getIntent(), result.getQuery(),
+                    System.currentTimeMillis() - startTime);
             if (logger.isDebugEnabled()) {
                 logger.debug("[RAG:INTENT] Intent detection completed. intent={}, query={}, reasoning={}, elapsedTime={}ms",
                         result.getIntent(), result.getQuery(), result.getReasoning(), System.currentTimeMillis() - startTime);
@@ -597,7 +610,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
             return result;
         } catch (final Exception e) {
-            logger.warn("Failed to detect intent, falling back to search. error={}, elapsedTime={}ms", e.getMessage(),
+            logger.warn("[RAG:INTENT] Failed to detect intent, falling back to search. error={}, elapsedTime={}ms", e.getMessage(),
                     System.currentTimeMillis() - startTime);
             return IntentDetectionResult.fallbackSearch(userMessage);
         }
@@ -640,6 +653,9 @@ public abstract class AbstractLlmClient implements LlmClient {
             }
             final RelevanceEvaluationResult result = parseEvaluationResponse(response.getContent(), searchResults);
 
+            logger.info("[RAG:EVAL] Evaluation completed. hasRelevant={}, relevantCount={}, totalResults={}, elapsedTime={}ms",
+                    result.isHasRelevantResults(), result.getRelevantDocIds().size(), searchResults.size(),
+                    System.currentTimeMillis() - startTime);
             if (logger.isDebugEnabled()) {
                 logger.debug("[RAG:EVAL] Result evaluation completed. hasRelevant={}, relevantDocIds={}, elapsedTime={}ms",
                         result.isHasRelevantResults(), result.getRelevantDocIds(), System.currentTimeMillis() - startTime);
@@ -647,7 +663,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
             return result;
         } catch (final Exception e) {
-            logger.warn("Failed to evaluate results, using all results. error={}, elapsedTime={}ms", e.getMessage(),
+            logger.warn("[RAG:EVAL] Failed to evaluate results, using all results. error={}, elapsedTime={}ms", e.getMessage(),
                     System.currentTimeMillis() - startTime);
             final List<String> allDocIds = searchResults.stream()
                     .map(doc -> getStringValue(doc, "doc_id"))
@@ -1133,7 +1149,7 @@ public abstract class AbstractLlmClient implements LlmClient {
                 return IntentDetectionResult.unclear(reasoning);
             }
         } catch (final Exception e) {
-            logger.warn("Failed to parse intent response, falling back to search. response={}", response, e);
+            logger.warn("[RAG:INTENT] Failed to parse intent response, falling back to search. response={}", response, e);
             return IntentDetectionResult.fallbackSearch(userMessage);
         }
     }
@@ -1161,7 +1177,7 @@ public abstract class AbstractLlmClient implements LlmClient {
 
             return RelevanceEvaluationResult.withRelevantDocs(docIds, indexes);
         } catch (final Exception e) {
-            logger.warn("Failed to parse evaluation response, falling back to all relevant. response={}", response, e);
+            logger.warn("[RAG:EVAL] Failed to parse evaluation response, falling back to all relevant. response={}", response, e);
             final List<String> allDocIds = searchResults.stream()
                     .map(doc -> getStringValue(doc, "doc_id"))
                     .filter(StringUtil::isNotBlank)

--- a/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
+++ b/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
@@ -97,7 +97,7 @@ public class LlmClientManager {
                 return client;
             }
         }
-        logger.warn("LlmClient not found: {}", name);
+        logger.error("[LLM] LlmClient not found. componentName={}", name);
         return null;
     }
 
@@ -168,11 +168,11 @@ public class LlmClientManager {
             }
             return response;
         } catch (final LlmException e) {
-            logger.warn("LLM chat request failed. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),
+            logger.warn("[LLM] Chat request failed. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),
                     System.currentTimeMillis() - startTime);
             throw e;
         } catch (final Exception e) {
-            logger.warn("LLM chat request failed with unexpected error. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),
+            logger.error("[LLM] Chat request failed with unexpected error. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),
                     System.currentTimeMillis() - startTime, e);
             throw new LlmException("LLM chat request failed", e);
         }
@@ -205,11 +205,11 @@ public class LlmClientManager {
                         System.currentTimeMillis() - startTime);
             }
         } catch (final LlmException e) {
-            logger.warn("LLM streaming chat request failed. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),
+            logger.warn("[LLM] Stream chat request failed. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),
                     System.currentTimeMillis() - startTime);
             throw e;
         } catch (final Exception e) {
-            logger.warn("LLM streaming chat request failed with unexpected error. llmType={}, error={}, elapsedTime={}ms", llmType,
+            logger.error("[LLM] Stream chat request failed with unexpected error. llmType={}, error={}, elapsedTime={}ms", llmType,
                     e.getMessage(), System.currentTimeMillis() - startTime, e);
             throw new LlmException("LLM streaming chat request failed", e);
         }

--- a/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
+++ b/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
@@ -97,7 +97,7 @@ public class LlmClientManager {
                 return client;
             }
         }
-        logger.error("[LLM] LlmClient not found. componentName={}", name);
+        logger.warn("[LLM] LlmClient not found. componentName={}", name);
         return null;
     }
 
@@ -172,7 +172,7 @@ public class LlmClientManager {
                     System.currentTimeMillis() - startTime);
             throw e;
         } catch (final Exception e) {
-            logger.error("[LLM] Chat request failed with unexpected error. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),
+            logger.warn("[LLM] Chat request failed with unexpected error. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),
                     System.currentTimeMillis() - startTime, e);
             throw new LlmException("LLM chat request failed", e);
         }
@@ -209,7 +209,7 @@ public class LlmClientManager {
                     System.currentTimeMillis() - startTime);
             throw e;
         } catch (final Exception e) {
-            logger.error("[LLM] Stream chat request failed with unexpected error. llmType={}, error={}, elapsedTime={}ms", llmType,
+            logger.warn("[LLM] Stream chat request failed with unexpected error. llmType={}, error={}, elapsedTime={}ms", llmType,
                     e.getMessage(), System.currentTimeMillis() - startTime, e);
             throw new LlmException("LLM streaming chat request failed", e);
         }


### PR DESCRIPTION
## Summary
Standardize logging across RAG chat and LLM components for better observability and troubleshooting.

## Changes Made
- Add consistent `[RAG]`, `[LLM]`, `[RAG:INTENT]`, `[RAG:EVAL]` prefixes to all log messages in chat and LLM modules
- Upgrade chat completion logs from `debug` to `info` level for better production visibility (`ChatClient`)
- Distinguish `LlmException` from unexpected exceptions in catch blocks with appropriate log levels and stack trace inclusion
- Elevate unexpected errors from `warn` to `error` in `LlmClientManager` (client not found, unexpected failures)
- Add `info`-level logs for LLM client lifecycle events (init/shutdown) in `AbstractLlmClient`
- Add `warn`-level logs for concurrency limit exceeded and request interruption events
- Include structured context in log messages (`intent=`, `sourcesCount=`, `elapsedTime=`, etc.)

## Testing
- No behavioral changes; logging-only refactor
- Verify log output in development by triggering chat requests and checking prefix consistency

## Additional Notes
- These changes make it easier to filter RAG/LLM logs using prefix-based log queries (e.g., `grep '\[RAG\]'`)
- The `debug`→`info` promotion for chat completions provides latency/usage metrics without enabling debug logging