### PR TITLE
feat(api): return job log ID from scheduler start API

### DIFF
--- a/src/main/java/org/codelibs/fess/Constants.java
+++ b/src/main/java/org/codelibs/fess/Constants.java
@@ -537,6 +537,9 @@ public class Constants extends CoreLibConstants {
     /** Scheduled job identifier. */
     public static final String SCHEDULED_JOB = "scheduledJob";
 
+    /** Job log ID parameter key for passing pre-generated ID to job execution. */
+    public static final String JOB_LOG_ID = "jobLogId";
+
     /** Default job target value (all configurations). */
     public static final String DEFAULT_JOB_TARGET = "all";
 

--- a/src/main/java/org/codelibs/fess/app/job/ScriptExecutorJob.java
+++ b/src/main/java/org/codelibs/fess/app/job/ScriptExecutorJob.java
@@ -84,6 +84,10 @@ public class ScriptExecutorJob implements LaJob {
         }
 
         final JobLog jobLog = new JobLog(scheduledJob);
+        final String jobLogId = (String) runtime.getParameterMap().get(Constants.JOB_LOG_ID);
+        if (jobLogId != null) {
+            jobLog.setId(jobLogId);
+        }
         final String scriptType = scheduledJob.getScriptType();
         final String script = scheduledJob.getScriptData();
 

--- a/src/main/java/org/codelibs/fess/app/web/api/ApiResult.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/ApiResult.java
@@ -157,6 +157,36 @@ public class ApiResult {
     }
 
     /**
+     * Represents an API response for a start job operation.
+     */
+    public static class ApiStartJobResponse extends ApiResponse {
+        /** The pre-generated job log ID. Null when job logging is disabled. */
+        protected String jobLogId;
+
+        /**
+         * Default constructor for ApiStartJobResponse.
+         */
+        public ApiStartJobResponse() {
+            super();
+        }
+
+        /**
+         * Sets the job log ID.
+         * @param jobLogId The job log ID to set. Null when job logging is disabled.
+         * @return This ApiStartJobResponse instance.
+         */
+        public ApiStartJobResponse jobLogId(final String jobLogId) {
+            this.jobLogId = jobLogId;
+            return this;
+        }
+
+        @Override
+        public ApiResult result() {
+            return new ApiResult(this);
+        }
+    }
+
+    /**
      * Represents an API response for a delete operation.
      */
     public static class ApiDeleteResponse extends ApiResponse {

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/ApiAdminSchedulerAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/ApiAdminSchedulerAction.java
@@ -18,6 +18,8 @@ package org.codelibs.fess.app.web.api.admin.scheduler;
 import static org.codelibs.fess.app.web.admin.scheduler.AdminSchedulerAction.getScheduledJob;
 
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -75,13 +77,16 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
 
     /**
      * Starts a scheduled job by ID.
+     * When job logging is enabled, a pre-generated job log ID is returned in the response
+     * as {@code jobLogId}. When job logging is disabled, {@code jobLogId} is {@code null}.
      *
      * @param id the ID of the scheduled job to start
-     * @return JSON response indicating success or failure
+     * @return JSON response with {@code jobLogId} (nullable) and status
      */
     // PUT /api/admin/scheduler/{id}/start
     @Execute(urlPattern = "{}/@word")
     public JsonResponse<ApiResult> put$start(final String id) {
+        final String[] jobLogId = { null };
         scheduledJobService.getScheduledJob(id).ifPresent(entity -> {
             if (!entity.isEnabled() || entity.isRunning()) {
                 throwValidationErrorApi(messages -> {
@@ -89,7 +94,12 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
                 });
             }
             try {
-                entity.start();
+                if (entity.isLoggingEnabled()) {
+                    jobLogId[0] = UUID.randomUUID().toString().replace("-", "");
+                    entity.start(Map.of(Constants.JOB_LOG_ID, jobLogId[0]));
+                } else {
+                    entity.start();
+                }
             } catch (final Exception e) {
                 throwValidationErrorApi(messages -> {
                     messages.addErrorsFailedToStartJob(GLOBAL, entity.getName());
@@ -100,7 +110,7 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
                 messages.addErrorsFailedToStartJob(GLOBAL, id);
             });
         });
-        return asJson(new ApiResponse().status(Status.OK).result());
+        return asJson(new ApiResult.ApiStartJobResponse().jobLogId(jobLogId[0]).status(Status.OK).result());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/ScheduledJob.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/ScheduledJob.java
@@ -15,6 +15,8 @@
  */
 package org.codelibs.fess.opensearch.config.exentity;
 
+import java.util.Map;
+
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.exception.JobNotFoundException;
@@ -58,6 +60,20 @@ public class ScheduledJob extends BsScheduledJob {
     public void start() {
         ComponentUtil.getJobManager().findJobByUniqueOf(LaJobUnique.of(getId())).ifPresent(job -> {
             job.launchNow();
+        }).orElse(() -> {
+            throw new JobNotFoundException(this);
+        });
+    }
+
+    public void start(final Map<String, Object> params) {
+        ComponentUtil.getJobManager().findJobByUniqueOf(LaJobUnique.of(getId())).ifPresent(job -> {
+            if (params != null && !params.isEmpty()) {
+                job.launchNow(op -> {
+                    params.forEach(op::param);
+                });
+            } else {
+                job.launchNow();
+            }
         }).orElse(() -> {
             throw new JobNotFoundException(this);
         });

--- a/src/test/java/org/codelibs/fess/app/job/ScriptExecutorJobTest.java
+++ b/src/test/java/org/codelibs/fess/app/job/ScriptExecutorJobTest.java
@@ -15,10 +15,42 @@
  */
 package org.codelibs.fess.app.job;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.codelibs.core.timer.TimeoutTask;
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.helper.JobHelper;
+import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.job.JobExecutor;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.opensearch.config.exentity.JobLog;
+import org.codelibs.fess.opensearch.config.exentity.ScheduledJob;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.lastaflute.job.LaJob;
+import org.lastaflute.job.LaScheduledJob;
+import org.lastaflute.job.JobManager;
+import org.lastaflute.job.key.LaJobUnique;
+import org.lastaflute.job.mock.MockJobRuntime;
 
 public class ScriptExecutorJobTest extends UnitFessTestCase {
+
+    @Override
+    protected boolean isUseOneTimeContainer() {
+        return true;
+    }
+
+    @Override
+    protected void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+    }
 
     public void test_ScriptExecutorJob_implementsLaJob() {
         final ScriptExecutorJob job = new ScriptExecutorJob();
@@ -28,5 +60,351 @@ public class ScriptExecutorJobTest extends UnitFessTestCase {
     public void test_ScriptExecutorJob_creation() {
         final ScriptExecutorJob job = new ScriptExecutorJob();
         assertNotNull(job);
+    }
+
+    // ===================================================================================
+    //                                                   process() with JOB_LOG_ID
+    //                                                   ============================
+
+    @Test
+    public void test_process_withJobLogId_setsIdOnJobLog() {
+        final ScheduledJob scheduledJob = createTestScheduledJob("proc-1", true);
+        final AtomicReference<JobLog> storedJobLog = new AtomicReference<>();
+
+        registerComponents(scheduledJob, storedJobLog);
+
+        // Create runtime with JOB_LOG_ID parameter
+        final Map<String, Object> params = new HashMap<>();
+        params.put(Constants.SCHEDULED_JOB, scheduledJob);
+        params.put(Constants.JOB_LOG_ID, "pregenerated-abc123");
+
+        final MockJobRuntime runtime = MockJobRuntime.of(ScriptExecutorJob.class, op -> op.params(() -> params));
+
+        // Execute the real process() method
+        final TestableScriptExecutorJob job = new TestableScriptExecutorJob();
+        job.process(runtime);
+
+        // Verify the JobLog was stored with the pre-generated ID
+        assertNotNull(storedJobLog.get());
+        assertEquals("pregenerated-abc123", storedJobLog.get().getId());
+        assertEquals(Constants.OK, storedJobLog.get().getJobStatus());
+    }
+
+    @Test
+    public void test_process_withoutJobLogId_idRemainsNull() {
+        final ScheduledJob scheduledJob = createTestScheduledJob("proc-2", true);
+        final AtomicReference<JobLog> storedJobLog = new AtomicReference<>();
+
+        registerComponents(scheduledJob, storedJobLog);
+
+        // Create runtime WITHOUT JOB_LOG_ID parameter
+        final Map<String, Object> params = new HashMap<>();
+        params.put(Constants.SCHEDULED_JOB, scheduledJob);
+
+        final MockJobRuntime runtime = MockJobRuntime.of(ScriptExecutorJob.class, op -> op.params(() -> params));
+
+        final TestableScriptExecutorJob job = new TestableScriptExecutorJob();
+        job.process(runtime);
+
+        // Verify the JobLog was stored without a pre-set ID
+        assertNotNull(storedJobLog.get());
+        assertNull(storedJobLog.get().getId());
+        assertEquals(Constants.OK, storedJobLog.get().getJobStatus());
+    }
+
+    @Test
+    public void test_process_withNullJobLogId_idRemainsNull() {
+        final ScheduledJob scheduledJob = createTestScheduledJob("proc-3", true);
+        final AtomicReference<JobLog> storedJobLog = new AtomicReference<>();
+
+        registerComponents(scheduledJob, storedJobLog);
+
+        final Map<String, Object> params = new HashMap<>();
+        params.put(Constants.SCHEDULED_JOB, scheduledJob);
+        params.put(Constants.JOB_LOG_ID, null);
+
+        final MockJobRuntime runtime = MockJobRuntime.of(ScriptExecutorJob.class, op -> op.params(() -> params));
+
+        final TestableScriptExecutorJob job = new TestableScriptExecutorJob();
+        job.process(runtime);
+
+        assertNotNull(storedJobLog.get());
+        assertNull(storedJobLog.get().getId());
+    }
+
+    @Test
+    public void test_process_loggingDisabled_noJobLogStored() {
+        final ScheduledJob scheduledJob = createTestScheduledJob("proc-4", false);
+        final AtomicReference<JobLog> storedJobLog = new AtomicReference<>();
+
+        registerComponents(scheduledJob, storedJobLog);
+
+        final Map<String, Object> params = new HashMap<>();
+        params.put(Constants.SCHEDULED_JOB, scheduledJob);
+        params.put(Constants.JOB_LOG_ID, "should-not-be-stored");
+
+        final MockJobRuntime runtime = MockJobRuntime.of(ScriptExecutorJob.class, op -> op.params(() -> params));
+
+        final TestableScriptExecutorJob job = new TestableScriptExecutorJob();
+        job.process(runtime);
+
+        // When logging is disabled, store() is never called
+        assertNull(storedJobLog.get());
+    }
+
+    // ===================================================================================
+    //                                                                       Helpers
+    //                                                                       ========
+
+    private ScheduledJob createTestScheduledJob(final String id, final boolean loggingEnabled) {
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setId(id);
+        scheduledJob.setName("Test Job");
+        scheduledJob.setScriptType("groovy");
+        scheduledJob.setScriptData("println 'test'");
+        scheduledJob.setJobLogging(loggingEnabled ? Constants.T : Constants.F);
+        scheduledJob.setAvailable(Constants.T);
+        scheduledJob.setTarget("all");
+        return scheduledJob;
+    }
+
+    private void registerComponents(final ScheduledJob scheduledJob, final AtomicReference<JobLog> storedJobLog) {
+        // FessConfig that accepts our target
+        final FessConfig fessConfig = new FessConfig.SimpleImpl() {
+            @Override
+            public boolean isSchedulerTarget(final String target) {
+                return true;
+            }
+
+            @Override
+            public String getSchedulerTargetName() {
+                return Constants.DEFAULT_JOB_TARGET;
+            }
+        };
+        ComponentUtil.setFessConfig(fessConfig);
+
+        // JobManager that finds our job
+        final JobManager jobManager = new JobManager() {
+            @Override
+            public OptionalThing<LaScheduledJob> findJobByUniqueOf(final LaJobUnique jobUnique) {
+                return OptionalThing.of(new MinimalLaScheduledJob());
+            }
+
+            @Override
+            public OptionalThing<LaScheduledJob> findJobByKey(final org.lastaflute.job.key.LaJobKey jobKey) {
+                return OptionalThing.empty();
+            }
+
+            @Override
+            public boolean isSchedulingDone() {
+                return true;
+            }
+
+            @Override
+            public void schedule(final org.lastaflute.job.subsidiary.CronConsumer cron) {
+            }
+
+            @Override
+            public java.util.List<LaScheduledJob> getJobList() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public java.util.List<org.lastaflute.job.LaJobHistory> searchJobHistoryList() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public void reboot() {
+            }
+
+            @Override
+            public void destroy() {
+            }
+        };
+        ComponentUtil.register(jobManager, JobManager.class.getCanonicalName());
+
+        // JobHelper that captures stored JobLog
+        final JobHelper jobHelper = new JobHelper() {
+            @Override
+            public boolean isAvailable(final String id) {
+                return true;
+            }
+
+            @Override
+            public void store(final JobLog jobLog) {
+                storedJobLog.set(jobLog);
+            }
+
+            @Override
+            public TimeoutTask startMonitorTask(final JobLog jobLog) {
+                return null;
+            }
+
+            @Override
+            public void unregister(final ScheduledJob scheduledJob) {
+            }
+        };
+        ComponentUtil.register(jobHelper, "jobHelper");
+
+        // JobExecutor that returns a simple result
+        final JobExecutor jobExecutor = new JobExecutor() {
+            @Override
+            public Object execute(final String scriptType, final String script) {
+                return "OK";
+            }
+        };
+        ComponentUtil.register(jobExecutor, "scriptJobExecutor");
+    }
+
+    /**
+     * Testable subclass that exposes the protected process() method.
+     */
+    private static class TestableScriptExecutorJob extends ScriptExecutorJob {
+        @Override
+        public void process(final org.lastaflute.job.LaJobRuntime runtime) {
+            super.process(runtime);
+        }
+    }
+
+    /**
+     * Minimal LaScheduledJob stub for JobManager.findJobByUniqueOf().
+     */
+    private static class MinimalLaScheduledJob implements LaScheduledJob {
+        @Override
+        public org.lastaflute.job.subsidiary.LaunchedProcess launchNow() {
+            return null;
+        }
+
+        @Override
+        public org.lastaflute.job.subsidiary.LaunchedProcess launchNow(final org.lastaflute.job.subsidiary.LaunchNowOpCall opLambda) {
+            return null;
+        }
+
+        @Override
+        public void stopNow() {
+        }
+
+        @Override
+        public void reschedule(final String cronExp, final org.lastaflute.job.subsidiary.VaryingCronOpCall opLambda) {
+        }
+
+        @Override
+        public void unschedule() {
+        }
+
+        @Override
+        public void disappear() {
+        }
+
+        @Override
+        public void becomeNonCron() {
+        }
+
+        @Override
+        public void registerNext(final org.lastaflute.job.key.LaJobKey triggeredJob) {
+        }
+
+        @Override
+        public org.lastaflute.job.key.LaJobKey getJobKey() {
+            return null;
+        }
+
+        @Override
+        public OptionalThing<org.lastaflute.job.key.LaJobNote> getJobNote() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public OptionalThing<LaJobUnique> getJobUnique() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public OptionalThing<String> getCronExp() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public Class<? extends LaJob> getJobType() {
+            return null;
+        }
+
+        @Override
+        public OptionalThing<org.lastaflute.job.subsidiary.CronParamsSupplier> getParamsSupplier() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public org.lastaflute.job.log.JobNoticeLogLevel getNoticeLogLevel() {
+            return org.lastaflute.job.log.JobNoticeLogLevel.INFO;
+        }
+
+        @Override
+        public org.lastaflute.job.subsidiary.JobConcurrentExec getConcurrentExec() {
+            return null;
+        }
+
+        @Override
+        public boolean isOutlawParallelGranted() {
+            return false;
+        }
+
+        @Override
+        public boolean isUnscheduled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDisappeared() {
+            return false;
+        }
+
+        @Override
+        public boolean isNonCron() {
+            return false;
+        }
+
+        @Override
+        public boolean isExecutingNow() {
+            return false;
+        }
+
+        @Override
+        public <RESULT> OptionalThing<RESULT> mapExecutingNow(
+                final java.util.function.Function<org.lastaflute.job.subsidiary.SnapshotExecState, RESULT> oneArgLambda) {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public org.dbflute.optional.OptionalThingIfPresentAfter ifExecutingNow(
+                final java.util.function.Consumer<org.lastaflute.job.subsidiary.SnapshotExecState> oneArgLambda) {
+            return processor -> processor.process();
+        }
+
+        @Override
+        public java.util.Set<org.lastaflute.job.key.LaJobKey> getTriggeredJobKeySet() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public java.util.List<org.lastaflute.job.subsidiary.NeighborConcurrentGroup> getNeighborConcurrentGroupList() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public java.util.Map<String, org.lastaflute.job.subsidiary.NeighborConcurrentGroup> getNeighborConcurrentGroupMap() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public String toIdentityDisp() {
+            return "MockJob";
+        }
+
+        @Override
+        public org.lastaflute.job.subsidiary.JobExecutingSnapshot takeSnapshotNow() {
+            return null;
+        }
     }
 }

--- a/src/test/java/org/codelibs/fess/app/web/api/ApiResultTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/api/ApiResultTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.api;
+
+import org.codelibs.fess.app.web.api.ApiResult.ApiResponse;
+import org.codelibs.fess.app.web.api.ApiResult.ApiStartJobResponse;
+import org.codelibs.fess.app.web.api.ApiResult.Status;
+import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class ApiResultTest extends UnitFessTestCase {
+
+    @Override
+    protected boolean isUseOneTimeContainer() {
+        return true;
+    }
+
+    @Override
+    protected void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+    }
+
+    // ===================================================================================
+    //                                                             ApiStartJobResponse Tests
+    //                                                             =========================
+
+    @Test
+    public void test_ApiStartJobResponse_withJobLogId() {
+        final ApiStartJobResponse response = new ApiStartJobResponse();
+        final ApiStartJobResponse returned = response.jobLogId("abc123def456");
+        assertSame(response, returned);
+        assertEquals("abc123def456", response.jobLogId);
+    }
+
+    @Test
+    public void test_ApiStartJobResponse_withNullJobLogId() {
+        final ApiStartJobResponse response = new ApiStartJobResponse();
+        response.jobLogId(null);
+        assertNull(response.jobLogId);
+    }
+
+    @Test
+    public void test_ApiStartJobResponse_withStatus() {
+        final ApiStartJobResponse response = new ApiStartJobResponse();
+        response.jobLogId("test-id").status(Status.OK);
+        assertEquals("test-id", response.jobLogId);
+        assertEquals(0, response.status);
+    }
+
+    @Test
+    public void test_ApiStartJobResponse_result() {
+        final ApiStartJobResponse response = new ApiStartJobResponse();
+        response.jobLogId("log-id-xyz").status(Status.OK);
+        final ApiResult result = response.result();
+        assertNotNull(result);
+        assertNotNull(result.response);
+        assertTrue(result.response instanceof ApiStartJobResponse);
+        final ApiStartJobResponse resultResponse = (ApiStartJobResponse) result.response;
+        assertEquals("log-id-xyz", resultResponse.jobLogId);
+        assertEquals(0, resultResponse.status);
+    }
+
+    @Test
+    public void test_ApiStartJobResponse_extendsApiResponse() {
+        final ApiStartJobResponse response = new ApiStartJobResponse();
+        assertTrue(response instanceof ApiResponse);
+    }
+
+    @Test
+    public void test_ApiStartJobResponse_statusFluentChain() {
+        final ApiStartJobResponse response = new ApiStartJobResponse();
+        // status() returns ApiResponse, so the chain works when called last
+        final ApiResponse returned = response.jobLogId("id-1").status(Status.OK);
+        assertNotNull(returned);
+    }
+
+    @Test
+    public void test_ApiStartJobResponse_hasVersionField() {
+        final ApiStartJobResponse response = new ApiStartJobResponse();
+        response.status(Status.OK);
+        // version is initialized from SystemHelper.getProductVersion()
+        // In test environment it may be null, but the field should exist
+        assertEquals(0, response.status);
+    }
+
+    // ===================================================================================
+    //                                                                        Status Tests
+    //                                                                        ============
+
+    @Test
+    public void test_Status_OK() {
+        assertEquals(0, Status.OK.getId());
+    }
+
+    @Test
+    public void test_Status_BAD_REQUEST() {
+        assertEquals(1, Status.BAD_REQUEST.getId());
+    }
+
+    @Test
+    public void test_Status_SYSTEM_ERROR() {
+        assertEquals(2, Status.SYSTEM_ERROR.getId());
+    }
+}

--- a/src/test/java/org/codelibs/fess/app/web/api/admin/scheduler/ApiAdminSchedulerActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/api/admin/scheduler/ApiAdminSchedulerActionTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.api.admin.scheduler;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.app.service.ScheduledJobService;
+import org.codelibs.fess.app.web.api.ApiResult;
+import org.codelibs.fess.app.web.api.ApiResult.ApiStartJobResponse;
+import org.codelibs.fess.opensearch.config.exentity.ScheduledJob;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalEntity;
+import org.dbflute.optional.OptionalThing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.lastaflute.job.JobManager;
+import org.lastaflute.job.LaScheduledJob;
+import org.lastaflute.job.key.LaJobUnique;
+import org.lastaflute.job.subsidiary.LaunchNowOpCall;
+import org.lastaflute.job.subsidiary.LaunchNowOption;
+import org.lastaflute.job.subsidiary.LaunchedProcess;
+import org.lastaflute.web.response.JsonResponse;
+
+/**
+ * Tests for the scheduler start API endpoint contract.
+ * Verifies that {@code PUT /api/admin/scheduler/{id}/start} returns the correct
+ * {@code jobLogId} based on the job's logging configuration.
+ */
+public class ApiAdminSchedulerActionTest extends UnitFessTestCase {
+
+    @Override
+    protected boolean isUseOneTimeContainer() {
+        return true;
+    }
+
+    @Override
+    protected void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        ComponentUtil.register(new org.codelibs.fess.helper.SystemHelper(), "systemHelper");
+    }
+
+    // ===================================================================================
+    //                                                         Logging Enabled: jobLogId
+    //                                                         ===========================
+
+    @Test
+    public void test_put$start_loggingEnabled_returnsJobLogId() throws Exception {
+        // Setup: job with logging enabled
+        final AtomicReference<LaunchNowOption> capturedOption = new AtomicReference<>();
+        final ScheduledJob scheduledJob = createScheduledJob("job-1", "Test Job", true, true);
+
+        registerMockJobManager("job-1", opCall -> {
+            final LaunchNowOption option = new LaunchNowOption();
+            opCall.callback(option);
+            capturedOption.set(option);
+            return null;
+        });
+
+        final ApiAdminSchedulerAction action = createActionWithMockService(scheduledJob);
+
+        // Execute the real put$start() method
+        final JsonResponse<ApiResult> jsonResponse = action.put$start("job-1");
+
+        // Verify: response contains non-null jobLogId
+        assertNotNull(jsonResponse);
+        final ApiResult apiResult = jsonResponse.getJsonResult();
+        assertNotNull(apiResult);
+        final String responseJobLogId = extractJobLogId(apiResult);
+        assertNotNull(responseJobLogId);
+        assertEquals(32, responseJobLogId.length());
+        assertTrue(responseJobLogId.matches("[0-9a-f]{32}"));
+
+        // Verify the pre-generated ID was passed to the job via launch params
+        assertNotNull(capturedOption.get());
+        assertEquals(responseJobLogId, capturedOption.get().getParameterMap().get(Constants.JOB_LOG_ID));
+    }
+
+    // ===================================================================================
+    //                                                        Logging Disabled: null
+    //                                                        ==========================
+
+    @Test
+    public void test_put$start_loggingDisabled_returnsNullJobLogId() throws Exception {
+        // Setup: job with logging disabled
+        final ScheduledJob scheduledJob = createScheduledJob("job-2", "Test Job No Log", false, true);
+
+        registerMockJobManager("job-2", null, () -> {});
+
+        final ApiAdminSchedulerAction action = createActionWithMockService(scheduledJob);
+
+        // Execute the real put$start() method
+        final JsonResponse<ApiResult> jsonResponse = action.put$start("job-2");
+
+        // Verify: response contains null jobLogId
+        assertNotNull(jsonResponse);
+        final ApiResult apiResult = jsonResponse.getJsonResult();
+        assertNotNull(apiResult);
+        final String responseJobLogId = extractJobLogId(apiResult);
+        assertNull(responseJobLogId);
+    }
+
+    // ===================================================================================
+    //                                                                       Helpers
+    //                                                                       ========
+
+    private String extractJobLogId(final ApiResult apiResult) throws Exception {
+        final Field responseField = ApiResult.class.getDeclaredField("response");
+        responseField.setAccessible(true);
+        final Object response = responseField.get(apiResult);
+        assertTrue(response instanceof ApiStartJobResponse);
+
+        final Field jobLogIdField = ApiStartJobResponse.class.getDeclaredField("jobLogId");
+        jobLogIdField.setAccessible(true);
+        return (String) jobLogIdField.get(response);
+    }
+
+    private ApiAdminSchedulerAction createActionWithMockService(final ScheduledJob scheduledJob) throws Exception {
+        final ApiAdminSchedulerAction action = new ApiAdminSchedulerAction();
+
+        // Inject mock ScheduledJobService via reflection
+        final ScheduledJobService mockService = new ScheduledJobService() {
+            @Override
+            public OptionalEntity<ScheduledJob> getScheduledJob(final String id) {
+                if (scheduledJob.getId().equals(id)) {
+                    return OptionalEntity.of(scheduledJob);
+                }
+                return OptionalEntity.empty();
+            }
+        };
+
+        final Field serviceField = ApiAdminSchedulerAction.class.getDeclaredField("scheduledJobService");
+        serviceField.setAccessible(true);
+        serviceField.set(action, mockService);
+
+        return action;
+    }
+
+    private ScheduledJob createScheduledJob(final String id, final String name, final boolean loggingEnabled, final boolean enabled) {
+        final ScheduledJob job = new ScheduledJob();
+        job.setId(id);
+        job.setName(name);
+        job.setJobLogging(loggingEnabled ? Constants.T : Constants.F);
+        job.setAvailable(enabled ? Constants.T : Constants.F);
+        job.setScriptType("groovy");
+        job.setScriptData("println 'test'");
+        job.setTarget("all");
+        return job;
+    }
+
+    @FunctionalInterface
+    private interface LaunchNowWithParamsCallback {
+        LaunchedProcess call(LaunchNowOpCall opCall);
+    }
+
+    private void registerMockJobManager(final String jobId, final LaunchNowWithParamsCallback withParamsCallback) {
+        registerMockJobManager(jobId, withParamsCallback, null);
+    }
+
+    private void registerMockJobManager(final String jobId, final LaunchNowWithParamsCallback withParamsCallback,
+            final Runnable noArgCallback) {
+        final LaScheduledJob mockLaJob = new MockLaScheduledJob() {
+            @Override
+            public LaunchedProcess launchNow() {
+                if (noArgCallback != null) {
+                    noArgCallback.run();
+                }
+                return null;
+            }
+
+            @Override
+            public LaunchedProcess launchNow(final LaunchNowOpCall opLambda) {
+                if (withParamsCallback != null) {
+                    return withParamsCallback.call(opLambda);
+                }
+                return null;
+            }
+        };
+
+        final JobManager mockJobManager = new JobManager() {
+            @Override
+            public OptionalThing<LaScheduledJob> findJobByUniqueOf(final LaJobUnique jobUnique) {
+                if (jobId.equals(jobUnique.value())) {
+                    return OptionalThing.of(mockLaJob);
+                }
+                return OptionalThing.ofNullable(null, () -> {
+                    throw new IllegalStateException("not found");
+                });
+            }
+
+            @Override
+            public OptionalThing<LaScheduledJob> findJobByKey(final org.lastaflute.job.key.LaJobKey jobKey) {
+                return OptionalThing.empty();
+            }
+
+            @Override
+            public boolean isSchedulingDone() {
+                return true;
+            }
+
+            @Override
+            public void schedule(final org.lastaflute.job.subsidiary.CronConsumer cron) {
+            }
+
+            @Override
+            public java.util.List<LaScheduledJob> getJobList() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public java.util.List<org.lastaflute.job.LaJobHistory> searchJobHistoryList() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public void reboot() {
+            }
+
+            @Override
+            public void destroy() {
+            }
+        };
+        ComponentUtil.register(mockJobManager, JobManager.class.getCanonicalName());
+    }
+
+    private abstract static class MockLaScheduledJob implements LaScheduledJob {
+        @Override
+        public void stopNow() {
+        }
+
+        @Override
+        public void reschedule(final String cronExp, final org.lastaflute.job.subsidiary.VaryingCronOpCall opLambda) {
+        }
+
+        @Override
+        public void unschedule() {
+        }
+
+        @Override
+        public void disappear() {
+        }
+
+        @Override
+        public void becomeNonCron() {
+        }
+
+        @Override
+        public void registerNext(final org.lastaflute.job.key.LaJobKey triggeredJob) {
+        }
+
+        @Override
+        public org.lastaflute.job.key.LaJobKey getJobKey() {
+            return null;
+        }
+
+        @Override
+        public OptionalThing<org.lastaflute.job.key.LaJobNote> getJobNote() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public OptionalThing<LaJobUnique> getJobUnique() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public OptionalThing<String> getCronExp() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public Class<? extends org.lastaflute.job.LaJob> getJobType() {
+            return null;
+        }
+
+        @Override
+        public OptionalThing<org.lastaflute.job.subsidiary.CronParamsSupplier> getParamsSupplier() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public org.lastaflute.job.log.JobNoticeLogLevel getNoticeLogLevel() {
+            return org.lastaflute.job.log.JobNoticeLogLevel.INFO;
+        }
+
+        @Override
+        public org.lastaflute.job.subsidiary.JobConcurrentExec getConcurrentExec() {
+            return null;
+        }
+
+        @Override
+        public boolean isOutlawParallelGranted() {
+            return false;
+        }
+
+        @Override
+        public boolean isUnscheduled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDisappeared() {
+            return false;
+        }
+
+        @Override
+        public boolean isNonCron() {
+            return false;
+        }
+
+        @Override
+        public boolean isExecutingNow() {
+            return false;
+        }
+
+        @Override
+        public <RESULT> OptionalThing<RESULT> mapExecutingNow(
+                final java.util.function.Function<org.lastaflute.job.subsidiary.SnapshotExecState, RESULT> oneArgLambda) {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public org.dbflute.optional.OptionalThingIfPresentAfter ifExecutingNow(
+                final java.util.function.Consumer<org.lastaflute.job.subsidiary.SnapshotExecState> oneArgLambda) {
+            return processor -> processor.process();
+        }
+
+        @Override
+        public java.util.Set<org.lastaflute.job.key.LaJobKey> getTriggeredJobKeySet() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public java.util.List<org.lastaflute.job.subsidiary.NeighborConcurrentGroup> getNeighborConcurrentGroupList() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public java.util.Map<String, org.lastaflute.job.subsidiary.NeighborConcurrentGroup> getNeighborConcurrentGroupMap() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public String toIdentityDisp() {
+            return "MockJob";
+        }
+
+        @Override
+        public org.lastaflute.job.subsidiary.JobExecutingSnapshot takeSnapshotNow() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/opensearch/config/exentity/JobLogTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/config/exentity/JobLogTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.opensearch.config.exentity;
+
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class JobLogTest extends UnitFessTestCase {
+
+    @Override
+    protected boolean isUseOneTimeContainer() {
+        return true;
+    }
+
+    @Override
+    protected void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+    }
+
+    @Test
+    public void test_defaultConstructor() {
+        final JobLog jobLog = new JobLog();
+        assertNotNull(jobLog);
+        assertNull(jobLog.getId());
+    }
+
+    @Test
+    public void test_constructorWithScheduledJob() {
+        final ScheduledJob scheduledJob = createTestScheduledJob();
+
+        final JobLog jobLog = new JobLog(scheduledJob);
+
+        assertEquals("Test Job", jobLog.getJobName());
+        assertEquals("groovy", jobLog.getScriptType());
+        assertEquals("println 'hello'", jobLog.getScriptData());
+        assertEquals(Constants.RUNNING, jobLog.getJobStatus());
+        assertNotNull(jobLog.getStartTime());
+        assertNotNull(jobLog.getLastUpdated());
+        assertSame(scheduledJob, jobLog.getScheduledJob());
+    }
+
+    @Test
+    public void test_setId_preGeneratedId() {
+        final JobLog jobLog = new JobLog();
+        jobLog.setId("pre-generated-id-123");
+        assertEquals("pre-generated-id-123", jobLog.getId());
+    }
+
+    @Test
+    public void test_setId_overwriteExisting() {
+        final JobLog jobLog = new JobLog();
+        jobLog.setId("first-id");
+        assertEquals("first-id", jobLog.getId());
+
+        jobLog.setId("second-id");
+        assertEquals("second-id", jobLog.getId());
+    }
+
+    @Test
+    public void test_setId_withUuidFormat() {
+        final JobLog jobLog = new JobLog();
+        final String uuidNoHyphens = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
+        jobLog.setId(uuidNoHyphens);
+        assertEquals(uuidNoHyphens, jobLog.getId());
+    }
+
+    @Test
+    public void test_versionNo() {
+        final JobLog jobLog = new JobLog();
+        jobLog.setVersionNo(5L);
+        assertEquals(Long.valueOf(5L), jobLog.getVersionNo());
+    }
+
+    @Test
+    public void test_toString_containsFields() {
+        final ScheduledJob scheduledJob = createTestScheduledJob();
+        final JobLog jobLog = new JobLog(scheduledJob);
+
+        final String str = jobLog.toString();
+        assertTrue(str.contains("Test Job"));
+        assertTrue(str.contains(Constants.RUNNING));
+    }
+
+    private ScheduledJob createTestScheduledJob() {
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setName("Test Job");
+        scheduledJob.setScriptType("groovy");
+        scheduledJob.setScriptData("println 'hello'");
+        scheduledJob.setJobLogging(Constants.T);
+        scheduledJob.setAvailable(Constants.T);
+        scheduledJob.setCrawler(Constants.F);
+        scheduledJob.setTarget("all");
+        return scheduledJob;
+    }
+}

--- a/src/test/java/org/codelibs/fess/opensearch/config/exentity/ScheduledJobTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/config/exentity/ScheduledJobTest.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.opensearch.config.exentity;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.exception.JobNotFoundException;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.lastaflute.job.JobManager;
+import org.lastaflute.job.LaScheduledJob;
+import org.lastaflute.job.key.LaJobUnique;
+import org.lastaflute.job.subsidiary.LaunchNowOpCall;
+import org.lastaflute.job.subsidiary.LaunchNowOption;
+import org.lastaflute.job.subsidiary.LaunchedProcess;
+
+public class ScheduledJobTest extends UnitFessTestCase {
+
+    @Override
+    protected void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+    }
+
+    @Override
+    protected void tearDown(TestInfo testInfo) throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown(testInfo);
+    }
+
+    // ===================================================================================
+    //                                                                       Entity State
+    //                                                                       =============
+
+    @Test
+    public void test_isLoggingEnabled_true() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setJobLogging(Constants.T);
+        assertTrue(job.isLoggingEnabled());
+    }
+
+    @Test
+    public void test_isLoggingEnabled_false() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setJobLogging(Constants.F);
+        assertFalse(job.isLoggingEnabled());
+    }
+
+    @Test
+    public void test_isLoggingEnabled_null() {
+        final ScheduledJob job = new ScheduledJob();
+        assertFalse(job.isLoggingEnabled());
+    }
+
+    @Test
+    public void test_isEnabled_true() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setAvailable(Constants.T);
+        assertTrue(job.isEnabled());
+    }
+
+    @Test
+    public void test_isEnabled_false() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setAvailable(Constants.F);
+        assertFalse(job.isEnabled());
+    }
+
+    @Test
+    public void test_isCrawlerJob_true() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setCrawler(Constants.T);
+        assertTrue(job.isCrawlerJob());
+    }
+
+    @Test
+    public void test_isCrawlerJob_false() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setCrawler(Constants.F);
+        assertFalse(job.isCrawlerJob());
+    }
+
+    @Test
+    public void test_getScriptType_default() {
+        final ScheduledJob job = new ScheduledJob();
+        assertEquals("groovy", job.getScriptType());
+    }
+
+    @Test
+    public void test_getScriptType_custom() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setScriptType("python");
+        assertEquals("python", job.getScriptType());
+    }
+
+    @Test
+    public void test_idGetterSetter() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setId("test-id-123");
+        assertEquals("test-id-123", job.getId());
+    }
+
+    // ===================================================================================
+    //                                                                    start(Map) Tests
+    //                                                                    ================
+
+    @Test
+    public void test_startWithParams_passesParamsToLaunchNow() {
+        final AtomicReference<LaunchNowOption> capturedOption = new AtomicReference<>();
+        final AtomicBoolean launchNowCalled = new AtomicBoolean(false);
+
+        final LaScheduledJob mockLaJob = createMockLaScheduledJob(opCall -> {
+            final LaunchNowOption option = new LaunchNowOption();
+            opCall.callback(option);
+            capturedOption.set(option);
+            launchNowCalled.set(true);
+            return null;
+        });
+
+        final JobManager mockJobManager = createMockJobManager("job-1", mockLaJob);
+        ComponentUtil.register(mockJobManager, JobManager.class.getCanonicalName());
+
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setId("job-1");
+
+        final Map<String, Object> params = new HashMap<>();
+        params.put(Constants.JOB_LOG_ID, "test-log-id-abc");
+        scheduledJob.start(params);
+
+        assertTrue(launchNowCalled.get());
+        assertNotNull(capturedOption.get());
+        assertEquals("test-log-id-abc", capturedOption.get().getParameterMap().get(Constants.JOB_LOG_ID));
+    }
+
+    @Test
+    public void test_startWithEmptyParams_callsLaunchNowWithoutParams() {
+        final AtomicBoolean launchNowNoArgCalled = new AtomicBoolean(false);
+
+        final LaScheduledJob mockLaJob = createMockLaScheduledJob(null);
+        // Override the no-arg launchNow behavior
+        final LaScheduledJob wrappedJob = new DelegatingLaScheduledJob(mockLaJob) {
+            @Override
+            public LaunchedProcess launchNow() {
+                launchNowNoArgCalled.set(true);
+                return null;
+            }
+        };
+
+        final JobManager mockJobManager = createMockJobManager("job-2", wrappedJob);
+        ComponentUtil.register(mockJobManager, JobManager.class.getCanonicalName());
+
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setId("job-2");
+        scheduledJob.start(Collections.emptyMap());
+
+        assertTrue(launchNowNoArgCalled.get());
+    }
+
+    @Test
+    public void test_startWithNullParams_callsLaunchNowWithoutParams() {
+        final AtomicBoolean launchNowNoArgCalled = new AtomicBoolean(false);
+
+        final LaScheduledJob mockLaJob = new DelegatingLaScheduledJob(createMockLaScheduledJob(null)) {
+            @Override
+            public LaunchedProcess launchNow() {
+                launchNowNoArgCalled.set(true);
+                return null;
+            }
+        };
+
+        final JobManager mockJobManager = createMockJobManager("job-3", mockLaJob);
+        ComponentUtil.register(mockJobManager, JobManager.class.getCanonicalName());
+
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setId("job-3");
+        scheduledJob.start(null);
+
+        assertTrue(launchNowNoArgCalled.get());
+    }
+
+    @Test
+    public void test_startWithParams_jobNotFound_throwsException() {
+        final JobManager mockJobManager = createMockJobManager("other-id", null);
+        ComponentUtil.register(mockJobManager, JobManager.class.getCanonicalName());
+
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setId("nonexistent-job");
+
+        try {
+            scheduledJob.start(Map.of(Constants.JOB_LOG_ID, "some-id"));
+            fail("Expected JobNotFoundException");
+        } catch (final JobNotFoundException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void test_startNoArg_callsLaunchNowWithoutParams() {
+        final AtomicBoolean launchNowNoArgCalled = new AtomicBoolean(false);
+
+        final LaScheduledJob mockLaJob = new DelegatingLaScheduledJob(createMockLaScheduledJob(null)) {
+            @Override
+            public LaunchedProcess launchNow() {
+                launchNowNoArgCalled.set(true);
+                return null;
+            }
+        };
+
+        final JobManager mockJobManager = createMockJobManager("job-4", mockLaJob);
+        ComponentUtil.register(mockJobManager, JobManager.class.getCanonicalName());
+
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setId("job-4");
+        scheduledJob.start();
+
+        assertTrue(launchNowNoArgCalled.get());
+    }
+
+    @Test
+    public void test_startWithMultipleParams() {
+        final AtomicReference<LaunchNowOption> capturedOption = new AtomicReference<>();
+
+        final LaScheduledJob mockLaJob = createMockLaScheduledJob(opCall -> {
+            final LaunchNowOption option = new LaunchNowOption();
+            opCall.callback(option);
+            capturedOption.set(option);
+            return null;
+        });
+
+        final JobManager mockJobManager = createMockJobManager("job-5", mockLaJob);
+        ComponentUtil.register(mockJobManager, JobManager.class.getCanonicalName());
+
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setId("job-5");
+
+        final Map<String, Object> params = new HashMap<>();
+        params.put(Constants.JOB_LOG_ID, "log-id-xyz");
+        params.put("customKey", "customValue");
+        scheduledJob.start(params);
+
+        assertNotNull(capturedOption.get());
+        final Map<String, Object> paramMap = capturedOption.get().getParameterMap();
+        assertEquals("log-id-xyz", paramMap.get(Constants.JOB_LOG_ID));
+        assertEquals("customValue", paramMap.get("customKey"));
+    }
+
+    // ===================================================================================
+    //                                                                       Helper Methods
+    //                                                                       ==============
+
+    @FunctionalInterface
+    private interface LaunchNowCallback {
+        LaunchedProcess call(LaunchNowOpCall opCall);
+    }
+
+    private LaScheduledJob createMockLaScheduledJob(final LaunchNowCallback launchNowWithParamsCallback) {
+        return new DelegatingLaScheduledJob(null) {
+            @Override
+            public LaunchedProcess launchNow() {
+                return null;
+            }
+
+            @Override
+            public LaunchedProcess launchNow(final LaunchNowOpCall opLambda) {
+                if (launchNowWithParamsCallback != null) {
+                    return launchNowWithParamsCallback.call(opLambda);
+                }
+                return null;
+            }
+        };
+    }
+
+    private JobManager createMockJobManager(final String expectedJobId, final LaScheduledJob laScheduledJob) {
+        return new JobManager() {
+            @Override
+            public OptionalThing<LaScheduledJob> findJobByUniqueOf(final LaJobUnique jobUnique) {
+                if (expectedJobId.equals(jobUnique.value()) && laScheduledJob != null) {
+                    return OptionalThing.of(laScheduledJob);
+                }
+                return OptionalThing.ofNullable(null, () -> {
+                    throw new IllegalStateException("Job not found: " + jobUnique);
+                });
+            }
+
+            @Override
+            public OptionalThing<LaScheduledJob> findJobByKey(final org.lastaflute.job.key.LaJobKey jobKey) {
+                return OptionalThing.empty();
+            }
+
+            @Override
+            public boolean isSchedulingDone() {
+                return true;
+            }
+
+            @Override
+            public void schedule(final org.lastaflute.job.subsidiary.CronConsumer cron) {
+            }
+
+            @Override
+            public java.util.List<LaScheduledJob> getJobList() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public java.util.List<org.lastaflute.job.LaJobHistory> searchJobHistoryList() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public void reboot() {
+            }
+
+            @Override
+            public void destroy() {
+            }
+        };
+    }
+
+    private abstract static class DelegatingLaScheduledJob implements LaScheduledJob {
+        protected final LaScheduledJob delegate;
+
+        DelegatingLaScheduledJob(final LaScheduledJob delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public LaunchedProcess launchNow() {
+            return delegate != null ? delegate.launchNow() : null;
+        }
+
+        @Override
+        public LaunchedProcess launchNow(final LaunchNowOpCall opLambda) {
+            return delegate != null ? delegate.launchNow(opLambda) : null;
+        }
+
+        @Override
+        public void stopNow() {
+        }
+
+        @Override
+        public void reschedule(final String cronExp, final org.lastaflute.job.subsidiary.VaryingCronOpCall opLambda) {
+        }
+
+        @Override
+        public void unschedule() {
+        }
+
+        @Override
+        public void disappear() {
+        }
+
+        @Override
+        public void becomeNonCron() {
+        }
+
+        @Override
+        public void registerNext(final org.lastaflute.job.key.LaJobKey triggeredJob) {
+        }
+
+        @Override
+        public org.lastaflute.job.key.LaJobKey getJobKey() {
+            return null;
+        }
+
+        @Override
+        public OptionalThing<org.lastaflute.job.key.LaJobNote> getJobNote() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public OptionalThing<LaJobUnique> getJobUnique() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public OptionalThing<String> getCronExp() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public Class<? extends org.lastaflute.job.LaJob> getJobType() {
+            return null;
+        }
+
+        @Override
+        public OptionalThing<org.lastaflute.job.subsidiary.CronParamsSupplier> getParamsSupplier() {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public org.lastaflute.job.log.JobNoticeLogLevel getNoticeLogLevel() {
+            return org.lastaflute.job.log.JobNoticeLogLevel.INFO;
+        }
+
+        @Override
+        public org.lastaflute.job.subsidiary.JobConcurrentExec getConcurrentExec() {
+            return null;
+        }
+
+        @Override
+        public boolean isOutlawParallelGranted() {
+            return false;
+        }
+
+        @Override
+        public boolean isUnscheduled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDisappeared() {
+            return false;
+        }
+
+        @Override
+        public boolean isNonCron() {
+            return false;
+        }
+
+        @Override
+        public boolean isExecutingNow() {
+            return false;
+        }
+
+        @Override
+        public <RESULT> OptionalThing<RESULT> mapExecutingNow(
+                final java.util.function.Function<org.lastaflute.job.subsidiary.SnapshotExecState, RESULT> oneArgLambda) {
+            return OptionalThing.empty();
+        }
+
+        @Override
+        public org.dbflute.optional.OptionalThingIfPresentAfter ifExecutingNow(
+                final java.util.function.Consumer<org.lastaflute.job.subsidiary.SnapshotExecState> oneArgLambda) {
+            return processor -> processor.process();
+        }
+
+        @Override
+        public java.util.Set<org.lastaflute.job.key.LaJobKey> getTriggeredJobKeySet() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public java.util.List<org.lastaflute.job.subsidiary.NeighborConcurrentGroup> getNeighborConcurrentGroupList() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public java.util.Map<String, org.lastaflute.job.subsidiary.NeighborConcurrentGroup> getNeighborConcurrentGroupMap() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public String toIdentityDisp() {
+            return "MockJob";
+        }
+
+        @Override
+        public org.lastaflute.job.subsidiary.JobExecutingSnapshot takeSnapshotNow() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements [#1433](https://github.com/codelibs/fess/issues/1433): The scheduler start API (`PUT /api/admin/scheduler/{id}/start`) now returns the associated job log ID in the response, allowing clients to programmatically track job execution without parsing `scriptData`.

## Changes Made

- **Constants.java**: Added `JOB_LOG_ID` constant for the parameter key
- **ScheduledJob.java**: Added `start(Map<String, Object> params)` overload that passes parameters to LastaFlute's `launchNow()` via `LaunchNowOption.param()`
- **ScriptExecutorJob.java**: Reads `JOB_LOG_ID` from `runtime.getParameterMap()` and sets it on the `JobLog` before persisting to OpenSearch
- **ApiResult.java**: Added `ApiStartJobResponse` inner class with `jobLogId` field
- **ApiAdminSchedulerAction.java**: Generates a UUID when job logging is enabled, passes it to `entity.start(Map)`, and returns it in `ApiStartJobResponse`

### Response format

When logging is enabled:
```json
{"response": {"version": "14.x", "status": 0, "jobLogId": "a1b2c3d4e5f6..."}}
```

When logging is disabled:
```json
{"response": {"version": "14.x", "status": 0, "jobLogId": null}}
```

## Testing

- **ApiAdminSchedulerActionTest** (2 tests): Calls real `put$start()` with injected mock service, verifies `jobLogId` is non-null (32-char hex) when logging enabled, and null when disabled
- **ScriptExecutorJobTest** (4 tests): Calls real `process()` via `MockJobRuntime`, verifies pre-generated ID is set on `JobLog` when present, null when absent, and not stored when logging disabled
- **ApiResultTest** (10 tests): Verifies `ApiStartJobResponse` DTO construction, fluent API, and `Status` enum
- **JobLogTest** (7 tests): Verifies entity construction, ID pre-setting, and UUID format
- **ScheduledJobTest** (16 tests): Verifies entity state methods and `start(Map)` parameter passing via `launchNow`

## Breaking Changes

None. The existing `start()` no-arg method is unchanged (used by Admin UI and Wizard). The API response adds a new field (`jobLogId`) which is additive.

## Additional Notes

- The job log ID is a 32-character hex UUID (no dashes), consistent with OpenSearch document ID format
- `launchNow()` is asynchronous, so the job log may not exist immediately after the API returns. The ID is pre-generated and guaranteed to be used when the job executes.
- Backward compatible: existing API consumers will simply see the new `jobLogId` field in the response