### PR TITLE
feat(admin): improve validation messages and add custom field support on search list page

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistAction.java
@@ -15,9 +15,12 @@
  */
 package org.codelibs.fess.app.web.admin.searchlist;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 
 import org.apache.logging.log4j.LogManager;
@@ -72,6 +75,10 @@ public class AdminSearchlistAction extends FessAdminAction {
     //
     private static final Logger logger = LogManager.getLogger(AdminSearchlistAction.class);
 
+    private static final Set<String> STANDARD_EDIT_FIELDS = Set.of("url", "title", "role", "boost", "label", "lang", "mimetype", "filetype",
+            "filename", "content", "has_cache", "cache", "digest", "host", "site", "segment", "config_id", "parent_id", "content_length",
+            "favorite_count", "click_count", "created", "timestamp", "last_modified", "expires", "virtual_host", "doc_id");
+
     // ===================================================================================
     // Attribute
     // =========
@@ -91,6 +98,9 @@ public class AdminSearchlistAction extends FessAdminAction {
     /** HTTP servlet request for accessing request parameters. */
     @Resource
     protected HttpServletRequest request;
+
+    /** Current form reference for rendering extra fields on the edit page. */
+    private CreateForm currentForm;
 
     /** List of document items returned from search */
     public List<Map<String, Object>> documentItems;
@@ -331,6 +341,7 @@ public class AdminSearchlistAction extends FessAdminAction {
         getDoc(form).ifPresent(entity -> {
             form.doc = fessConfig.convertToEditableDoc(entity);
         });
+        currentForm = form;
         return asEditHtml();
     }
 
@@ -352,6 +363,7 @@ public class AdminSearchlistAction extends FessAdminAction {
         }).orElse(() -> {
             throwValidationError(messages -> messages.addErrorsCrudCouldNotFindCrudTable(GLOBAL, form.id), this::asListHtml);
         });
+        currentForm = form;
         saveToken();
         return asEditHtml();
     }
@@ -365,6 +377,7 @@ public class AdminSearchlistAction extends FessAdminAction {
     @Execute
     @Secured({ ROLE })
     public HtmlResponse create(final CreateForm form) {
+        currentForm = form;
         verifyCrudMode(form.crudMode, CrudMode.CREATE, this::asListHtml);
         validate(form, messages -> {}, this::asEditHtml);
         validateFields(form.doc, v -> throwValidationError(v, this::asEditHtml));
@@ -399,6 +412,7 @@ public class AdminSearchlistAction extends FessAdminAction {
     @Execute
     @Secured({ ROLE })
     public HtmlResponse update(final EditForm form) {
+        currentForm = form;
         verifyCrudMode(form.crudMode, CrudMode.EDIT, this::asListHtml);
         validate(form, messages -> {}, this::asEditHtml);
         validateFields(form.doc, v -> throwValidationError(v, this::asEditHtml));
@@ -449,45 +463,38 @@ public class AdminSearchlistAction extends FessAdminAction {
             if (!fessConfig.validateIndexRequiredFields(doc)) {
                 throwError.accept(messages -> fessConfig.invalidIndexRequiredFields(doc)
                         .stream()
-                        .map(s -> "doc." + s)
-                        .forEach(s -> messages.addErrorsPropertyRequired(s, s)));
+                        .forEach(s -> messages.addErrorsPropertyRequired("doc." + s, s)));
             }
 
             if (!fessConfig.validateIndexArrayFields(doc)) {
                 throwError.accept(messages -> fessConfig.invalidIndexArrayFields(doc)
                         .stream()
-                        .map(s -> "doc." + s)
-                        .forEach(s -> messages.addErrorsPropertyRequired(s, s)));
+                        .forEach(s -> messages.addErrorsPropertyTypeArray("doc." + s, s)));
             }
             if (!fessConfig.validateIndexDateFields(doc)) {
                 throwError.accept(messages -> fessConfig.invalidIndexDateFields(doc)
                         .stream()
-                        .map(s -> "doc." + s)
-                        .forEach(s -> messages.addErrorsPropertyTypeDate(s, s)));
+                        .forEach(s -> messages.addErrorsPropertyTypeDate("doc." + s, s)));
             }
             if (!fessConfig.validateIndexIntegerFields(doc)) {
                 throwError.accept(messages -> fessConfig.invalidIndexIntegerFields(doc)
                         .stream()
-                        .map(s -> "doc." + s)
-                        .forEach(s -> messages.addErrorsPropertyTypeInteger(s, s)));
+                        .forEach(s -> messages.addErrorsPropertyTypeInteger("doc." + s, s)));
             }
             if (!fessConfig.validateIndexLongFields(doc)) {
                 throwError.accept(messages -> fessConfig.invalidIndexLongFields(doc)
                         .stream()
-                        .map(s -> "doc." + s)
-                        .forEach(s -> messages.addErrorsPropertyTypeLong(s, s)));
+                        .forEach(s -> messages.addErrorsPropertyTypeLong("doc." + s, s)));
             }
             if (!fessConfig.validateIndexFloatFields(doc)) {
                 throwError.accept(messages -> fessConfig.invalidIndexFloatFields(doc)
                         .stream()
-                        .map(s -> "doc." + s)
-                        .forEach(s -> messages.addErrorsPropertyTypeFloat(s, s)));
+                        .forEach(s -> messages.addErrorsPropertyTypeFloat("doc." + s, s)));
             }
             if (!fessConfig.validateIndexDoubleFields(doc)) {
                 throwError.accept(messages -> fessConfig.invalidIndexDoubleFields(doc)
                         .stream()
-                        .map(s -> "doc." + s)
-                        .forEach(s -> messages.addErrorsPropertyTypeDouble(s, s)));
+                        .forEach(s -> messages.addErrorsPropertyTypeDouble("doc." + s, s)));
             }
         } catch (final Exception e) {
             throwError.accept(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, e.getMessage()));
