### PR TITLE
fix(search): handle invalid Base64 in similarDocHash decoding

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/DocumentHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/DocumentHelper.java
@@ -331,11 +331,12 @@ public class DocumentHelper {
      */
     public String decodeSimilarDocHash(final String hash) {
         if (hash != null && hash.startsWith(SIMILAR_DOC_HASH_PREFIX) && hash.length() > SIMILAR_DOC_HASH_PREFIX.length()) {
-            final byte[] decode = Base64.getUrlDecoder().decode(hash.substring(SIMILAR_DOC_HASH_PREFIX.length()));
-            try (BufferedReader reader =
-                    new BufferedReader(new InputStreamReader(new GZIPInputStream(new ByteArrayInputStream(decode)), Constants.UTF_8))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                    new GZIPInputStream(
+                            new ByteArrayInputStream(Base64.getUrlDecoder().decode(hash.substring(SIMILAR_DOC_HASH_PREFIX.length())))),
+                    Constants.UTF_8))) {
                 return ReaderUtil.readText(reader);
-            } catch (final IOException e) {
+            } catch (final Exception e) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Failed to decode similar document hash: hash={}", hash, e);
                 }


### PR DESCRIPTION
## Summary

Fix search failure caused by malformed `sdh` (similarDocHash) URL parameter containing invalid Base64 characters.

## Changes Made

- Moved `Base64.getUrlDecoder().decode()` inside the try-with-resources block in `DocumentHelper.decodeSimilarDocHash()`
- Broadened the catch clause from `IOException` to `Exception` to also handle `IllegalArgumentException` from invalid Base64 input
- On decode failure, the method returns the original hash value (existing behavior for other error types)

## Context

When a request includes an `sdh` parameter with illegal Base64 characters (e.g., `*`/0x2a from bots or URL manipulation), `Base64.getUrlDecoder().decode()` throws `IllegalArgumentException`. This exception was not caught, propagating up to `RankFusionProcessor.searchWithMainSearcher()` where it was silently swallowed, returning empty search results to the user.

```
WARN RankFusionProcessor - Main searcher failed to execute search for query: xml
Caused by: java.lang.IllegalArgumentException: Illegal base64 character 2a
    at DocumentHelper.decodeSimilarDocHash(DocumentHelper.java:334)
```

## Testing

- Existing `DocumentHelperTest` passes
- Manual verification: search with malformed `sdh` parameter now returns normal results instead of empty