### PR TITLE
chore(deps): bump OpenSearch to 3.6.0 and kopf to 15.6.0

### DIFF
--- a/deps.xml
+++ b/deps.xml
@@ -6,10 +6,10 @@
 	<property name="suggest.dir" value="${basedir}/src/main/webapp/WEB-INF/env/suggest" />
 	<property name="thumbnail.dir" value="${basedir}/src/main/webapp/WEB-INF/env/thumbnail" />
 	<property name="site.dir" value="${basedir}/src/main/webapp/WEB-INF/site" />
-	<!-- property name="kopf.version" value="15.5.0" / -->
-	<!-- property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/tags/v${kopf.version}.zip" / -->
-	<property name="kopf.version" value="main" />
-	<property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/heads/${kopf.version}.zip" />
+	<property name="kopf.version" value="15.6.0" />
+	<property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/tags/v${kopf.version}.zip" />
+	<!-- property name="kopf.version" value="main" / -->
+	<!-- property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/heads/${kopf.version}.zip" / -->
 
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />

--- a/module.xml
+++ b/module.xml
@@ -6,7 +6,7 @@
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://maven.codelibs.org" />
-	<property name="opensearch.version" value="3.5.0" />
+	<property name="opensearch.version" value="3.6.0" />
 
 	<target name="install.modules">
 		<mkdir dir="${target.dir}" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,8 +17,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-extension" />
-			<param name="plugin.version" value="3.5.0" />
-			<param name="plugin.zip.version" value="3.5.0" />
+			<param name="plugin.version" value="3.6.0" />
+			<param name="plugin.zip.version" value="3.6.0" />
 		</antcall>
 		<!-- analysis-fess -->
 		<antcall target="install.plugin">
@@ -26,8 +26,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-fess" />
-			<param name="plugin.version" value="3.5.0" />
-			<param name="plugin.zip.version" value="3.5.0" />
+			<param name="plugin.version" value="3.6.0" />
+			<param name="plugin.zip.version" value="3.6.0" />
 		</antcall>
 		<!-- configsync -->
 		<antcall target="install.plugin">
@@ -35,8 +35,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="configsync" />
-			<param name="plugin.version" value="3.5.0" />
-			<param name="plugin.zip.version" value="3.5.0" />
+			<param name="plugin.version" value="3.6.0" />
+			<param name="plugin.zip.version" value="3.6.0" />
 		</antcall>
 		<!-- minhash -->
 		<antcall target="install.plugin">
@@ -44,8 +44,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="minhash" />
-			<param name="plugin.version" value="3.5.0" />
-			<param name="plugin.zip.version" value="3.5.0" />
+			<param name="plugin.version" value="3.6.0" />
+			<param name="plugin.zip.version" value="3.6.0" />
 		</antcall>
 
 		<antcall target="remove.jars" />

--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -173,7 +173,7 @@ public class SystemHelper {
             logger.debug("Initializing {}", this.getClass().getSimpleName());
         }
         final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        cal.set(2027, 8 - 1, 1); // EOL Date
+        cal.set(2027, 10 - 1, 1); // EOL Date
         eolTime = cal.getTimeInMillis();
         if (isEoled()) {
             logger.error("Your system is out of support. See https://fess.codelibs.org/eol.html");


### PR DESCRIPTION
## Summary
- Upgrade OpenSearch plugins from 3.5.0 to 3.6.0
- Switch fess-kopf from `main` branch to tagged release `15.6.0`
- Extend EOL date from 2027-08-01 to 2027-10-01

## Changes Made
- **module.xml**: Update `opensearch.version` from `3.5.0` to `3.6.0`
- **plugin.xml**: Update version for `analysis-extension`, `analysis-fess`, `configsync`, and `minhash` plugins from `3.5.0` to `3.6.0`
- **deps.xml**: Switch kopf from `main` branch (`refs/heads/`) to tagged release `v15.6.0` (`refs/tags/`)
- **SystemHelper.java**: Extend EOL date from August 2027 to October 2027

## Testing
- Verify OpenSearch plugins download correctly with `mvn antrun:run`
- Confirm application starts successfully with updated dependencies

## Breaking Changes
- None

## Additional Notes
- This aligns the project with OpenSearch 3.6.0 release
- Kopf is now pinned to a stable tag instead of tracking the main branch