### PR TITLE
chore(web): upgrade Servlet version from 6.0 to 6.1

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -17,8 +17,8 @@
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-                             web-app_6_0.xsd"
-         version="6.0">
+                             web-app_6_1.xsd"
+         version="6.1">
 
   <!-- ================================================================================= -->
   <!--                                                                    Servlet Filter -->

--- a/src/test/java/org/codelibs/fess/webapp/WebXmlTest.java
+++ b/src/test/java/org/codelibs/fess/webapp/WebXmlTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.webapp;
+
+import java.io.InputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class WebXmlTest extends UnitFessTestCase {
+
+    private Document webXmlDocument;
+
+    @Override
+    protected void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("../webapp/WEB-INF/web.xml")) {
+            if (is == null) {
+                try (InputStream is2 = Thread.currentThread().getContextClassLoader().getResourceAsStream("web.xml")) {
+                    if (is2 != null) {
+                        webXmlDocument = builder.parse(is2);
+                    }
+                }
+            } else {
+                webXmlDocument = builder.parse(is);
+            }
+        }
+        if (webXmlDocument == null) {
+            final java.io.File file = new java.io.File("src/main/webapp/WEB-INF/web.xml");
+            if (file.exists()) {
+                webXmlDocument = builder.parse(file);
+            }
+        }
+    }
+
+    @Test
+    public void test_webXmlExists() {
+        assertNotNull(webXmlDocument, "web.xml should be parseable");
+    }
+
+    @Test
+    public void test_servletVersion() {
+        if (webXmlDocument == null) {
+            return;
+        }
+        final Element root = webXmlDocument.getDocumentElement();
+        assertEquals("web-app", root.getLocalName());
+        assertEquals("6.1", root.getAttribute("version"));
+    }
+
+    @Test
+    public void test_namespace() {
+        if (webXmlDocument == null) {
+            return;
+        }
+        final Element root = webXmlDocument.getDocumentElement();
+        assertEquals("https://jakarta.ee/xml/ns/jakartaee", root.getNamespaceURI());
+    }
+
+    @Test
+    public void test_schemaLocation() {
+        if (webXmlDocument == null) {
+            return;
+        }
+        final Element root = webXmlDocument.getDocumentElement();
+        final String schemaLocation = root.getAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "schemaLocation");
+        assertTrue("schemaLocation should reference web-app_6_1.xsd", schemaLocation.contains("web-app_6_1.xsd"));
+    }
+}


### PR DESCRIPTION
## Summary
Upgrade the Servlet specification version in web.xml from 6.0 to 6.1, aligning with the latest Jakarta EE Servlet API.

## Changes Made
- Updated `web.xml` schema reference from `web-app_6_0.xsd` to `web-app_6_1.xsd`
- Updated `web.xml` version attribute from `6.0` to `6.1`
- Added `WebXmlTest` to validate web.xml parsing, version, namespace, and schema location

## Testing
- New unit test `WebXmlTest` covers:
  - web.xml is parseable
  - Servlet version is `6.1`
  - Namespace is `https://jakarta.ee/xml/ns/jakartaee`
  - Schema location references `web-app_6_1.xsd`

## Breaking Changes
- None. This is a spec version bump with no behavioral changes.