### PR TITLE
fix(log): add EcsLayout to LlmFile appender for Docker JSON logging

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -69,7 +69,7 @@
 		</RollingFile>
 		<RollingFile name="LlmFile" fileName="${log.file.basedir}/fess-llm.log"
 			filePattern="${log.file.basedir}/fess-llm${backup.date.suffix}-%i.log.gz">
-			<PatternLayout><Pattern>${log.pattern}</Pattern></PatternLayout>
+			<PatternLayout><Pattern>${log.pattern}</Pattern></PatternLayout><!-- <EcsLayout serviceName="fess" eventDataset="app" /> -->
 			<Policies>
 				<TimeBasedTriggeringPolicy />
 				<SizeBasedTriggeringPolicy size="100 MB" />


### PR DESCRIPTION
## Summary
Add the commented-out EcsLayout to the LlmFile appender in log4j2.xml so that Docker environments produce consistent JSON (ECS) formatted logs across all log files.

## Changes Made
- Added `<!-- <EcsLayout serviceName="fess" eventDataset="app" /> -->` to the LlmFile appender in `src/main/resources/log4j2.xml`
- Matches the existing pattern used by AppFile, crawler, suggest, and thumbnail appenders

## Context
In Docker environments, the Dockerfile runs a `sed` command that uncomments `<EcsLayout ... />` entries in all log4j2.xml files to enable JSON (ECS) format logging. The `run.sh` entrypoint then uses `tail -qF` to stream all log files to stdout.

The LlmFile appender was missing this commented-out EcsLayout, so `fess-llm.log` (which includes ChatApiManager and other LLM-related logs) remained in plain text format (`%d [%t] %-5p %msg%n`) while all other log files output JSON. This caused inconsistent log formats in `docker logs` output.

## Testing
- Non-Docker: No impact — EcsLayout remains commented out, PatternLayout is used as before
- Docker: The Dockerfile's sed processing will now also activate EcsLayout for fess-llm.log, producing consistent JSON output