### PR TITLE
fix(log): include exception message in CPU stats warning log

### DIFF
--- a/src/main/java/org/codelibs/fess/timer/LoadControlMonitorTarget.java
+++ b/src/main/java/org/codelibs/fess/timer/LoadControlMonitorTarget.java
@@ -70,9 +70,9 @@ public class LoadControlMonitorTarget implements TimeoutTarget {
             systemHelper.setSearchEngineCpuPercent((short) 0);
             consecutiveFailures++;
             if (consecutiveFailures <= 3) {
-                logger.warn("Failed to get search engine CPU stats.", e);
+                logger.warn("Failed to get search engine CPU stats: {}", e.getMessage(), e);
             } else if (logger.isDebugEnabled()) {
-                logger.debug("Failed to get search engine CPU stats.", e);
+                logger.debug("Failed to get search engine CPU stats: {}", e.getMessage(), e);
             }
         }
     }


### PR DESCRIPTION
## Summary
Include exception message in the `LoadControlMonitorTarget` warning log so that the root cause is visible in single-line log consumers like Slack notifications.

## Changes Made
- Modified `LoadControlMonitorTarget.expired()` to embed `e.getMessage()` in the warn/debug log format string
- Log4j2's `{}` placeholder renders the exception message inline, while the trailing `e` argument preserves the full stack trace in log files

### Before
```
[2026-04-01T13:17:49.399] WARN ...LoadControlMonitorTarget - Failed to get search engine CPU stats.
```

### After
```
[2026-04-01T13:17:49.399] WARN ...LoadControlMonitorTarget - Failed to get search engine CPU stats: request timed out after 10000ms
```

## Testing
- Verified compilation with `mvn compile`
- No logic changes; only log message formatting

## Additional Notes
- No breaking changes
- The full stack trace is still available in log files for detailed debugging