### PR TITLE
fix(security): mask sensitive tokens in EntraIdAuthenticator debug logs

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -333,7 +333,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     protected void validateNonce(final StateData stateData, final IAuthenticationResult authData) {
         final String idToken = authData.idToken();
         if (logger.isDebugEnabled()) {
-            logger.debug("idToken={}", idToken);
+            logger.debug("idToken={}***", idToken.substring(0, Math.min(8, idToken.length())));
         }
         try {
             final JWTClaimsSet claimsSet = JWTParser.parse(idToken).getJWTClaimsSet();
@@ -363,7 +363,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     public IAuthenticationResult getAccessToken(final String refreshToken) {
         final String authority = getAuthority() + getTenant() + "/";
         if (logger.isDebugEnabled()) {
-            logger.debug("refreshToken={}, authority={}", refreshToken, authority);
+            logger.debug("refreshToken={}***, authority={}", refreshToken.substring(0, Math.min(8, refreshToken.length())), authority);
         }
         try {
             final ConfidentialClientApplication app = ConfidentialClientApplication


### PR DESCRIPTION
## Summary
- Truncate `idToken` and `refreshToken` to first 8 characters in debug log output in `EntraIdAuthenticator`
- Prevents full token exposure in log files, improving security posture

## Test plan
- [ ] Verify debug logging still works with `idToken` truncated to 8 chars + `***`
- [ ] Verify debug logging still works with `refreshToken` truncated to 8 chars + `***`
- [ ] Confirm tokens shorter than 8 characters are handled correctly via `Math.min()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)