### PR TITLE
fix(admin): add null-safe handling for optional form fields in General settings

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
@@ -190,14 +190,14 @@ public class AdminGeneralAction extends FessAdminAction {
         fessConfig.setDefaultSortValue(form.defaultSortValue);
         fessConfig.setVirtualHostValue(form.virtualHostValue);
         fessConfig.setAppendQueryParameter(isCheckboxEnabled(form.appendQueryParameter));
-        fessConfig.setIgnoreFailureType(form.ignoreFailureType);
+        fessConfig.setIgnoreFailureType(form.ignoreFailureType != null ? form.ignoreFailureType : StringUtil.EMPTY);
         fessConfig.setFailureCountThreshold(form.failureCountThreshold);
         fessConfig.setWebApiPopularWord(isCheckboxEnabled(form.popularWord));
         fessConfig.setCsvFileEncoding(form.csvFileEncoding);
         fessConfig.setPurgeSearchLogDay(form.purgeSearchLogDay);
         fessConfig.setPurgeJobLogDay(form.purgeJobLogDay);
         fessConfig.setPurgeUserInfoDay(form.purgeUserInfoDay);
-        fessConfig.setPurgeByBots(form.purgeByBots);
+        fessConfig.setPurgeByBots(form.purgeByBots != null ? form.purgeByBots : StringUtil.EMPTY);
         fessConfig.setNotificationTo(form.notificationTo);
         fessConfig.setSuggestSearchLog(isCheckboxEnabled(form.suggestSearchLog));
         fessConfig.setSuggestDocuments(isCheckboxEnabled(form.suggestDocuments));
@@ -211,9 +211,10 @@ public class AdminGeneralAction extends FessAdminAction {
         fessConfig.setLdapBaseDn(form.ldapBaseDn);
         fessConfig.setLdapAccountFilter(form.ldapAccountFilter);
         fessConfig.setLdapGroupFilter(form.ldapGroupFilter);
-        fessConfig.setLdapMemberofAttribute(form.ldapMemberofAttribute);
-        fessConfig.setLdapSecurityAuthentication(form.ldapSecurityAuthentication);
-        fessConfig.setLdapInitialContextFactory(form.ldapInitialContextFactory);
+        fessConfig.setLdapMemberofAttribute(form.ldapMemberofAttribute != null ? form.ldapMemberofAttribute : StringUtil.EMPTY);
+        fessConfig.setLdapSecurityAuthentication(
+                form.ldapSecurityAuthentication != null ? form.ldapSecurityAuthentication : StringUtil.EMPTY);
+        fessConfig.setLdapInitialContextFactory(form.ldapInitialContextFactory != null ? form.ldapInitialContextFactory : StringUtil.EMPTY);
         fessConfig.setNotificationLogin(form.notificationLogin);
         fessConfig.setNotificationSearchTop(form.notificationSearchTop);
         fessConfig.setNotificationAdvanceSearch(form.notificationAdvanceSearch);


### PR DESCRIPTION
## Summary
Add null-safe handling for optional text fields in the General admin settings to prevent NullPointerException when these fields are cleared or not submitted.

## Changes Made
- Guard `ignoreFailureType` with null check, defaulting to empty string
- Guard `purgeByBots` with null check, defaulting to empty string
- Guard `ldapMemberofAttribute` with null check, defaulting to empty string
- Guard `ldapSecurityAuthentication` with null check, defaulting to empty string
- Guard `ldapInitialContextFactory` with null check, defaulting to empty string

## Testing
- Verify General admin settings can be saved with all optional text fields cleared
- Verify existing values are preserved when fields are populated

## Breaking Changes
- None

## Additional Notes
- These fields are optional in the UI and can be submitted as null when cleared, but the underlying `fessConfig` setters do not accept null values