### PR TITLE
fix(chat): send final SSE chunk content instead of dropping it

### DIFF
--- a/src/main/java/org/codelibs/fess/api/chat/ChatApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/chat/ChatApiManager.java
@@ -312,7 +312,7 @@ public class ChatApiManager extends BaseApiManager {
                 @Override
                 public void onChunk(final String content, final boolean done) {
                     try {
-                        if (!done && content != null && !content.isEmpty()) {
+                        if (content != null && !content.isEmpty()) {
                             sendSseEvent(writer, "chunk", Map.of("content", content));
                         }
                     } catch (final Exception e) {


### PR DESCRIPTION
## Summary
Fix a bug where the last SSE chunk in chat streaming responses was silently discarded when it still carried content.

## Changes Made
- Removed the `!done` guard from `onChunk` in `ChatApiManager` so that the final chunk's content is sent to the client via SSE
- Previously, when `done` was `true` and the chunk contained content, that content was never delivered

## Testing
- Verify chat streaming responses include the complete final chunk
- Confirm no duplicate or empty events are sent after the stream ends

## Breaking Changes
- None

## Additional Notes
- The `done` flag only signals that this is the last chunk; it should not suppress content delivery