### PR TITLE
refactor(chat,llm): simplify search result flow and make LLM prompts configurable

### DIFF
--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -159,7 +159,7 @@ public class ChatClient {
             // For SUMMARY intent, search by URL; for SEARCH/FAQ, search with query
             ChatSearchResult searchResult;
             if (intentResult.getIntent() == ChatIntent.SUMMARY && StringUtil.isNotBlank(intentResult.getDocumentUrl())) {
-                searchResult = searchByUrlWithMetadata(intentResult.getDocumentUrl());
+                searchResult = searchByUrl(intentResult.getDocumentUrl());
             } else {
                 final String query = StringUtil.isBlank(intentResult.getQuery()) ? userMessage : intentResult.getQuery();
                 searchResult = searchWithQueryAndMetadata(query, safeFields, safeExtraQueries);
@@ -282,7 +282,7 @@ public class ChatClient {
                 final String documentUrl = intentResult.getDocumentUrl();
                 phaseStartTime = System.currentTimeMillis();
                 callback.onPhaseStart(ChatPhaseCallback.PHASE_SEARCH, "Searching for document...", documentUrl);
-                final ChatSearchResult urlSearchResult = searchByUrlWithMetadata(documentUrl);
+                final ChatSearchResult urlSearchResult = searchByUrl(documentUrl);
                 final List<Map<String, Object>> urlResults = urlSearchResult.getDocuments();
                 searchQueryId = urlSearchResult.getQueryId();
                 searchRequestedTime = urlSearchResult.getRequestedTime();
@@ -728,21 +728,7 @@ public class ChatClient {
     }
 
     private ChatSearchResult searchWithQueryAndMetadata(final String query) {
-        if (StringUtil.isBlank(query)) {
-            return new ChatSearchResult(Collections.emptyList(), null, 0L);
-        }
-
-        if (query.length() > MAX_QUERY_LENGTH) {
-            logger.warn("[RAG] Rejected LLM-generated query exceeding max length. length={}", query.length());
-            return new ChatSearchResult(Collections.emptyList(), null, 0L);
-        }
-
-        if (DANGEROUS_QUERY_PATTERN.matcher(query).find()) {
-            logger.warn("[RAG] Rejected LLM-generated query with dangerous pattern. query={}", query);
-            return new ChatSearchResult(Collections.emptyList(), null, 0L);
-        }
-
-        return searchDocumentsWithMetadata(query);
+        return searchWithQueryAndMetadata(query, Collections.emptyMap(), new String[0]);
     }
 
     /**
@@ -760,25 +746,11 @@ public class ChatClient {
 
     private ChatSearchResult searchWithQueryAndMetadata(final String query, final Map<String, String[]> fields,
             final String[] extraQueries) {
-        if (fields.isEmpty() && extraQueries.length == 0) {
-            return searchWithQueryAndMetadata(query);
+        final ChatSearchResult rejected = validateQuery(query);
+        if (rejected != null) {
+            return rejected;
         }
-
-        if (StringUtil.isBlank(query)) {
-            return new ChatSearchResult(Collections.emptyList(), null, 0L);
-        }
-
-        if (query.length() > MAX_QUERY_LENGTH) {
-            logger.warn("[RAG] Rejected LLM-generated query exceeding max length. length={}", query.length());
-            return new ChatSearchResult(Collections.emptyList(), null, 0L);
-        }
-
-        if (DANGEROUS_QUERY_PATTERN.matcher(query).find()) {
-            logger.warn("[RAG] Rejected LLM-generated query with dangerous pattern. query={}", query);
-            return new ChatSearchResult(Collections.emptyList(), null, 0L);
-        }
-
-        return searchDocumentsWithMetadata(query, fields, extraQueries);
+        return searchDocuments(query, fields, extraQueries);
     }
 
     /**
@@ -834,41 +806,6 @@ public class ChatClient {
                     System.currentTimeMillis() - startTime);
             return Collections.emptyList();
         }
-    }
-
-    /**
-     * Searches for documents by URL.
-     *
-     * @param url the URL to search for
-     * @return list of documents matching the URL
-     */
-    protected List<Map<String, Object>> searchByUrl(final String url) {
-        if (StringUtil.isBlank(url)) {
-            return Collections.emptyList();
-        }
-
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final int maxDocs = fessConfig.getRagChatContextMaxDocumentsAsInteger();
-
-        try {
-            final SearchRenderData data = new SearchRenderData();
-            final ChatSearchRequestParams params =
-                    new ChatSearchRequestParams("url:\"" + escapeQueryValue(url) + "\"", maxDocs, fessConfig);
-
-            ComponentUtil.getSearchHelper().search(params, data, OptionalThing.empty());
-
-            setLastSearchMetadata(data.getQueryId(), data.getRequestedTime());
-
-            @SuppressWarnings("unchecked")
-            final List<Map<String, Object>> docs = (List<Map<String, Object>>) data.getDocumentItems();
-            if (docs != null) {
-                return docs;
-            }
-        } catch (final Exception e) {
-            logger.warn("Failed to search documents by URL: url={}", url, e);
-        }
-
-        return Collections.emptyList();
     }
 
     /**
@@ -931,78 +868,66 @@ public class ChatClient {
         return ComponentUtil.getFessConfig().getRagChatHistoryMaxMessagesAsInteger();
     }
 
-    /** Thread-local storage for search metadata captured during searchDocuments calls. */
-    private static final ThreadLocal<String> lastSearchQueryId = new ThreadLocal<>();
-
-    /** Thread-local storage for search metadata captured during searchDocuments calls. */
-    private static final ThreadLocal<Long> lastSearchRequestedTime = new ThreadLocal<>();
-
     /**
-     * Stores search metadata for retrieval by internal callers.
+     * Searches for documents relevant to the user's query.
+     * Delegates to the multi-argument variant with empty filters.
      *
-     * @param queryId the query ID from SearchRenderData
-     * @param requestedTime the requested time from SearchRenderData
+     * @param query the search query
+     * @return a ChatSearchResult with documents and search metadata
      */
-    protected void setLastSearchMetadata(final String queryId, final long requestedTime) {
-        lastSearchQueryId.set(queryId);
-        lastSearchRequestedTime.set(requestedTime);
+    protected ChatSearchResult searchDocuments(final String query) {
+        return searchDocuments(query, Collections.emptyMap(), new String[0]);
     }
 
     /**
-     * Clears search metadata from ThreadLocal to prevent stale data on error paths.
+     * Searches for documents by URL.
+     *
+     * @param url the URL to search for
+     * @return a ChatSearchResult with documents and search metadata
      */
-    private void clearLastSearchMetadata() {
-        lastSearchQueryId.remove();
-        lastSearchRequestedTime.remove();
-    }
-
-    /**
-     * Creates a ChatSearchResult by calling the protected searchDocuments method
-     * and retrieving captured metadata.
-     */
-    private ChatSearchResult searchDocumentsWithMetadata(final String query) {
-        try {
-            final List<Map<String, Object>> docs = searchDocuments(query);
-            return buildChatSearchResult(docs);
-        } finally {
-            clearLastSearchMetadata();
+    protected ChatSearchResult searchByUrl(final String url) {
+        if (StringUtil.isBlank(url)) {
+            return new ChatSearchResult(Collections.emptyList(), null, 0L);
         }
-    }
 
-    /**
-     * Creates a ChatSearchResult by calling the protected searchDocuments method
-     * and retrieving captured metadata.
-     */
-    private ChatSearchResult searchDocumentsWithMetadata(final String query, final Map<String, String[]> fields,
-            final String[] extraQueries) {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final int maxDocs = fessConfig.getRagChatContextMaxDocumentsAsInteger();
+
         try {
-            final List<Map<String, Object>> docs = searchDocuments(query, fields, extraQueries);
-            return buildChatSearchResult(docs);
-        } finally {
-            clearLastSearchMetadata();
+            final SearchRenderData data = new SearchRenderData();
+            final ChatSearchRequestParams params =
+                    new ChatSearchRequestParams("url:\"" + escapeQueryValue(url) + "\"", maxDocs, fessConfig);
+
+            ComponentUtil.getSearchHelper().search(params, data, OptionalThing.empty());
+
+            @SuppressWarnings("unchecked")
+            final List<Map<String, Object>> docs = (List<Map<String, Object>>) data.getDocumentItems();
+            if (docs != null) {
+                return new ChatSearchResult(docs, data.getQueryId(), data.getRequestedTime());
+            }
+        } catch (final Exception e) {
+            logger.warn("Failed to search documents by URL: url={}", url, e);
         }
+
+        return new ChatSearchResult(Collections.emptyList(), null, 0L);
     }
 
     /**
-     * Creates a ChatSearchResult by calling the protected searchByUrl method
-     * and retrieving captured metadata.
+     * Validates a query and returns an empty result if invalid, or null if validation passed.
      */
-    private ChatSearchResult searchByUrlWithMetadata(final String url) {
-        try {
-            final List<Map<String, Object>> docs = searchByUrl(url);
-            return buildChatSearchResult(docs);
-        } finally {
-            clearLastSearchMetadata();
+    private ChatSearchResult validateQuery(final String query) {
+        if (StringUtil.isBlank(query)) {
+            return new ChatSearchResult(Collections.emptyList(), null, 0L);
         }
-    }
-
-    /**
-     * Creates a ChatSearchResult from documents and captured ThreadLocal metadata.
-     */
-    private ChatSearchResult buildChatSearchResult(final List<Map<String, Object>> docs) {
-        final String queryId = lastSearchQueryId.get();
-        final Long requestedTime = lastSearchRequestedTime.get();
-        return new ChatSearchResult(docs, queryId, requestedTime != null ? requestedTime : 0L);
+        if (query.length() > MAX_QUERY_LENGTH) {
+            logger.warn("[RAG] Rejected LLM-generated query exceeding max length. length={}", query.length());
+            return new ChatSearchResult(Collections.emptyList(), null, 0L);
+        }
+        if (DANGEROUS_QUERY_PATTERN.matcher(query).find()) {
+            logger.warn("[RAG] Rejected LLM-generated query with dangerous pattern. query={}", query);
+            return new ChatSearchResult(Collections.emptyList(), null, 0L);
+        }
+        return null;
     }
 
     /**
@@ -1012,66 +937,13 @@ public class ChatClient {
      * users only see documents they are authorized to access.
      * <p>
      * This is the primary extension point for subclasses to customize search behavior.
-     * It is called by backward-compatible (no-filter) methods.
-     * <p>
-     * Subclasses that override this method should call {@link #setLastSearchMetadata(String, long)}
-     * to provide queryId and requestedTime for go URL generation.
-     *
-     * @param query the search query
-     * @return a list of documents matching the query
-     */
-    protected List<Map<String, Object>> searchDocuments(final String query) {
-        final long startTime = System.currentTimeMillis();
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final int maxDocs = fessConfig.getRagChatContextMaxDocumentsAsInteger();
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("[RAG] Starting document search. query={}, maxDocs={}", query, maxDocs);
-        }
-
-        try {
-            final SearchRenderData data = new SearchRenderData();
-            final ChatSearchRequestParams params = new ChatSearchRequestParams(query, maxDocs, fessConfig);
-
-            ComponentUtil.getSearchHelper().search(params, data, OptionalThing.empty());
-
-            setLastSearchMetadata(data.getQueryId(), data.getRequestedTime());
-
-            @SuppressWarnings("unchecked")
-            final List<Map<String, Object>> docs = (List<Map<String, Object>>) data.getDocumentItems();
-            if (docs != null) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("[RAG] Document search completed. query={}, resultCount={}, elapsedTime={}ms", query, docs.size(),
-                            System.currentTimeMillis() - startTime);
-                }
-                return docs;
-            }
-        } catch (final Exception e) {
-            logger.warn("Failed to search documents for RAG: query={}, elapsedTime={}ms", query, System.currentTimeMillis() - startTime, e);
-        }
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("[RAG] Document search returned no results. query={}, elapsedTime={}ms", query,
-                    System.currentTimeMillis() - startTime);
-        }
-        return new ArrayList<>();
-    }
-
-    /**
-     * Searches for documents relevant to the user's query with filters.
-     * Filter-aware variant used by the chat API when filters are specified.
      *
      * @param query the search query
      * @param fields the field filters (e.g., label)
      * @param extraQueries the extra query filters (e.g., filetype, timestamp)
-     * @return a list of documents matching the query
+     * @return a ChatSearchResult with documents and search metadata
      */
-    protected List<Map<String, Object>> searchDocuments(final String query, final Map<String, String[]> fields,
-            final String[] extraQueries) {
-        if (fields.isEmpty() && extraQueries.length == 0) {
-            return searchDocuments(query);
-        }
-
+    protected ChatSearchResult searchDocuments(final String query, final Map<String, String[]> fields, final String[] extraQueries) {
         final long startTime = System.currentTimeMillis();
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final int maxDocs = fessConfig.getRagChatContextMaxDocumentsAsInteger();
@@ -1086,8 +958,6 @@ public class ChatClient {
 
             ComponentUtil.getSearchHelper().search(params, data, OptionalThing.empty());
 
-            setLastSearchMetadata(data.getQueryId(), data.getRequestedTime());
-
             @SuppressWarnings("unchecked")
             final List<Map<String, Object>> docs = (List<Map<String, Object>>) data.getDocumentItems();
             if (docs != null) {
@@ -1095,7 +965,7 @@ public class ChatClient {
                     logger.debug("[RAG] Document search completed. query={}, resultCount={}, elapsedTime={}ms", query, docs.size(),
                             System.currentTimeMillis() - startTime);
                 }
-                return docs;
+                return new ChatSearchResult(docs, data.getQueryId(), data.getRequestedTime());
             }
         } catch (final Exception e) {
             logger.warn("Failed to search documents for RAG: query={}, elapsedTime={}ms", query, System.currentTimeMillis() - startTime, e);
@@ -1105,7 +975,7 @@ public class ChatClient {
             logger.debug("[RAG] Document search returned no results. query={}, elapsedTime={}ms", query,
                     System.currentTimeMillis() - startTime);
         }
-        return new ArrayList<>();
+        return new ChatSearchResult(new ArrayList<>(), null, 0L);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -76,6 +76,29 @@ public abstract class AbstractLlmClient implements LlmClient {
     /** Semaphore for limiting concurrent LLM requests. Initialized lazily in init(). */
     protected volatile Semaphore concurrencyLimiter;
 
+    /** The system prompt for LLM interactions. */
+    protected String systemPrompt;
+    /** The prompt for detecting user intent. */
+    protected String intentDetectionPrompt;
+    /** The system prompt for handling unclear intents. */
+    protected String unclearIntentSystemPrompt;
+    /** The system prompt for handling no results. */
+    protected String noResultsSystemPrompt;
+    /** The system prompt for handling document not found. */
+    protected String documentNotFoundSystemPrompt;
+    /** The prompt for evaluating responses. */
+    protected String evaluationPrompt;
+    /** The system prompt for answer generation. */
+    protected String answerGenerationSystemPrompt;
+    /** The system prompt for summary generation. */
+    protected String summarySystemPrompt;
+    /** The system prompt for FAQ answer generation. */
+    protected String faqAnswerSystemPrompt;
+    /** The system prompt for direct answer generation. */
+    protected String directAnswerSystemPrompt;
+    /** The prompt for query regeneration. */
+    protected String queryRegenerationPrompt;
+
     /**
      * Default constructor.
      */
@@ -271,77 +294,222 @@ public abstract class AbstractLlmClient implements LlmClient {
      *
      * @return the system prompt
      */
-    protected abstract String getSystemPrompt();
+    protected String getSystemPrompt() {
+        if (systemPrompt == null) {
+            throw new LlmException("systemPrompt is not configured for " + getName());
+        }
+        return systemPrompt;
+    }
 
     /**
      * Gets the intent detection prompt template.
      *
      * @return the intent detection prompt
      */
-    protected abstract String getIntentDetectionPrompt();
+    protected String getIntentDetectionPrompt() {
+        if (intentDetectionPrompt == null) {
+            throw new LlmException("intentDetectionPrompt is not configured for " + getName());
+        }
+        return intentDetectionPrompt;
+    }
 
     /**
      * Gets the system prompt for unclear intent responses.
      *
      * @return the unclear intent system prompt
      */
-    protected abstract String getUnclearIntentSystemPrompt();
+    protected String getUnclearIntentSystemPrompt() {
+        if (unclearIntentSystemPrompt == null) {
+            throw new LlmException("unclearIntentSystemPrompt is not configured for " + getName());
+        }
+        return unclearIntentSystemPrompt;
+    }
 
     /**
      * Gets the system prompt for no-results responses.
      *
      * @return the no-results system prompt
      */
-    protected abstract String getNoResultsSystemPrompt();
+    protected String getNoResultsSystemPrompt() {
+        if (noResultsSystemPrompt == null) {
+            throw new LlmException("noResultsSystemPrompt is not configured for " + getName());
+        }
+        return noResultsSystemPrompt;
+    }
 
     /**
      * Gets the system prompt for document-not-found responses.
      *
      * @return the document-not-found system prompt
      */
-    protected abstract String getDocumentNotFoundSystemPrompt();
+    protected String getDocumentNotFoundSystemPrompt() {
+        if (documentNotFoundSystemPrompt == null) {
+            throw new LlmException("documentNotFoundSystemPrompt is not configured for " + getName());
+        }
+        return documentNotFoundSystemPrompt;
+    }
 
     /**
      * Gets the evaluation prompt for relevance checking.
      *
      * @return the evaluation prompt
      */
-    protected abstract String getEvaluationPrompt();
+    protected String getEvaluationPrompt() {
+        if (evaluationPrompt == null) {
+            throw new LlmException("evaluationPrompt is not configured for " + getName());
+        }
+        return evaluationPrompt;
+    }
 
     /**
      * Gets the system prompt for answer generation.
      *
      * @return the answer generation system prompt
      */
-    protected abstract String getAnswerGenerationSystemPrompt();
+    protected String getAnswerGenerationSystemPrompt() {
+        if (answerGenerationSystemPrompt == null) {
+            throw new LlmException("answerGenerationSystemPrompt is not configured for " + getName());
+        }
+        return answerGenerationSystemPrompt;
+    }
 
     /**
      * Gets the system prompt for summary generation.
      *
      * @return the summary system prompt
      */
-    protected abstract String getSummarySystemPrompt();
+    protected String getSummarySystemPrompt() {
+        if (summarySystemPrompt == null) {
+            throw new LlmException("summarySystemPrompt is not configured for " + getName());
+        }
+        return summarySystemPrompt;
+    }
 
     /**
      * Gets the system prompt for FAQ answer generation.
      *
      * @return the FAQ answer system prompt
      */
-    protected abstract String getFaqAnswerSystemPrompt();
+    protected String getFaqAnswerSystemPrompt() {
+        if (faqAnswerSystemPrompt == null) {
+            throw new LlmException("faqAnswerSystemPrompt is not configured for " + getName());
+        }
+        return faqAnswerSystemPrompt;
+    }
 
     /**
      * Gets the system prompt for direct answer generation.
      *
      * @return the direct answer system prompt
      */
-    protected abstract String getDirectAnswerSystemPrompt();
+    protected String getDirectAnswerSystemPrompt() {
+        if (directAnswerSystemPrompt == null) {
+            throw new LlmException("directAnswerSystemPrompt is not configured for " + getName());
+        }
+        return directAnswerSystemPrompt;
+    }
 
     /**
      * Gets the query regeneration prompt template.
      *
      * @return the query regeneration prompt
      */
-    protected abstract String getQueryRegenerationPrompt();
+    protected String getQueryRegenerationPrompt() {
+        if (queryRegenerationPrompt == null) {
+            throw new LlmException("queryRegenerationPrompt is not configured for " + getName());
+        }
+        return queryRegenerationPrompt;
+    }
+
+    /** Sets the system prompt for LLM interactions.
+     * @param systemPrompt the system prompt */
+    public void setSystemPrompt(final String systemPrompt) {
+        this.systemPrompt = systemPrompt;
+    }
+
+    /** Sets the prompt for detecting user intent.
+     * @param intentDetectionPrompt the intent detection prompt */
+    public void setIntentDetectionPrompt(final String intentDetectionPrompt) {
+        this.intentDetectionPrompt = intentDetectionPrompt;
+    }
+
+    /** Sets the system prompt for handling unclear intents.
+     * @param unclearIntentSystemPrompt the unclear intent system prompt */
+    public void setUnclearIntentSystemPrompt(final String unclearIntentSystemPrompt) {
+        this.unclearIntentSystemPrompt = unclearIntentSystemPrompt;
+    }
+
+    /** Sets the system prompt for handling no results.
+     * @param noResultsSystemPrompt the no results system prompt */
+    public void setNoResultsSystemPrompt(final String noResultsSystemPrompt) {
+        this.noResultsSystemPrompt = noResultsSystemPrompt;
+    }
+
+    /** Sets the system prompt for handling document not found.
+     * @param documentNotFoundSystemPrompt the document not found system prompt */
+    public void setDocumentNotFoundSystemPrompt(final String documentNotFoundSystemPrompt) {
+        this.documentNotFoundSystemPrompt = documentNotFoundSystemPrompt;
+    }
+
+    /** Sets the prompt for evaluating responses.
+     * @param evaluationPrompt the evaluation prompt */
+    public void setEvaluationPrompt(final String evaluationPrompt) {
+        this.evaluationPrompt = evaluationPrompt;
+    }
+
+    /** Sets the system prompt for answer generation.
+     * @param answerGenerationSystemPrompt the answer generation system prompt */
+    public void setAnswerGenerationSystemPrompt(final String answerGenerationSystemPrompt) {
+        this.answerGenerationSystemPrompt = answerGenerationSystemPrompt;
+    }
+
+    /** Sets the system prompt for summary generation.
+     * @param summarySystemPrompt the summary system prompt */
+    public void setSummarySystemPrompt(final String summarySystemPrompt) {
+        this.summarySystemPrompt = summarySystemPrompt;
+    }
+
+    /** Sets the system prompt for FAQ answer generation.
+     * @param faqAnswerSystemPrompt the FAQ answer system prompt */
+    public void setFaqAnswerSystemPrompt(final String faqAnswerSystemPrompt) {
+        this.faqAnswerSystemPrompt = faqAnswerSystemPrompt;
+    }
+
+    /** Sets the system prompt for direct answer generation.
+     * @param directAnswerSystemPrompt the direct answer system prompt */
+    public void setDirectAnswerSystemPrompt(final String directAnswerSystemPrompt) {
+        this.directAnswerSystemPrompt = directAnswerSystemPrompt;
+    }
+
+    /** Sets the prompt for query regeneration.
+     * @param queryRegenerationPrompt the query regeneration prompt */
+    public void setQueryRegenerationPrompt(final String queryRegenerationPrompt) {
+        this.queryRegenerationPrompt = queryRegenerationPrompt;
+    }
+
+    /**
+     * Gets an integer configuration value using the config prefix and key suffix.
+     * Returns the configured value if it is a positive integer, otherwise returns the default.
+     *
+     * @param keySuffix the key suffix (appended to getConfigPrefix() + ".")
+     * @param defaultValue the default value
+     * @return the configured or default value
+     */
+    protected int getConfigInt(final String keySuffix, final int defaultValue) {
+        final String key = getConfigPrefix() + "." + keySuffix;
+        final String configValue = ComponentUtil.getFessConfig().getOrDefault(key, null);
+        if (configValue != null) {
+            try {
+                final int value = Integer.parseInt(configValue);
+                if (value > 0) {
+                    return value;
+                }
+            } catch (final NumberFormatException e) {
+                logger.warn("Invalid config value for key={}. Using default: {}", key, defaultValue);
+            }
+        }
+        return defaultValue;
+    }
 
     /**
      * Gets the maximum characters for context building for a specific prompt type.

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -90,10 +90,6 @@
       <param-name>antiClickJackingEnabled</param-name>
       <param-value>false</param-value>
     </init-param>
-    <init-param>
-      <param-name>xssProtectionEnabled</param-name>
-      <param-value>false</param-value>
-    </init-param>
   </filter>
 
   <!-- ================================================================================= -->

--- a/src/test/java/org/codelibs/fess/api/WebApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/api/WebApiManagerTest.java
@@ -875,6 +875,10 @@ public class WebApiManagerTest extends UnitFessTestCase {
         }
 
         @Override
+        public void sendRedirect(String location, int sc, boolean clearBuffer) {
+        }
+
+        @Override
         public void setDateHeader(String name, long date) {
         }
 

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -1001,18 +1001,17 @@ public class ChatClientTest extends UnitFessTestCase {
         }
 
         @Override
-        protected List<Map<String, Object>> searchDocuments(final String query) {
+        protected ChatSearchResult searchDocuments(final String query) {
             searchDocumentsCalled = true;
             searchedQueries.add(query);
-            return searchResultsToReturn;
+            return new ChatSearchResult(searchResultsToReturn, null, 0L);
         }
 
         @Override
-        protected List<Map<String, Object>> searchDocuments(final String query, final Map<String, String[]> fields,
-                final String[] extraQueries) {
+        protected ChatSearchResult searchDocuments(final String query, final Map<String, String[]> fields, final String[] extraQueries) {
             searchDocumentsCalled = true;
             searchedQueries.add(query);
-            return searchResultsToReturn;
+            return new ChatSearchResult(searchResultsToReturn, null, 0L);
         }
 
         boolean wasSearchDocumentsCalled() {

--- a/src/test/java/org/codelibs/fess/cors/CorsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/cors/CorsHandlerTest.java
@@ -742,6 +742,10 @@ public class CorsHandlerTest extends UnitFessTestCase {
             }
 
             @Override
+            public void sendRedirect(String location, int sc, boolean clearBuffer) {
+            }
+
+            @Override
             public void setDateHeader(String name, long date) {
             }
 

--- a/src/test/java/org/codelibs/fess/filter/CorsFilterTest.java
+++ b/src/test/java/org/codelibs/fess/filter/CorsFilterTest.java
@@ -720,6 +720,10 @@ public class CorsFilterTest extends UnitFessTestCase {
         }
 
         @Override
+        public void sendRedirect(String location, int sc, boolean clearBuffer) {
+        }
+
+        @Override
         public void setDateHeader(String name, long date) {
         }
 

--- a/src/test/java/org/codelibs/fess/filter/LoadControlFilterTest.java
+++ b/src/test/java/org/codelibs/fess/filter/LoadControlFilterTest.java
@@ -984,6 +984,10 @@ public class LoadControlFilterTest extends UnitFessTestCase {
         }
 
         @Override
+        public void sendRedirect(String location, int sc, boolean clearBuffer) {
+        }
+
+        @Override
         public void setDateHeader(String name, long date) {
         }
 

--- a/src/test/java/org/codelibs/fess/filter/WebApiFilterTest.java
+++ b/src/test/java/org/codelibs/fess/filter/WebApiFilterTest.java
@@ -780,6 +780,10 @@ public class WebApiFilterTest extends UnitFessTestCase {
             }
 
             @Override
+            public void sendRedirect(String location, int sc, boolean clearBuffer) throws IOException {
+            }
+
+            @Override
             public void setDateHeader(String name, long date) {
             }
 


### PR DESCRIPTION
## Summary
Simplify the ChatClient search result flow by eliminating ThreadLocal-based metadata passing, and make AbstractLlmClient prompts configurable via DI setters instead of requiring abstract method overrides.

## Changes Made
- **ChatClient**: Refactored `searchDocuments()` and `searchByUrl()` to return `ChatSearchResult` directly, removing the ThreadLocal-based `setLastSearchMetadata`/`clearLastSearchMetadata`/`buildChatSearchResult` pattern and the intermediate `searchDocumentsWithMetadata`/`searchByUrlWithMetadata` wrappers
- **ChatClient**: Extracted duplicate query validation (blank check, max length, dangerous pattern) into a single `validateQuery()` method
- **ChatClient**: Consolidated the no-filter `searchWithQueryAndMetadata(query)` overload to delegate to the filter-aware variant
- **AbstractLlmClient**: Converted 11 abstract prompt getter methods to concrete methods backed by configurable fields with public setters, enabling DI-based prompt configuration instead of requiring subclass overrides
- **AbstractLlmClient**: Added `getConfigInt()` utility method for typed integer config retrieval with validation
- **web.xml**: Removed deprecated `xssProtectionEnabled` init-param from the HttpHeaderSecurityFilter
- **Test files**: Added `sendRedirect(String, int, boolean)` override to mock HttpServletResponse implementations for Servlet 6.x API compatibility

## Testing
- Updated ChatClientTest mock to match the new `ChatSearchResult` return type signatures
- Existing unit tests cover the refactored behavior

## Breaking Changes
- `searchDocuments()` now returns `ChatSearchResult` instead of `List<Map<String, Object>>` — LLM plugin subclasses overriding this method need to update their signatures
- Abstract prompt methods in `AbstractLlmClient` are no longer abstract — subclasses can now configure prompts via setters or continue overriding

## Additional Notes
- The ThreadLocal removal eliminates a class of potential memory leak and stale-data bugs on error paths
- The `validateQuery()` extraction reduces code duplication from 3 copies to 1