### PR TITLE
feat(llm): add HTTP proxy support to LLM clients

### DIFF
--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -27,11 +27,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -135,13 +140,14 @@ public abstract class AbstractLlmClient implements LlmClient {
                 .setConnectionRequestTimeout(Timeout.ofMilliseconds(timeout))
                 .setResponseTimeout(Timeout.ofMilliseconds(timeout))
                 .build();
-        httpClient = HttpClients.custom()
+        final HttpClientBuilder builder = HttpClients.custom()
                 .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
                         .setDefaultConnectionConfig(ConnectionConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(timeout)).build())
                         .build())
                 .setDefaultRequestConfig(requestConfig)
-                .disableAutomaticRetries()
-                .build();
+                .disableAutomaticRetries();
+        configureProxy(builder);
+        httpClient = builder.build();
         if (logger.isDebugEnabled()) {
             logger.debug("Initialized {} with timeout: {}ms", getClass().getSimpleName(), timeout);
         }
@@ -153,6 +159,72 @@ public abstract class AbstractLlmClient implements LlmClient {
         concurrencyLimiter = new Semaphore(getMaxConcurrentRequests());
 
         startAvailabilityCheck();
+    }
+
+    /**
+     * Configures proxy settings on the HTTP client builder if a proxy is configured.
+     * Reads proxy configuration via {@link #getProxyHost()}, {@link #getProxyPort()},
+     * {@link #getProxyUsername()}, and {@link #getProxyPassword()}. When username is
+     * provided, registers a {@link BasicCredentialsProvider} for proxy authentication.
+     *
+     * @param builder the HTTP client builder to configure
+     */
+    protected void configureProxy(final HttpClientBuilder builder) {
+        final String proxyHost = getProxyHost();
+        final Integer proxyPort = getProxyPort();
+        if (StringUtil.isBlank(proxyHost) || proxyPort == null) {
+            return;
+        }
+        final HttpHost proxy = new HttpHost(proxyHost, proxyPort);
+        builder.setProxy(proxy);
+        final String proxyUsername = getProxyUsername();
+        if (StringUtil.isNotBlank(proxyUsername)) {
+            final String proxyPassword = getProxyPassword();
+            final BasicCredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(new AuthScope(proxyHost, proxyPort),
+                    new UsernamePasswordCredentials(proxyUsername, proxyPassword != null ? proxyPassword.toCharArray() : new char[0]));
+            builder.setDefaultCredentialsProvider(credsProvider);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("[LLM] {} using proxy. host={}, port={}, authenticated={}", getName(), proxyHost, proxyPort,
+                    StringUtil.isNotBlank(proxyUsername));
+        }
+    }
+
+    /**
+     * Gets the HTTP proxy host. Defaults to {@code http.proxy.host} from FessConfig.
+     *
+     * @return the proxy host, or null/blank if no proxy is configured
+     */
+    protected String getProxyHost() {
+        return ComponentUtil.getFessConfig().getHttpProxyHost();
+    }
+
+    /**
+     * Gets the HTTP proxy port. Defaults to {@code http.proxy.port} from FessConfig.
+     *
+     * @return the proxy port, or null if no proxy is configured
+     */
+    protected Integer getProxyPort() {
+        return ComponentUtil.getFessConfig().getHttpProxyPortAsInteger();
+    }
+
+    /**
+     * Gets the HTTP proxy username. Defaults to {@code http.proxy.username} from FessConfig.
+     *
+     * @return the proxy username, or null/blank if no proxy authentication is required
+     */
+    protected String getProxyUsername() {
+        return ComponentUtil.getFessConfig().getHttpProxyUsername();
+    }
+
+    /**
+     * Gets the HTTP proxy password. Defaults to {@code http.proxy.password} from FessConfig.
+     *
+     * @return the proxy password, or null if no proxy authentication is required
+     */
+    protected String getProxyPassword() {
+        return ComponentUtil.getFessConfig().getHttpProxyPassword();
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/llm/AbstractLlmClientTest.java
+++ b/src/test/java/org/codelibs/fess/llm/AbstractLlmClientTest.java
@@ -21,6 +21,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -1014,6 +1017,99 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
         assertEquals("Q3", request.getMessages().get(1).getContent());
     }
 
