### PR TITLE
fix(build): register custom Log4j2 plugins via annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,15 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-core</artifactId>
+							<version>${log4j.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
## Summary
Eliminate the Log4j2 startup WARN caused by Fess custom plugins not being registered in `Log4j2Plugins.dat`.

## Changes Made
- `pom.xml`: Add `annotationProcessorPaths` entry for `org.apache.logging.log4j:log4j-core` to `maven-compiler-plugin` configuration so that the Log4j `PluginProcessor` runs during compilation.
- As a result, `META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat` now includes:
  - `org.codelibs.fess.util.ErrorToWarnRewritePolicy`
  - `org.codelibs.fess.util.LogNotificationAppender`

## Background
Fess emitted the following WARN at every startup:

```
main WARN Some custom `Core` Log4j plugins are not properly registered:
    org.codelibs.fess.util.ErrorToWarnRewritePolicy
    org.codelibs.fess.util.LogNotificationAppender
```

Log4j 2.24+ expects custom `@Plugin` classes to be listed in the compile-time-generated `Log4j2Plugins.dat`. Because `maven-compiler-plugin` had no `annotationProcessorPaths` configured, the `PluginProcessor` never ran and Log4j fell back to classpath scanning, which is slower and produces this warning.

## Testing
- `mvn clean compile -DskipTests` completes successfully.
- Verified both plugin class names are present in `target/classes/META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat`.
- Expected: the `Some custom Core Log4j plugins are not properly registered` WARN no longer appears on startup.

## Breaking Changes
None.

## Additional Notes
- Scope intentionally limited to `fess` since no other repository defines Log4j2 `@Plugin` classes today. If a sibling repo adds one later, the same configuration should be applied there (or lifted into `fess-parent`).
- Migrating to the new Log4j 2.24+ `org.apache.logging.log4j.plugins.Plugin` API is out of scope.