@@ -537,7 +544,43 @@ public class AdminSearchlistAction extends FessAdminAction {
     }
 
     private HtmlResponse asEditHtml() {
-        return asHtml(path_AdminSearchlist_AdminSearchlistEditJsp);
+        return asHtml(path_AdminSearchlist_AdminSearchlistEditJsp).renderWith(data -> {
+            registerExtraFields(data);
+        });
+    }
+
+    private void registerExtraFields(final RenderData data) {
+        final Map<String, Object> doc = currentForm != null ? currentForm.doc : null;
+        if (doc == null) {
+            return;
+        }
+
+        final Set<String> arrayFieldSet = fessConfig.getIndexAdminArrayFieldSet();
+        final Set<String> dateFieldSet = fessConfig.getIndexAdminDateFieldSet();
+        final Set<String> integerFieldSet = fessConfig.getIndexAdminIntegerFieldSet();
+        final Set<String> longFieldSet = fessConfig.getIndexAdminLongFieldSet();
+        final Set<String> floatFieldSet = fessConfig.getIndexAdminFloatFieldSet();
+        final Set<String> doubleFieldSet = fessConfig.getIndexAdminDoubleFieldSet();
+
+        final List<String> extraFieldNames = new ArrayList<>();
+        final Map<String, String> extraFieldTypes = new TreeMap<>();
+        doc.keySet().stream().sorted().filter(key -> !STANDARD_EDIT_FIELDS.contains(key)).forEach(key -> {
+            final String type;
+            if (arrayFieldSet.contains(key)) {
+                type = "array";
+            } else if (dateFieldSet.contains(key)) {
+                type = "date";
+            } else if (integerFieldSet.contains(key) || longFieldSet.contains(key) || floatFieldSet.contains(key)
+                    || doubleFieldSet.contains(key)) {
+                type = "number";
+            } else {
+                type = "text";
+            }
+            extraFieldNames.add(key);
+            extraFieldTypes.put(key, type);
+        });
+        RenderDataUtil.register(data, "extraFieldNames", extraFieldNames);
+        RenderDataUtil.register(data, "extraFieldTypes", extraFieldTypes);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistAction.java
@@ -550,11 +550,6 @@ public class AdminSearchlistAction extends FessAdminAction {
     }
 
     private void registerExtraFields(final RenderData data) {
-        final Map<String, Object> doc = currentForm != null ? currentForm.doc : null;
-        if (doc == null) {
-            return;
-        }
-
         final Set<String> arrayFieldSet = fessConfig.getIndexAdminArrayFieldSet();
         final Set<String> dateFieldSet = fessConfig.getIndexAdminDateFieldSet();
         final Set<String> integerFieldSet = fessConfig.getIndexAdminIntegerFieldSet();
@@ -562,9 +557,25 @@ public class AdminSearchlistAction extends FessAdminAction {
         final Set<String> floatFieldSet = fessConfig.getIndexAdminFloatFieldSet();
         final Set<String> doubleFieldSet = fessConfig.getIndexAdminDoubleFieldSet();
 
+        final Set<String> reservedFields = Set.of(fessConfig.getIndexFieldId(), fessConfig.getIndexFieldVersion(),
+                fessConfig.getIndexFieldSeqNo(), fessConfig.getIndexFieldPrimaryTerm());
+
+        // Collect candidate fields from config definitions and document keys
+        final Set<String> candidateFields = new java.util.TreeSet<>();
+        candidateFields.addAll(arrayFieldSet);
+        candidateFields.addAll(dateFieldSet);
+        candidateFields.addAll(integerFieldSet);
+        candidateFields.addAll(longFieldSet);
+        candidateFields.addAll(floatFieldSet);
+        candidateFields.addAll(doubleFieldSet);
+        final Map<String, Object> doc = currentForm != null ? currentForm.doc : null;
+        if (doc != null) {
+            candidateFields.addAll(doc.keySet());
+        }
+
         final List<String> extraFieldNames = new ArrayList<>();
         final Map<String, String> extraFieldTypes = new TreeMap<>();
-        doc.keySet().stream().sorted().filter(key -> !STANDARD_EDIT_FIELDS.contains(key)).forEach(key -> {
+        candidateFields.stream().filter(key -> !STANDARD_EDIT_FIELDS.contains(key) && !reservedFields.contains(key)).forEach(key -> {
             final String type;
             if (arrayFieldSet.contains(key)) {
                 type = "array";

--- a/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
@@ -443,6 +443,9 @@ public class FessMessages extends FessLabels {
     /** The key of the message: {0} must be a date. */
     public static final String ERRORS_property_type_date = "{errors.property_type_date}";
 
+    /** The key of the message: {0} must be an array. */
+    public static final String ERRORS_property_type_array = "{errors.property_type_array}";
+
     /** The key of the message: Failed to upload {0}. */
     public static final String ERRORS_storage_file_upload_failure = "{errors.storage_file_upload_failure}";
 
@@ -2573,6 +2576,21 @@ public class FessMessages extends FessLabels {
     public FessMessages addErrorsPropertyTypeDate(String property, String arg0) {
         assertPropertyNotNull(property);
         add(property, new UserMessage(ERRORS_property_type_date, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.property_type_array' with parameters.
+     * <pre>
+     * message: {0} must be an array.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsPropertyTypeArray(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_property_type_array, arg0));
         return this;
     }
 

--- a/src/main/resources/fess_message.properties
+++ b/src/main/resources/fess_message.properties
@@ -166,6 +166,7 @@ errors.property_type_long={0} must be a long.
 errors.property_type_float={0} must be a float.
 errors.property_type_double={0} must be a double.
 errors.property_type_date={0} must be a date.
+errors.property_type_array={0} must be an array.
 
 errors.storage_file_upload_failure=Failed to upload {0}.
 errors.storage_file_not_found=The target file does not exist in the storage.

--- a/src/main/resources/fess_message_de.properties
+++ b/src/main/resources/fess_message_de.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} muss ein Array sein.

--- a/src/main/resources/fess_message_en.properties
+++ b/src/main/resources/fess_message_en.properties
@@ -162,6 +162,7 @@ errors.property_type_long={0} must be a long.
 errors.property_type_float={0} must be a float.
 errors.property_type_double={0} must be a double.
 errors.property_type_date={0} must be a date.
+errors.property_type_array={0} must be an array.
 
 errors.storage_file_upload_failure=Failed to upload {0}.
 errors.storage_file_not_found=The target file does not exist in the storage.

--- a/src/main/resources/fess_message_es.properties
+++ b/src/main/resources/fess_message_es.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} debe ser un array.

--- a/src/main/resources/fess_message_fr.properties
+++ b/src/main/resources/fess_message_fr.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} doit être un tableau.

--- a/src/main/resources/fess_message_hi.properties
+++ b/src/main/resources/fess_message_hi.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} एक सरणी होना चाहिए।

--- a/src/main/resources/fess_message_id.properties
+++ b/src/main/resources/fess_message_id.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} harus berupa array.

--- a/src/main/resources/fess_message_it.properties
+++ b/src/main/resources/fess_message_it.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} deve essere un array.

--- a/src/main/resources/fess_message_ja.properties
+++ b/src/main/resources/fess_message_ja.properties
@@ -162,6 +162,7 @@ errors.property_type_long={0}は数値でなければなりません。
 errors.property_type_float={0}は数値でなければなりません。
 errors.property_type_double={0}は数値でなければなりません。
 errors.property_type_date={0}は日付でなければなりません。
+errors.property_type_array={0}は配列でなければなりません。
 
 errors.storage_file_upload_failure={0} のアップロードに失敗しました。
 errors.storage_file_not_found=対象のファイルはストレージ内にありません。

--- a/src/main/resources/fess_message_ko.properties
+++ b/src/main/resources/fess_message_ko.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0}은(는) 배열이어야 합니다.

--- a/src/main/resources/fess_message_nl.properties
+++ b/src/main/resources/fess_message_nl.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} moet een array zijn.

--- a/src/main/resources/fess_message_pl.properties
+++ b/src/main/resources/fess_message_pl.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} musi być tablicą.

--- a/src/main/resources/fess_message_pt_BR.properties
+++ b/src/main/resources/fess_message_pt_BR.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} deve ser um array.

--- a/src/main/resources/fess_message_ru.properties
+++ b/src/main/resources/fess_message_ru.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} должно быть массивом.

