### PR TITLE
chore(deps): bump fess-parent version to 15.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.6.0-SNAPSHOT</version>
+		<version>15.6.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary
Bump fess-parent version from 15.6.0-SNAPSHOT to 15.6.0 for release.

## Changes Made
- Updated `fess-parent` version in `pom.xml` from `15.6.0-SNAPSHOT` to `15.6.0`

## Testing
- Build verification with `mvn package`

## Breaking Changes
- None

## Additional Notes
- Standard version bump to remove SNAPSHOT suffix for release