### PR TITLE
chore(deps): remove jakarta.activation and add oauth2-oidc-sdk dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -990,16 +990,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>jakarta.activation</groupId>
-			<artifactId>jakarta.activation-api</artifactId>
-			<version>${jakarta.activation.api.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.activation</groupId>
-			<artifactId>jakarta.activation</artifactId>
-			<version>${jakarta.activation.version}</version>
-		</dependency>
 
 		<!-- logging -->
 		<dependency>
@@ -1321,6 +1311,11 @@
 					<artifactId>javax.mail</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.nimbusds</groupId>
+			<artifactId>oauth2-oidc-sdk</artifactId>
+			<version>${oauth2.oidc.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
## Summary
Update Maven dependencies in pom.xml by removing unused Jakarta Activation packages and adding the Nimbus OAuth2 OIDC SDK.

## Changes Made
- Removed `jakarta.activation:jakarta.activation-api` dependency
- Removed `com.sun.activation:jakarta.activation` dependency
- Added `com.nimbusds:oauth2-oidc-sdk` dependency for OAuth2/OIDC support

## Testing
- Build verification with `mvn package`

## Breaking Changes
- None expected. Jakarta Activation removal should be safe if no longer referenced.

## Additional Notes
- The oauth2-oidc-sdk library provides standards-compliant OAuth 2.0 and OpenID Connect support