### PR TITLE
fix(api): suppress WARN log for client errors in JSON API responses

### DIFF
--- a/src/main/java/org/codelibs/fess/api/json/SearchApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/json/SearchApiManager.java
@@ -1295,7 +1295,7 @@ public class SearchApiManager extends BaseApiManager {
             message = escapeJsonKeyValue("error_code:", errorCode);
             if (logger.isDebugEnabled()) {
                 logger.debug("[{}] {}", errorCode, stacktraceString.get().replace("\n", "\\n"));
-            } else {
+            } else if (status >= 500) {
                 logger.warn("[{}] {}", errorCode, t.getMessage());
             }
         }


### PR DESCRIPTION
## Summary
Stop logging client errors (4xx) at WARN level in `SearchApiManager.writeJsonResponse()`. Only server errors (5xx) are now logged at WARN; 4xx errors are logged only when DEBUG is enabled.

## Changes Made
- Modified `writeJsonResponse(int status, Throwable t)` in `SearchApiManager.java` to check `status >= 500` before logging at WARN level
- Previously, all exceptions (including 4xx client errors like "No user session") were logged at WARN regardless of HTTP status code

## Context
The "No user session" WARN log was appearing periodically from the favorites API (`/api/v1/documents/{id}/favorite`, `/api/v1/documents/favorites`) when requests arrived without a valid session — e.g., from monitoring bots, expired browser sessions, or API clients without cookie management. These are expected client-side conditions, not server-side issues, and should not produce WARN-level noise.

## Testing
- `SearchApiManagerTest` passes (3/3)
- 4xx responses: no log output in normal operation, full stack trace at DEBUG level when enabled
- 5xx responses: WARN log with error code and message (unchanged behavior)