### PR TITLE
fix: migrate remaining javax references to jakarta namespace

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/MarkdownRenderer.java
+++ b/src/main/java/org/codelibs/fess/helper/MarkdownRenderer.java
@@ -17,7 +17,7 @@ package org.codelibs.fess.helper;
 
 import java.util.Arrays;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/codelibs/fess/mylasta/direction/sponsor/FessMultipartRequestHandler.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/sponsor/FessMultipartRequestHandler.java
@@ -61,7 +61,7 @@ public class FessMultipartRequestHandler implements MultipartRequestHandler {
     //                                   Temporary Directory
     //                                   -------------------
     // used as repository for requested parameters
-    protected static final String CONTEXT_TEMPDIR_KEY = "javax.servlet.context.tempdir"; // prior
+    protected static final String CONTEXT_TEMPDIR_KEY = jakarta.servlet.ServletContext.TEMPDIR; // prior
     protected static final String JAVA_IO_TMPDIR_KEY = "java.io.tmpdir"; // secondary
 
     // ===================================================================================

--- a/src/test/java/org/codelibs/fess/mylasta/direction/sponsor/FessMultipartRequestHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/sponsor/FessMultipartRequestHandlerTest.java
@@ -15,9 +15,13 @@
  */
 package org.codelibs.fess.mylasta.direction.sponsor;
 
+import java.lang.reflect.Field;
+
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import jakarta.servlet.ServletContext;
 
 public class FessMultipartRequestHandlerTest extends UnitFessTestCase {
 
@@ -31,21 +35,39 @@ public class FessMultipartRequestHandlerTest extends UnitFessTestCase {
         super.tearDown(testInfo);
     }
 
-    // Basic test to verify test framework is working
     @Test
-    public void test_basicAssertion() {
-        assertTrue(true);
-        assertFalse(false);
-        assertNotNull("test");
-        assertEquals(1, 1);
+    public void test_contextTempdirKey_equalsJakartaConstant() throws Exception {
+        final Field field = FessMultipartRequestHandler.class.getDeclaredField("CONTEXT_TEMPDIR_KEY");
+        field.setAccessible(true);
+        final String value = (String) field.get(null);
+        assertEquals(ServletContext.TEMPDIR, value);
     }
 
-    // Test placeholder for future implementation
     @Test
-    public void test_placeholder() {
-        // This test verifies the test class can be instantiated and run
-        String testValue = "test";
-        assertNotNull(testValue);
-        assertEquals("test", testValue);
+    public void test_contextTempdirKey_isJakartaNamespace() throws Exception {
+        final Field field = FessMultipartRequestHandler.class.getDeclaredField("CONTEXT_TEMPDIR_KEY");
+        field.setAccessible(true);
+        final String value = (String) field.get(null);
+        assertEquals("jakarta.servlet.context.tempdir", value);
+        assertFalse(value.startsWith("javax."));
+    }
+
+    @Test
+    public void test_jakartaServletContextTempdir_value() {
+        assertEquals("jakarta.servlet.context.tempdir", ServletContext.TEMPDIR);
+    }
+
+    @Test
+    public void test_javaIoTmpdirKey() throws Exception {
+        final Field field = FessMultipartRequestHandler.class.getDeclaredField("JAVA_IO_TMPDIR_KEY");
+        field.setAccessible(true);
+        final String value = (String) field.get(null);
+        assertEquals("java.io.tmpdir", value);
+    }
+
+    @Test
+    public void test_instantiation() {
+        final FessMultipartRequestHandler handler = new FessMultipartRequestHandler();
+        assertNotNull(handler);
     }
 }


### PR DESCRIPTION
## Summary
Migrate remaining `javax` references to `jakarta` namespace for Jakarta EE compatibility.

## Changes Made
- **MarkdownRenderer.java**: Updated import from `javax.annotation.PostConstruct` to `jakarta.annotation.PostConstruct`
- **FessMultipartRequestHandler.java**: Replaced hardcoded string `"javax.servlet.context.tempdir"` with the `jakarta.servlet.ServletContext.TEMPDIR` constant for type-safety and correctness
- **FessMultipartRequestHandlerTest.java**: Replaced placeholder tests with meaningful tests that verify the TEMPDIR constant value, namespace correctness, and fallback key

## Testing
- Unit tests validate that `CONTEXT_TEMPDIR_KEY` equals `jakarta.servlet.ServletContext.TEMPDIR`
- Tests confirm the value uses `jakarta` namespace (not `javax`)
- Tests verify `JAVA_IO_TMPDIR_KEY` fallback constant

## Breaking Changes
- None

## Additional Notes
- These were the remaining `javax` references that needed migration to `jakarta`