+    // ========== Proxy configuration tests ==========
+
+    @Test
+    public void test_proxyGetters_defaultDelegatesToFessConfig() {
+        // Default impls read from FessConfig. In the test environment, http.proxy.host
+        // is empty (the property exists with a default empty value), so the getters
+        // return empty/default values without throwing.
+        assertNotNull(client.getProxyHost(), "getProxyHost() should not return null");
+        // Empty by default in test FessConfig.
+        assertEquals("", client.getProxyHost());
+        // http.proxy.port has a default of 8080.
+        assertEquals(Integer.valueOf(8080), client.getProxyPort());
+        assertNotNull(client.getProxyUsername(), "getProxyUsername() should not return null");
+        assertEquals("", client.getProxyUsername());
+        assertNotNull(client.getProxyPassword(), "getProxyPassword() should not return null");
+        assertEquals("", client.getProxyPassword());
+    }
+
+    @Test
+    public void test_configureProxy_noOpWhenHostBlank() {
+        // Blank host -> no-op (no proxy applied, no exception). Build the client to confirm.
+        client.setTestProxy("", 8080, "", "");
+        final HttpClientBuilder builder = HttpClients.custom();
+        client.testConfigureProxy(builder);
+        try (CloseableHttpClient http = builder.build()) {
+            assertNotNull(http);
+        } catch (final Exception e) {
+            fail("Building client without proxy should not throw: " + e);
+        }
+    }
+
+    @Test
+    public void test_configureProxy_noOpWhenHostNull() {
+        client.setTestProxy(null, 8080, null, null);
+        final HttpClientBuilder builder = HttpClients.custom();
+        client.testConfigureProxy(builder);
+        try (CloseableHttpClient http = builder.build()) {
+            assertNotNull(http);
+        } catch (final Exception e) {
+            fail("Building client with null host should not throw: " + e);
+        }
+    }
+
+    @Test
+    public void test_configureProxy_noOpWhenPortNull() {
+        // Host set but port null -> still no-op (both required).
+        client.setTestProxy("proxy.example.com", null, "", "");
+        final HttpClientBuilder builder = HttpClients.custom();
+        client.testConfigureProxy(builder);
+        try (CloseableHttpClient http = builder.build()) {
+            assertNotNull(http);
+        } catch (final Exception e) {
+            fail("Building client with null port should not throw: " + e);
+        }
+    }
+
+    @Test
+    public void test_configureProxy_appliesProxyWithoutAuth() {
+        client.setTestProxy("proxy.example.com", 8080, "", "");
+        final HttpClientBuilder builder = HttpClients.custom();
+        client.testConfigureProxy(builder);
+        try (CloseableHttpClient http = builder.build()) {
+            assertNotNull(http);
+        } catch (final Exception e) {
+            fail("Building client with proxy should not throw: " + e);
+        }
+    }
+
+    @Test
+    public void test_configureProxy_appliesProxyWithBasicAuth() {
+        client.setTestProxy("proxy.example.com", 8080, "user", "pass");
+        final HttpClientBuilder builder = HttpClients.custom();
+        client.testConfigureProxy(builder);
+        try (CloseableHttpClient http = builder.build()) {
+            assertNotNull(http);
+        } catch (final Exception e) {
+            fail("Building client with authenticated proxy should not throw: " + e);
+        }
+    }
+
+    @Test
+    public void test_configureProxy_handlesNullPasswordWithUsername() {
+        // Null password but non-blank username -> uses empty password char[], no NPE.
+        client.setTestProxy("proxy.example.com", 8080, "user", null);
+        final HttpClientBuilder builder = HttpClients.custom();
+        client.testConfigureProxy(builder);
+        try (CloseableHttpClient http = builder.build()) {
+            assertNotNull(http);
+        } catch (final Exception e) {
+            fail("Building client with null password should not throw: " + e);
+        }
+    }
+
     // ========== Testable subclass ==========
 
     @FunctionalInterface
