### PR TITLE
Fix RankFusionProcessor boundary bugs and improve robustness

### DIFF
--- a/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
@@ -178,6 +178,9 @@ public class RankFusionProcessor implements AutoCloseable {
     public List<Map<String, Object>> search(final String query, final SearchRequestParams params,
             final OptionalThing<FessUserBean> userBean) {
         final RankFusionSearcher[] availableSearchers = getAvailableSearchers();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Searching with {} available searchers for query={}", availableSearchers.length, query);
+        }
         if (availableSearchers.length == 0) {
             logger.warn("No searchers available for query: {}", query);
             return createResponseList(Collections.emptyList(), 0, Relation.EQUAL_TO.toString(), 0, false, null, params.getStartPosition(),
@@ -235,6 +238,10 @@ public class RankFusionProcessor implements AutoCloseable {
         final int pageSize = params.getPageSize();
         final int startPosition = params.getStartPosition();
         if (startPosition * 2 >= windowSize) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Deep pagination detected: startPosition={}, windowSize={}, falling back to main searcher", startPosition,
+                        windowSize);
+            }
             int offset = params.getOffset();
             if (offset < 0) {
                 offset = 0;
@@ -264,15 +271,9 @@ public class RankFusionProcessor implements AutoCloseable {
         final OptionalThing<HttpServletResponse> responseOpt = LaResponseUtil.getOptionalResponse();
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final int rankConstant = fessConfig.getRankFusionRankConstantAsInteger();
-        // Guard against division by zero (should not happen due to caller checks, but defensive)
-        if (searchers.length == 0) {
-            logger.warn("searchWithMultipleSearchers called with empty searcher array");
-            return createResponseList(Collections.emptyList(), 0, Relation.EQUAL_TO.toString(), 0, false, null, params.getStartPosition(),
-                    params.getPageSize(), 0);
-        }
         final int size = windowSize / searchers.length;
         if (logger.isDebugEnabled()) {
-            logger.debug("Search parameters: windowSize={}, rankConstant={}", size, rankConstant);
+            logger.debug("Search parameters: windowSize={}, sizePerSearcher={}, rankConstant={}", windowSize, size, rankConstant);
         }
         final List<Future<SearchResult>> resultList = new ArrayList<>();
         for (int i = 0; i < searchers.length; i++) {
@@ -368,6 +369,11 @@ public class RankFusionProcessor implements AutoCloseable {
         }
         if (logger.isDebugEnabled()) {
             logger.debug("Calculated offset: {}, total fused documents: {}", offset, fusedDocs.size());
+            final int logLimit = Math.min(10, fusedDocs.size());
+            for (int i = 0; i < logLimit; i++) {
+                final Map<String, Object> doc = fusedDocs.get(i);
+                logger.debug("Fused rank[{}]: id={}, score={}", i, doc.get(idField), doc.get(scoreField));
+            }
         }
         final SearchResult mainResult = results[0];
         long allRecordCount = mainResult.getAllRecordCount();
@@ -389,13 +395,10 @@ public class RankFusionProcessor implements AutoCloseable {
      */
     protected List<Map<String, Object>> extractList(final List<Map<String, Object>> docs, final int pageSize, final int startPosition) {
         final int size = docs.size();
-        if (size == 0) {
-            return docs; // empty
+        if (size == 0 || startPosition >= size) {
+            return Collections.emptyList();
         }
         int fromIndex = startPosition;
-        if (fromIndex >= size) {
-            fromIndex = size - 1;
-        }
         int toIndex = startPosition + pageSize;
         if (toIndex >= size) {
             toIndex = size;
@@ -464,11 +467,18 @@ public class RankFusionProcessor implements AutoCloseable {
      * @return float representation of the value, or 0.0f if conversion fails
      */
     protected float toFloat(final Object value) {
-        if (value instanceof final Float f) {
-            return f;
+        if (value instanceof final Number n) {
+            return n.floatValue();
         }
         if (value instanceof final String s) {
-            return Float.parseFloat(s);
+            try {
+                return Float.parseFloat(s);
+            } catch (final NumberFormatException e) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Failed to parse float value: {}", s);
+                }
+                return 0.0f;
+            }
         }
         return 0.0f;
     }
@@ -639,7 +649,7 @@ public class RankFusionProcessor implements AutoCloseable {
      */
     public void register(final RankFusionSearcher searcher) {
         if (logger.isDebugEnabled()) {
-            logger.debug("Registering searcher: {}", searcher.getClass().getSimpleName());
+            logger.debug("Registering searcher: class={}, name={}", searcher.getClass().getSimpleName(), searcher.getName());
         }
         searchers.add(searcher);
         synchronized (this) {

--- a/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
@@ -271,6 +271,11 @@ public class RankFusionProcessor implements AutoCloseable {
         final OptionalThing<HttpServletResponse> responseOpt = LaResponseUtil.getOptionalResponse();
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final int rankConstant = fessConfig.getRankFusionRankConstantAsInteger();
+        if (searchers.length == 0) {
+            logger.warn("searchWithMultipleSearchers called with empty searcher array");
+            return createResponseList(Collections.emptyList(), 0, Relation.EQUAL_TO.toString(), 0, false, null, params.getStartPosition(),
+                    params.getPageSize(), 0);
+        }
         final int size = windowSize / searchers.length;
         if (logger.isDebugEnabled()) {
             logger.debug("Search parameters: windowSize={}, sizePerSearcher={}, rankConstant={}", windowSize, size, rankConstant);
@@ -398,8 +403,8 @@ public class RankFusionProcessor implements AutoCloseable {
         if (size == 0 || startPosition >= size) {
             return Collections.emptyList();
         }
-        int fromIndex = startPosition;
-        int toIndex = startPosition + pageSize;
+        int fromIndex = Math.max(0, startPosition);
+        int toIndex = fromIndex + pageSize;
         if (toIndex >= size) {
             toIndex = size;
         }

--- a/src/test/java/org/codelibs/fess/helper/ProcessHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ProcessHelperTest.java
@@ -88,7 +88,9 @@ public class ProcessHelperTest extends UnitFessTestCase {
     @Test
     public void test_startProcess_basicCommand() {
         String sessionId = "test_session";
-        List<String> cmdList = Arrays.asList("echo", "hello");
+        // Use "sleep 10" instead of "echo hello" to keep the process alive long enough
+        // to verify isProcessRunning(). The process is destroyed immediately after assertions.
+        List<String> cmdList = Arrays.asList("sleep", "10");
         Consumer<ProcessBuilder> pbCall = pb -> {
             pb.redirectErrorStream(true);
         };
@@ -101,9 +103,6 @@ public class ProcessHelperTest extends UnitFessTestCase {
 
             Set<String> sessionIds = processHelper.getRunningSessionIdSet();
             assertTrue(sessionIds.contains(sessionId));
-
-            // Wait a bit for the process to complete
-            Thread.sleep(100);
 
             // Clean up
             processHelper.destroyProcess(sessionId);
@@ -264,26 +263,20 @@ public class ProcessHelperTest extends UnitFessTestCase {
     public void test_destroy_allProcesses() {
         String sessionId1 = "test_destroy_all1";
         String sessionId2 = "test_destroy_all2";
-        List<String> cmdList = Arrays.asList("echo", "hello");
+        // Use "sleep 10" to keep processes alive for verification; destroyed immediately after.
+        List<String> cmdList = Arrays.asList("sleep", "10");
         Consumer<ProcessBuilder> pbCall = pb -> {
             pb.redirectErrorStream(true);
         };
 
         try {
-            // Start multiple processes
             processHelper.startProcess(sessionId1, cmdList, pbCall);
             processHelper.startProcess(sessionId2, cmdList, pbCall);
 
             assertTrue(processHelper.isProcessRunning());
 
-            // Wait a bit for the processes to start
-            Thread.sleep(50);
-
             // Destroy all processes
             processHelper.destroy();
-
-            // Wait a bit for destruction to complete
-            Thread.sleep(100);
 
             assertFalse(processHelper.isProcessRunning());
         } catch (Exception e) {
@@ -409,22 +402,23 @@ public class ProcessHelperTest extends UnitFessTestCase {
     @Test
     public void test_processHelper_synchronization() {
         String sessionId = "test_sync";
-        List<String> cmdList = Arrays.asList("echo", "hello");
+        // Use "sleep 10" to keep processes alive for synchronization verification.
+        List<String> cmdList = Arrays.asList("sleep", "10");
         Consumer<ProcessBuilder> pbCall = pb -> {
             pb.redirectErrorStream(true);
         };
 
         try {
-            // Test that multiple calls to startProcess with same sessionId work correctly
+            // Start two processes with the same session ID (second should replace first)
             JobProcess jobProcess1 = processHelper.startProcess(sessionId, cmdList, pbCall);
             JobProcess jobProcess2 = processHelper.startProcess(sessionId, cmdList, pbCall);
 
             assertNotNull(jobProcess1);
             assertNotNull(jobProcess2);
 
-            // Only one process should be running for the session
             assertTrue(processHelper.isProcessRunning(sessionId));
 
+            // Only one process should be registered for the session
             Set<String> sessionIds = processHelper.getRunningSessionIdSet();
             assertEquals(1, sessionIds.size());
             assertTrue(sessionIds.contains(sessionId));

--- a/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorEdgeCaseTest.java
+++ b/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorEdgeCaseTest.java
@@ -280,6 +280,147 @@ public class RankFusionProcessorEdgeCaseTest extends UnitFessTestCase {
         processor.close();
     }
 
+    // ===== toFloat tests =====
+
+    @Test
+    public void test_toFloat_withFloat() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            assertEquals(1.5f, processor.toFloat(Float.valueOf(1.5f)));
+            assertEquals(0.0f, processor.toFloat(Float.valueOf(0.0f)));
+            assertEquals(-1.0f, processor.toFloat(Float.valueOf(-1.0f)));
+        }
+    }
+
+    @Test
+    public void test_toFloat_withDouble() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            assertEquals(1.5f, processor.toFloat(Double.valueOf(1.5)));
+            assertEquals(0.0f, processor.toFloat(Double.valueOf(0.0)));
+        }
+    }
+
+    @Test
+    public void test_toFloat_withInteger() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            assertEquals(1.0f, processor.toFloat(Integer.valueOf(1)));
+            assertEquals(0.0f, processor.toFloat(Integer.valueOf(0)));
+            assertEquals(42.0f, processor.toFloat(Integer.valueOf(42)));
+        }
+    }
+
+    @Test
+    public void test_toFloat_withLong() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            assertEquals(100.0f, processor.toFloat(Long.valueOf(100L)));
+        }
+    }
+
+    @Test
+    public void test_toFloat_withValidString() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            assertEquals(1.5f, processor.toFloat("1.5"));
+            assertEquals(0.0f, processor.toFloat("0.0"));
+            assertEquals(-1.0f, processor.toFloat("-1.0"));
+        }
+    }
+
+    @Test
+    public void test_toFloat_withInvalidString() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            assertEquals(0.0f, processor.toFloat("not_a_number"));
+            assertEquals(0.0f, processor.toFloat(""));
+            assertEquals(0.0f, processor.toFloat("abc123"));
+        }
+    }
+
+    @Test
+    public void test_toFloat_withNull() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            assertEquals(0.0f, processor.toFloat(null));
+        }
+    }
+
+    @Test
+    public void test_toFloat_withUnsupportedType() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            assertEquals(0.0f, processor.toFloat(Boolean.TRUE));
+            assertEquals(0.0f, processor.toFloat(new Object()));
+        }
+    }
+
+    // ===== extractList tests =====
+
+    @Test
+    public void test_extractList_emptyList() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            final List<Map<String, Object>> result = processor.extractList(List.of(), 10, 0);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    public void test_extractList_startPositionBeyondSize() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            final List<Map<String, Object>> docs = List.of(Map.of("id", "1"), Map.of("id", "2"), Map.of("id", "3"));
+            final List<Map<String, Object>> result = processor.extractList(docs, 10, 100);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    public void test_extractList_startPositionEqualsSize() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            final List<Map<String, Object>> docs = List.of(Map.of("id", "1"), Map.of("id", "2"));
+            final List<Map<String, Object>> result = processor.extractList(docs, 10, 2);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    public void test_extractList_normalPagination() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            final List<Map<String, Object>> docs =
+                    List.of(Map.of("id", "0"), Map.of("id", "1"), Map.of("id", "2"), Map.of("id", "3"), Map.of("id", "4"));
+            final List<Map<String, Object>> result = processor.extractList(docs, 2, 0);
+            assertEquals(2, result.size());
+            assertEquals("0", result.get(0).get("id"));
+            assertEquals("1", result.get(1).get("id"));
+        }
+    }
+
+    @Test
+    public void test_extractList_secondPage() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            final List<Map<String, Object>> docs =
+                    List.of(Map.of("id", "0"), Map.of("id", "1"), Map.of("id", "2"), Map.of("id", "3"), Map.of("id", "4"));
+            final List<Map<String, Object>> result = processor.extractList(docs, 2, 2);
+            assertEquals(2, result.size());
+            assertEquals("2", result.get(0).get("id"));
+            assertEquals("3", result.get(1).get("id"));
+        }
+    }
+
+    @Test
+    public void test_extractList_lastPagePartial() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            final List<Map<String, Object>> docs =
+                    List.of(Map.of("id", "0"), Map.of("id", "1"), Map.of("id", "2"), Map.of("id", "3"), Map.of("id", "4"));
+            final List<Map<String, Object>> result = processor.extractList(docs, 3, 3);
+            assertEquals(2, result.size());
+            assertEquals("3", result.get(0).get("id"));
+            assertEquals("4", result.get(1).get("id"));
+        }
+    }
+
+    @Test
+    public void test_extractList_pageSizeExceedsRemaining() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            final List<Map<String, Object>> docs = List.of(Map.of("id", "0"), Map.of("id", "1"));
+            final List<Map<String, Object>> result = processor.extractList(docs, 100, 0);
+            assertEquals(2, result.size());
+        }
+    }
+
     /**
      * Test searcher that returns configurable number of documents.
      */