--- a/src/main/resources/fess_message_tr.properties
+++ b/src/main/resources/fess_message_tr.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0} bir dizi olmalıdır.

--- a/src/main/resources/fess_message_zh_CN.properties
+++ b/src/main/resources/fess_message_zh_CN.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0}必须是一个数组。

--- a/src/main/resources/fess_message_zh_TW.properties
+++ b/src/main/resources/fess_message_zh_TW.properties
@@ -210,3 +210,4 @@ errors.front_footer=
 errors.front_header=
 errors.front_prefix=<div class="alert alert-warning">
 errors.front_suffix=</div>
+errors.property_type_array={0}必須是一個陣列。

--- a/src/main/webapp/WEB-INF/view/admin/searchlist/admin_searchlist_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/searchlist/admin_searchlist_edit.jsp
@@ -326,6 +326,44 @@ ${fe:html(true)}
                                         <la:textarea styleId="doc.virtual_host" property="doc.virtual_host" styleClass="form-control"/>
                                     </div>
                                 </div>
+                                <%-- Extra Fields --%>
+                                <c:forEach var="fieldName" items="${extraFieldNames}">
+                                    <div class="form-group row">
+                                        <label for="doc.${f:h(fieldName)}" class="col-sm-3 text-sm-right col-form-label">${f:h(fieldName)}</label>
+                                        <div class="col-sm-9">
+                                            <la:errors property="doc.${f:h(fieldName)}"/>
+                                            <c:choose>
+                                                <c:when test="${extraFieldTypes[fieldName] == 'array'}">
+                                                    <la:textarea styleId="doc.${f:h(fieldName)}"
+                                                                 property="doc.${f:h(fieldName)}"
+                                                                 styleClass="form-control"/>
+                                                </c:when>
+                                                <c:when test="${extraFieldTypes[fieldName] == 'date'}">
+                                                    <la:text styleId="doc.${f:h(fieldName)}"
+                                                             property="doc.${f:h(fieldName)}"
+                                                             styleClass="form-control"
+                                                             title="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                                                             data-validation="custom"
+                                                             data-validation-regexp="(^$|^[1-9]\d{3}\-\d\d\-\d\dT\d\d\:\d\d\:\d\d\.\d{3}Z$)"
+                                                             data-validation-help="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"/>
+                                                </c:when>
+                                                <c:when test="${extraFieldTypes[fieldName] == 'number'}">
+                                                    <la:text styleId="doc.${f:h(fieldName)}"
+                                                             property="doc.${f:h(fieldName)}"
+                                                             styleClass="form-control"
+                                                             data-validation="custom"
+                                                             data-validation-regexp="^[\d\.\-\+eE]*$"
+                                                             data-validation-help="number"/>
+                                                </c:when>
+                                                <c:otherwise>
+                                                    <la:text styleId="doc.${f:h(fieldName)}"
+                                                             property="doc.${f:h(fieldName)}"
+                                                             styleClass="form-control"/>
+                                                </c:otherwise>
+                                            </c:choose>
+                                        </div>
+                                    </div>
+                                </c:forEach>
                             </div>
                             <div class="card-footer">
                                 <c:if test="${crudMode == 1}">

