### PR TITLE
docs(claude-md): add plugin build tip and i18n guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ mvn jdeb:jdeb           # Build .deb package
 mvn test                                    # Run unit tests (*Test.java)
 mvn test -Dtest=ClassName                   # Run single unit test
 
+# To install fess jar for plugin dependency resolution:
+# Change pom.xml <packaging>war</packaging> to <packaging>jar</packaging> first
+mvn clean install -DskipTests               # Then revert packaging back to war
+
 # Integration tests (*Tests.java) - requires running Fess server
 mvn test -P integrationTests -Dtest.fess.url="http://localhost:8080" -Dtest.search_engine.url="http://localhost:9201"
 ```
@@ -164,6 +168,9 @@ opensearch/{index}/
 - Format: `key=value` (e.g., `userId={}`, `url={}`)
 - Prefix with `[name]` when context identification is needed
 - Mask sensitive values (passwords, tokens)
+
+## i18n / Localization
+- This project supports up to 21 languages. When modifying user-facing strings, error codes, or labels, always propagate changes to ALL language files (fess_label_*.properties and frontend i18n files).
 
 ## Important Patterns for AI Assistants
 


### PR DESCRIPTION
## Summary
Improve CLAUDE.md with practical guidance for AI assistants and contributors working on the Fess codebase.

## Changes Made
- Added instructions for installing fess as a jar dependency for plugin compilation (change packaging to jar, install, then revert)
- Added i18n/Localization section documenting the 21-language support requirement, reminding contributors to propagate user-facing string changes to all language files

## Testing
- Documentation-only change, no code impact

## Additional Notes
- The plugin build tip mirrors guidance already in the workspace-level CLAUDE.md, ensuring it's also available when working directly in the fess repo
- The i18n reminder helps prevent incomplete localization when modifying labels or messages