--- a/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorEdgeCaseTest.java
+++ b/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorEdgeCaseTest.java
@@ -421,6 +421,16 @@ public class RankFusionProcessorEdgeCaseTest extends UnitFessTestCase {
         }
     }
 
+    @Test
+    public void test_extractList_negativeStartPosition() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            final List<Map<String, Object>> docs = List.of(Map.of("id", "0"), Map.of("id", "1"));
+            final List<Map<String, Object>> result = processor.extractList(docs, 10, -1);
+            assertEquals(2, result.size());
+            assertEquals("0", result.get(0).get("id"));
+        }
+    }
+
     /**
      * Test searcher that returns configurable number of documents.
      */


### PR DESCRIPTION
## Summary
Fixed boundary condition bugs in `extractList()` and `toFloat()`, added defensive guards, improved debug logging, and added comprehensive test coverage for edge cases.

## Key Changes

### Bug Fixes
- **`extractList()` boundary bug**: Fixed incorrect behavior when `startPosition >= size` — previously returned the last element, now correctly returns an empty list
- **`extractList()` negative startPosition**: Added guard using `Math.max(0, startPosition)` to prevent `IndexOutOfBoundsException` from negative values
- **`toFloat()` crash on invalid strings**: `Float.parseFloat()` previously threw `NumberFormatException` for non-numeric strings, crashing the search. Now catches the exception and returns `0.0f` with debug logging
- **`toFloat()` limited type support**: Only handled `Float` instances. Now handles all `Number` types (Double, Integer, Long, BigDecimal, etc.) via `Number.floatValue()`
- **Misleading log message**: Fixed debug log that printed `sizePerSearcher` as `windowSize`

### Defensive Guards
- **Retained empty searcher array guard** in `searchWithMultipleSearchers()` to prevent division by zero (`windowSize / searchers.length`). Although the current caller guarantees `length >= 2`, this `protected` method could be called by subclasses directly

### Debug Logging Improvements
Added debug logging (all gated behind `isDebugEnabled()`) for:
- Number of available searchers at search start
- Deep pagination detection with fallback behavior
- Search parameters (windowSize, sizePerSearcher, rankConstant)
- Top 10 fused documents with their IDs and scores
- Searcher registration with both class name and searcher name

### Test Coverage
Added 16 new edge case tests:
- `toFloat()`: Float, Double, Integer, Long, valid/invalid strings, null, unsupported types
- `extractList()`: empty list, pagination boundaries, partial pages, startPosition beyond size, negative startPosition