### PR TITLE
feat(script): make audit log max length configurable and fix truncation order

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/ActivityHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ActivityHelper.java
@@ -234,12 +234,12 @@ public class ActivityHelper {
         if (script == null) {
             return "-";
         }
-        String normalized = script.replace('\n', ' ').replace('\r', ' ').replace('\t', '_');
-        final int maxLength = 1000;
+        final int maxLength = ComponentUtil.getFessConfig().getScriptAuditLogMaxLengthAsInteger();
+        String normalized = script;
         if (normalized.length() > maxLength) {
-            return normalized.substring(0, maxLength - 3) + "...";
+            normalized = normalized.substring(0, maxLength - 3) + "...";
         }
-        return normalized;
+        return normalized.replace('\n', ' ').replace('\r', ' ').replace('\t', '_');
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -67,6 +67,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. true */
     String SCRIPT_AUDIT_LOG_ENABLED = "script.audit.log.enabled";
 
+    /** The key of the configuration. e.g. 100 */
+    String SCRIPT_AUDIT_LOG_MAX_LENGTH = "script.audit.log.max.length";
+
     /** The key of the configuration. e.g. -Djava.awt.headless=true<br>
      * -Dfile.encoding=UTF-8<br>
      * -Djna.nosys=true<br>
@@ -2215,6 +2218,21 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * @return The determination, true or false. (if not found, exception but basically no way)
      */
     boolean isScriptAuditLogEnabled();
+
+    /**
+     * Get the value for the key 'script.audit.log.max.length'. <br>
+     * The value is, e.g. 100 <br>
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getScriptAuditLogMaxLength();
+
+    /**
+     * Get the value for the key 'script.audit.log.max.length' as {@link Integer}. <br>
+     * The value is, e.g. 100 <br>
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getScriptAuditLogMaxLengthAsInteger();
 
     /**
      * Get the value for the key 'jvm.crawler.options'. <br>
@@ -9647,6 +9665,14 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return is(FessConfig.SCRIPT_AUDIT_LOG_ENABLED);
         }
 
+        public String getScriptAuditLogMaxLength() {
+            return get(FessConfig.SCRIPT_AUDIT_LOG_MAX_LENGTH);
+        }
+
+        public Integer getScriptAuditLogMaxLengthAsInteger() {
+            return getAsInteger(FessConfig.SCRIPT_AUDIT_LOG_MAX_LENGTH);
+        }
+
         public String getJvmCrawlerOptions() {
             return get(FessConfig.JVM_CRAWLER_OPTIONS);
         }
@@ -13110,6 +13136,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.APP_EXTENSION_NAMES, "");
             defaultMap.put(FessConfig.APP_AUDIT_LOG_FORMAT, "");
             defaultMap.put(FessConfig.SCRIPT_AUDIT_LOG_ENABLED, "true");
+            defaultMap.put(FessConfig.SCRIPT_AUDIT_LOG_MAX_LENGTH, "100");
             defaultMap.put(FessConfig.JVM_CRAWLER_OPTIONS,
                     "-Djava.awt.headless=true\n-Dfile.encoding=UTF-8\n-Djna.nosys=true\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dhttp.maxConnections=20\n-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager\n-server\n-Xms128m\n-Xmx512m\n-XX:MaxMetaspaceSize=128m\n-XX:CompressedClassSpaceSize=32m\n-XX:-UseGCOverheadLimit\n-XX:+UseTLAB\n-XX:+DisableExplicitGC\n-XX:-HeapDumpOnOutOfMemoryError\n-XX:-OmitStackTraceInFastThrow\n-XX:+UnlockExperimentalVMOptions\n-XX:+UseG1GC\n-XX:InitiatingHeapOccupancyPercent=45\n-XX:G1HeapRegionSize=1m\n-XX:MaxGCPauseMillis=60000\n-XX:G1NewSizePercent=5\n-XX:G1MaxNewSizePercent=5\n-Djcifs.smb.client.responseTimeout=30000\n-Djcifs.smb.client.soTimeout=35000\n-Djcifs.smb.client.connTimeout=60000\n-Djcifs.smb.client.sessionTimeout=60000\n-Djcifs.smb1.smb.client.connTimeout=60000\n-Djcifs.smb1.smb.client.soTimeout=35000\n-Djcifs.smb1.smb.client.responseTimeout=30000\n-Dio.netty.noUnsafe=true\n-Dio.netty.noKeySetOptimization=true\n-Dio.netty.recycler.maxCapacityPerThread=0\n-Dlog4j.shutdownHookEnabled=false\n-Dlog4j2.formatMsgNoLookups=true\n-Dlog4j2.disable.jmx=true\n-Dlog4j.skipJansi=true\n-Dsun.java2d.cmm=sun.java2d.cmm.kcms.KcmsServiceProvider\n-Dorg.apache.pdfbox.rendering.UsePureJavaCMYKConversion=true\n");
             defaultMap.put(FessConfig.JVM_SUGGEST_OPTIONS,

--- a/src/main/java/org/codelibs/fess/script/groovy/GroovyEngine.java
+++ b/src/main/java/org/codelibs/fess/script/groovy/GroovyEngine.java
@@ -70,6 +70,8 @@ public class GroovyEngine extends AbstractScriptEngine {
     /** Maximum length of script text included in warning log messages. Configurable via DI. */
     protected int maxScriptLogLength = 200;
 
+    protected boolean scriptAuditLogEnabled;
+
     private Cache<String, CachedScript> scriptCache;
 
     /**
@@ -87,6 +89,8 @@ public class GroovyEngine extends AbstractScriptEngine {
     @PostConstruct
     public void init() {
         buildScriptCache();
+        scriptAuditLogEnabled = ComponentUtil.available() && ComponentUtil.getFessConfig().isScriptAuditLogEnabled()
+                && ComponentUtil.hasComponent("activityHelper");
     }
 
     private void buildScriptCache() {
@@ -229,6 +233,9 @@ public class GroovyEngine extends AbstractScriptEngine {
      */
     protected ScheduledJob getCurrentScheduledJob() {
         try {
+            if (!ComponentUtil.hasComponent("jobHelper")) {
+                return null;
+            }
             final LaJobRuntime runtime = ComponentUtil.getJobHelper().getJobRuntime();
             if (runtime != null) {
                 final Object job = runtime.getParameterMap().get(Constants.SCHEDULED_JOB);
@@ -251,11 +258,14 @@ public class GroovyEngine extends AbstractScriptEngine {
      * @param result the execution result (e.g., "success" or "failure:ExceptionType")
      */
     protected void logScriptExecution(final String script, final String result) {
+        if (!scriptAuditLogEnabled) {
+            return;
+        }
         try {
-            final ScheduledJob job = getCurrentScheduledJob();
             String source = "unknown";
             String user = "system";
 
+            final ScheduledJob job = getCurrentScheduledJob();
             if (job != null) {
                 source = "scheduler:" + job.getName();
                 if (job.getCreatedBy() != null) {

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -43,6 +43,7 @@ app.audit.log.format=
 
 # Script audit log settings.
 script.audit.log.enabled=true
+script.audit.log.max.length=100
 
 # JVM options for the crawler process.
 jvm.crawler.options=\

--- a/src/test/java/org/codelibs/fess/helper/ActivityHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ActivityHelperTest.java
@@ -300,25 +300,25 @@ public class ActivityHelperTest extends UnitFessTestCase {
 
     @Test
     public void test_normalizeScript_longScript() {
-        // Create a script longer than 1000 characters
+        // Create a script longer than 100 characters (default max length)
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 1100; i++) {
+        for (int i = 0; i < 120; i++) {
             sb.append("a");
         }
         String longScript = sb.toString();
 
         String result = activityHelper.normalizeScript(longScript);
 
-        // Should be truncated to 1000 characters (997 + "...")
-        assertEquals(1000, result.length());
+        // Should be truncated to 100 characters (97 + "...")
+        assertEquals(100, result.length());
         assertTrue(result.endsWith("..."));
     }
 
     @Test
     public void test_normalizeScript_exactlyMaxLength() {
-        // Create a script of exactly 1000 characters
+        // Create a script of exactly 100 characters (default max length)
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 100; i++) {
             sb.append("b");
         }
         String exactScript = sb.toString();
@@ -326,15 +326,15 @@ public class ActivityHelperTest extends UnitFessTestCase {
         String result = activityHelper.normalizeScript(exactScript);
 
         // Should not be truncated
-        assertEquals(1000, result.length());
+        assertEquals(100, result.length());
         assertFalse(result.endsWith("..."));
     }
 
     @Test
     public void test_normalizeScript_lessThanMaxLength() {
-        // Create a script of 999 characters
+        // Create a script of 99 characters (one less than default max length)
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 999; i++) {
+        for (int i = 0; i < 99; i++) {
             sb.append("c");
         }
         String shortScript = sb.toString();
@@ -342,8 +342,24 @@ public class ActivityHelperTest extends UnitFessTestCase {
         String result = activityHelper.normalizeScript(shortScript);
 
         // Should not be truncated
-        assertEquals(999, result.length());
+        assertEquals(99, result.length());
         assertFalse(result.endsWith("..."));
+    }
+
+    @Test
+    public void test_normalizeScript_truncateBeforeReplace() {
+        // Script with control chars beyond the truncation point
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 97; i++) {
+            sb.append("x");
+        }
+        for (int i = 0; i < 53; i++) {
+            sb.append("\n");
+        }
+        String result = activityHelper.normalizeScript(sb.toString());
+        assertEquals(100, result.length());
+        assertTrue(result.endsWith("..."));
+        assertEquals("x".repeat(97) + "...", result);
     }
 
     OptionalThing<FessUserBean> createUser(String name, String[] permissions) {


### PR DESCRIPTION
## Summary
- Add configurable `script.audit.log.max.length` property (default: 100) to control the maximum length of script text in audit logs
- Fix truncation order in `normalizeScript` to truncate before replacing control characters
- Optimize `GroovyEngine.logScriptExecution` with early-exit when audit logging is disabled

## Changes Made
- **ActivityHelper.java**: Read max length from `FessConfig` instead of hardcoded value; reorder to truncate first, then replace control characters (`\n`, `\r`, `\t`)
- **FessConfig.java**: Add `script.audit.log.max.length` config key with `String` and `Integer` accessors, default value `100`
- **fess_config.properties**: Add `script.audit.log.max.length=100`
- **GroovyEngine.java**: Cache `scriptAuditLogEnabled` flag at init; add early return in `logScriptExecution` when disabled; add null-safety check for `jobHelper` component in `getCurrentScheduledJob`
- **ActivityHelperTest.java**: Update test expectations for new default max length (100); add `test_normalizeScript_truncateBeforeReplace` to verify truncation happens before control character replacement

## Testing
- Updated unit tests in `ActivityHelperTest` cover truncation at the new default length
- New test verifies that control characters beyond the truncation point are not replaced (truncate-before-replace semantics)

## Breaking Changes
- Default max length changed from 1000 to 100. Deployments relying on the previous 1000-character limit should set `script.audit.log.max.length=1000` explicitly.