### PR TITLE
fix: differentiate log levels by HTTP status in SearchEngineApiManager

### DIFF
--- a/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
@@ -116,16 +116,29 @@ public class SearchEngineApiManager extends BaseApiManager {
                 throw new WebApiException(HttpServletResponse.SC_FORBIDDEN, "Invalid session.");
             });
         } catch (final WebApiException e) {
+            final int statusCode = e.getStatusCode();
             String message;
             if (Constants.TRUE.equalsIgnoreCase(ComponentUtil.getFessConfig().getApiJsonResponseExceptionIncluded())) {
-                logger.warn("Failed to access Web API.", e);
+                if (statusCode >= 400 && statusCode < 500) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Failed to access Web API.", e);
+                    }
+                } else {
+                    logger.warn("Failed to access Web API.", e);
+                }
                 message = e.getMessage();
             } else {
                 final String errorCode = UUID.randomUUID().toString();
                 message = "[" + errorCode + "] Failed to access to Web API.";
-                logger.warn(message, e);
+                if (statusCode >= 400 && statusCode < 500) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(message, e);
+                    }
+                } else {
+                    logger.warn(message, e);
+                }
             }
-            response.sendError(e.getStatusCode(), message);
+            response.sendError(statusCode, message);
         }
     }
 


### PR DESCRIPTION
## Summary

- Differentiate log levels by HTTP status code in `SearchEngineApiManager.process()` catch block
  - **4xx (client errors)**: `logger.debug()` — session expiry, invalid tokens are expected in normal operation
  - **5xx (server errors)**: `logger.warn()` — requires operator investigation
- Follows the existing pattern in `SearchApiManager` (`isDebugEnabled()` guard + `logger.debug()`)

## Changes

- `SearchEngineApiManager.java`: check `e.getStatusCode()` in catch block, route 4xx to DEBUG and 5xx to WARN
- No changes to UUID error code generation, `api.json.response.exception.included` config, or `response.sendError()` behavior

## Test plan

- [x] `mvn compile` passes
- [x] `mvn formatter:format && mvn license:format` applied
- [ ] Start Fess, verify 403 (session expiry) is logged at DEBUG level
- [ ] Start Fess, verify 500 (server error) is logged at WARN level