### PR TITLE
docs(readme): bump documentation links to 15.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Fess is a very powerful and easily deployable Enterprise Search Server. You can quickly install and run Fess on any platform where you can run the Java Runtime Environment. Fess is provided under the [Apache License 2.0](LICENSE).
 
 Fess is based on [OpenSearch](https://github.com/opensearch-project/OpenSearch), but knowledge/experience about OpenSearch is _not_ required. Fess provides an easy to use Administration GUI to configure the system via your browser.
-Fess also contains a Crawler, which can crawl documents on a [web server](https://fess.codelibs.org/15.5/admin/webconfig-guide.html), [file system](https://fess.codelibs.org/15.5/admin/fileconfig-guide.html), or [Data Store](https://fess.codelibs.org/15.5/admin/dataconfig-guide.html) (such as a CSV or database). Many file formats are supported including (but not limited to): Microsoft Office, PDF, and zip.
+Fess also contains a Crawler, which can crawl documents on a [web server](https://fess.codelibs.org/15.6/admin/webconfig-guide.html), [file system](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html), or [Data Store](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html) (such as a CSV or database). Many file formats are supported including (but not limited to): Microsoft Office, PDF, and zip.
 
 *[Fess Site Search](https://github.com/codelibs/fess-site-search)* is a free alternative to [Google Site Search](https://enterprise.google.com/search/products/gss.html). For more details, see the [FSS JS Generator documentation](https://fss-generator.codelibs.org/docs/manual).
 
@@ -27,15 +27,15 @@ There are 2 ways to try Fess. The first is to download and install yourself. The
 
 ### Download and Install/Run
 
-Fess 15.5 is now available and can be downloaded on the [Releases page](https://github.com/codelibs/fess/releases "download"). Downloads come in 3 flavors: deb, rpm, zip.
+Fess 15.6 is now available and can be downloaded on the [Releases page](https://github.com/codelibs/fess/releases "download"). Downloads come in 3 flavors: deb, rpm, zip.
 
 The following commands show how to use the zip download:
 
-    $ unzip fess-15.5.x.zip
-    $ cd fess-15.5.x
+    $ unzip fess-15.6.x.zip
+    $ cd fess-15.6.x
     $ ./bin/fess
 
-For more details, see the [Installation Guide](https://fess.codelibs.org/15.5/install/index.html).
+For more details, see the [Installation Guide](https://fess.codelibs.org/15.6/install/index.html).
 
 ### Docker
 
@@ -51,7 +51,7 @@ We provide Docker images on [ghcr.io](https://github.com/orgs/codelibs/packages)
 
 ![Admin UI](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-You can register crawling targets in the Admin UI on the (Web, File, Data Store) crawler configuration pages, and then start the Crawler manually on the [Scheduler page](https://fess.codelibs.org/15.5/admin/scheduler-guide.html).
+You can register crawling targets in the Admin UI on the (Web, File, Data Store) crawler configuration pages, and then start the Crawler manually on the [Scheduler page](https://fess.codelibs.org/15.6/admin/scheduler-guide.html).
 
 ## Migration from another search provider
 
@@ -59,7 +59,7 @@ Please see [MIGRATION.md](MIGRATION.md).
 
 ## Data Store
 
-Currently, Fess supports crawling the following [storage locations and APIs](https://fess.codelibs.org/15.5/admin/dataconfig-guide.html):
+Currently, Fess supports crawling the following [storage locations and APIs](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html):
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)


### PR DESCRIPTION
## Summary
Updates README.md so documentation URLs and install instructions point to the Fess 15.6 release line instead of 15.5.

## Changes Made
- Update six references from `15.5` to `15.6` in README.md:
  - Documentation URLs under `fess.codelibs.org` (webconfig, fileconfig, dataconfig, scheduler, install guides)
  - "Fess 15.5 is now available" → "Fess 15.6 is now available"
  - Zip download filename / extracted directory example

## Testing
- Docs-only change; no build or test impact.
- Links verified to match the 15.6 docs layout.

## Breaking Changes
- None.

## Additional Notes
- Follows the 15.6.0 release and the subsequent bump to 15.7.0-SNAPSHOT on master; README had been left on the previous 15.5 doc series.