### PR TITLE
fix(log): remove deprecated packages attribute from log4j2 config

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.codelibs.fess.util">
+<Configuration status="WARN">
 
 	<Properties>
 		<Property name="domain.name" value="${sys:fess.log.name:-fess}" />

--- a/src/main/webapp/WEB-INF/env/crawler/resources/log4j2.xml
+++ b/src/main/webapp/WEB-INF/env/crawler/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.codelibs.fess.util">
+<Configuration status="WARN">
 
 	<Properties>
 		<Property name="domain.name" value="${sys:fess.log.name:-fess}" />

--- a/src/main/webapp/WEB-INF/env/suggest/resources/log4j2.xml
+++ b/src/main/webapp/WEB-INF/env/suggest/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.codelibs.fess.util">
+<Configuration status="WARN">
 
 	<Properties>
 		<Property name="domain.name" value="${sys:fess.log.name:-fess}" />

--- a/src/main/webapp/WEB-INF/env/thumbnail/resources/log4j2.xml
+++ b/src/main/webapp/WEB-INF/env/thumbnail/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.codelibs.fess.util">
+<Configuration status="WARN">
 
 	<Properties>
 		<Property name="domain.name" value="${sys:fess.log.name:-fess}" />


### PR DESCRIPTION
## Summary
Remove the deprecated `packages` attribute from all log4j2.xml configuration files to eliminate the startup WARN log in Log4j 2.25.3.

## Changes Made
- Removed `packages="org.codelibs.fess.util"` from 4 log4j2.xml files:
  - `src/main/resources/log4j2.xml`
  - `src/main/webapp/WEB-INF/env/crawler/resources/log4j2.xml`
  - `src/main/webapp/WEB-INF/env/suggest/resources/log4j2.xml`
  - `src/main/webapp/WEB-INF/env/thumbnail/resources/log4j2.xml`

## Background
Log4j 2.25.3 deprecates runtime package scanning via the `packages` attribute. The Log4j2 annotation processor already generates `Log4j2Plugins.dat` at build time, which registers custom plugins (`ErrorToWarnRewritePolicy`, `LogNotificationAppender`) without needing the `packages` attribute.

## Testing
- Verified `Log4j2Plugins.dat` contains both custom plugins after build
- Confirmed the deprecation WARN log is no longer emitted on startup