### PR TITLE
refactor(llm): enhance RAG and LLM debug logging for observability

### DIFF
--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -443,6 +443,8 @@ public class ChatClient {
                 searchRequestedTime = querySearchResult.getRequestedTime();
                 callback.onPhaseComplete(ChatPhaseCallback.PHASE_SEARCH);
 
+                logger.info("[RAG] Search completed. query={}, resultCount={}, elapsedTime={}ms", query, searchResults.size(),
+                        System.currentTimeMillis() - phaseStartTime);
                 if (logger.isDebugEnabled()) {
                     logger.debug("[RAG] Phase {} completed. query={}, resultCount={}, phaseElapsedTime={}ms",
                             ChatPhaseCallback.PHASE_SEARCH, query, searchResults.size(), System.currentTimeMillis() - phaseStartTime);
@@ -542,8 +544,9 @@ public class ChatClient {
 
             session.addMessage(assistantMessage);
 
-            logger.info("[RAG] Enhanced chat completed. sessionId={}, intent={}, sourcesCount={}, responseLength={}, elapsedTime={}ms",
-                    session.getSessionId(), intentResult.getIntent(), sources.size(), fullResponse.length(),
+            logger.info(
+                    "[RAG] Enhanced chat completed. sessionId={}, userId={}, intent={}, sourcesCount={}, responseLength={}, elapsedTime={}ms",
+                    session.getSessionId(), userId, intentResult.getIntent(), sources.size(), fullResponse.length(),
                     System.currentTimeMillis() - startTime);
 
             return new ChatResult(session.getSessionId(), assistantMessage, sources);

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -401,6 +401,10 @@ public abstract class AbstractLlmClient implements LlmClient {
         if (concurrencyLimiter == null) {
             return chat(request);
         }
+        if (logger.isDebugEnabled()) {
+            logger.debug("[LLM] Acquiring concurrency permit. name={}, availablePermits={}, maxConcurrent={}", getName(),
+                    concurrencyLimiter.availablePermits(), getMaxConcurrentRequests());
+        }
         try {
             if (!concurrencyLimiter.tryAcquire(getConcurrencyWaitTimeoutMs(), TimeUnit.MILLISECONDS)) {
                 logger.warn("[LLM] Concurrency limit exceeded. name={}, maxConcurrent={}, waitTimeout={}ms", getName(),
@@ -430,6 +434,10 @@ public abstract class AbstractLlmClient implements LlmClient {
         if (concurrencyLimiter == null) {
             streamChat(request, callback);
             return;
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("[LLM] Acquiring concurrency permit. name={}, availablePermits={}, maxConcurrent={}", getName(),
+                    concurrencyLimiter.availablePermits(), getMaxConcurrentRequests());
         }
         try {
             if (!concurrencyLimiter.tryAcquire(getConcurrencyWaitTimeoutMs(), TimeUnit.MILLISECONDS)) {
@@ -550,6 +558,10 @@ public abstract class AbstractLlmClient implements LlmClient {
             applyPromptTypeParams(request, "intent");
 
             final LlmChatResponse response = chatWithConcurrencyControl(request);
+            if (logger.isDebugEnabled()) {
+                logger.debug("[RAG:INTENT] LLM response. promptTokens={}, completionTokens={}, totalTokens={}, finishReason={}",
+                        response.getPromptTokens(), response.getCompletionTokens(), response.getTotalTokens(), response.getFinishReason());
+            }
             if (isEmptyContentWithLengthFinish(response)) {
                 logger.warn(
                         "[RAG:INTENT] Empty content with finish_reason=length detected (possible reasoning model token exhaustion). Falling back to search. userMessage={}",
@@ -593,6 +605,10 @@ public abstract class AbstractLlmClient implements LlmClient {
             applyPromptTypeParams(request, "intent");
 
             final LlmChatResponse response = chatWithConcurrencyControl(request);
+            if (logger.isDebugEnabled()) {
+                logger.debug("[RAG:INTENT] LLM response. promptTokens={}, completionTokens={}, totalTokens={}, finishReason={}",
+                        response.getPromptTokens(), response.getCompletionTokens(), response.getTotalTokens(), response.getFinishReason());
+            }
             if (isEmptyContentWithLengthFinish(response)) {
                 logger.warn(
                         "[RAG:INTENT] Empty content with finish_reason=length detected (possible reasoning model token exhaustion). Falling back to search. userMessage={}",
@@ -641,6 +657,10 @@ public abstract class AbstractLlmClient implements LlmClient {
             applyPromptTypeParams(request, "evaluation");
 
             final LlmChatResponse response = chatWithConcurrencyControl(request);
+            if (logger.isDebugEnabled()) {
+                logger.debug("[RAG:EVAL] LLM response. promptTokens={}, completionTokens={}, totalTokens={}, finishReason={}",
+                        response.getPromptTokens(), response.getCompletionTokens(), response.getTotalTokens(), response.getFinishReason());
+            }
             if (isEmptyContentWithLengthFinish(response)) {
                 logger.warn(
                         "[RAG:EVAL] Empty content with finish_reason=length detected (possible reasoning model token exhaustion). Falling back to all relevant. userMessage={}",
@@ -1119,6 +1139,10 @@ public abstract class AbstractLlmClient implements LlmClient {
 
         for (int i = startIndex; i < history.size(); i++) {
             request.addMessage(history.get(i));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("[RAG:ANSWER] History included. totalHistory={}, includedCount={}, startIndex={}, usedChars={}, budgetChars={}",
+                    history.size(), history.size() - startIndex, startIndex, budgetChars - remaining, budgetChars);
         }
     }
 

--- a/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
+++ b/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
@@ -163,8 +163,7 @@ public class LlmClientManager {
             }
             final LlmChatResponse response = client.chat(request);
             if (logger.isDebugEnabled()) {
-                logger.debug("[LLM] LLM chat request completed. llmType={}, contentLength={}, elapsedTime={}ms", llmType,
-                        response.getContent() != null ? response.getContent().length() : 0, System.currentTimeMillis() - startTime);
+                logger.debug("[LLM] LLM chat request completed. llmType={}", llmType);
             }
             return response;
         } catch (final LlmException e) {
@@ -201,8 +200,7 @@ public class LlmClientManager {
             }
             client.streamChat(request, callback);
             if (logger.isDebugEnabled()) {
-                logger.debug("[LLM] LLM streaming chat request completed. llmType={}, elapsedTime={}ms", llmType,
-                        System.currentTimeMillis() - startTime);
+                logger.debug("[LLM] LLM streaming chat request completed. llmType={}", llmType);
             }
         } catch (final LlmException e) {
             logger.warn("[LLM] Stream chat request failed. llmType={}, error={}, elapsedTime={}ms", llmType, e.getMessage(),


### PR DESCRIPTION
## Summary
Enhance RAG and LLM logging to improve observability and debugging capabilities.

## Changes Made
- **ChatClient**: Add info-level log for search phase completion with query, result count, and elapsed time; include `userId` in enhanced chat completion log
- **AbstractLlmClient**: Add debug-level logs for concurrency permit acquisition (available permits, max concurrent), LLM response token usage (prompt/completion/total tokens, finish reason) for intent and evaluation phases, and history inclusion details (count, start index, character budget)
- **LlmClientManager**: Simplify redundant debug log messages that duplicate information already logged at lower levels

## Testing
- Logging changes only; no behavioral impact
- Verified compilation

## Additional Notes
- Follows existing `[RAG]`/`[LLM]` prefix conventions established in #3070
- New detailed logs use debug level to avoid noise in production