### PR TITLE
refactor(llm): downgrade LLM lifecycle logs from INFO to DEBUG

### DIFF
--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -145,8 +145,10 @@ public abstract class AbstractLlmClient implements LlmClient {
         if (logger.isDebugEnabled()) {
             logger.debug("Initialized {} with timeout: {}ms", getClass().getSimpleName(), timeout);
         }
-        logger.info("[LLM] {} initialized. model={}, timeout={}ms, maxConcurrent={}", getName(), getModel(), getTimeout(),
-                getMaxConcurrentRequests());
+        if (logger.isDebugEnabled()) {
+            logger.debug("[LLM] {} initialized. model={}, timeout={}ms, maxConcurrent={}", getName(), getModel(), getTimeout(),
+                    getMaxConcurrentRequests());
+        }
 
         concurrencyLimiter = new Semaphore(getMaxConcurrentRequests());
 
@@ -157,7 +159,9 @@ public abstract class AbstractLlmClient implements LlmClient {
      * Cleans up resources.
      */
     public void destroy() {
-        logger.info("[LLM] {} shutting down.", getName());
+        if (logger.isDebugEnabled()) {
+            logger.debug("[LLM] {} shutting down.", getName());
+        }
         if (availabilityCheckTask != null && !availabilityCheckTask.isCanceled()) {
             availabilityCheckTask.cancel();
             if (logger.isDebugEnabled()) {
@@ -211,7 +215,7 @@ public abstract class AbstractLlmClient implements LlmClient {
         cachedAvailability = currentState;
 
         if (previousState != currentState) {
-            logger.info("{} availability changed: {} -> {}", getName(), previousState, currentState);
+            logger.debug("{} availability changed: {} -> {}", getName(), previousState, currentState);
         } else if (logger.isDebugEnabled()) {
             logger.debug("{} availability check completed. available={}", getName(), currentState);
         }

--- a/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
+++ b/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
@@ -134,8 +134,8 @@ public class LlmClientManager {
      * @param client The LLM client to register
      */
     public void register(final LlmClient client) {
-        if (logger.isInfoEnabled()) {
-            logger.info("Loaded LlmClient: {}", client.getClass().getSimpleName());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Loaded LlmClient: {}", client.getClass().getSimpleName());
         }
         clientList.add(client);
     }


### PR DESCRIPTION
## Summary
Reduce log noise by downgrading LLM lifecycle log messages from INFO to DEBUG level.

## Changes Made
- `AbstractLlmClient`: Changed initialization, shutdown, and availability change logs from `logger.info` to `logger.debug` with appropriate guard checks
- `LlmClientManager`: Changed client registration log from `logger.info` to `logger.debug`

## Testing
- Existing unit tests cover functionality; log level changes do not affect behavior

## Breaking Changes
- None

## Additional Notes
- LLM lifecycle messages (init, shutdown, registration, availability changes) are operational details that are useful during debugging but add noise at INFO level in production