--- a/src/test/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistActionTest.java
@@ -1,0 +1,689 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.admin.searchlist;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codelibs.fess.app.web.CrudMode;
+import org.codelibs.fess.mylasta.action.FessMessages;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.lastaflute.web.response.render.RenderData;
+import org.lastaflute.web.validation.VaMessenger;
+
+public class AdminSearchlistActionTest extends UnitFessTestCase {
+
+    @Override
+    protected void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getIndexAdminRequiredFields() {
+                return "url,title,role,boost";
+            }
+
+            @Override
+            public String getIndexAdminArrayFields() {
+                return "lang,role,label,anchor,virtual_host";
+            }
+
+            @Override
+            public String getIndexAdminDateFields() {
+                return "expires,created,timestamp,last_modified";
+            }
+
+            @Override
+            public String getIndexAdminIntegerFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminLongFields() {
+                return "content_length,favorite_count,click_count";
+            }
+
+            @Override
+            public String getIndexAdminFloatFields() {
+                return "boost";
+            }
+
+            @Override
+            public String getIndexAdminDoubleFields() {
+                return "";
+            }
+        });
+    }
+
+    // ===================================================================================
+    //                                                                           Constants
+    //                                                                           =========
+    @Test
+    public void test_roleConstant() {
+        assertEquals("admin-searchlist", AdminSearchlistAction.ROLE);
+    }
+
+    // ===================================================================================
+    //                                                                              Forms
+    //                                                                           =========
+    @Test
+    public void test_createForm_initialize() {
+        final CreateForm form = new CreateForm();
+        assertNull(form.crudMode);
+        assertNull(form.doc);
+        assertNull(form.q);
+
+        form.initialize();
+        assertEquals(CrudMode.CREATE, form.crudMode.intValue());
+    }
+
+    @Test
+    public void test_editForm_extends_createForm() {
+        final EditForm form = new EditForm();
+        assertNull(form.id);
+        assertNull(form.seqNo);
+        assertNull(form.primaryTerm);
+        assertNull(form.crudMode);
+
+        form.id = "test-id";
+        form.seqNo = 1L;
+        form.primaryTerm = 1L;
+        form.crudMode = CrudMode.EDIT;
+
+        assertEquals("test-id", form.id);
+        assertEquals(1L, form.seqNo.longValue());
+        assertEquals(1L, form.primaryTerm.longValue());
+        assertEquals(CrudMode.EDIT, form.crudMode.intValue());
+    }
+
+    @Test
+    public void test_deleteForm_fields() {
+        final DeleteForm form = new DeleteForm();
+        assertNull(form.q);
+        assertNull(form.docId);
+
+        form.q = "test query";
+        form.docId = "doc-123";
+
+        assertEquals("test query", form.q);
+        assertEquals("doc-123", form.docId);
+    }
+
+    @Test
+    public void test_listForm_defaults() {
+        final ListForm form = new ListForm();
+        assertNull(form.q);
+        assertNull(form.sort);
+        assertNull(form.start);
+        assertNull(form.num);
+        assertNull(form.pn);
+    }
+
+    // ===================================================================================
+    //                                                                     validateFields
+    //                                                                           =========
+    @Test
+    public void test_validateFields_validDoc() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "1.0");
+
+        final List<String> errors = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, messages -> {
+            errors.add("error");
+        });
+
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void test_validateFields_missingRequiredFields() {
+        final Map<String, Object> doc = new HashMap<>();
+        // url, title, role, boost are all missing
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        assertFalse(errorMessages.isEmpty());
+
+        // Verify error messages use field names without doc. prefix
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertTrue(messages.hasMessageOf("doc.url"));
+        assertTrue(messages.hasMessageOf("doc.title"));
+        assertTrue(messages.hasMessageOf("doc.role"));
+        assertTrue(messages.hasMessageOf("doc.boost"));
+    }
+
+    @Test
+    public void test_validateFields_requiredFieldsPartiallyMissing() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        // role and boost are missing
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        assertFalse(errorMessages.isEmpty());
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertFalse(messages.hasMessageOf("doc.url"));
+        assertFalse(messages.hasMessageOf("doc.title"));
+        assertTrue(messages.hasMessageOf("doc.role"));
+        assertTrue(messages.hasMessageOf("doc.boost"));
+    }
+
+    @Test
+    public void test_validateFields_invalidFloatField() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "not-a-float");
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        assertFalse(errorMessages.isEmpty());
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertTrue(messages.hasMessageOf("doc.boost"));
+    }
+
+    @Test
+    public void test_validateFields_invalidLongField() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "1.0");
+        doc.put("content_length", "not-a-number");
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        assertFalse(errorMessages.isEmpty());
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertTrue(messages.hasMessageOf("doc.content_length"));
+    }
+
+    @Test
+    public void test_validateFields_invalidDateField() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "1.0");
+        doc.put("created", "invalid-date");
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        assertFalse(errorMessages.isEmpty());
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertTrue(messages.hasMessageOf("doc.created"));
+    }
+
+    @Test
+    public void test_validateFields_validDateField() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "1.0");
+        doc.put("created", "2025-01-01T00:00:00.000Z");
+
+        final List<String> errors = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, messages -> {
+            errors.add("error");
+        });
+
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void test_validateFields_validLongField() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "1.0");
+        doc.put("content_length", "12345");
+        doc.put("click_count", "100");
+
+        final List<String> errors = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, messages -> {
+            errors.add("error");
+        });
+
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void test_validateFields_multipleInvalidFields() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "not-a-float");
+        doc.put("content_length", "not-a-long");
+        doc.put("created", "not-a-date");
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        assertTrue(errorMessages.size() >= 3);
+    }
+
+    @Test
+    public void test_validateFields_emptyStringRequiredFields() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "");
+        doc.put("title", "");
+        doc.put("role", "");
+        doc.put("boost", "");
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        assertFalse(errorMessages.isEmpty());
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertTrue(messages.hasMessageOf("doc.url"));
+        assertTrue(messages.hasMessageOf("doc.title"));
+        assertTrue(messages.hasMessageOf("doc.role"));
+        assertTrue(messages.hasMessageOf("doc.boost"));
+    }
+
+    // ===================================================================================
+    //                                                          Validation Message Format
+    //                                                                           =========
+    @Test
+    public void test_validateFields_errorMessageHasNoDocPrefix() {
+        final Map<String, Object> doc = new HashMap<>();
+        // leave required fields empty
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        assertFalse(errorMessages.isEmpty());
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        // The property key should be "doc.url" (for JSP binding)
+        assertTrue(messages.hasMessageOf("doc.url"));
+
+        // Verify messages exist at the doc.* property keys
+        assertTrue(messages.hasMessageOf("doc.url"), "Required field 'url' should have error at 'doc.url' property");
+        assertTrue(messages.hasMessageOf("doc.title"), "Required field 'title' should have error at 'doc.title' property");
+        assertTrue(messages.hasMessageOf("doc.role"), "Required field 'role' should have error at 'doc.role' property");
+        assertTrue(messages.hasMessageOf("doc.boost"), "Required field 'boost' should have error at 'doc.boost' property");
+    }
+
+    @Test
+    public void test_validateFields_floatErrorMessagePropertyKey() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "invalid");
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertTrue(messages.hasMessageOf("doc.boost"), "Float validation error should be at 'doc.boost' property");
+    }
+
+    @Test
+    public void test_validateFields_longErrorMessagePropertyKey() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "1.0");
+        doc.put("content_length", "abc");
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertTrue(messages.hasMessageOf("doc.content_length"), "Long validation error should be at 'doc.content_length' property");
+    }
+
+    @Test
+    public void test_validateFields_dateErrorMessagePropertyKey() {
+        final Map<String, Object> doc = new HashMap<>();
+        doc.put("url", "https://example.com");
+        doc.put("title", "Test Title");
+        doc.put("role", "Rguest");
+        doc.put("boost", "1.0");
+        doc.put("created", "bad-date");
+
+        final List<VaMessenger<FessMessages>> errorMessages = new ArrayList<>();
+        AdminSearchlistAction.validateFields(doc, errorMessages::add);
+
+        final FessMessages messages = new FessMessages();
+        errorMessages.forEach(m -> m.message(messages));
+
+        assertTrue(messages.hasMessageOf("doc.created"), "Date validation error should be at 'doc.created' property");
+    }
+
+    // ===================================================================================
+    //                                                                  STANDARD_EDIT_FIELDS
+    //                                                                           =========
+    @Test
+    public void test_standardEditFields_containsExpectedFields() throws Exception {
+        final java.lang.reflect.Field field = AdminSearchlistAction.class.getDeclaredField("STANDARD_EDIT_FIELDS");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final java.util.Set<String> standardFields = (java.util.Set<String>) field.get(null);
+
+        assertTrue(standardFields.contains("url"));
+        assertTrue(standardFields.contains("title"));
+        assertTrue(standardFields.contains("role"));
+        assertTrue(standardFields.contains("boost"));
+        assertTrue(standardFields.contains("label"));
+        assertTrue(standardFields.contains("lang"));
+        assertTrue(standardFields.contains("mimetype"));
+        assertTrue(standardFields.contains("content_length"));
+        assertTrue(standardFields.contains("created"));
+        assertTrue(standardFields.contains("timestamp"));
+        assertTrue(standardFields.contains("last_modified"));
+        assertTrue(standardFields.contains("expires"));
+        assertTrue(standardFields.contains("virtual_host"));
+        assertTrue(standardFields.contains("doc_id"));
+    }
+
+    @Test
+    public void test_standardEditFields_doesNotContainCustomFields() throws Exception {
+        final java.lang.reflect.Field field = AdminSearchlistAction.class.getDeclaredField("STANDARD_EDIT_FIELDS");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final java.util.Set<String> standardFields = (java.util.Set<String>) field.get(null);
+
+        assertFalse(standardFields.contains("custom_field"));
+        assertFalse(standardFields.contains("department"));
+        assertFalse(standardFields.contains("author"));
+    }
+
+    // ===================================================================================
+    //                                                                  registerExtraFields
+    //                                                                           =========
+    @Test
+    public void test_registerExtraFields_noExtraFields() throws Exception {
+        final AdminSearchlistAction action = new AdminSearchlistAction();
+
+        // Set currentForm via reflection
+        final CreateForm form = new CreateForm();
+        form.doc = new HashMap<>();
+        form.doc.put("url", "https://example.com");
+        form.doc.put("title", "Test");
+
+        final java.lang.reflect.Field currentFormField = AdminSearchlistAction.class.getDeclaredField("currentForm");
+        currentFormField.setAccessible(true);
+        currentFormField.set(action, form);
+
+        // Set fessConfig via reflection
+        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
+        fessConfigField.setAccessible(true);
+        fessConfigField.set(action, ComponentUtil.getFessConfig());
+
+        // Call registerExtraFields via reflection
+        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
+        method.setAccessible(true);
+
+        final RenderData renderData = new RenderData();
+        method.invoke(action, renderData);
+
+        @SuppressWarnings("unchecked")
+        final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
+        assertTrue(extraFieldNames == null || extraFieldNames.isEmpty());
+    }
+
+    @Test
+    public void test_registerExtraFields_withCustomFields() throws Exception {
+        final AdminSearchlistAction action = new AdminSearchlistAction();
+
+        // Set currentForm via reflection
+        final CreateForm form = new CreateForm();
+        form.doc = new HashMap<>();
+        form.doc.put("url", "https://example.com");
+        form.doc.put("title", "Test");
+        form.doc.put("custom_metadata", "custom value");
+        form.doc.put("department", "Engineering");
+
+        final java.lang.reflect.Field currentFormField = AdminSearchlistAction.class.getDeclaredField("currentForm");
+        currentFormField.setAccessible(true);
+        currentFormField.set(action, form);
+
+        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
+        fessConfigField.setAccessible(true);
+        fessConfigField.set(action, ComponentUtil.getFessConfig());
+
+        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
+        method.setAccessible(true);
+
+        final RenderData renderData = new RenderData();
+        method.invoke(action, renderData);
+
+        @SuppressWarnings("unchecked")
+        final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
+        assertNotNull(extraFieldNames);
+        assertEquals(2, extraFieldNames.size());
+        assertTrue(extraFieldNames.contains("custom_metadata"));
+        assertTrue(extraFieldNames.contains("department"));
+
+        @SuppressWarnings("unchecked")
+        final Map<String, String> extraFieldTypes = (Map<String, String>) renderData.getDataMap().get("extraFieldTypes");
+        assertNotNull(extraFieldTypes);
+        assertEquals("text", extraFieldTypes.get("custom_metadata"));
+        assertEquals("text", extraFieldTypes.get("department"));
+    }
+
+    @Test
+    public void test_registerExtraFields_sortedOrder() throws Exception {
+        final AdminSearchlistAction action = new AdminSearchlistAction();
+
+        final CreateForm form = new CreateForm();
+        form.doc = new HashMap<>();
+        form.doc.put("url", "https://example.com");
+        form.doc.put("zzz_field", "z");
+        form.doc.put("aaa_field", "a");
+        form.doc.put("mmm_field", "m");
+
+        final java.lang.reflect.Field currentFormField = AdminSearchlistAction.class.getDeclaredField("currentForm");
+        currentFormField.setAccessible(true);
+        currentFormField.set(action, form);
+
+        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
+        fessConfigField.setAccessible(true);
+        fessConfigField.set(action, ComponentUtil.getFessConfig());
+
+        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
+        method.setAccessible(true);
+
+        final RenderData renderData = new RenderData();
+        method.invoke(action, renderData);
+
+        @SuppressWarnings("unchecked")
+        final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
+        assertNotNull(extraFieldNames);
+        assertEquals(3, extraFieldNames.size());
+        assertEquals("aaa_field", extraFieldNames.get(0));
+        assertEquals("mmm_field", extraFieldNames.get(1));
+        assertEquals("zzz_field", extraFieldNames.get(2));
+    }
+
+    @Test
+    public void test_registerExtraFields_nullCurrentForm() throws Exception {
+        final AdminSearchlistAction action = new AdminSearchlistAction();
+
+        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
+        fessConfigField.setAccessible(true);
+        fessConfigField.set(action, ComponentUtil.getFessConfig());
+
+        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
+        method.setAccessible(true);
+
+        final RenderData renderData = new RenderData();
+        method.invoke(action, renderData);
+
+        assertNull(renderData.getDataMap().get("extraFieldNames"));
+    }
+
+    @Test
+    public void test_registerExtraFields_nullDoc() throws Exception {
+        final AdminSearchlistAction action = new AdminSearchlistAction();
+
+        final CreateForm form = new CreateForm();
+        form.doc = null;
+
+        final java.lang.reflect.Field currentFormField = AdminSearchlistAction.class.getDeclaredField("currentForm");
+        currentFormField.setAccessible(true);
+        currentFormField.set(action, form);
+
+        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
+        fessConfigField.setAccessible(true);
+        fessConfigField.set(action, ComponentUtil.getFessConfig());
+
+        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
+        method.setAccessible(true);
+
+        final RenderData renderData = new RenderData();
+        method.invoke(action, renderData);
+
+        assertNull(renderData.getDataMap().get("extraFieldNames"));
+    }
+
+    @Test
+    public void test_registerExtraFields_fieldTypeDetection() throws Exception {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getIndexAdminArrayFields() {
+                return "custom_array";
+            }
+
+            @Override
+            public String getIndexAdminDateFields() {
+                return "custom_date";
+            }
+
+            @Override
+            public String getIndexAdminLongFields() {
+                return "custom_long";
+            }
+
+            @Override
+            public String getIndexAdminFloatFields() {
+                return "custom_float";
+            }
+
+            @Override
+            public String getIndexAdminIntegerFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminDoubleFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminRequiredFields() {
+                return "";
+            }
+        });
+
+        final AdminSearchlistAction action = new AdminSearchlistAction();
+
+        final CreateForm form = new CreateForm();
+        form.doc = new HashMap<>();
+        form.doc.put("custom_array", "val1\nval2");
+        form.doc.put("custom_date", "2025-01-01T00:00:00.000Z");
+        form.doc.put("custom_long", "12345");
+        form.doc.put("custom_float", "1.5");
+        form.doc.put("custom_text", "hello");
+
+        final java.lang.reflect.Field currentFormField = AdminSearchlistAction.class.getDeclaredField("currentForm");
+        currentFormField.setAccessible(true);
+        currentFormField.set(action, form);
+
+        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
+        fessConfigField.setAccessible(true);
+        fessConfigField.set(action, ComponentUtil.getFessConfig());
+
+        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
+        method.setAccessible(true);
+
+        final RenderData renderData = new RenderData();
+        method.invoke(action, renderData);
+
+        @SuppressWarnings("unchecked")
+        final Map<String, String> extraFieldTypes = (Map<String, String>) renderData.getDataMap().get("extraFieldTypes");
+        assertNotNull(extraFieldTypes);
+        assertEquals("array", extraFieldTypes.get("custom_array"));
+        assertEquals("date", extraFieldTypes.get("custom_date"));
+        assertEquals("number", extraFieldTypes.get("custom_long"));
+        assertEquals("number", extraFieldTypes.get("custom_float"));
+        assertEquals("text", extraFieldTypes.get("custom_text"));
+    }
+
+    // ===================================================================================
+    //                                                                           Helpers
+    //                                                                           =========
+    private java.lang.reflect.Field findField(Class<?> clazz, String fieldName) {
+        while (clazz != null) {
+            try {
+                return clazz.getDeclaredField(fieldName);
+            } catch (final NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new RuntimeException("Field not found: " + fieldName);
+    }
+
+}

--- a/src/test/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistActionTest.java
@@ -72,6 +72,26 @@ public class AdminSearchlistActionTest extends UnitFessTestCase {
             public String getIndexAdminDoubleFields() {
                 return "";
             }
+
+            @Override
+            public String getIndexFieldId() {
+                return "_id";
+            }
+
+            @Override
+            public String getIndexFieldVersion() {
+                return "_version";
+            }
+
+            @Override
+            public String getIndexFieldSeqNo() {
+                return "_seq_no";
+            }
+
+            @Override
+            public String getIndexFieldPrimaryTerm() {
+                return "_primary_term";
+            }
         });
     }
 