@@ -1036,6 +1132,43 @@ public class AbstractLlmClientTest extends UnitFessTestCase {
         private int testHistoryMaxChars = 4000;
         private int testHistoryAssistantMaxChars = 500;
         private int testHistoryAssistantSummaryMaxChars = 500;
+        private boolean overrideProxy = false;
+        private String testProxyHost;
+        private Integer testProxyPort;
+        private String testProxyUsername;
+        private String testProxyPassword;
+
+        void setTestProxy(final String host, final Integer port, final String username, final String password) {
+            this.overrideProxy = true;
+            this.testProxyHost = host;
+            this.testProxyPort = port;
+            this.testProxyUsername = username;
+            this.testProxyPassword = password;
+        }
+
+        @Override
+        protected String getProxyHost() {
+            return overrideProxy ? testProxyHost : super.getProxyHost();
+        }
+
+        @Override
+        protected Integer getProxyPort() {
+            return overrideProxy ? testProxyPort : super.getProxyPort();
+        }
+
+        @Override
+        protected String getProxyUsername() {
+            return overrideProxy ? testProxyUsername : super.getProxyUsername();
+        }
+
+        @Override
+        protected String getProxyPassword() {
+            return overrideProxy ? testProxyPassword : super.getProxyPassword();
+        }
+
+        void testConfigureProxy(final HttpClientBuilder builder) {
+            configureProxy(builder);
+        }
 
         void setTestIntentDetectionPrompt(final String prompt) {
             this.testIntentDetectionPrompt = prompt;


### PR DESCRIPTION
## Summary
Route LLM HTTP traffic through the configured `http.proxy.*` settings when present, with optional Basic authentication, so deployments behind a corporate proxy can reach OpenAI/Ollama/Gemini and similar endpoints without bespoke wiring.

## Changes Made
- `AbstractLlmClient#init` now delegates to a new `configureProxy(HttpClientBuilder)` method that:
  - Reads proxy host/port from FessConfig (`http.proxy.host`, `http.proxy.port`).
  - Skips configuration when host is blank or port is null.
  - Sets the proxy via `HttpClientBuilder#setProxy`.
  - When a proxy username is provided, registers a `BasicCredentialsProvider` scoped to the proxy host/port. Null passwords degrade to an empty `char[]` rather than throwing.
  - Logs proxy usage at DEBUG, masking credentials (only the `authenticated` flag is logged).
- Added four protected getters (`getProxyHost`, `getProxyPort`, `getProxyUsername`, `getProxyPassword`) that default to FessConfig but can be overridden by subclasses for client-specific overrides.
- Test coverage in `AbstractLlmClientTest` for: default delegation to FessConfig, no-op when host/port missing, proxy applied without auth, proxy applied with Basic auth, and null-password handling.

## Testing
- `mvn test -Dtest=AbstractLlmClientTest`
- Existing unit tests remain green.

## Breaking Changes
- None. Behavior is unchanged when `http.proxy.host` is blank (the default). Subclasses that previously composed their own `HttpClientBuilder` are unaffected because the new method is invoked from `AbstractLlmClient#init` only.

## Additional Notes
- The proxy getters are intentionally `protected` so per-client plugins (e.g., a future `llm.openai.proxy.host`) can override them without duplicating the auth wiring.
- Credentials provider is scoped to `(proxyHost, proxyPort)` rather than `ANY` to avoid leaking credentials to unrelated targets if the upstream client ever follows a redirect.