### PR TITLE
feat(audit): add ACCESS_DENIED activity log on admin role check failure

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/FessAdminAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/FessAdminAction.java
@@ -238,10 +238,25 @@ public abstract class FessAdminAction extends FessBaseAction {
     @Override
     public ActionResponse godHandPrologue(final ActionRuntime runtime) {
         try {
-            return super.godHandPrologue(runtime);
+            return superGodHandPrologue(runtime);
         } catch (final UserRoleLoginException e) {
+            activityHelper.accessDenied(getUserBean(), runtime.getRequestPath());
             return redirect(e.getActionClass());
         }
+    }
+
+    /**
+     * Calls the parent's godHandPrologue method.
+     * <p>
+     * This method exists to allow subclasses or tests to override
+     * the behavior of the parent class invocation.
+     * </p>
+     *
+     * @param runtime the action runtime context
+     * @return the action response from the parent
+     */
+    protected ActionResponse superGodHandPrologue(final ActionRuntime runtime) {
+        return super.godHandPrologue(runtime);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/ActivityHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ActivityHelper.java
@@ -243,6 +243,19 @@ public class ActivityHelper {
     }
 
     /**
+     * Log the access denied activity.
+     * @param user The user.
+     * @param path The path.
+     */
+    public void accessDenied(final OptionalThing<FessUserBean> user, final String path) {
+        final Map<String, String> valueMap = new LinkedHashMap<>();
+        valueMap.put("action", Action.ACCESS_DENIED.name());
+        valueMap.put("user", user.map(FessUserBean::getUserId).orElse("-"));
+        valueMap.put("path", path);
+        log(valueMap);
+    }
+
+    /**
      * Print the log.
      * @param action The action.
      * @param user The user.
@@ -348,7 +361,11 @@ public class ActivityHelper {
         /**
          * The script execution action.
          */
-        SCRIPT_EXECUTION;
+        SCRIPT_EXECUTION,
+        /**
+         * The access denied action.
+         */
+        ACCESS_DENIED;
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/base/FessAdminActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/FessAdminActionTest.java
@@ -18,10 +18,24 @@ package org.codelibs.fess.app.web.base;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
+import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.app.web.RootAction;
+import org.codelibs.fess.entity.FessUser;
+import org.codelibs.fess.exception.UserRoleLoginException;
+import org.codelibs.fess.helper.ActivityHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.lastaflute.web.response.ActionResponse;
+import org.lastaflute.web.response.HtmlResponse;
+import org.lastaflute.web.ruts.process.ActionRuntime;
 
 public class FessAdminActionTest extends UnitFessTestCase {
 
@@ -350,6 +364,87 @@ public class FessAdminActionTest extends UnitFessTestCase {
     }
 
     // ===================================================================================
+    //                                                         godHandPrologue Tests
+    //                                                         =========================
+
+    @Test
+    public void test_godHandPrologue_callsAccessDeniedOnUserRoleLoginException() {
+        final List<Map<String, String>> capturedLogs = new ArrayList<>();
+        final ActivityHelper spyActivityHelper = createSpyActivityHelper(capturedLogs);
+
+        final TestActionRuntime testRuntime = new TestActionRuntime("/admin/user/");
+        final FessAdminAction action =
+                createGodHandAction(spyActivityHelper, OptionalThing.of(new FessUserBean(new TestUser("admin", new String[0]))), true);
+
+        action.godHandPrologue(testRuntime);
+
+        assertEquals(1, capturedLogs.size());
+        assertEquals("admin", capturedLogs.get(0).get("user"));
+        assertEquals("/admin/user/", capturedLogs.get(0).get("path"));
+    }
+
+    @Test
+    public void test_godHandPrologue_callsAccessDeniedWithEmptyUser() {
+        final List<Map<String, String>> capturedLogs = new ArrayList<>();
+        final ActivityHelper spyActivityHelper = createSpyActivityHelper(capturedLogs);
+
+        final TestActionRuntime testRuntime = new TestActionRuntime("/admin/role/");
+        final FessAdminAction action = createGodHandAction(spyActivityHelper, OptionalThing.empty(), true);
+
+        action.godHandPrologue(testRuntime);
+
+        assertEquals(1, capturedLogs.size());
+        assertEquals("-", capturedLogs.get(0).get("user"));
+        assertEquals("/admin/role/", capturedLogs.get(0).get("path"));
+    }
+
+    @Test
+    public void test_godHandPrologue_doesNotCallAccessDeniedOnNormalFlow() {
+        final List<Map<String, String>> capturedLogs = new ArrayList<>();
+        final ActivityHelper spyActivityHelper = createSpyActivityHelper(capturedLogs);
+
+        final TestActionRuntime testRuntime = new TestActionRuntime("/admin/user/");
+        final FessAdminAction action =
+                createGodHandAction(spyActivityHelper, OptionalThing.of(new FessUserBean(new TestUser("admin", new String[0]))), false);
+
+        action.godHandPrologue(testRuntime);
+
+        assertEquals(0, capturedLogs.size());
+    }
+
+    @Test
+    public void test_godHandPrologue_returnsRedirectResponse() {
+        final ActivityHelper spyActivityHelper = createSpyActivityHelper(new ArrayList<>());
+
+        final TestActionRuntime testRuntime = new TestActionRuntime("/admin/user/");
+        final FessAdminAction action =
+                createGodHandAction(spyActivityHelper, OptionalThing.of(new FessUserBean(new TestUser("admin", new String[0]))), true);
+
+        final ActionResponse response = action.godHandPrologue(testRuntime);
+        assertNotNull(response);
+    }
+
+    @Test
+    public void test_godHandPrologue_accessDeniedWithVariousPaths() {
+        final List<Map<String, String>> capturedLogs = new ArrayList<>();
+        final ActivityHelper spyActivityHelper = createSpyActivityHelper(capturedLogs);
+
+        final String[] paths = { "/admin/user/", "/admin/role/", "/admin/group/", "/admin/scheduler/" };
+        for (final String path : paths) {
+            capturedLogs.clear();
+            final TestActionRuntime testRuntime = new TestActionRuntime(path);
+            final FessAdminAction action = createGodHandAction(spyActivityHelper,
+                    OptionalThing.of(new FessUserBean(new TestUser("testuser", new String[0]))), true);
+
+            action.godHandPrologue(testRuntime);
+
+            assertEquals(1, capturedLogs.size());
+            assertEquals("testuser", capturedLogs.get(0).get("user"));
+            assertEquals(path, capturedLogs.get(0).get("path"));
+        }
+    }
+
+    // ===================================================================================
     //                                                                      Helper Methods
     //                                                                      ==============
 
@@ -360,6 +455,91 @@ public class FessAdminActionTest extends UnitFessTestCase {
                 return "admin-test";
             }
         };
+    }
+
+    private ActivityHelper createSpyActivityHelper(final List<Map<String, String>> capturedLogs) {
+        return new ActivityHelper() {
+            @Override
+            public void accessDenied(final OptionalThing<FessUserBean> user, final String path) {
+                final Map<String, String> log = new LinkedHashMap<>();
+                log.put("user", user.map(FessUserBean::getUserId).orElse("-"));
+                log.put("path", path);
+                capturedLogs.add(log);
+            }
+        };
+    }
+
+    private FessAdminAction createGodHandAction(final ActivityHelper spyActivityHelper, final OptionalThing<FessUserBean> userBean,
+            final boolean throwException) {
+        return new FessAdminAction() {
+            {
+                activityHelper = spyActivityHelper;
+            }
+
+            @Override
+            protected String getActionRole() {
+                return "admin-test";
+            }
+
+            @Override
+            protected OptionalThing<FessUserBean> getUserBean() {
+                return userBean;
+            }
+
+            @Override
+            protected ActionResponse superGodHandPrologue(final ActionRuntime runtime) {
+                if (throwException) {
+                    throw new UserRoleLoginException(RootAction.class);
+                }
+                return ActionResponse.undefined();
+            }
+
+            @Override
+            protected HtmlResponse redirect(final Class<?> actionType) {
+                return HtmlResponse.undefined();
+            }
+        };
+    }
+
+    static class TestActionRuntime extends ActionRuntime {
+
+        TestActionRuntime(final String requestPath) {
+            super(requestPath, null, null);
+        }
+    }
+
+    static class TestUser implements FessUser {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String[] permissions;
+
+        TestUser(final String name, final String[] permissions) {
+            this.name = name;
+            this.permissions = permissions;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String[] getRoleNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getGroupNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getPermissions() {
+            return permissions;
+        }
     }
 
     private static void assertThrows(final Class<? extends Throwable> expectedType, final Runnable runnable) {

--- a/src/test/java/org/codelibs/fess/helper/ActivityHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ActivityHelperTest.java
@@ -239,6 +239,40 @@ public class ActivityHelperTest extends UnitFessTestCase {
                 localLogMsg.get());
     }
 
+    // ===== Access Denied Audit Log Tests =====
+
+    @Test
+    public void test_accessDenied() {
+        activityHelper.useEcsFormat = false;
+        activityHelper.accessDenied(OptionalThing.empty(), "/admin/user/");
+        assertEquals("action:ACCESS_DENIED\tuser:-\tpath:/admin/user/", localLogMsg.get());
+
+        activityHelper.accessDenied(createUser("testuser", new String[0]), "/admin/user/");
+        assertEquals("action:ACCESS_DENIED\tuser:testuser\tpath:/admin/user/", localLogMsg.get());
+
+        activityHelper.accessDenied(createUser("testuser", new String[] { "111", "222" }), "/admin/role/");
+        assertEquals("action:ACCESS_DENIED\tuser:testuser\tpath:/admin/role/", localLogMsg.get());
+    }
+
+    @Test
+    public void test_accessDenied_ecs() {
+        activityHelper.useEcsFormat = true;
+        activityHelper.accessDenied(OptionalThing.empty(), "/admin/user/");
+        assertEquals(
+                "{\"@timestamp\":\"2022-01-01T00:00:00.000Z\",\"log.level\":\"INFO\",\"ecs.version\":\"1.2.0\",\"service.name\":\"fess\",\"event.dataset\":\"app\",\"process.thread.name\":\"main\",\"log.logger\":\"org.codelibs.fess.helper.ActivityHelperTest$1\",\"labels.action\":\"ACCESS_DENIED\",\"labels.user\":\"-\",\"labels.path\":\"\\/admin\\/user\\/\"}",
+                localLogMsg.get());
+
+        activityHelper.accessDenied(createUser("testuser", new String[0]), "/admin/user/");
+        assertEquals(
+                "{\"@timestamp\":\"2022-01-01T00:00:00.000Z\",\"log.level\":\"INFO\",\"ecs.version\":\"1.2.0\",\"service.name\":\"fess\",\"event.dataset\":\"app\",\"process.thread.name\":\"main\",\"log.logger\":\"org.codelibs.fess.helper.ActivityHelperTest$1\",\"labels.action\":\"ACCESS_DENIED\",\"labels.user\":\"testuser\",\"labels.path\":\"\\/admin\\/user\\/\"}",
+                localLogMsg.get());
+
+        activityHelper.accessDenied(createUser("testuser", new String[] { "111", "222" }), "/admin/role/");
+        assertEquals(
+                "{\"@timestamp\":\"2022-01-01T00:00:00.000Z\",\"log.level\":\"INFO\",\"ecs.version\":\"1.2.0\",\"service.name\":\"fess\",\"event.dataset\":\"app\",\"process.thread.name\":\"main\",\"log.logger\":\"org.codelibs.fess.helper.ActivityHelperTest$1\",\"labels.action\":\"ACCESS_DENIED\",\"labels.user\":\"testuser\",\"labels.path\":\"\\/admin\\/role\\/\"}",
+                localLogMsg.get());
+    }
+
     // ===== Script Execution Audit Log Tests =====
 
     @Test


### PR DESCRIPTION
## Summary
- Add ACCESS_DENIED audit logging when `UserRoleLoginException` is caught in `FessAdminAction.godHandPrologue()`
- Record user identity and request path for security audit trail

## Changes Made
- **FessAdminAction**: Catch `UserRoleLoginException` and call `activityHelper.accessDenied()` before redirecting. Extract `super.godHandPrologue()` into `superGodHandPrologue()` for testability.
- **ActivityHelper**: Add `accessDenied()` method and `ACCESS_DENIED` enum value to log denied access events with user and path.
- **FessAdminActionTest**: Add tests for `godHandPrologue` covering exception handling, normal flow, empty user, and various paths.
- **ActivityHelperTest**: Add tests for `accessDenied()` in both plain and ECS log formats.

## Testing
- Unit tests added for both `FessAdminAction.godHandPrologue()` and `ActivityHelper.accessDenied()`
- Tests cover: exception path with/without user, normal flow (no exception), multiple admin paths, both log formats