### PR TITLE
fix(crawler): use SitemapsRule for sitemap content validation

### DIFF
--- a/src/main/resources/crawler/rule.xml
+++ b/src/main/resources/crawler/rule.xml
@@ -23,7 +23,7 @@
 		</postConstruct>
 	</component>
 
-	<component name="sitemapsRule" class="org.codelibs.fess.crawler.rule.impl.RegexRule" >
+	<component name="sitemapsRule" class="org.codelibs.fess.crawler.rule.impl.SitemapsRule" >
 		<property name="ruleId">"sitemapsRule"</property>
 		<property name="responseProcessor">
 			<component class="org.codelibs.fess.crawler.processor.impl.SitemapsResponseProcessor">


### PR DESCRIPTION
## Summary
Switch the `sitemapsRule` component from `RegexRule` to `SitemapsRule` to enable content-based sitemap validation in addition to URL pattern matching.

## Changes Made
- Changed `sitemapsRule` class in `crawler/rule.xml` from `RegexRule` to `SitemapsRule`
- `SitemapsRule` extends `RegexRule` and adds content validation via `SitemapsHelper.isValid()`, ensuring that only actual sitemap content is processed as sitemaps

## Testing
- `SitemapsRule` is an existing class in fess-crawler that has its own test coverage
- Previously, any URL matching the sitemap pattern (e.g., `sitemap-generator.xml`) would be treated as a sitemap regardless of content

## Additional Notes
- Companion PR: codelibs/fess-crawler#154 (sitemaps protocol compliance improvements)