### PR TITLE
fix(security): mask Authorization header value in SPNEGO error messages

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -188,7 +188,16 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                     logger.debug("principal={}", principal);
                 }
             } catch (final Exception e) {
-                final String msg = "Failed to process Authorization Header: " + request.getHeader(Constants.AUTHZ_HEADER);
+                final String authzHeader = request.getHeader(Constants.AUTHZ_HEADER);
+                final String maskedHeader;
+                if (authzHeader == null) {
+                    maskedHeader = "null";
+                } else if (authzHeader.length() <= 10) {
+                    maskedHeader = "***";
+                } else {
+                    maskedHeader = authzHeader.substring(0, 10) + "***";
+                }
+                final String msg = "Failed to process Authorization Header: " + maskedHeader;
                 if (logger.isDebugEnabled()) {
                     logger.debug(msg);
                 }


### PR DESCRIPTION
## Summary
- SPNEGO認証失敗時の例外メッセージとデバッグログで、Authorizationヘッダーの値をマスクするように修正
- Kerberos/NTLMトークンやBase64エンコードされた認証情報がログや例外メッセージに漏洩するリスクを防止
- ヘッダー値の先頭10文字のみ表示し、残りを `***` でマスク（スキーム名の確認は可能）

## Test plan
- [ ] SPNEGO認証が有効な環境で認証失敗時のログを確認し、トークンがマスクされていることを検証
- [ ] `mvn package` ビルド成功を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)