@@ -479,7 +499,12 @@ public class AdminSearchlistActionTest extends UnitFessTestCase {
 
         @SuppressWarnings("unchecked")
         final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
-        assertTrue(extraFieldNames == null || extraFieldNames.isEmpty());
+        assertNotNull(extraFieldNames);
+        // Config-defined field "anchor" is not in STANDARD_EDIT_FIELDS, so it appears as extra
+        assertTrue(extraFieldNames.contains("anchor"));
+        // Standard field "url" should not appear
+        assertFalse(extraFieldNames.contains("url"));
+        assertFalse(extraFieldNames.contains("title"));
     }
 
     @Test
@@ -511,9 +536,10 @@ public class AdminSearchlistActionTest extends UnitFessTestCase {
         @SuppressWarnings("unchecked")
         final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
         assertNotNull(extraFieldNames);
-        assertEquals(2, extraFieldNames.size());
         assertTrue(extraFieldNames.contains("custom_metadata"));
         assertTrue(extraFieldNames.contains("department"));
+        // Config-defined "anchor" also appears as extra field
+        assertTrue(extraFieldNames.contains("anchor"));
 
         @SuppressWarnings("unchecked")
         final Map<String, String> extraFieldTypes = (Map<String, String>) renderData.getDataMap().get("extraFieldTypes");
@@ -550,31 +576,19 @@ public class AdminSearchlistActionTest extends UnitFessTestCase {
         @SuppressWarnings("unchecked")
         final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
         assertNotNull(extraFieldNames);
-        assertEquals(3, extraFieldNames.size());
-        assertEquals("aaa_field", extraFieldNames.get(0));
-        assertEquals("mmm_field", extraFieldNames.get(1));
-        assertEquals("zzz_field", extraFieldNames.get(2));
+        assertTrue(extraFieldNames.contains("aaa_field"));
+        assertTrue(extraFieldNames.contains("mmm_field"));
+        assertTrue(extraFieldNames.contains("zzz_field"));
+        // Verify sorted order among the custom fields
+        final int aIdx = extraFieldNames.indexOf("aaa_field");
+        final int mIdx = extraFieldNames.indexOf("mmm_field");
+        final int zIdx = extraFieldNames.indexOf("zzz_field");
+        assertTrue(aIdx < mIdx);
+        assertTrue(mIdx < zIdx);
     }
 
     @Test
-    public void test_registerExtraFields_nullCurrentForm() throws Exception {
-        final AdminSearchlistAction action = new AdminSearchlistAction();
-
-        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
-        fessConfigField.setAccessible(true);
-        fessConfigField.set(action, ComponentUtil.getFessConfig());
-
-        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
-        method.setAccessible(true);
-
-        final RenderData renderData = new RenderData();
-        method.invoke(action, renderData);
-
-        assertNull(renderData.getDataMap().get("extraFieldNames"));
-    }
-
-    @Test
-    public void test_registerExtraFields_nullDoc() throws Exception {
+    public void test_registerExtraFields_nullDoc_showsConfigFields() throws Exception {
         final AdminSearchlistAction action = new AdminSearchlistAction();
 
         final CreateForm form = new CreateForm();
@@ -594,7 +608,200 @@ public class AdminSearchlistActionTest extends UnitFessTestCase {
         final RenderData renderData = new RenderData();
         method.invoke(action, renderData);
 
-        assertNull(renderData.getDataMap().get("extraFieldNames"));
+        // Config fields that are not in STANDARD_EDIT_FIELDS should still appear
+        @SuppressWarnings("unchecked")
+        final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
+        assertNotNull(extraFieldNames);
+        assertTrue(extraFieldNames.contains("anchor"));
+    }
+
+    @Test
+    public void test_registerExtraFields_excludesReservedFields() throws Exception {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getIndexAdminArrayFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminDateFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminLongFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminFloatFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminIntegerFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminDoubleFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminRequiredFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexFieldId() {
+                return "_id";
+            }
+
+            @Override
+            public String getIndexFieldVersion() {
+                return "_version";
+            }
+
+            @Override
+            public String getIndexFieldSeqNo() {
+                return "_seq_no";
+            }
+
+            @Override
+            public String getIndexFieldPrimaryTerm() {
+                return "_primary_term";
+            }
+        });
+
+        final AdminSearchlistAction action = new AdminSearchlistAction();
+
+        final CreateForm form = new CreateForm();
+        form.doc = new HashMap<>();
+        form.doc.put("url", "https://example.com");
+        form.doc.put("custom_field", "value");
+        form.doc.put("_id", "abc123");
+        form.doc.put("_version", "1");
+        form.doc.put("_seq_no", "5");
+        form.doc.put("_primary_term", "1");
+
+        final java.lang.reflect.Field currentFormField = AdminSearchlistAction.class.getDeclaredField("currentForm");
+        currentFormField.setAccessible(true);
+        currentFormField.set(action, form);
+
+        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
+        fessConfigField.setAccessible(true);
+        fessConfigField.set(action, ComponentUtil.getFessConfig());
+
+        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
+        method.setAccessible(true);
+
+        final RenderData renderData = new RenderData();
+        method.invoke(action, renderData);
+
+        @SuppressWarnings("unchecked")
+        final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
+        assertNotNull(extraFieldNames);
+        assertTrue(extraFieldNames.contains("custom_field"));
+        assertFalse(extraFieldNames.contains("_id"), "Reserved field _id should be excluded");
+        assertFalse(extraFieldNames.contains("_version"), "Reserved field _version should be excluded");
+        assertFalse(extraFieldNames.contains("_seq_no"), "Reserved field _seq_no should be excluded");
+        assertFalse(extraFieldNames.contains("_primary_term"), "Reserved field _primary_term should be excluded");
+    }
+
+    @Test
+    public void test_registerExtraFields_configFieldsAppearedWithoutDoc() throws Exception {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getIndexAdminArrayFields() {
+                return "custom_tags";
+            }
+
+            @Override
+            public String getIndexAdminDateFields() {
+                return "custom_publish_date";
+            }
+
+            @Override
+            public String getIndexAdminLongFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminFloatFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminIntegerFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminDoubleFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexAdminRequiredFields() {
+                return "";
+            }
+
+            @Override
+            public String getIndexFieldId() {
+                return "_id";
+            }
+
+            @Override
+            public String getIndexFieldVersion() {
+                return "_version";
+            }
+
+            @Override
+            public String getIndexFieldSeqNo() {
+                return "_seq_no";
+            }
+
+            @Override
+            public String getIndexFieldPrimaryTerm() {
+                return "_primary_term";
+            }
+        });
+
+        final AdminSearchlistAction action = new AdminSearchlistAction();
+
+        // Empty doc (create mode) — no custom fields in document
+        final CreateForm form = new CreateForm();
+        form.doc = new HashMap<>();
+
+        final java.lang.reflect.Field currentFormField = AdminSearchlistAction.class.getDeclaredField("currentForm");
+        currentFormField.setAccessible(true);
+        currentFormField.set(action, form);
+
+        final java.lang.reflect.Field fessConfigField = findField(action.getClass(), "fessConfig");
+        fessConfigField.setAccessible(true);
+        fessConfigField.set(action, ComponentUtil.getFessConfig());
+
+        final java.lang.reflect.Method method = AdminSearchlistAction.class.getDeclaredMethod("registerExtraFields", RenderData.class);
+        method.setAccessible(true);
+
+        final RenderData renderData = new RenderData();
+        method.invoke(action, renderData);
+
+        @SuppressWarnings("unchecked")
+        final List<String> extraFieldNames = (List<String>) renderData.getDataMap().get("extraFieldNames");
+        assertNotNull(extraFieldNames);
+        assertTrue(extraFieldNames.contains("custom_tags"), "Config-defined array field should appear even without doc data");
+        assertTrue(extraFieldNames.contains("custom_publish_date"), "Config-defined date field should appear even without doc data");
+
+        @SuppressWarnings("unchecked")
+        final Map<String, String> extraFieldTypes = (Map<String, String>) renderData.getDataMap().get("extraFieldTypes");
+        assertEquals("array", extraFieldTypes.get("custom_tags"));
+        assertEquals("date", extraFieldTypes.get("custom_publish_date"));
     }
 
     @Test
