### PR TITLE
fix(index): correct analyzer filters and dynamic template names

### DIFF
--- a/src/main/resources/fess_indices/_aws/fess.json
+++ b/src/main/resources/fess_indices/_aws/fess.json
@@ -761,10 +761,12 @@
           "tokenizer": "standard",
           "filter": [
             "truncate20_filter",
+            "possessive_stemmer_en_filter",
             "lowercase",
+            "stopword_en_filter",
             "english_keywords",
             "english_override",
-            "possessive_stemmer_en_filter"
+            "stemmer_en_filter"
           ]
         },
         "finnish_analyzer": {
@@ -811,6 +813,7 @@
             "lowercase",
             "german_stop",
             "german_normalization",
+            "german_keywords",
             "german_override",
             "german_stemmer"
           ]
@@ -960,7 +963,8 @@
             "lowercase",
             "arabic_normalization",
             "persian_normalization",
-            "persian_stop"
+            "persian_stop",
+            "persian_keywords"
           ]
         },
         "portuguese_analyzer": {
@@ -982,6 +986,7 @@
             "truncate20_filter",
             "lowercase",
             "romanian_stop",
+            "romanian_keywords",
             "romanian_override",
             "romanian_stemmer"
           ]
@@ -1048,7 +1053,8 @@
           "filter": [
             "truncate20_filter",
             "lowercase",
-            "thai_stop"
+            "thai_stop",
+            "thai_keywords"
           ]
         },
         "turkish_analyzer": {

--- a/src/main/resources/fess_indices/_aws/fess/doc.json
+++ b/src/main/resources/fess_indices/_aws/fess/doc.json
@@ -37,7 +37,7 @@
         }
       },
       {
-        "lang_ca": {
+        "lang_ckb-iq": {
           "match": "*_ckb-iq",
           "mapping": {
             "type": "text",
@@ -91,7 +91,7 @@
         }
       },
       {
-        "lang_en": {
+        "lang_en-ie": {
           "match": "*_en-ie",
           "mapping": {
             "type": "text",
@@ -185,7 +185,7 @@
           "match": "*_hi",
           "mapping": {
             "type": "text",
-            "analyzer": "empty_analyzer"
+            "analyzer": "hindi_analyzer"
           }
         }
       },
@@ -208,7 +208,7 @@
         }
       },
       {
-        "lang_hu": {
+        "lang_hy": {
           "match": "*_hy",
           "mapping": {
             "type": "text",

--- a/src/main/resources/fess_indices/_cloud/fess.json
+++ b/src/main/resources/fess_indices/_cloud/fess.json
@@ -761,10 +761,12 @@
           "tokenizer": "standard",
           "filter": [
             "truncate20_filter",
+            "possessive_stemmer_en_filter",
             "lowercase",
+            "stopword_en_filter",
             "english_keywords",
             "english_override",
-            "possessive_stemmer_en_filter"
+            "stemmer_en_filter"
           ]
         },
         "finnish_analyzer": {
@@ -811,6 +813,7 @@
             "lowercase",
             "german_stop",
             "german_normalization",
+            "german_keywords",
             "german_override",
             "german_stemmer"
           ]
@@ -960,7 +963,8 @@
             "lowercase",
             "arabic_normalization",
             "persian_normalization",
-            "persian_stop"
+            "persian_stop",
+            "persian_keywords"
           ]
         },
         "portuguese_analyzer": {
@@ -982,6 +986,7 @@
             "truncate20_filter",
             "lowercase",
             "romanian_stop",
+            "romanian_keywords",
             "romanian_override",
             "romanian_stemmer"
           ]
@@ -1048,7 +1053,8 @@
           "filter": [
             "truncate20_filter",
             "lowercase",
-            "thai_stop"
+            "thai_stop",
+            "thai_keywords"
           ]
         },
         "turkish_analyzer": {

--- a/src/main/resources/fess_indices/_cloud/fess/doc.json
+++ b/src/main/resources/fess_indices/_cloud/fess/doc.json
@@ -37,7 +37,7 @@
         }
       },
       {
-        "lang_ca": {
+        "lang_ckb-iq": {
           "match": "*_ckb-iq",
           "mapping": {
             "type": "text",
@@ -91,7 +91,7 @@
         }
       },
       {
-        "lang_en": {
+        "lang_en-ie": {
           "match": "*_en-ie",
           "mapping": {
             "type": "text",
@@ -185,7 +185,7 @@
           "match": "*_hi",
           "mapping": {
             "type": "text",
-            "analyzer": "empty_analyzer"
+            "analyzer": "hindi_analyzer"
           }
         }
       },
@@ -208,7 +208,7 @@
         }
       },
       {
-        "lang_hu": {
+        "lang_hy": {
           "match": "*_hy",
           "mapping": {
             "type": "text",

--- a/src/main/resources/fess_indices/fess.json
+++ b/src/main/resources/fess_indices/fess.json
@@ -806,10 +806,12 @@
           "tokenizer": "standard",
           "filter": [
             "truncate20_filter",
+            "possessive_stemmer_en_filter",
             "lowercase",
+            "stopword_en_filter",
             "english_keywords",
             "english_override",
-            "possessive_stemmer_en_filter"
+            "stemmer_en_filter"
           ]
         },
         "finnish_analyzer": {
@@ -856,6 +858,7 @@
             "lowercase",
             "german_stop",
             "german_normalization",
+            "german_keywords",
             "german_override",
             "german_stemmer"
           ]
@@ -1005,7 +1008,8 @@
             "lowercase",
             "arabic_normalization",
             "persian_normalization",
-            "persian_stop"
+            "persian_stop",
+            "persian_keywords"
           ]
         },
         "portuguese_analyzer": {
@@ -1027,6 +1031,7 @@
             "truncate20_filter",
             "lowercase",
             "romanian_stop",
+            "romanian_keywords",
             "romanian_override",
             "romanian_stemmer"
           ]
@@ -1093,7 +1098,8 @@
           "filter": [
             "truncate20_filter",
             "lowercase",
-            "thai_stop"
+            "thai_stop",
+            "thai_keywords"
           ]
         },
         "traditional_chinese_analyzer": {

--- a/src/main/resources/fess_indices/fess/doc.json
+++ b/src/main/resources/fess_indices/fess/doc.json
@@ -37,7 +37,7 @@
         }
       },
       {
-        "lang_ca": {
+        "lang_ckb-iq": {
           "match": "*_ckb-iq",
           "mapping": {
             "type": "text",
@@ -91,7 +91,7 @@
         }
       },
       {
-        "lang_en": {
+        "lang_en-ie": {
           "match": "*_en-ie",
           "mapping": {
             "type": "text",
@@ -185,7 +185,7 @@
           "match": "*_hi",
           "mapping": {
             "type": "text",
-            "analyzer": "empty_analyzer"
+            "analyzer": "hindi_analyzer"
           }
         }
       },
@@ -208,7 +208,7 @@
         }
       },
       {
-        "lang_hu": {
+        "lang_hy": {
           "match": "*_hy",
           "mapping": {
             "type": "text",


### PR DESCRIPTION
## Summary
- Fix incorrect analyzer filter configurations and dynamic template name mismatches in OpenSearch index mappings

## Changes Made
- **English analyzer**: Reorder filters to apply `possessive_stemmer_en_filter` before `lowercase`, add `stopword_en_filter`, and replace `possessive_stemmer_en_filter` at end with `stemmer_en_filter`
- **German analyzer**: Add missing `german_keywords` filter before `german_override`
- **Persian analyzer**: Add missing `persian_keywords` filter
- **Romanian analyzer**: Add missing `romanian_keywords` filter before `romanian_override`
- **Thai analyzer**: Add missing `thai_keywords` filter
- **Dynamic templates**: Fix template name mismatches (`lang_ca` → `lang_ckb-iq`, `lang_en` → `lang_en-ie`, `lang_hu` → `lang_hy`)
- **Hindi mapping**: Change analyzer from `empty_analyzer` to `hindi_analyzer`
- Applied consistently across `fess.json`, `_aws/fess.json`, and `_cloud/fess.json` variants

## Testing
- Verify index creation with updated mappings on OpenSearch
- Confirm multi-language search results are correctly analyzed

## Breaking Changes
- Existing indices will need to be recreated to apply the updated analyzer configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)