### PR TITLE
fix(security): prevent path traversal and symlink attacks in IndexExportJob

### DIFF
--- a/src/main/java/org/codelibs/fess/job/IndexExportJob.java
+++ b/src/main/java/org/codelibs/fess/job/IndexExportJob.java
@@ -16,11 +16,15 @@
 package org.codelibs.fess.job;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -180,8 +184,20 @@ public class IndexExportJob {
         final String content = formatter.format(source, excludeFields);
 
         try {
+            final Path basePath = Paths.get(exportPath);
+            Files.createDirectories(basePath);
+            final Path realBase = basePath.toRealPath();
             Files.createDirectories(filePath.getParent());
-            Files.writeString(filePath, content, StandardCharsets.UTF_8);
+            final Path realParent = filePath.getParent().toRealPath();
+            if (!realParent.startsWith(realBase)) {
+                logger.warn("Symlink traversal detected: url={}, realParent={}, realBase={}", url, realParent, realBase);
+                return;
+            }
+            final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+            try (OutputStream out = Files.newOutputStream(filePath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING,
+                    LinkOption.NOFOLLOW_LINKS)) {
+                out.write(bytes);
+            }
         } catch (final IOException e) {
             logger.warn("Failed to export document: url={}", url, e);
         }
@@ -220,17 +236,26 @@ public class IndexExportJob {
             final String[] components = (host + "/" + path).split("/");
             final StringBuilder sanitized = new StringBuilder();
             for (int i = 0; i < components.length; i++) {
-                if (i > 0) {
-                    sanitized.append('/');
-                }
                 String component = components[i].replaceAll("[<>:\"|?*\\\\]", "_");
+                if (".".equals(component) || "..".equals(component)) {
+                    continue;
+                }
                 if (component.length() > MAX_PATH_COMPONENT_LENGTH) {
                     component = component.substring(0, MAX_PATH_COMPONENT_LENGTH);
+                }
+                if (sanitized.length() > 0) {
+                    sanitized.append('/');
                 }
                 sanitized.append(component);
             }
 
-            return Paths.get(exportPath, sanitized.toString());
+            final Path resolved = Paths.get(exportPath, sanitized.toString()).normalize();
+            final Path baseDir = Paths.get(exportPath).normalize();
+            if (!resolved.startsWith(baseDir)) {
+                logger.warn("Path traversal detected: url={}, resolved={}", url, resolved);
+                return Paths.get(exportPath, "_invalid", hashString(url) + formatter.getFileExtension());
+            }
+            return resolved;
         } catch (final Exception e) {
             logger.debug("Failed to parse URL: {}", url, e);
             return Paths.get(exportPath, "_invalid", hashString(url) + formatter.getFileExtension());

--- a/src/test/java/org/codelibs/fess/job/IndexExportJobTest.java
+++ b/src/test/java/org/codelibs/fess/job/IndexExportJobTest.java
@@ -1570,4 +1570,123 @@ public class IndexExportJobTest extends UnitFessTestCase {
         assertTrue(result.toString().contains("path"));
         assertTrue(result.toString().endsWith("page.html"));
     }
+
+    // --- path traversal prevention tests ---
+
+    @Test
+    public void test_buildFilePath_dotDotTraversal() {
+        final Path result =
+                indexExportJob.buildFilePath(tempDir.toString(), "http://example.com/foo/../../etc/passwd", new HtmlIndexExportFormatter());
+        assertNotNull(result);
+        assertTrue(result.normalize().startsWith(tempDir.normalize()), "Path must stay within base directory: " + result);
+    }
+
+    @Test
+    public void test_buildFilePath_dotDotStripped() {
+        final Path result =
+                indexExportJob.buildFilePath(tempDir.toString(), "http://example.com/foo/../../etc/passwd", new HtmlIndexExportFormatter());
+        assertNotNull(result);
+        assertFalse(result.toString().contains(".."));
+        assertTrue(result.normalize().startsWith(tempDir.normalize()), "Path must stay within base directory: " + result);
+    }
+
+    @Test
+    public void test_buildFilePath_singleDotIgnored() {
+        final Path result =
+                indexExportJob.buildFilePath(tempDir.toString(), "http://example.com/./path/./page.html", new HtmlIndexExportFormatter());
+        assertNotNull(result);
+        assertFalse(result.toString().contains("_invalid"));
+        assertTrue(result.normalize().startsWith(tempDir.normalize()), "Path must stay within base directory: " + result);
+        assertTrue(result.toString().contains("example.com"));
+        assertTrue(result.toString().endsWith("page.html"));
+    }
+
+    @Test
+    public void test_buildFilePath_multipleDotDotSequences() {
+        final Path result = indexExportJob.buildFilePath(tempDir.toString(), "http://example.com/a/b/c/../../../../../../../tmp/evil",
+                new HtmlIndexExportFormatter());
+        assertNotNull(result);
+        assertTrue(result.normalize().startsWith(tempDir.normalize()), "Path must stay within base directory: " + result);
+    }
+
+    @Test
+    public void test_buildFilePath_percentEncodedDotDot() {
+        final Path result = indexExportJob.buildFilePath(tempDir.toString(), "http://example.com/%2e%2e/%2e%2e/etc/passwd",
+                new HtmlIndexExportFormatter());
+        assertNotNull(result);
+        assertFalse(result.toString().contains(".."));
+        assertTrue(result.normalize().startsWith(tempDir.normalize()), "Path must stay within base directory: " + result);
+    }
+
+    @Test
+    public void test_buildFilePath_backslashTraversal() {
+        final Path result = indexExportJob.buildFilePath(tempDir.toString(), "http://example.com/foo\\..\\..\\etc\\passwd",
+                new HtmlIndexExportFormatter());
+        assertNotNull(result);
+        assertTrue(result.normalize().startsWith(tempDir.normalize()), "Path must stay within base directory: " + result);
+    }
+
+    @Test
+    public void test_buildFilePath_onlyDotDotComponents() {
+        final Path result =
+                indexExportJob.buildFilePath(tempDir.toString(), "http://example.com/../../../", new HtmlIndexExportFormatter());
+        assertNotNull(result);
+        assertTrue(result.normalize().startsWith(tempDir.normalize()), "Path must stay within base directory: " + result);
+    }
+
+    @Test
+    public void test_buildFilePath_encodedSlashTraversal() {
+        final Path result =
+                indexExportJob.buildFilePath(tempDir.toString(), "http://example.com/%2Fetc%2Fpasswd", new HtmlIndexExportFormatter());
+        assertNotNull(result);
+        assertTrue(result.normalize().startsWith(tempDir.normalize()), "Path must stay within base directory: " + result);
+    }
+
+    // --- symlink traversal prevention tests ---
+
+    @Test
+    public void test_exportDocument_symlinkIntermediateDir() throws Exception {
+        final Path outsideDir = Files.createTempDirectory("outside");
+        try {
+            final Path hostDir = tempDir.resolve("evil.com");
+            Files.createSymbolicLink(hostDir, outsideDir);
+
+            final Map<String, Object> source = new LinkedHashMap<>();
+            source.put("url", "http://evil.com/secret.html");
+            source.put("content", "should not be written outside");
+
+            indexExportJob.exportDocument(source, tempDir.toString(), Collections.emptySet(), new HtmlIndexExportFormatter());
+
+            assertFalse(Files.exists(outsideDir.resolve("secret.html")), "File must not be written outside base directory via symlink");
+        } finally {
+            Files.deleteIfExists(tempDir.resolve("evil.com"));
+            deleteRecursive(outsideDir);
+        }
+    }
+
+    @Test
+    public void test_exportDocument_symlinkAtLeafFile() throws Exception {
+        final Path outsideDir = Files.createTempDirectory("outside");
+        try {
+            final Path outsideTarget = outsideDir.resolve("stolen.html");
+            Files.writeString(outsideTarget, "original", StandardCharsets.UTF_8);
+
+            final Path hostDir = tempDir.resolve("example.com");
+            Files.createDirectories(hostDir);
+            final Path symlinkFile = hostDir.resolve("page.html");
+            Files.createSymbolicLink(symlinkFile, outsideTarget);
+
+            final Map<String, Object> source = new LinkedHashMap<>();
+            source.put("url", "http://example.com/page.html");
+            source.put("content", "overwritten via symlink");
+
+            indexExportJob.exportDocument(source, tempDir.toString(), Collections.emptySet(), new HtmlIndexExportFormatter());
+
+            assertEquals("original", Files.readString(outsideTarget));
+        } finally {
+            Files.deleteIfExists(tempDir.resolve("example.com/page.html"));
+            Files.deleteIfExists(tempDir.resolve("example.com"));
+            deleteRecursive(outsideDir);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Strip `.` and `..` path components and normalize resolved paths in `buildFilePath()` to prevent directory traversal attacks
- Validate that resolved file paths stay within the export base directory, falling back to `_invalid/` directory for malicious URLs
- Add symlink traversal prevention in `exportDocument()` by resolving real paths and using `NOFOLLOW_LINKS` when writing files
- Add comprehensive tests for path traversal and symlink attack scenarios

## Test plan
- [ ] Verify existing `IndexExportJobTest` tests pass
- [ ] Verify new path traversal prevention tests pass (dot-dot, encoded, backslash variants)
- [ ] Verify new symlink traversal prevention tests pass (intermediate dir symlink, leaf file symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)