### PR TITLE
feat(chat): add smart summary mode and turn-based history packing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1392,6 +1392,12 @@
 			<groupId>org.dbflute.mail</groupId>
 			<artifactId>mailflute</artifactId>
 			<version>${mailflute.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.sun.mail</groupId>
+					<artifactId>jakarta.mail</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- csv -->

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -41,6 +41,7 @@ import org.codelibs.fess.helper.MarkdownRenderer;
 import org.codelibs.fess.llm.ChatIntent;
 import org.codelibs.fess.llm.IntentDetectionResult;
 import org.codelibs.fess.llm.LlmChatResponse;
+import org.codelibs.fess.llm.LlmClient;
 import org.codelibs.fess.llm.LlmClientManager;
 import org.codelibs.fess.llm.LlmException;
 import org.codelibs.fess.llm.LlmMessage;
@@ -523,14 +524,18 @@ public class ChatClient {
      */
     protected List<LlmMessage> extractHistory(final ChatSession session) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final String assistantContentMode = fessConfig.getOrDefault("rag.chat.history.assistant.content", "source_titles");
+        final String assistantContentMode = fessConfig.getOrDefault("rag.chat.history.assistant.content", "smart_summary");
+
+        final LlmClient client = llmClientManager.getClient();
+        final int assistantMaxChars = client != null ? client.getHistoryAssistantMaxChars() : 800;
+        final int summaryMaxChars = client != null ? client.getHistoryAssistantSummaryMaxChars() : 800;
 
         final List<LlmMessage> history = new ArrayList<>();
         for (final ChatMessage msg : session.getMessages()) {
             if (msg.isUser()) {
                 history.add(LlmMessage.user(msg.getContent()));
             } else if (msg.isAssistant()) {
-                final String content = buildAssistantHistoryContent(msg, assistantContentMode);
+                final String content = buildAssistantHistoryContent(msg, assistantContentMode, assistantMaxChars, summaryMaxChars);
                 if (content != null) {
                     history.add(LlmMessage.assistant(content));
                 }
@@ -543,19 +548,24 @@ public class ChatClient {
      * Builds the assistant message content for history based on the specified mode.
      *
      * @param msg the assistant chat message
-     * @param mode the content mode (full, source_titles, source_titles_and_urls, truncated, none)
+     * @param mode the content mode (full, smart_summary, source_titles, source_titles_and_urls, truncated, none)
+     * @param assistantMaxChars the maximum characters for truncated mode
+     * @param summaryMaxChars the maximum characters for summary modes
      * @return the content string for history, or null if the message should be excluded
      */
-    protected String buildAssistantHistoryContent(final ChatMessage msg, final String mode) {
+    protected String buildAssistantHistoryContent(final ChatMessage msg, final String mode, final int assistantMaxChars,
+            final int summaryMaxChars) {
         switch (mode) {
         case "full":
             return msg.getContent();
+        case "smart_summary":
+            return buildSmartSummaryContent(msg, summaryMaxChars);
         case "source_titles":
-            return buildSourceTitlesContent(msg);
+            return buildSourceTitlesContent(msg, summaryMaxChars);
         case "source_titles_and_urls":
             return buildSourceTitlesAndUrlsContent(msg);
         case "truncated":
-            return buildTruncatedContent(msg);
+            return buildTruncatedContent(msg, assistantMaxChars);
         case "none":
             return null;
         default:
@@ -567,29 +577,32 @@ public class ChatClient {
      * Builds a summary string from source document titles.
      *
      * @param msg the assistant chat message
+     * @param summaryMaxChars the maximum characters for the content summary
      * @return a string listing referenced document titles
      */
-    protected String buildSourceTitlesContent(final ChatMessage msg) {
+    protected String buildSourceTitlesContent(final ChatMessage msg, final int summaryMaxChars) {
         final List<ChatSource> sources = msg.getSources();
         if (sources == null || sources.isEmpty()) {
-            return buildTruncatedContent(msg);
+            return buildTruncatedContent(msg, summaryMaxChars);
         }
-        final String titles =
-                sources.stream().map(ChatSource::getTitle).filter(t -> t != null && !t.isEmpty()).collect(Collectors.joining(", "));
-        if (titles.isEmpty()) {
-            return buildTruncatedContent(msg);
+        final int maxSuffixLen = Math.max(0, summaryMaxChars / 4);
+        final String suffix = buildSourceTitlesSuffix(sources, maxSuffixLen);
+        if (suffix.isEmpty()) {
+            return buildTruncatedContent(msg, summaryMaxChars);
         }
-        final String sourceSuffix = "\n[Referenced documents: " + titles + "]";
         final String content = msg.getContent();
         if (content == null || content.isEmpty()) {
-            return sourceSuffix;
+            return suffix;
         }
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final int maxChars = Integer.parseInt(fessConfig.getOrDefault("rag.chat.history.assistant.summary.max.chars", "500"));
-        if (content.length() <= maxChars) {
-            return content + sourceSuffix;
+        final String truncMarker = "... [truncated]";
+        final int bodyBudget = Math.max(0, summaryMaxChars - suffix.length() - truncMarker.length());
+        if (content.length() <= bodyBudget) {
+            return content + suffix;
         }
-        return content.substring(0, maxChars) + "... [truncated]" + sourceSuffix;
+        if (bodyBudget <= 0) {
+            return suffix;
+        }
+        return content.substring(0, bodyBudget) + truncMarker + suffix;
     }
 
     /**
@@ -623,22 +636,81 @@ public class ChatClient {
 
     /**
      * Builds a truncated version of the assistant message content.
-     * The maximum length is controlled by {@code rag.chat.history.assistant.max.chars}.
      *
      * @param msg the assistant chat message
+     * @param maxChars the maximum characters for the content
      * @return the truncated content
      */
-    protected String buildTruncatedContent(final ChatMessage msg) {
+    protected String buildTruncatedContent(final ChatMessage msg, final int maxChars) {
         final String content = msg.getContent();
         if (content == null) {
             return null;
         }
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final int maxChars = Integer.parseInt(fessConfig.getOrDefault("rag.chat.history.assistant.max.chars", "500"));
         if (content.length() <= maxChars) {
             return content;
         }
         return content.substring(0, maxChars) + "...";
+    }
+
+    /**
+     * Builds a smart summary of the assistant message for history.
+     * Preserves the beginning (direct answer) and end (conclusion) of long responses,
+     * omitting the middle section, and appends source titles.
+     *
+     * @param msg the assistant chat message
+     * @param maxChars the maximum characters for the summary
+     * @return the summarized content with source titles
+     */
+    protected String buildSmartSummaryContent(final ChatMessage msg, final int maxChars) {
+        final String content = msg.getContent();
+        if (content == null) {
+            return null;
+        }
+        final String omitMarker = "\n...[omitted]...\n";
+        final int maxSuffixLen = Math.max(0, maxChars / 4);
+        final String suffix = buildSourceTitlesSuffix(msg.getSources(), maxSuffixLen);
+        final int bodyBudget = Math.max(0, maxChars - suffix.length() - omitMarker.length());
+        if (content.length() <= bodyBudget) {
+            return content + suffix;
+        }
+        if (bodyBudget <= 0) {
+            return suffix.isEmpty() ? content.substring(0, Math.min(content.length(), maxChars)) : suffix;
+        }
+        final int headChars = (int) (bodyBudget * 0.6);
+        final int tailChars = bodyBudget - headChars;
+        final String head = content.substring(0, headChars);
+        final String tail = content.substring(content.length() - tailChars);
+        return head + omitMarker + tail + suffix;
+    }
+
+    /**
+     * Builds the source titles suffix string (e.g., "\n[Referenced documents: Title1, Title2]").
+     * Returns an empty string if no sources or titles are available.
+     *
+     * @param sources the source documents
+     * @return the source titles suffix, or empty string
+     */
+    private String buildSourceTitlesSuffix(final List<ChatSource> sources) {
+        return buildSourceTitlesSuffix(sources, Integer.MAX_VALUE);
+    }
+
+    private String buildSourceTitlesSuffix(final List<ChatSource> sources, final int maxSuffixLength) {
+        if (sources == null || sources.isEmpty()) {
+            return "";
+        }
+        final String titles =
+                sources.stream().map(ChatSource::getTitle).filter(t -> t != null && !t.isEmpty()).collect(Collectors.joining(", "));
+        if (titles.isEmpty()) {
+            return "";
+        }
+        final String suffix = "\n[Referenced documents: " + titles + "]";
+        if (suffix.length() <= maxSuffixLength) {
+            return suffix;
+        }
+        if (maxSuffixLength <= 0) {
+            return "";
+        }
+        return suffix.substring(0, maxSuffixLength);
     }
 
     private static final int MAX_QUERY_LENGTH = 1000;

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.llm;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -368,11 +369,55 @@ public abstract class AbstractLlmClient implements LlmClient {
 
     /**
      * Gets the maximum characters for conversation history in LLM requests.
+     * Each LlmClient implementation should override to define defaults appropriate
+     * for its target model. The default returns 4000 for backward compatibility.
      *
      * @return the maximum history characters
      */
     protected int getHistoryMaxChars() {
-        return Integer.parseInt(ComponentUtil.getFessConfig().getOrDefault("rag.chat.history.max.chars", "2000"));
+        return 4000;
+    }
+
+    /**
+     * Gets the maximum number of history messages for intent detection.
+     * The default returns 6. Override in subclasses for provider-specific tuning.
+     *
+     * @return the maximum number of messages
+     */
+    protected int getIntentHistoryMaxMessages() {
+        return 6;
+    }
+
+    /**
+     * Gets the maximum characters for intent detection history.
+     * The default returns 3000. Override in subclasses for provider-specific tuning.
+     *
+     * @return the maximum characters
+     */
+    protected int getIntentHistoryMaxChars() {
+        return 3000;
+    }
+
+    /**
+     * Gets the maximum characters for assistant message content in history.
+     * The default returns 800. Override in subclasses for provider-specific tuning.
+     *
+     * @return the maximum characters
+     */
+    @Override
+    public int getHistoryAssistantMaxChars() {
+        return 800;
+    }
+
+    /**
+     * Gets the maximum characters for assistant summary content in history.
+     * The default returns 800. Override in subclasses for provider-specific tuning.
+     *
+     * @return the maximum characters
+     */
+    @Override
+    public int getHistoryAssistantSummaryMaxChars() {
+        return 800;
     }
 
     // --- Concurrency control ---
@@ -974,9 +1019,24 @@ public abstract class AbstractLlmClient implements LlmClient {
         if (history == null || history.isEmpty()) {
             return;
         }
-        final int maxHistory = Integer.parseInt(ComponentUtil.getFessConfig().getOrDefault("rag.chat.intent.history.max.messages", "4"));
-        final int start = Math.max(0, history.size() - maxHistory);
-        for (int i = start; i < history.size(); i++) {
+        final int maxMessages = getIntentHistoryMaxMessages();
+        final int maxChars = getIntentHistoryMaxChars();
+
+        int remaining = maxChars;
+        final int earliest = Math.max(0, history.size() - maxMessages);
+        int startIndex = history.size();
+
+        for (int i = history.size() - 1; i >= earliest; i--) {
+            final int msgLen = history.get(i).getContent().length();
+            if (msgLen <= remaining) {
+                remaining -= msgLen;
+                startIndex = i;
+            } else {
+                break;
+            }
+        }
+
+        for (int i = startIndex; i < history.size(); i++) {
             request.addMessage(history.get(i));
         }
     }
@@ -1158,26 +1218,50 @@ public abstract class AbstractLlmClient implements LlmClient {
             return;
         }
 
-        // Walk from newest to oldest, accumulating messages that fit
-        int remaining = budgetChars;
-        int startIndex = history.size();
-        for (int i = history.size() - 1; i >= 0; i--) {
-            final int msgLen = history.get(i).getContent().length();
-            if (msgLen <= remaining) {
-                remaining -= msgLen;
-                startIndex = i;
+        // Build turn list: group adjacent user-assistant pairs as turns, standalone messages as single-message turns
+        final List<int[]> turns = new ArrayList<>();
+        int idx = 0;
+        while (idx < history.size()) {
+            if (idx + 1 < history.size() && "user".equals(history.get(idx).getRole())
+                    && "assistant".equals(history.get(idx + 1).getRole())) {
+                turns.add(new int[] { idx, idx + 2 });
+                idx += 2;
             } else {
-                break;
+                turns.add(new int[] { idx, idx + 1 });
+                idx++;
             }
         }
 
-        if (startIndex < history.size() && startIndex > 0) {
-            logger.warn("[RAG:ANSWER] History truncated to fit context window. originalSize={}, includedFrom={}, budgetChars={}",
-                    history.size(), startIndex, budgetChars);
+        // Walk from newest turn to oldest, selecting contiguous newest turns that fit within budget
+        int remaining = budgetChars;
+        int firstIncludedTurn = turns.size();
+        for (int t = turns.size() - 1; t >= 0; t--) {
+            final int[] turn = turns.get(t);
+            int turnLen = 0;
+            for (int i = turn[0]; i < turn[1]; i++) {
+                turnLen += history.get(i).getContent().length();
+            }
+            if (turnLen <= remaining) {
+                remaining -= turnLen;
+                firstIncludedTurn = t;
+            } else {
+                break; // Stop at first non-fitting turn to maintain contiguous recency
+            }
         }
 
-        // If even the newest message exceeds the budget, truncate it to provide minimal context
-        if (startIndex == history.size() && !history.isEmpty() && budgetChars > CONTEXT_TRUNCATION_BUFFER) {
+        if (firstIncludedTurn < turns.size()) {
+            for (int t = firstIncludedTurn; t < turns.size(); t++) {
+                final int[] turn = turns.get(t);
+                for (int i = turn[0]; i < turn[1]; i++) {
+                    request.addMessage(history.get(i));
+                }
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("[RAG:ANSWER] History included. totalHistory={}, includedTurns={}/{}, usedChars={}, budgetChars={}",
+                        history.size(), turns.size() - firstIncludedTurn, turns.size(), budgetChars - remaining, budgetChars);
+            }
+        } else if (budgetChars > CONTEXT_TRUNCATION_BUFFER) {
+            // Fallback: truncate the newest message to fit
             final LlmMessage newest = history.get(history.size() - 1);
             final String truncated = newest.getContent().substring(0, Math.min(budgetChars, newest.getContent().length()));
             request.addMessage(new LlmMessage(newest.getRole(), truncated));
@@ -1185,15 +1269,9 @@ public abstract class AbstractLlmClient implements LlmClient {
                 logger.debug("[RAG:ANSWER] Newest history message truncated to fit budget. originalLength={}, truncatedLength={}",
                         newest.getContent().length(), truncated.length());
             }
-            return;
-        }
-
-        for (int i = startIndex; i < history.size(); i++) {
-            request.addMessage(history.get(i));
-        }
-        if (logger.isDebugEnabled()) {
-            logger.debug("[RAG:ANSWER] History included. totalHistory={}, includedCount={}, startIndex={}, usedChars={}, budgetChars={}",
-                    history.size(), history.size() - startIndex, startIndex, budgetChars - remaining, budgetChars);
+        } else {
+            logger.warn("[RAG:ANSWER] History truncated to fit context window. originalSize={}, budgetChars={}", history.size(),
+                    budgetChars);
         }
     }
 

--- a/src/main/java/org/codelibs/fess/llm/LlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/LlmClient.java
@@ -184,4 +184,22 @@ public interface LlmClient {
      * @param callback the streaming callback
      */
     void generateDirectAnswer(String userMessage, List<LlmMessage> history, LlmStreamCallback callback);
+
+    /**
+     * Gets the maximum characters for assistant message in history.
+     *
+     * @return the maximum characters
+     */
+    default int getHistoryAssistantMaxChars() {
+        return 800;
+    }
+
+    /**
+     * Gets the maximum characters for assistant summary in history.
+     *
+     * @return the maximum characters
+     */
+    default int getHistoryAssistantSummaryMaxChars() {
+        return 800;
+    }
 }

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -1965,11 +1965,8 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. 10000 */
     String RAG_CHAT_SESSION_MAX_SIZE = "rag.chat.session.max.size";
 
-    /** The key of the configuration. e.g. 20 */
+    /** The key of the configuration. e.g. 30 */
     String RAG_CHAT_HISTORY_MAX_MESSAGES = "rag.chat.history.max.messages";
-
-    /** The key of the configuration. e.g. 4 */
-    String RAG_CHAT_INTENT_HISTORY_MAX_MESSAGES = "rag.chat.intent.history.max.messages";
 
     /** The key of the configuration. e.g. title,url,content,doc_id,content_title,content_description */
     String RAG_CHAT_CONTENT_FIELDS = "rag.chat.content.fields";
@@ -1983,17 +1980,8 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. 3 */
     String RAG_CHAT_HIGHLIGHT_NUMBER_OF_FRAGMENTS = "rag.chat.highlight.number.of.fragments";
 
-    /** The key of the configuration. e.g. source_titles */
+    /** The key of the configuration. e.g. smart_summary */
     String RAG_CHAT_HISTORY_ASSISTANT_CONTENT = "rag.chat.history.assistant.content";
-
-    /** The key of the configuration. e.g. 500 */
-    String RAG_CHAT_HISTORY_ASSISTANT_MAX_CHARS = "rag.chat.history.assistant.max.chars";
-
-    /** The key of the configuration. e.g. 500 */
-    String RAG_CHAT_HISTORY_ASSISTANT_SUMMARY_MAX_CHARS = "rag.chat.history.assistant.summary.max.chars";
-
-    /** The key of the configuration. e.g. 2000 */
-    String RAG_CHAT_HISTORY_MAX_CHARS = "rag.chat.history.max.chars";
 
     /** The key of the configuration. e.g. /var/lib/fess/export */
     String INDEX_EXPORT_PATH = "index.export.path";
@@ -9303,35 +9291,18 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /**
      * Get the value for the key 'rag.chat.history.max.messages'. <br>
-     * The value is, e.g. 20 <br>
+     * The value is, e.g. 30 <br>
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getRagChatHistoryMaxMessages();
 
     /**
      * Get the value for the key 'rag.chat.history.max.messages' as {@link Integer}. <br>
-     * The value is, e.g. 20 <br>
+     * The value is, e.g. 30 <br>
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      * @throws NumberFormatException When the property is not integer.
      */
     Integer getRagChatHistoryMaxMessagesAsInteger();
-
-    /**
-     * Get the value for the key 'rag.chat.intent.history.max.messages'. <br>
-     * The value is, e.g. 4 <br>
-     * comment: Maximum number of history messages used for intent detection.
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getRagChatIntentHistoryMaxMessages();
-
-    /**
-     * Get the value for the key 'rag.chat.intent.history.max.messages' as {@link Integer}. <br>
-     * The value is, e.g. 4 <br>
-     * comment: Maximum number of history messages used for intent detection.
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     * @throws NumberFormatException When the property is not integer.
-     */
-    Integer getRagChatIntentHistoryMaxMessagesAsInteger();
 
     /**
      * Get the value for the key 'rag.chat.content.fields'. <br>
@@ -9392,60 +9363,11 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /**
      * Get the value for the key 'rag.chat.history.assistant.content'. <br>
-     * The value is, e.g. source_titles <br>
-     * comment: History content mode for assistant messages (full, source_titles, source_titles_and_urls, truncated, none).
+     * The value is, e.g. smart_summary <br>
+     * comment: History content mode for assistant messages (full, smart_summary, source_titles, source_titles_and_urls, truncated, none).
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getRagChatHistoryAssistantContent();
-
-    /**
-     * Get the value for the key 'rag.chat.history.assistant.max.chars'. <br>
-     * The value is, e.g. 500 <br>
-     * comment: Maximum characters for assistant history content.
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getRagChatHistoryAssistantMaxChars();
-
-    /**
-     * Get the value for the key 'rag.chat.history.assistant.max.chars' as {@link Integer}. <br>
-     * The value is, e.g. 500 <br>
-     * comment: Maximum characters for assistant history content.
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     * @throws NumberFormatException When the property is not integer.
-     */
-    Integer getRagChatHistoryAssistantMaxCharsAsInteger();
-
-    /**
-     * Get the value for the key 'rag.chat.history.assistant.summary.max.chars'. <br>
-     * The value is, e.g. 500 <br>
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getRagChatHistoryAssistantSummaryMaxChars();
-
-    /**
-     * Get the value for the key 'rag.chat.history.assistant.summary.max.chars' as {@link Integer}. <br>
-     * The value is, e.g. 500 <br>
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     * @throws NumberFormatException When the property is not integer.
-     */
-    Integer getRagChatHistoryAssistantSummaryMaxCharsAsInteger();
-
-    /**
-     * Get the value for the key 'rag.chat.history.max.chars'. <br>
-     * The value is, e.g. 2000 <br>
-     * comment: Maximum total characters for conversation history in LLM requests.
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getRagChatHistoryMaxChars();
-
-    /**
-     * Get the value for the key 'rag.chat.history.max.chars' as {@link Integer}. <br>
-     * The value is, e.g. 2000 <br>
-     * comment: Maximum total characters for conversation history in LLM requests.
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     * @throws NumberFormatException When the property is not integer.
-     */
-    Integer getRagChatHistoryMaxCharsAsInteger();
 
     /**
      * Get the value for the key 'index.export.path'. <br>
@@ -12917,14 +12839,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return getAsInteger(FessConfig.RAG_CHAT_HISTORY_MAX_MESSAGES);
         }
 
-        public String getRagChatIntentHistoryMaxMessages() {
-            return get(FessConfig.RAG_CHAT_INTENT_HISTORY_MAX_MESSAGES);
-        }
-
-        public Integer getRagChatIntentHistoryMaxMessagesAsInteger() {
-            return getAsInteger(FessConfig.RAG_CHAT_INTENT_HISTORY_MAX_MESSAGES);
-        }
-
         public String getRagChatContentFields() {
             return get(FessConfig.RAG_CHAT_CONTENT_FIELDS);
         }
@@ -12955,30 +12869,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
         public String getRagChatHistoryAssistantContent() {
             return get(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_CONTENT);
-        }
-
-        public String getRagChatHistoryAssistantMaxChars() {
-            return get(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_MAX_CHARS);
-        }
-
-        public Integer getRagChatHistoryAssistantMaxCharsAsInteger() {
-            return getAsInteger(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_MAX_CHARS);
-        }
-
-        public String getRagChatHistoryAssistantSummaryMaxChars() {
-            return get(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_SUMMARY_MAX_CHARS);
-        }
-
-        public Integer getRagChatHistoryAssistantSummaryMaxCharsAsInteger() {
-            return getAsInteger(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_SUMMARY_MAX_CHARS);
-        }
-
-        public String getRagChatHistoryMaxChars() {
-            return get(FessConfig.RAG_CHAT_HISTORY_MAX_CHARS);
-        }
-
-        public Integer getRagChatHistoryMaxCharsAsInteger() {
-            return getAsInteger(FessConfig.RAG_CHAT_HISTORY_MAX_CHARS);
         }
 
         public String getIndexExportPath() {
@@ -13595,16 +13485,12 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.RAG_CHAT_CONTEXT_MAX_DOCUMENTS, "5");
             defaultMap.put(FessConfig.RAG_CHAT_SESSION_TIMEOUT_MINUTES, "30");
             defaultMap.put(FessConfig.RAG_CHAT_SESSION_MAX_SIZE, "10000");
-            defaultMap.put(FessConfig.RAG_CHAT_HISTORY_MAX_MESSAGES, "20");
-            defaultMap.put(FessConfig.RAG_CHAT_INTENT_HISTORY_MAX_MESSAGES, "4");
+            defaultMap.put(FessConfig.RAG_CHAT_HISTORY_MAX_MESSAGES, "30");
             defaultMap.put(FessConfig.RAG_CHAT_CONTENT_FIELDS, "title,url,content,doc_id,content_title,content_description");
             defaultMap.put(FessConfig.RAG_CHAT_MESSAGE_MAX_LENGTH, "4000");
             defaultMap.put(FessConfig.RAG_CHAT_HIGHLIGHT_FRAGMENT_SIZE, "500");
             defaultMap.put(FessConfig.RAG_CHAT_HIGHLIGHT_NUMBER_OF_FRAGMENTS, "3");
-            defaultMap.put(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_CONTENT, "source_titles");
-            defaultMap.put(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_MAX_CHARS, "500");
-            defaultMap.put(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_SUMMARY_MAX_CHARS, "500");
-            defaultMap.put(FessConfig.RAG_CHAT_HISTORY_MAX_CHARS, "2000");
+            defaultMap.put(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_CONTENT, "smart_summary");
             defaultMap.put(FessConfig.INDEX_EXPORT_PATH, "/var/lib/fess/export");
             defaultMap.put(FessConfig.INDEX_EXPORT_EXCLUDE_FIELDS, "cache");
             defaultMap.put(FessConfig.INDEX_EXPORT_SCROLL_SIZE, "100");

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1587,9 +1587,7 @@ rag.chat.context.max.documents=5
 # Session settings.
 rag.chat.session.timeout.minutes=30
 rag.chat.session.max.size=10000
-rag.chat.history.max.messages=20
-# Maximum number of history messages used for intent detection.
-rag.chat.intent.history.max.messages=4
+rag.chat.history.max.messages=30
 
 # Enhanced RAG flow settings.
 # Fields to retrieve for full document content.
@@ -1598,13 +1596,8 @@ rag.chat.message.max.length=4000
 # Highlight settings for RAG search.
 rag.chat.highlight.fragment.size=500
 rag.chat.highlight.number.of.fragments=3
-# History content mode for assistant messages (full, source_titles, source_titles_and_urls, truncated, none).
-rag.chat.history.assistant.content=source_titles
-# Maximum characters for assistant history content.
-rag.chat.history.assistant.max.chars=500
-rag.chat.history.assistant.summary.max.chars=500
-# Maximum total characters for conversation history in LLM requests.
-rag.chat.history.max.chars=2000
+# History content mode for assistant messages (full, smart_summary, source_titles, source_titles_and_urls, truncated, none).
+rag.chat.history.assistant.content=smart_summary
 
 # Index Export
 index.export.path=/var/lib/fess/export

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -56,14 +56,14 @@ public class ChatClientTest extends UnitFessTestCase {
     @Test
     public void test_buildAssistantHistoryContent_full() {
         final ChatMessage msg = ChatMessage.assistantMessage("Full response text here.");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "full");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "full", 500, 500);
         assertEquals("Full response text here.", result);
     }
 
     @Test
     public void test_buildAssistantHistoryContent_none() {
         final ChatMessage msg = ChatMessage.assistantMessage("Any content");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "none");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "none", 500, 500);
         assertNull(result);
     }
 
@@ -79,14 +79,14 @@ public class ChatClientTest extends UnitFessTestCase {
         doc2.put("url", "http://example.com/start");
         msg.addSource(new ChatSource(2, doc2));
 
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles", 500, 500);
         assertEquals("Response text\n[Referenced documents: Installation Guide, Quick Start]", result);
     }
 
     @Test
     public void test_buildAssistantHistoryContent_sourceTitles_withoutSources() {
         final ChatMessage msg = ChatMessage.assistantMessage("Response without sources");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles", 500, 500);
         // Falls back to full content when no sources
         assertEquals("Response without sources", result);
     }
@@ -99,45 +99,21 @@ public class ChatClientTest extends UnitFessTestCase {
         doc.put("url", "http://example.com/install");
         msg.addSource(new ChatSource(1, doc));
 
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles_and_urls");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles_and_urls", 500, 500);
         assertEquals("[References: Install Guide (http://example.com/install)]", result);
     }
 
     @Test
     public void test_buildAssistantHistoryContent_truncated() {
-        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public String getOrDefault(final String key, final String defaultValue) {
-                if ("rag.chat.history.assistant.max.chars".equals(key)) {
-                    return "20";
-                }
-                return defaultValue;
-            }
-        });
-
         final ChatMessage msg = ChatMessage.assistantMessage("This is a long response that should be truncated.");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "truncated");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "truncated", 20, 500);
         assertEquals("This is a long respo...", result);
     }
 
     @Test
     public void test_buildAssistantHistoryContent_truncated_shortContent() {
-        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public String getOrDefault(final String key, final String defaultValue) {
-                if ("rag.chat.history.assistant.max.chars".equals(key)) {
-                    return "500";
-                }
-                return defaultValue;
-            }
-        });
-
         final ChatMessage msg = ChatMessage.assistantMessage("Short");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "truncated");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "truncated", 500, 500);
         assertEquals("Short", result);
     }
 
@@ -346,13 +322,11 @@ public class ChatClientTest extends UnitFessTestCase {
                 if ("rag.chat.history.assistant.content".equals(key)) {
                     return "truncated";
                 }
-                if ("rag.chat.history.assistant.max.chars".equals(key)) {
-                    return "10";
-                }
                 return defaultValue;
             }
         });
 
+        chatClient.setTestAssistantMaxChars(10);
         final ChatSession session = new ChatSession();
         session.addUserMessage("Q1");
         session.addAssistantMessage("This is a very long response text that should be truncated");
@@ -361,6 +335,279 @@ public class ChatClientTest extends UnitFessTestCase {
         assertEquals(2, history.size());
         assertEquals("assistant", history.get(1).getRole());
         assertEquals("This is a ...", history.get(1).getContent());
+    }
+
+    // ========== smart_summary tests ==========
+
+    @Test
+    public void test_buildAssistantHistoryContent_smartSummary() {
+        final ChatMessage msg = ChatMessage.assistantMessage("A".repeat(1000));
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("title", "Test Doc");
+        msg.addSource(new ChatSource(1, doc));
+
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
+        assertTrue(result.contains("...[omitted]..."));
+        assertTrue(result.contains("[Referenced documents: Test Doc]"));
+        // Head (300) + omitted marker + tail (200) + source titles
+        assertTrue(result.length() < 1000);
+    }
+
+    @Test
+    public void test_buildAssistantHistoryContent_smartSummary_shortContent() {
+        final ChatMessage msg = ChatMessage.assistantMessage("Short response");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
+        assertEquals("Short response", result);
+    }
+
+    @Test
+    public void test_buildAssistantHistoryContent_smartSummary_noSources() {
+        final ChatMessage msg = ChatMessage.assistantMessage("A".repeat(1000));
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
+        assertTrue(result.contains("...[omitted]..."));
+        assertFalse(result.contains("[Referenced documents:"));
+    }
+
+    @Test
+    public void test_extractHistory_smartSummaryMode() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getOrDefault(final String key, final String defaultValue) {
+                if ("rag.chat.history.assistant.content".equals(key)) {
+                    return "smart_summary";
+                }
+                return defaultValue;
+            }
+        });
+
+        chatClient.setTestSummaryMaxChars(20);
+        final ChatSession session = new ChatSession();
+        session.addUserMessage("Q1");
+        session.addAssistantMessage("This is a fairly long response that should be summarized using smart summary mode.");
+
+        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        assertEquals(2, history.size());
+        assertEquals("assistant", history.get(1).getRole());
+        assertTrue(history.get(1).getContent().contains("...[omitted]..."));
+    }
+
+    // ========== additional smart_summary tests ==========
+
+    @Test
+    public void test_smartSummary_nullContent() {
+        final ChatMessage msg = ChatMessage.assistantMessage(null);
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
+        assertNull(result);
+    }
+
+    @Test
+    public void test_smartSummary_exactlyAtBudget() {
+        // omitMarker = "\n...[omitted]...\n" (18 chars), suffix="" (no sources), bodyBudget = 500 - 0 - 18 = 482
+        // Content of 482 chars is <= bodyBudget, so returned with suffix (empty) appended as-is
+        final String content = "X".repeat(482);
+        final ChatMessage msg = ChatMessage.assistantMessage(content);
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
+        assertEquals(content, result);
+    }
+
+    @Test
+    public void test_smartSummary_headTailRatio() {
+        // Use 1000-char content with summaryMaxChars=500, no sources
+        // omitMarker="\n...[omitted]...\n" (17 chars), suffix="", bodyBudget=500-0-17=483
+        // headChars = (int)(483 * 0.6) = 289, tailChars = 483 - 289 = 194
+        final String content = "A".repeat(1000);
+        final ChatMessage msg = ChatMessage.assistantMessage(content);
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
+        final String omitMarker = "\n...[omitted]...\n";
+        final int omitIdx = result.indexOf(omitMarker);
+        assertTrue(omitIdx > 0);
+        final String head = result.substring(0, omitIdx);
+        final String tail = result.substring(omitIdx + omitMarker.length());
+        // Verify 60/40 ratio: head=289, tail=194
+        assertEquals(289, head.length());
+        assertEquals(194, tail.length());
+        // Head should be ~60% of bodyBudget
+        final double headRatio = (double) head.length() / (head.length() + tail.length());
+        assertTrue(headRatio > 0.55 && headRatio < 0.65);
+    }
+
+    @Test
+    public void test_smartSummary_withMultipleSources() {
+        final ChatMessage msg = createAssistantWithSources("A".repeat(1000), "Guide A", "Guide B", "Guide C");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
+        assertTrue(result.contains("[Referenced documents: Guide A, Guide B, Guide C]"));
+        assertTrue(result.contains("...[omitted]..."));
+    }
+
+    @Test
+    public void test_smartSummary_budgetEnforcesMaxChars() {
+        final ChatMessage msg = createAssistantWithSources("A".repeat(5000), "Title1", "Title2");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
+        // Result should not exceed summaryMaxChars by much (suffix may push slightly, but the body is budgeted)
+        assertTrue(result.length() <= 500 + 50, "result length " + result.length() + " exceeds reasonable bound");
+    }
+
+    @Test
+    public void test_smartSummary_longSourceTitlesExceedBudget() {
+        // When source titles alone are very long, suffix is truncated to maxChars/4
+        final String longTitle = "T".repeat(1000);
+        final ChatMessage msg = createAssistantWithSources("A".repeat(500), longTitle);
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 200, 200);
+        // maxSuffixLen = 200/4 = 50, suffix is truncated to 50 chars
+        assertNotNull(result);
+        // The suffix portion should not exceed maxSuffixLen
+        assertTrue(result.length() <= 250, "result length " + result.length() + " exceeds reasonable bound");
+    }
+
+    @Test
+    public void test_smartSummary_verySmallBudget() {
+        final ChatMessage msg = createAssistantWithSources("Hello world, this is some content.", "Doc");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 10, 10);
+        // Should not crash; maxSuffixLen=10/4=2, suffix gets truncated severely
+        // bodyBudget may be 0 or negative => suffix or truncated content returned
+        assertNotNull(result);
+        assertTrue(result.length() > 0);
+    }
+
+    // ========== additional source_titles tests ==========
+
+    @Test
+    public void test_sourceTitles_truncatesLongContent() {
+        final ChatMessage msg = createAssistantWithSources("A".repeat(1000), "My Doc");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles", 500, 500);
+        assertTrue(result.contains("... [truncated]"));
+        assertTrue(result.contains("[Referenced documents: My Doc]"));
+    }
+
+    @Test
+    public void test_sourceTitles_budgetEnforcesMaxChars() {
+        final ChatMessage msg = createAssistantWithSources("A".repeat(2000), "Title");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles", 500, 500);
+        assertTrue(result.length() <= 500 + 50, "result length " + result.length() + " exceeds reasonable bound");
+    }
+
+    @Test
+    public void test_sourceTitles_longTitlesExceedBudget() {
+        final String longTitle = "T".repeat(1000);
+        final ChatMessage msg = createAssistantWithSources("Short content", longTitle);
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles", 200, 200);
+        // maxSuffixLen = 200/4 = 50, suffix truncated
+        assertNotNull(result);
+        assertTrue(result.length() <= 250);
+    }
+
+    @Test
+    public void test_sourceTitles_nullContent_withSources() {
+        final ChatMessage msg = createAssistantWithSources(null, "Doc A", "Doc B");
+        // Manually set content to null via assistantMessage then add sources
+        final ChatMessage nullMsg = ChatMessage.assistantMessage(null);
+        for (int i = 0; i < msg.getSources().size(); i++) {
+            nullMsg.addSource(msg.getSources().get(i));
+        }
+        final String result = chatClient.testBuildAssistantHistoryContent(nullMsg, "source_titles", 500, 500);
+        // null content with sources => returns suffix only
+        assertNotNull(result);
+        assertTrue(result.contains("[Referenced documents: Doc A, Doc B]"));
+    }
+
+    @Test
+    public void test_sourceTitles_emptyTitles() {
+        final ChatMessage msg = ChatMessage.assistantMessage("Some content here that is quite long enough to be truncated.");
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("title", "");
+        doc.put("url", "http://example.com/1");
+        msg.addSource(new ChatSource(1, doc));
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "source_titles", 500, 500);
+        // Empty titles => suffix is empty => falls back to truncated
+        assertEquals("Some content here that is quite long enough to be truncated.", result);
+    }
+
+    // ========== additional truncated tests ==========
+
+    @Test
+    public void test_truncated_nullContent() {
+        final ChatMessage msg = ChatMessage.assistantMessage(null);
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "truncated", 500, 500);
+        assertNull(result);
+    }
+
+    @Test
+    public void test_truncated_exactlyAtLimit() {
+        final String content = "A".repeat(500);
+        final ChatMessage msg = ChatMessage.assistantMessage(content);
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "truncated", 500, 500);
+        assertEquals(content, result);
+    }
+
+    @Test
+    public void test_truncated_oneCharOver() {
+        final String content = "A".repeat(501);
+        final ChatMessage msg = ChatMessage.assistantMessage(content);
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "truncated", 500, 500);
+        assertEquals("A".repeat(500) + "...", result);
+    }
+
+    // ========== extractHistory integration tests ==========
+
+    @Test
+    public void test_extractHistory_defaultMode_isSmartSummary() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getOrDefault(final String key, final String defaultValue) {
+                // Do not override the key — let it use defaultValue
+                return defaultValue;
+            }
+        });
+
+        chatClient.setTestSummaryMaxChars(50);
+        final ChatSession session = new ChatSession();
+        session.addUserMessage("Q1");
+        session.addAssistantMessage("A".repeat(200));
+
+        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        assertEquals(2, history.size());
+        // Default mode is smart_summary, so long content should be summarized
+        assertTrue(history.get(1).getContent().contains("...[omitted]..."));
+    }
+
+    @Test
+    public void test_extractHistory_unknownMode_returnsFull() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getOrDefault(final String key, final String defaultValue) {
+                if ("rag.chat.history.assistant.content".equals(key)) {
+                    return "unknown_mode";
+                }
+                return defaultValue;
+            }
+        });
+
+        final ChatSession session = new ChatSession();
+        session.addUserMessage("Q1");
+        session.addAssistantMessage("Full content here");
+
+        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        assertEquals(2, history.size());
+        assertEquals("Full content here", history.get(1).getContent());
+    }
+
+    // ========== helper method ==========
+
+    private ChatMessage createAssistantWithSources(final String content, final String... titles) {
+        final ChatMessage msg = ChatMessage.assistantMessage(content);
+        for (int i = 0; i < titles.length; i++) {
+            final Map<String, Object> doc = new HashMap<>();
+            doc.put("title", titles[i]);
+            doc.put("url", "http://example.com/" + i);
+            msg.addSource(new ChatSource(i + 1, doc));
+        }
+        return msg;
     }
 
     // ========== escapeQueryValue tests ==========
@@ -683,6 +930,8 @@ public class ChatClientTest extends UnitFessTestCase {
         private boolean searchDocumentsCalled = false;
         private final List<String> searchedQueries = new ArrayList<>();
         private List<Map<String, Object>> searchResultsToReturn = Collections.emptyList();
+        private int testAssistantMaxChars = 800;
+        private int testSummaryMaxChars = 800;
 
         void setSearchResults(final List<Map<String, Object>> results) {
             this.searchResultsToReturn = results;
@@ -692,12 +941,41 @@ public class ChatClientTest extends UnitFessTestCase {
             return searchedQueries;
         }
 
-        String testBuildAssistantHistoryContent(final ChatMessage msg, final String mode) {
-            return buildAssistantHistoryContent(msg, mode);
+        void setTestAssistantMaxChars(final int maxChars) {
+            testAssistantMaxChars = maxChars;
+        }
+
+        void setTestSummaryMaxChars(final int maxChars) {
+            testSummaryMaxChars = maxChars;
+        }
+
+        String testBuildAssistantHistoryContent(final ChatMessage msg, final String mode, final int assistantMaxChars,
+                final int summaryMaxChars) {
+            return buildAssistantHistoryContent(msg, mode, assistantMaxChars, summaryMaxChars);
         }
 
         List<LlmMessage> testExtractHistory(final ChatSession session) {
             return extractHistory(session);
+        }
+
+        @Override
+        protected List<LlmMessage> extractHistory(final ChatSession session) {
+            final FessConfig fessConfig = ComponentUtil.getFessConfig();
+            final String assistantContentMode = fessConfig.getOrDefault("rag.chat.history.assistant.content", "smart_summary");
+
+            final List<LlmMessage> history = new ArrayList<>();
+            for (final ChatMessage msg : session.getMessages()) {
+                if (msg.isUser()) {
+                    history.add(LlmMessage.user(msg.getContent()));
+                } else if (msg.isAssistant()) {
+                    final String content =
+                            buildAssistantHistoryContent(msg, assistantContentMode, testAssistantMaxChars, testSummaryMaxChars);
+                    if (content != null) {
+                        history.add(LlmMessage.assistant(content));
+                    }
+                }
+            }
+            return history;
         }
 
         String testEscapeQueryValue(final String value) {

--- a/src/test/java/org/codelibs/fess/llm/AbstractLlmClientTest.java
+++ b/src/test/java/org/codelibs/fess/llm/AbstractLlmClientTest.java
@@ -81,7 +81,31 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_buildIntentRequest_trimsHistoryToMaxFour() {
+    public void test_buildIntentRequest_trimsHistoryToMaxSix() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Q1"));
+        history.add(LlmMessage.assistant("A1"));
+        history.add(LlmMessage.user("Q2"));
+        history.add(LlmMessage.assistant("A2"));
+        history.add(LlmMessage.user("Q3"));
+        history.add(LlmMessage.assistant("A3"));
+        history.add(LlmMessage.user("Q4"));
+        history.add(LlmMessage.assistant("A4"));
+        final LlmChatRequest request = client.testBuildIntentRequest("Q5", history);
+        final List<LlmMessage> messages = request.getMessages();
+        // system + 6 history (last 6: Q2,A2,Q3,A3,Q4,A4) + user = 8 messages
+        assertEquals(8, messages.size());
+        // First history message should be Q2 (Q1,A1 trimmed)
+        assertEquals("Q2", messages.get(1).getContent());
+        assertEquals("A2", messages.get(2).getContent());
+        assertEquals("Q3", messages.get(3).getContent());
+        assertEquals("A3", messages.get(4).getContent());
+        assertEquals("Q4", messages.get(5).getContent());
+        assertEquals("A4", messages.get(6).getContent());
+    }
+
+    @Test
+    public void test_buildIntentRequest_historyExactlySix() {
         final List<LlmMessage> history = new ArrayList<>();
         history.add(LlmMessage.user("Q1"));
         history.add(LlmMessage.assistant("A1"));
@@ -91,30 +115,14 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
         history.add(LlmMessage.assistant("A3"));
         final LlmChatRequest request = client.testBuildIntentRequest("Q4", history);
         final List<LlmMessage> messages = request.getMessages();
-        // system + 4 history (last 4: Q2,A2,Q3,A3) + user = 6 messages
-        assertEquals(6, messages.size());
-        // First history message should be Q2 (Q1,A1 trimmed)
-        assertEquals("Q2", messages.get(1).getContent());
-        assertEquals("A2", messages.get(2).getContent());
-        assertEquals("Q3", messages.get(3).getContent());
-        assertEquals("A3", messages.get(4).getContent());
-    }
-
-    @Test
-    public void test_buildIntentRequest_historyExactlyFour() {
-        final List<LlmMessage> history = new ArrayList<>();
-        history.add(LlmMessage.user("Q1"));
-        history.add(LlmMessage.assistant("A1"));
-        history.add(LlmMessage.user("Q2"));
-        history.add(LlmMessage.assistant("A2"));
-        final LlmChatRequest request = client.testBuildIntentRequest("Q3", history);
-        final List<LlmMessage> messages = request.getMessages();
-        // system + 4 history + user = 6 messages (all included)
-        assertEquals(6, messages.size());
+        // system + 6 history + user = 8 messages (all included)
+        assertEquals(8, messages.size());
         assertEquals("Q1", messages.get(1).getContent());
         assertEquals("A1", messages.get(2).getContent());
         assertEquals("Q2", messages.get(3).getContent());
         assertEquals("A2", messages.get(4).getContent());
+        assertEquals("Q3", messages.get(5).getContent());
+        assertEquals("A3", messages.get(6).getContent());
     }
 
     @Test
@@ -494,23 +502,25 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
 
     @Test
     public void test_buildIntentRequest_manyTurns_trimmed() {
-        // Verify maxHistory=4 still applies for structured messages
+        // Verify maxHistory=6 applies for structured messages
         final List<LlmMessage> history = new ArrayList<>();
-        for (int i = 1; i <= 6; i++) {
+        for (int i = 1; i <= 8; i++) {
             history.add(LlmMessage.user("Question " + i));
         }
 
-        final LlmChatRequest request = client.testBuildIntentRequest("Question 7", history);
+        final LlmChatRequest request = client.testBuildIntentRequest("Question 9", history);
         final List<LlmMessage> messages = request.getMessages();
 
-        // system + 4 history (last 4) + user = 6 messages
-        assertEquals(6, messages.size());
+        // system + 6 history (last 6) + user = 8 messages
+        assertEquals(8, messages.size());
         assertEquals("system", messages.get(0).getRole());
         assertEquals("Question 3", messages.get(1).getContent());
         assertEquals("Question 4", messages.get(2).getContent());
         assertEquals("Question 5", messages.get(3).getContent());
         assertEquals("Question 6", messages.get(4).getContent());
-        assertTrue(messages.get(5).getContent().contains("Question 7"));
+        assertEquals("Question 7", messages.get(5).getContent());
+        assertEquals("Question 8", messages.get(6).getContent());
+        assertTrue(messages.get(7).getContent().contains("Question 9"));
     }
 
     @Test
@@ -692,6 +702,318 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
         assertTrue(userMsg.contains("</user_input>"));
     }
 
+    // ========== addHistoryWithBudget tests ==========
+
+    @Test
+    public void test_addHistoryWithBudget_allFit() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Hi")); // 2 chars
+        history.add(LlmMessage.assistant("Hello")); // 5 chars
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 100);
+        assertEquals(2, request.getMessages().size());
+        assertEquals("Hi", request.getMessages().get(0).getContent());
+        assertEquals("Hello", request.getMessages().get(1).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_skipsLargeMessage() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Q1")); // 2 chars
+        history.add(LlmMessage.assistant("A".repeat(200))); // 200 chars - too large
+        history.add(LlmMessage.user("Q2")); // 2 chars
+        history.add(LlmMessage.assistant("A2")); // 2 chars
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 10);
+        // Q2 and A2 fit (4 chars), Q1 fits (6 chars), but A1 is too large and skipped
+        // Pair integrity: Q1 without A1 => Q1 excluded
+        // Result: Q2, A2
+        assertEquals(2, request.getMessages().size());
+        assertEquals("Q2", request.getMessages().get(0).getContent());
+        assertEquals("A2", request.getMessages().get(1).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_pairIntegrity() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Q1")); // 2 chars
+        history.add(LlmMessage.assistant("A".repeat(50))); // 50 chars
+        history.add(LlmMessage.user("Q2")); // 2 chars
+        history.add(LlmMessage.assistant("A2")); // 2 chars
+        final LlmChatRequest request = new LlmChatRequest();
+        // Budget=10: Q2(2)+A2(2)=4 fit, Q1(2) fits but A1(50) doesn't => pair excluded
+        client.testAddHistoryWithBudget(request, history, 10);
+        assertEquals(2, request.getMessages().size());
+        assertEquals("Q2", request.getMessages().get(0).getContent());
+        assertEquals("A2", request.getMessages().get(1).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_emptyHistory() {
+        final List<LlmMessage> history = new ArrayList<>();
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 100);
+        assertEquals(0, request.getMessages().size());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_fallbackTruncation() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("A".repeat(500)));
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 200);
+        assertEquals(1, request.getMessages().size());
+        assertEquals(200, request.getMessages().get(0).getContent().length());
+    }
+
+    // ========== addIntentHistory tests ==========
+
+    @Test
+    public void test_addIntentHistory_withCharBudget() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Short")); // 5 chars
+        history.add(LlmMessage.assistant("A".repeat(500))); // 500 chars
+        history.add(LlmMessage.user("Q2")); // 2 chars
+        history.add(LlmMessage.assistant("A2")); // 2 chars
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, history);
+        // Default: maxMessages=6, maxChars=3000
+        // From newest: A2(2), Q2(2+2=4), assistant(500+4=504), Short(5+504=509) => all fit
+        assertEquals(4, request.getMessages().size());
+    }
+
+    @Test
+    public void test_addIntentHistory_maxMessages() {
+        final List<LlmMessage> history = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            history.add(LlmMessage.user("Q" + i));
+        }
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, history);
+        // maxMessages=6, so only last 6
+        assertEquals(6, request.getMessages().size());
+        assertEquals("Q4", request.getMessages().get(0).getContent());
+    }
+
+    @Test
+    public void test_addIntentHistory_charBudgetCutsOff() {
+        client.setTestIntentHistoryMaxChars(10);
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("A".repeat(20))); // 20 chars - won't fit
+        history.add(LlmMessage.user("Q2")); // 2 chars
+        history.add(LlmMessage.assistant("A2")); // 2 chars
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, history);
+        // Budget=10: A2(2), Q2(4) fit, then A*20 breaks => only Q2, A2
+        assertEquals(2, request.getMessages().size());
+        assertEquals("Q2", request.getMessages().get(0).getContent());
+        assertEquals("A2", request.getMessages().get(1).getContent());
+    }
+
+    // ========== addHistoryWithBudget — turn-based packing tests ==========
+
+    @Test
+    public void test_addHistoryWithBudget_turnBasedPacking_twoCompleteTurns() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Q1")); // 2
+        history.add(LlmMessage.assistant("A1")); // 2
+        history.add(LlmMessage.user("Q2")); // 2
+        history.add(LlmMessage.assistant("A2")); // 2
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 100);
+        assertEquals(4, request.getMessages().size());
+        assertEquals("Q1", request.getMessages().get(0).getContent());
+        assertEquals("A1", request.getMessages().get(1).getContent());
+        assertEquals("Q2", request.getMessages().get(2).getContent());
+        assertEquals("A2", request.getMessages().get(3).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_turnBasedPacking_newestTurnOnly() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("A".repeat(100))); // 100
+        history.add(LlmMessage.assistant("B".repeat(100))); // 100
+        history.add(LlmMessage.user("Q2")); // 2
+        history.add(LlmMessage.assistant("A2")); // 2
+        final LlmChatRequest request = new LlmChatRequest();
+        // Budget=10: newest turn Q2+A2=4 fits, older turn=200 doesn't
+        client.testAddHistoryWithBudget(request, history, 10);
+        assertEquals(2, request.getMessages().size());
+        assertEquals("Q2", request.getMessages().get(0).getContent());
+        assertEquals("A2", request.getMessages().get(1).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_turnBasedPacking_contiguousRecency() {
+        // 3 turns: turn0(Q1+A1=4), turn1(big=200), turn2(Q3+A3=4)
+        // Budget=20: turn2 fits (4, remaining=16), turn1 doesn't fit (200>16), stop
+        // Even though turn0 (4 chars) would fit individually, contiguity is maintained
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Q1")); // 2
+        history.add(LlmMessage.assistant("A1")); // 2
+        history.add(LlmMessage.user("B".repeat(100))); // 100
+        history.add(LlmMessage.assistant("C".repeat(100))); // 100
+        history.add(LlmMessage.user("Q3")); // 2
+        history.add(LlmMessage.assistant("A3")); // 2
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 20);
+        assertEquals(2, request.getMessages().size());
+        assertEquals("Q3", request.getMessages().get(0).getContent());
+        assertEquals("A3", request.getMessages().get(1).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_turnBasedPacking_standaloneUserMessage() {
+        // A user message not followed by assistant is treated as standalone turn
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Q1")); // 2 - standalone
+        history.add(LlmMessage.user("Q2")); // 2 - standalone (no preceding assistant)
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 100);
+        assertEquals(2, request.getMessages().size());
+        assertEquals("Q1", request.getMessages().get(0).getContent());
+        assertEquals("Q2", request.getMessages().get(1).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_turnBasedPacking_mixedStandaloneAndPairs() {
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Q1")); // standalone turn (2)
+        history.add(LlmMessage.user("Q2")); // 2
+        history.add(LlmMessage.assistant("A2")); // pair turn (4)
+        history.add(LlmMessage.user("Q3")); // standalone turn (2)
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 100);
+        assertEquals(4, request.getMessages().size());
+        assertEquals("Q1", request.getMessages().get(0).getContent());
+        assertEquals("Q2", request.getMessages().get(1).getContent());
+        assertEquals("A2", request.getMessages().get(2).getContent());
+        assertEquals("Q3", request.getMessages().get(3).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_singleLargeMessage_truncation() {
+        // Single message larger than budget triggers truncation fallback
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("A".repeat(500)));
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 200);
+        assertEquals(1, request.getMessages().size());
+        assertEquals(200, request.getMessages().get(0).getContent().length());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_exactBudget() {
+        // Total chars exactly equals budget
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("AAAA")); // 4
+        history.add(LlmMessage.assistant("BBBBBB")); // 6
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 10);
+        assertEquals(2, request.getMessages().size());
+        assertEquals("AAAA", request.getMessages().get(0).getContent());
+        assertEquals("BBBBBB", request.getMessages().get(1).getContent());
+    }
+
+    @Test
+    public void test_addHistoryWithBudget_multipleTurns_budgetTight() {
+        // 3 turns: turn0(Q1+A1=10), turn1(Q2+A2=10), turn2(Q3+A3=10)
+        // Budget=25: turn2(10) fits (remaining=15), turn1(10) fits (remaining=5), turn0(10) doesn't
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("QQQQQ")); // 5
+        history.add(LlmMessage.assistant("AAAAA")); // 5
+        history.add(LlmMessage.user("RRRRR")); // 5
+        history.add(LlmMessage.assistant("SSSSS")); // 5
+        history.add(LlmMessage.user("TTTTT")); // 5
+        history.add(LlmMessage.assistant("UUUUU")); // 5
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddHistoryWithBudget(request, history, 25);
+        assertEquals(4, request.getMessages().size());
+        assertEquals("RRRRR", request.getMessages().get(0).getContent());
+        assertEquals("SSSSS", request.getMessages().get(1).getContent());
+        assertEquals("TTTTT", request.getMessages().get(2).getContent());
+        assertEquals("UUUUU", request.getMessages().get(3).getContent());
+    }
+
+    // ========== additional addIntentHistory tests ==========
+
+    @Test
+    public void test_addIntentHistory_emptyHistory() {
+        final List<LlmMessage> history = new ArrayList<>();
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, history);
+        assertEquals(0, request.getMessages().size());
+    }
+
+    @Test
+    public void test_addIntentHistory_nullHistory() {
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, null);
+        assertEquals(0, request.getMessages().size());
+    }
+
+    @Test
+    public void test_addIntentHistory_allFitWithinBothLimits() {
+        client.setTestIntentHistoryMaxChars(3000);
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("Q1")); // 2
+        history.add(LlmMessage.assistant("A1")); // 2
+        history.add(LlmMessage.user("Q2")); // 2
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, history);
+        assertEquals(3, request.getMessages().size());
+        assertEquals("Q1", request.getMessages().get(0).getContent());
+        assertEquals("A1", request.getMessages().get(1).getContent());
+        assertEquals("Q2", request.getMessages().get(2).getContent());
+    }
+
+    @Test
+    public void test_addIntentHistory_charBudgetMoreRestrictiveThanMessages() {
+        client.setTestIntentHistoryMaxChars(5);
+        // maxMessages=6, but charBudget=5
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("QQQ")); // 3 chars
+        history.add(LlmMessage.assistant("AAA")); // 3 chars
+        history.add(LlmMessage.user("Q2")); // 2 chars
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, history);
+        // From newest: Q2(2) fits (remaining=3), AAA(3) fits (remaining=0), QQQ(3) doesn't
+        assertEquals(2, request.getMessages().size());
+        assertEquals("AAA", request.getMessages().get(0).getContent());
+        assertEquals("Q2", request.getMessages().get(1).getContent());
+    }
+
+    @Test
+    public void test_addIntentHistory_messageCountMoreRestrictiveThanChars() {
+        client.setTestIntentHistoryMaxChars(10000);
+        // Use a client with maxMessages=6, provide 8 messages
+        final List<LlmMessage> history = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            history.add(LlmMessage.user("Q" + i));
+        }
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, history);
+        // maxMessages=6, so only last 6
+        assertEquals(6, request.getMessages().size());
+        assertEquals("Q2", request.getMessages().get(0).getContent());
+    }
+
+    @Test
+    public void test_addIntentHistory_contiguousBlock() {
+        client.setTestIntentHistoryMaxChars(10);
+        // Messages: [big(20), small(2), small(2)]
+        // From newest: small(2) fits (remaining=8), small(2) fits (remaining=6), big(20) doesn't => break
+        final List<LlmMessage> history = new ArrayList<>();
+        history.add(LlmMessage.user("A".repeat(20))); // 20 chars
+        history.add(LlmMessage.user("Q2")); // 2 chars
+        history.add(LlmMessage.user("Q3")); // 2 chars
+        final LlmChatRequest request = new LlmChatRequest();
+        client.testAddIntentHistory(request, history);
+        assertEquals(2, request.getMessages().size());
+        assertEquals("Q2", request.getMessages().get(0).getContent());
+        assertEquals("Q3", request.getMessages().get(1).getContent());
+    }
+
     // ========== Testable subclass ==========
 
     @FunctionalInterface
@@ -709,6 +1031,11 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
         private String lastChatPrompt;
         private LlmChatRequest lastChatRequest;
         private StreamChatCapture streamChatCapture;
+        private int testIntentHistoryMaxMessages = 6;
+        private int testIntentHistoryMaxChars = 3000;
+        private int testHistoryMaxChars = 4000;
+        private int testHistoryAssistantMaxChars = 500;
+        private int testHistoryAssistantSummaryMaxChars = 500;
 
         void setTestIntentDetectionPrompt(final String prompt) {
             this.testIntentDetectionPrompt = prompt;
@@ -768,6 +1095,18 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
 
         String testStripHtmlTags(final String text) {
             return stripHtmlTags(text);
+        }
+
+        void setTestIntentHistoryMaxChars(final int maxChars) {
+            this.testIntentHistoryMaxChars = maxChars;
+        }
+
+        void testAddHistoryWithBudget(final LlmChatRequest request, final List<LlmMessage> history, final int budget) {
+            addHistoryWithBudget(request, history, budget);
+        }
+
+        void testAddIntentHistory(final LlmChatRequest request, final List<LlmMessage> history) {
+            addIntentHistory(request, history);
         }
 
         // Implement abstract methods
@@ -904,6 +1243,31 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
         @Override
         protected int getEvaluationDescriptionMaxChars() {
             return 500;
+        }
+
+        @Override
+        protected int getHistoryMaxChars() {
+            return testHistoryMaxChars;
+        }
+
+        @Override
+        protected int getIntentHistoryMaxMessages() {
+            return testIntentHistoryMaxMessages;
+        }
+
+        @Override
+        protected int getIntentHistoryMaxChars() {
+            return testIntentHistoryMaxChars;
+        }
+
+        @Override
+        public int getHistoryAssistantMaxChars() {
+            return testHistoryAssistantMaxChars;
+        }
+
+        @Override
+        public int getHistoryAssistantSummaryMaxChars() {
+            return testHistoryAssistantSummaryMaxChars;
         }
 
         @Override


### PR DESCRIPTION
## Summary
- Introduce a `smart_summary` history mode that preserves the beginning (60%) and end (40%) of long assistant responses while omitting the middle section, replacing `source_titles` as the default
- Refactor history packing to group user-assistant message pairs as turns, maintaining pair integrity within the character budget
- Move history configuration from static `fess_config.properties` to `LlmClient` interface methods, enabling per-provider tuning by LLM plugin implementations

## Changes Made
- **ChatClient**: Add `buildSmartSummaryContent()` with head/tail splitting and `buildSourceTitlesSuffix()` helper; parameterize `buildAssistantHistoryContent()` with `assistantMaxChars` and `summaryMaxChars`
- **AbstractLlmClient**: Refactor `addHistoryWithBudget()` to use turn-based grouping (user+assistant pairs); add `addIntentHistory()` with both message count and character budget; increase intent history default from 4 to 6 messages; add `getIntentHistoryMaxMessages()`, `getIntentHistoryMaxChars()`, `getHistoryAssistantMaxChars()`, `getHistoryAssistantSummaryMaxChars()` methods
- **LlmClient interface**: Add `getHistoryAssistantMaxChars()` and `getHistoryAssistantSummaryMaxChars()` default methods
- **FessConfig / fess_config.properties**: Remove `rag.chat.history.max.chars`, `rag.chat.history.assistant.max.chars`, `rag.chat.history.assistant.summary.max.chars`, and `rag.chat.intent.history.max.messages` properties (now delegated to LlmClient); update defaults (`history.max.messages` 20→30, `assistant.content` `source_titles`→`smart_summary`)
- **pom.xml**: Exclude `jakarta.mail` from mailflute dependency

## Testing
- Added ~40 new unit tests covering smart summary mode, turn-based packing, intent history budgeting, edge cases (null content, exact budget, very small budget, long source titles)
- Updated existing tests for new method signatures and default values

## Breaking Changes
- Removed config properties: `rag.chat.history.max.chars`, `rag.chat.history.assistant.max.chars`, `rag.chat.history.assistant.summary.max.chars`, `rag.chat.intent.history.max.messages` — LLM plugins should override `LlmClient` methods instead
- Default assistant history mode changed from `source_titles` to `smart_summary`
- Default intent history messages increased from 4 to 6

## Additional Notes
- LLM plugin implementations (fess-llm-openai, fess-llm-ollama, fess-llm-gemini) can override the new `LlmClient` methods to tune history limits per model
- The `smart_summary` mode is designed to maximize context efficiency by keeping the direct answer and conclusion while omitting verbose middle sections