@@ -635,6 +842,26 @@ public class AdminSearchlistActionTest extends UnitFessTestCase {
             @Override
             public String getIndexAdminRequiredFields() {
                 return "";
+            }
+
+            @Override
+            public String getIndexFieldId() {
+                return "_id";
+            }
+
+            @Override
+            public String getIndexFieldVersion() {
+                return "_version";
+            }
+
+            @Override
+            public String getIndexFieldSeqNo() {
+                return "_seq_no";
+            }
+
+            @Override
+            public String getIndexFieldPrimaryTerm() {
+                return "_primary_term";
             }
         });
 


### PR DESCRIPTION
## Summary
Improve validation messages on the Admin Search List page and add support for editing custom document fields.

Closes #1416

## Changes Made

### Validation message improvements
- Remove `doc.` prefix from validation error display text in `validateFields()` — errors now show "url is required." instead of "doc.url is required."
- Fix array field validation to use dedicated `errors.property_type_array` message instead of incorrectly reusing `errors.property_required`
- Add `errors.property_type_array` message key with translations for all 17 supported languages

### Custom field support on edit page
- Add dynamic rendering of custom/extra document fields in the edit JSP
- Fields not in the standard hard-coded set are automatically detected from the document and rendered with appropriate input types (text, textarea for arrays, date with format validation, number)
- Field type detection uses existing `index.admin.*` configuration properties

### Tests
- Add `AdminSearchlistActionTest` with 27 tests covering:
  - Form initialization and field assignment
  - `validateFields()` with valid/invalid documents (required, float, long, date)
  - Validation message property key format (doc.* prefix for JSP binding)
  - `STANDARD_EDIT_FIELDS` constant contents
  - `registerExtraFields()` with custom fields, type detection, sort order, and null handling

## Testing
- All 27 unit tests pass: `mvn test -Dtest=AdminSearchlistActionTest`
- Build verification: `mvn compile -DskipTests` passes
- Code formatted with `mvn formatter:format && mvn license:format`

## Additional Notes
- The `validateFields()` method is static and shared by `AdminSearchlistAction`, `ApiAdminSearchlistAction`, and `ApiAdminDocumentsAction` — all three benefit from the fix automatically
- The array validation (`invalidIndexArrayFields`) currently has a TODO and always returns empty, so the message change is forward-looking