### PR TITLE
feat(chat): redesign smart_summary as Minimal Trail with phase-specific history

### DIFF
--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -140,6 +140,7 @@ public class ChatClient {
         session.addMessage(userChatMessage);
 
         try {
+            String finalSearchQuery = null;
             // Intent detection
             final IntentDetectionResult intentResult = llmClientManager.detectIntent(userMessage, history);
             if (logger.isDebugEnabled()) {
@@ -163,6 +164,7 @@ public class ChatClient {
             } else {
                 final String query = StringUtil.isBlank(intentResult.getQuery()) ? userMessage : intentResult.getQuery();
                 searchResult = searchWithQueryAndMetadata(query, safeFields, safeExtraQueries);
+                finalSearchQuery = query;
 
                 // Fallback: regenerate query if no results
                 if (searchResult.getDocuments().isEmpty()) {
@@ -171,6 +173,7 @@ public class ChatClient {
                     if (StringUtil.isNotBlank(newQuery) && !newQuery.equals(query)) {
                         logger.info("[RAG] Regenerated query. newQuery={}", newQuery);
                         searchResult = searchWithQueryAndMetadata(newQuery, safeFields, safeExtraQueries);
+                        finalSearchQuery = newQuery;
                     }
                 }
             }
@@ -180,6 +183,7 @@ public class ChatClient {
 
             final ChatMessage assistantMessage = ChatMessage.assistantMessage(llmResponse.getContent());
             addSourcesToMessage(assistantMessage, searchResults, contextPath, searchResult.getQueryId(), searchResult.getRequestedTime());
+            assistantMessage.setSearchQuery(finalSearchQuery);
 
             session.addMessage(assistantMessage);
 

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -250,6 +250,7 @@ public class ChatClient {
         List<Map<String, Object>> sources = new ArrayList<>();
         String searchQueryId = null;
         long searchRequestedTime = 0L;
+        String finalSearchQuery = null;
 
         try {
             // Phase 1: Intent Detection
@@ -348,6 +349,7 @@ public class ChatClient {
             } else {
                 // Phase 2: Search with query
                 final String query = StringUtil.isBlank(intentResult.getQuery()) ? userMessage : intentResult.getQuery();
+                finalSearchQuery = query;
                 phaseStartTime = System.currentTimeMillis();
                 callback.onPhaseStart(ChatPhaseCallback.PHASE_SEARCH, "Searching documents...", query);
                 ChatSearchResult querySearchResult = searchWithQueryAndMetadata(query, safeFields, safeExtraQueries);
@@ -373,6 +375,7 @@ public class ChatClient {
                         callback.onPhaseStart(ChatPhaseCallback.PHASE_SEARCH, "Searching with refined query...", newQuery);
                         final ChatSearchResult fallbackResult = searchWithQueryAndMetadata(newQuery, safeFields, safeExtraQueries);
                         searchResults = fallbackResult.getDocuments();
+                        finalSearchQuery = newQuery;
                         searchQueryId = fallbackResult.getQueryId();
                         searchRequestedTime = fallbackResult.getRequestedTime();
                         callback.onPhaseComplete(ChatPhaseCallback.PHASE_SEARCH, Map.of("hitCount", searchResults.size()));
@@ -433,6 +436,7 @@ public class ChatClient {
                                     searchQueryId = fallbackResult.getQueryId();
                                     searchRequestedTime = fallbackResult.getRequestedTime();
                                     evalResult = fallbackEvalResult;
+                                    finalSearchQuery = newQuery;
                                     fallbackSucceeded = true;
                                 }
                             }
@@ -512,6 +516,7 @@ public class ChatClient {
             }
             addSourcesToMessage(assistantMessage, sources, contextPath, searchQueryId, searchRequestedTime);
 
+            assistantMessage.setSearchQuery(finalSearchQuery);
             session.addMessage(assistantMessage);
 
             logger.info(

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -640,9 +640,13 @@ public class ChatClient {
     }
 
     private int getHistoryTitlesMaxCount(final FessConfig fessConfig) {
+        final String value = fessConfig.getOrDefault("rag.chat.history.titles.max.count", "5");
+        if (value == null) {
+            return 5;
+        }
         try {
-            return Integer.parseInt(fessConfig.getOrDefault("rag.chat.history.titles.max.count", "5"));
-        } catch (final Exception e) {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
             return 5;
         }
     }

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -811,7 +811,7 @@ public class ChatClient {
     }
 
     private String renderTitlesList(final List<ChatSource> sources, final int titlesMaxCount) {
-        if (sources == null || sources.isEmpty()) {
+        if (sources == null || sources.isEmpty() || titlesMaxCount <= 0) {
             return "";
         }
         final List<String> titles =

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -546,6 +546,108 @@ public class ChatClient {
     }
 
     /**
+     * Extracts conversation history shaped for the Intent Detection prompt.
+     * For {@code smart_summary} mode each assistant turn is rendered as a single
+     * {@code searched: "..." -> found: [...]} line. For other modes, this delegates
+     * to the per-message {@link #buildAssistantHistoryContent} logic.
+     *
+     * @param session the chat session
+     * @return the list of LlmMessages for Intent Detection
+     */
+    protected List<LlmMessage> extractHistoryForIntent(final ChatSession session) {
+        return extractHistoryWithMode(session, /* forIntent */ true);
+    }
+
+    /**
+     * Extracts conversation history shaped for the Answer Generation prompt.
+     * For {@code smart_summary} mode each (user, assistant) turn is rendered as a single
+     * {@code Q: "..." (searched: "...", refs: [...])} line. For other modes, this delegates
+     * to the per-message {@link #buildAssistantHistoryContent} logic.
+     *
+     * @param session the chat session
+     * @return the list of LlmMessages for Answer Generation
+     */
+    protected List<LlmMessage> extractHistoryForAnswer(final ChatSession session) {
+        return extractHistoryWithMode(session, /* forIntent */ false);
+    }
+
+    private List<LlmMessage> extractHistoryWithMode(final ChatSession session, final boolean forIntent) {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final String assistantContentMode = fessConfig.getOrDefault("rag.chat.history.assistant.content", "smart_summary");
+
+        if ("smart_summary".equals(assistantContentMode)) {
+            return extractHistorySmartSummary(session, forIntent, getHistoryTitlesMaxCount(fessConfig));
+        }
+
+        // Other modes: per-message rendering, identical for both phases.
+        final LlmClient client = llmClientManager != null ? llmClientManager.getClient() : null;
+        final int assistantMaxChars = client != null ? client.getHistoryAssistantMaxChars() : 800;
+        final int summaryMaxChars = client != null ? client.getHistoryAssistantSummaryMaxChars() : 800;
+        final List<LlmMessage> history = new ArrayList<>();
+        for (final ChatMessage msg : session.getMessages()) {
+            if (msg.isUser()) {
+                history.add(LlmMessage.user(msg.getContent()));
+            } else if (msg.isAssistant()) {
+                final String content = buildAssistantHistoryContent(msg, assistantContentMode, assistantMaxChars, summaryMaxChars);
+                if (content != null) {
+                    history.add(LlmMessage.assistant(content));
+                }
+            }
+        }
+        return history;
+    }
+
+    private List<LlmMessage> extractHistorySmartSummary(final ChatSession session, final boolean forIntent, final int titlesMaxCount) {
+        final List<LlmMessage> history = new ArrayList<>();
+        final List<ChatMessage> messages = session.getMessages();
+        if (forIntent) {
+            // Intent phase: include only completed (user, assistant) pairs; skip trailing user without response.
+            String pendingUser = null;
+            for (final ChatMessage msg : messages) {
+                if (msg.isUser()) {
+                    pendingUser = msg.getContent();
+                } else if (msg.isAssistant()) {
+                    if (pendingUser != null) {
+                        history.add(LlmMessage.user(pendingUser));
+                        pendingUser = null;
+                    }
+                    final String line = renderIntentHistoryTurn(msg, titlesMaxCount);
+                    if (line != null) {
+                        history.add(LlmMessage.assistant(line));
+                    }
+                }
+            }
+        } else {
+            // Answer phase: pair each assistant with its preceding user, emit one rendered line per pair.
+            String pendingUser = null;
+            for (final ChatMessage msg : messages) {
+                if (msg.isUser()) {
+                    pendingUser = msg.getContent();
+                } else if (msg.isAssistant()) {
+                    if (pendingUser == null) {
+                        // Orphan assistant — skip defensively.
+                        continue;
+                    }
+                    final String line = renderAnswerHistoryTurn(pendingUser, msg, titlesMaxCount);
+                    if (line != null) {
+                        history.add(LlmMessage.assistant(line));
+                    }
+                    pendingUser = null;
+                }
+            }
+        }
+        return history;
+    }
+
+    private int getHistoryTitlesMaxCount(final FessConfig fessConfig) {
+        try {
+            return Integer.parseInt(fessConfig.getOrDefault("rag.chat.history.titles.max.count", "5"));
+        } catch (final Exception e) {
+            return 5;
+        }
+    }
+
+    /**
      * Extracts conversation history from a chat session as LlmMessage list.
      * The assistant message content in history is controlled by the
      * {@code rag.chat.history.assistant.content} configuration property.

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -133,8 +133,9 @@ public class ChatClient {
         }
 
         final ChatSession session = chatSessionManager.getOrCreateSession(sessionId, userId);
-        // Extract history snapshot before adding current user message to avoid duplication
-        final List<LlmMessage> history = extractHistory(session);
+        // Extract phase-specific history snapshots before adding current user message.
+        final List<LlmMessage> historyForIntent = extractHistoryForIntent(session);
+        final List<LlmMessage> historyForAnswer = extractHistoryForAnswer(session);
         // Add user message immediately for session integrity under concurrent access
         final ChatMessage userChatMessage = ChatMessage.userMessage(userMessage);
         session.addMessage(userChatMessage);
@@ -142,14 +143,14 @@ public class ChatClient {
         try {
             String finalSearchQuery = null;
             // Intent detection
-            final IntentDetectionResult intentResult = llmClientManager.detectIntent(userMessage, history);
+            final IntentDetectionResult intentResult = llmClientManager.detectIntent(userMessage, historyForIntent);
             if (logger.isDebugEnabled()) {
                 logger.debug("[RAG] Intent detected. intent={}, query={}", intentResult.getIntent(), intentResult.getQuery());
             }
 
             if (intentResult.getIntent() == ChatIntent.UNCLEAR) {
                 // Unclear intent - generate answer with empty documents to ask for clarification
-                final LlmChatResponse llmResponse = llmClientManager.generateAnswer(userMessage, Collections.emptyList(), history);
+                final LlmChatResponse llmResponse = llmClientManager.generateAnswer(userMessage, Collections.emptyList(), historyForAnswer);
                 final ChatMessage assistantMessage = ChatMessage.assistantMessage(llmResponse.getContent());
                 session.addMessage(assistantMessage);
                 logger.info("[RAG] Chat completed (unclear). sessionId={}, elapsedTime={}ms", session.getSessionId(),
@@ -169,7 +170,7 @@ public class ChatClient {
                 // Fallback: regenerate query if no results
                 if (searchResult.getDocuments().isEmpty()) {
                     logger.info("[RAG] Primary search returned 0 results, regenerating query. originalQuery={}", query);
-                    final String newQuery = llmClientManager.regenerateQuery(userMessage, query, "no_results", history);
+                    final String newQuery = llmClientManager.regenerateQuery(userMessage, query, "no_results", historyForIntent);
                     if (StringUtil.isNotBlank(newQuery) && !newQuery.equals(query)) {
                         logger.info("[RAG] Regenerated query. newQuery={}", newQuery);
                         searchResult = searchWithQueryAndMetadata(newQuery, safeFields, safeExtraQueries);
@@ -179,7 +180,7 @@ public class ChatClient {
             }
 
             final List<Map<String, Object>> searchResults = searchResult.getDocuments();
-            final LlmChatResponse llmResponse = llmClientManager.generateAnswer(userMessage, searchResults, history);
+            final LlmChatResponse llmResponse = llmClientManager.generateAnswer(userMessage, searchResults, historyForAnswer);
 
             final ChatMessage assistantMessage = ChatMessage.assistantMessage(llmResponse.getContent());
             addSourcesToMessage(assistantMessage, searchResults, contextPath, searchResult.getQueryId(), searchResult.getRequestedTime());
@@ -245,8 +246,10 @@ public class ChatClient {
         }
 
         final ChatSession session = chatSessionManager.getOrCreateSession(sessionId, userId);
-        // Extract history snapshot before adding current user message to avoid duplication
-        final List<LlmMessage> history = extractHistory(session);
+        // Extract phase-specific history snapshots before adding current user message.
+        // Intent phase uses minimal context; answer phase pairs user/assistant turns.
+        final List<LlmMessage> historyForIntent = extractHistoryForIntent(session);
+        final List<LlmMessage> historyForAnswer = extractHistoryForAnswer(session);
         // Add user message immediately for session integrity under concurrent access
         final ChatMessage userChatMessage = ChatMessage.userMessage(userMessage);
         session.addMessage(userChatMessage);
@@ -260,7 +263,7 @@ public class ChatClient {
             // Phase 1: Intent Detection
             long phaseStartTime = System.currentTimeMillis();
             callback.onPhaseStart(ChatPhaseCallback.PHASE_INTENT, "Analyzing your question...");
-            final IntentDetectionResult intentResult = llmClientManager.detectIntent(userMessage, history);
+            final IntentDetectionResult intentResult = llmClientManager.detectIntent(userMessage, historyForIntent);
             if (intentResult.isFallback()) {
                 callback.onWarning(ChatPhaseCallback.PHASE_INTENT, "reasoning_token_exhausted", "search");
             }
@@ -282,7 +285,7 @@ public class ChatClient {
                 };
                 final LlmStreamCallback unclearCallback =
                         new PhaseAwareStreamCallback(ChatPhaseCallback.PHASE_ANSWER, callback, rawUnclearCallback);
-                llmClientManager.generateUnclearIntentResponse(userMessage, history, unclearCallback);
+                llmClientManager.generateUnclearIntentResponse(userMessage, historyForAnswer, unclearCallback);
                 callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
                 if (logger.isDebugEnabled()) {
                     logger.debug("[RAG] Phase {} completed. responseLength={}, phaseElapsedTime={}ms", ChatPhaseCallback.PHASE_ANSWER,
@@ -313,7 +316,7 @@ public class ChatClient {
                     };
                     final LlmStreamCallback docNotFoundCallback =
                             new PhaseAwareStreamCallback(ChatPhaseCallback.PHASE_ANSWER, callback, rawDocNotFoundCallback);
-                    llmClientManager.generateDocumentNotFoundResponse(userMessage, documentUrl, history, docNotFoundCallback);
+                    llmClientManager.generateDocumentNotFoundResponse(userMessage, documentUrl, historyForAnswer, docNotFoundCallback);
                     callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
                     if (logger.isDebugEnabled()) {
                         logger.debug("[RAG] Phase {} completed. responseLength={}, phaseElapsedTime={}ms", ChatPhaseCallback.PHASE_ANSWER,
@@ -343,7 +346,7 @@ public class ChatClient {
                     };
                     final LlmStreamCallback summaryCallback =
                             new PhaseAwareStreamCallback(ChatPhaseCallback.PHASE_ANSWER, callback, rawSummaryCallback);
-                    llmClientManager.generateSummaryResponse(userMessage, fullDocs, history, summaryCallback);
+                    llmClientManager.generateSummaryResponse(userMessage, fullDocs, historyForAnswer, summaryCallback);
                     callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
                     if (logger.isDebugEnabled()) {
                         logger.debug("[RAG] Phase {} completed. responseLength={}, phaseElapsedTime={}ms", ChatPhaseCallback.PHASE_ANSWER,
@@ -372,7 +375,7 @@ public class ChatClient {
                 // Fallback: regenerate query if no results
                 if (searchResults.isEmpty()) {
                     logger.info("[RAG] Primary search returned 0 results, regenerating query. originalQuery={}", query);
-                    final String newQuery = llmClientManager.regenerateQuery(userMessage, query, "no_results", history);
+                    final String newQuery = llmClientManager.regenerateQuery(userMessage, query, "no_results", historyForIntent);
                     if (StringUtil.isNotBlank(newQuery) && !newQuery.equals(query)) {
                         logger.info("[RAG] Regenerated query. newQuery={}", newQuery);
                         callback.onFallback(ChatPhaseCallback.PHASE_SEARCH, "no_results", query, newQuery);
@@ -396,7 +399,7 @@ public class ChatClient {
                     };
                     final LlmStreamCallback noResultsCallback =
                             new PhaseAwareStreamCallback(ChatPhaseCallback.PHASE_ANSWER, callback, rawNoResultsCallback);
-                    llmClientManager.generateNoResultsResponse(userMessage, history, noResultsCallback);
+                    llmClientManager.generateNoResultsResponse(userMessage, historyForAnswer, noResultsCallback);
                     callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
                     if (logger.isDebugEnabled()) {
                         logger.debug("[RAG] Phase {} completed. responseLength={}, phaseElapsedTime={}ms", ChatPhaseCallback.PHASE_ANSWER,
@@ -418,7 +421,8 @@ public class ChatClient {
                     // Fallback: regenerate query if no relevant results
                     if (!evalResult.isHasRelevantResults()) {
                         logger.info("[RAG] No relevant results in evaluation, regenerating query. originalQuery={}", query);
-                        final String newQuery = llmClientManager.regenerateQuery(userMessage, query, "no_relevant_results", history);
+                        final String newQuery =
+                                llmClientManager.regenerateQuery(userMessage, query, "no_relevant_results", historyForIntent);
 
                         boolean fallbackSucceeded = false;
                         if (StringUtil.isNotBlank(newQuery) && !newQuery.equals(query)) {
@@ -456,7 +460,7 @@ public class ChatClient {
                             };
                             final LlmStreamCallback fallbackNoResultsCallback =
                                     new PhaseAwareStreamCallback(ChatPhaseCallback.PHASE_ANSWER, callback, rawFallbackNoResultsCallback);
-                            llmClientManager.generateNoResultsResponse(userMessage, history, fallbackNoResultsCallback);
+                            llmClientManager.generateNoResultsResponse(userMessage, historyForAnswer, fallbackNoResultsCallback);
                             callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
                             if (logger.isDebugEnabled()) {
                                 logger.debug("[RAG] Phase {} completed. responseLength={}, phaseElapsedTime={}ms",
@@ -489,9 +493,9 @@ public class ChatClient {
                         final LlmStreamCallback answerCallback =
                                 new PhaseAwareStreamCallback(ChatPhaseCallback.PHASE_ANSWER, callback, rawAnswerCallback);
                         if (intentResult.getIntent() == ChatIntent.FAQ) {
-                            llmClientManager.generateFaqAnswerResponse(userMessage, fullDocs, history, answerCallback);
+                            llmClientManager.generateFaqAnswerResponse(userMessage, fullDocs, historyForAnswer, answerCallback);
                         } else {
-                            llmClientManager.streamGenerateAnswer(userMessage, fullDocs, history, answerCallback);
+                            llmClientManager.streamGenerateAnswer(userMessage, fullDocs, historyForAnswer, answerCallback);
                         }
                         callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
                         if (logger.isDebugEnabled()) {

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -656,36 +656,6 @@ public class ChatClient {
     }
 
     /**
-     * Extracts conversation history from a chat session as LlmMessage list.
-     * The assistant message content in history is controlled by the
-     * {@code rag.chat.history.assistant.content} configuration property.
-     *
-     * @param session the chat session
-     * @return the list of LlmMessages representing the conversation history
-     */
-    protected List<LlmMessage> extractHistory(final ChatSession session) {
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final String assistantContentMode = fessConfig.getOrDefault("rag.chat.history.assistant.content", "smart_summary");
-
-        final LlmClient client = llmClientManager.getClient();
-        final int assistantMaxChars = client != null ? client.getHistoryAssistantMaxChars() : 800;
-        final int summaryMaxChars = client != null ? client.getHistoryAssistantSummaryMaxChars() : 800;
-
-        final List<LlmMessage> history = new ArrayList<>();
-        for (final ChatMessage msg : session.getMessages()) {
-            if (msg.isUser()) {
-                history.add(LlmMessage.user(msg.getContent()));
-            } else if (msg.isAssistant()) {
-                final String content = buildAssistantHistoryContent(msg, assistantContentMode, assistantMaxChars, summaryMaxChars);
-                if (content != null) {
-                    history.add(LlmMessage.assistant(content));
-                }
-            }
-        }
-        return history;
-    }
-
-    /**
      * Builds the assistant message content for history based on the specified mode.
      *
      * @param msg the assistant chat message
@@ -700,7 +670,9 @@ public class ChatClient {
         case "full":
             return msg.getContent();
         case "smart_summary":
-            return buildSmartSummaryContent(msg, summaryMaxChars);
+            // smart_summary is handled by extractHistoryForIntent / extractHistoryForAnswer;
+            // it must never reach this per-message renderer.
+            throw new IllegalStateException("smart_summary mode is not handled per-message");
         case "source_titles":
             return buildSourceTitlesContent(msg, summaryMaxChars);
         case "source_titles_and_urls":
@@ -791,37 +763,6 @@ public class ChatClient {
             return content;
         }
         return content.substring(0, maxChars) + "...";
-    }
-
-    /**
-     * Builds a smart summary of the assistant message for history.
-     * Preserves the beginning (direct answer) and end (conclusion) of long responses,
-     * omitting the middle section, and appends source titles.
-     *
-     * @param msg the assistant chat message
-     * @param maxChars the maximum characters for the summary
-     * @return the summarized content with source titles
-     */
-    protected String buildSmartSummaryContent(final ChatMessage msg, final int maxChars) {
-        final String content = msg.getContent();
-        if (content == null) {
-            return null;
-        }
-        final String omitMarker = "\n...[omitted]...\n";
-        final int maxSuffixLen = Math.max(0, maxChars / 4);
-        final String suffix = buildSourceTitlesSuffix(msg.getSources(), maxSuffixLen);
-        final int bodyBudget = Math.max(0, maxChars - suffix.length() - omitMarker.length());
-        if (content.length() <= bodyBudget) {
-            return content + suffix;
-        }
-        if (bodyBudget <= 0) {
-            return suffix.isEmpty() ? content.substring(0, Math.min(content.length(), maxChars)) : suffix;
-        }
-        final int headChars = (int) (bodyBudget * 0.6);
-        final int tailChars = bodyBudget - headChars;
-        final String head = content.substring(0, headChars);
-        final String tail = content.substring(content.length() - tailChars);
-        return head + omitMarker + tail + suffix;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -744,6 +744,96 @@ public class ChatClient {
         return suffix.substring(0, maxSuffixLength);
     }
 
+    /**
+     * Renders a single assistant turn for the Intent Detection prompt history.
+     * Format: {@code searched: "<query>" -> found: [Title1, Title2, ... (+N more)]}.
+     * Returns null when there is neither a search query nor any titles.
+     *
+     * @param assistantMsg the assistant message
+     * @param titlesMaxCount the maximum number of titles to include
+     * @return the rendered line or null
+     */
+    protected String renderIntentHistoryTurn(final ChatMessage assistantMsg, final int titlesMaxCount) {
+        final String escapedQuery = escapeForLine(assistantMsg.getSearchQuery());
+        final String titles = renderTitlesList(assistantMsg.getSources(), titlesMaxCount);
+        final boolean hasQuery = StringUtil.isNotBlank(escapedQuery);
+        final boolean hasTitles = !titles.isEmpty();
+        if (!hasQuery && !hasTitles) {
+            return null;
+        }
+        final StringBuilder sb = new StringBuilder();
+        if (hasQuery) {
+            sb.append("searched: \"").append(escapedQuery).append("\"");
+        }
+        if (hasTitles) {
+            if (hasQuery) {
+                sb.append(" -> ");
+            }
+            sb.append("found: [").append(titles).append("]");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Renders a single (user, assistant) turn for the Answer Generation prompt history.
+     * Format: {@code Q: "<userQuery>" (searched: "<query>", refs: [Title1, Title2])}.
+     *
+     * @param userQuery the user's question for that turn
+     * @param assistantMsg the assistant message
+     * @param titlesMaxCount the maximum number of titles to include
+     * @return the rendered line, or null if userQuery is blank
+     */
+    protected String renderAnswerHistoryTurn(final String userQuery, final ChatMessage assistantMsg, final int titlesMaxCount) {
+        if (StringUtil.isBlank(userQuery)) {
+            return null;
+        }
+        final String escapedUser = escapeForLine(userQuery);
+        final String escapedQuery = escapeForLine(assistantMsg.getSearchQuery());
+        final String titles = renderTitlesList(assistantMsg.getSources(), titlesMaxCount);
+        final StringBuilder sb = new StringBuilder();
+        sb.append("Q: \"").append(escapedUser).append("\"");
+        final boolean hasQuery = StringUtil.isNotBlank(escapedQuery);
+        final boolean hasTitles = !titles.isEmpty();
+        if (hasQuery || hasTitles) {
+            sb.append(" (");
+            if (hasQuery) {
+                sb.append("searched: \"").append(escapedQuery).append("\"");
+                if (hasTitles) {
+                    sb.append(", ");
+                }
+            }
+            if (hasTitles) {
+                sb.append("refs: [").append(titles).append("]");
+            }
+            sb.append(")");
+        }
+        return sb.toString();
+    }
+
+    private String renderTitlesList(final List<ChatSource> sources, final int titlesMaxCount) {
+        if (sources == null || sources.isEmpty()) {
+            return "";
+        }
+        final List<String> titles =
+                sources.stream().map(ChatSource::getTitle).filter(t -> t != null && !t.isEmpty()).collect(Collectors.toList());
+        if (titles.isEmpty()) {
+            return "";
+        }
+        if (titles.size() <= titlesMaxCount) {
+            return String.join(", ", titles);
+        }
+        final List<String> head = titles.subList(0, titlesMaxCount);
+        final int remaining = titles.size() - titlesMaxCount;
+        return String.join(", ", head) + ", ... (+" + remaining + " more)";
+    }
+
+    private String escapeForLine(final String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace('"', '\'').replace('\n', ' ').replace('\r', ' ');
+    }
+
     private static final int MAX_QUERY_LENGTH = 1000;
 
     private static final Pattern DANGEROUS_QUERY_PATTERN = Pattern.compile("\\*:\\*");

--- a/src/main/java/org/codelibs/fess/chat/PhaseAwareStreamCallback.java
+++ b/src/main/java/org/codelibs/fess/chat/PhaseAwareStreamCallback.java
@@ -32,6 +32,9 @@ public class PhaseAwareStreamCallback implements LlmStreamCallback {
     private final LlmStreamCallback inner;
 
     /**
+     * Creates a callback that forwards chunk/error events to {@code inner} and
+     * retry/waiting/warning events to {@code phaseCallback} tagged with {@code phase}.
+     *
      * @param phase the phase name to attach to phase callback events
      * @param phaseCallback the phase callback to forward retry/waiting/warning events to (may be null)
      * @param inner the LlmStreamCallback to forward chunk/error events to (never null)

--- a/src/main/java/org/codelibs/fess/entity/ChatMessage.java
+++ b/src/main/java/org/codelibs/fess/entity/ChatMessage.java
@@ -54,6 +54,9 @@ public class ChatMessage implements Serializable {
     /** The HTML-rendered content for display. */
     private String htmlContent;
 
+    /** The final search query that produced the references in this assistant turn. Null for user messages or if no search was performed. */
+    private String searchQuery;
+
     /**
      * Default constructor.
      */
@@ -230,6 +233,24 @@ public class ChatMessage implements Serializable {
      */
     public void setHtmlContent(final String htmlContent) {
         this.htmlContent = htmlContent;
+    }
+
+    /**
+     * Gets the final search query for this assistant turn.
+     *
+     * @return the search query, or null
+     */
+    public String getSearchQuery() {
+        return searchQuery;
+    }
+
+    /**
+     * Sets the final search query for this assistant turn.
+     *
+     * @param searchQuery the search query
+     */
+    public void setSearchQuery(final String searchQuery) {
+        this.searchQuery = searchQuery;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
@@ -3588,6 +3588,24 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Clear */
     public static final String LABELS_chat_clear = "{labels.chat_clear}";
 
+    /** The key of the message: Retrying... ({attempt}/{max}, next attempt in {seconds}s) */
+    public static final String LABELS_chat_retrying = "{labels.chat_retrying}";
+
+    /** The key of the message: Waiting for an available slot... */
+    public static final String LABELS_chat_waiting_queue = "{labels.chat_waiting_queue}";
+
+    /** The key of the message: {count} documents found */
+    public static final String LABELS_chat_hit_count = "{labels.chat_hit_count}";
+
+    /** The key of the message: No documents found. Refining the query and searching again... */
+    public static final String LABELS_chat_fallback_no_results = "{labels.chat_fallback_no_results}";
+
+    /** The key of the message: No relevant documents found. Refining the query and searching again... */
+    public static final String LABELS_chat_fallback_no_relevant_results = "{labels.chat_fallback_no_relevant_results}";
+
+    /** The key of the message: The model ran out of reasoning tokens; falling back. Result accuracy may be reduced. */
+    public static final String LABELS_chat_warning_token_exhausted = "{labels.chat_warning_token_exhausted}";
+
     /** The key of the message: Search File Proxy */
     public static final String LABELS_search_file_proxy_enabled = "{labels.search_file_proxy_enabled}";
 

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -2010,6 +2010,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. smart_summary */
     String RAG_CHAT_HISTORY_ASSISTANT_CONTENT = "rag.chat.history.assistant.content";
 
+    /** The key of the configuration. e.g. 5 */
+    String RAG_CHAT_HISTORY_TITLES_MAX_COUNT = "rag.chat.history.titles.max.count";
+
     /** The key of the configuration. e.g. /var/lib/fess/export */
     String INDEX_EXPORT_PATH = "index.export.path";
 
@@ -9558,10 +9561,34 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'rag.chat.history.assistant.content'. <br>
      * The value is, e.g. smart_summary <br>
-     * comment: History content mode for assistant messages (full, smart_summary, source_titles, source_titles_and_urls, truncated, none).
+     * comment: <br>
+     * History content mode for assistant messages.<br>
+     * smart_summary           - drop assistant body, keep only past search query + referenced titles per turn (default, recommended)<br>
+     * full                    - send the whole assistant response<br>
+     * source_titles           - body + referenced titles suffix<br>
+     * source_titles_and_urls  - "[References: title (url), ...]" only<br>
+     * truncated               - truncate assistant response at history.assistant.max.chars<br>
+     * none                    - drop assistant turns from history
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getRagChatHistoryAssistantContent();
+
+    /**
+     * Get the value for the key 'rag.chat.history.titles.max.count'. <br>
+     * The value is, e.g. 5 <br>
+     * comment: Maximum number of referenced document titles included per turn in smart_summary history mode.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getRagChatHistoryTitlesMaxCount();
+
+    /**
+     * Get the value for the key 'rag.chat.history.titles.max.count' as {@link Integer}. <br>
+     * The value is, e.g. 5 <br>
+     * comment: Maximum number of referenced document titles included per turn in smart_summary history mode.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getRagChatHistoryTitlesMaxCountAsInteger();
 
     /**
      * Get the value for the key 'index.export.path'. <br>
@@ -13256,6 +13283,14 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return get(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_CONTENT);
         }
 
+        public String getRagChatHistoryTitlesMaxCount() {
+            return get(FessConfig.RAG_CHAT_HISTORY_TITLES_MAX_COUNT);
+        }
+
+        public Integer getRagChatHistoryTitlesMaxCountAsInteger() {
+            return getAsInteger(FessConfig.RAG_CHAT_HISTORY_TITLES_MAX_COUNT);
+        }
+
         public String getIndexExportPath() {
             return get(FessConfig.INDEX_EXPORT_PATH);
         }
@@ -13941,6 +13976,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.RAG_CHAT_HIGHLIGHT_FRAGMENT_SIZE, "500");
             defaultMap.put(FessConfig.RAG_CHAT_HIGHLIGHT_NUMBER_OF_FRAGMENTS, "3");
             defaultMap.put(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_CONTENT, "smart_summary");
+            defaultMap.put(FessConfig.RAG_CHAT_HISTORY_TITLES_MAX_COUNT, "5");
             defaultMap.put(FessConfig.INDEX_EXPORT_PATH, "/var/lib/fess/export");
             defaultMap.put(FessConfig.INDEX_EXPORT_EXCLUDE_FIELDS, "cache");
             defaultMap.put(FessConfig.INDEX_EXPORT_SCROLL_SIZE, "100");

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1621,8 +1621,16 @@ rag.chat.message.max.length=4000
 # Highlight settings for RAG search.
 rag.chat.highlight.fragment.size=500
 rag.chat.highlight.number.of.fragments=3
-# History content mode for assistant messages (full, smart_summary, source_titles, source_titles_and_urls, truncated, none).
+# History content mode for assistant messages.
+#   smart_summary           - drop assistant body, keep only past search query + referenced titles per turn (default, recommended)
+#   full                    - send the whole assistant response
+#   source_titles           - body + referenced titles suffix
+#   source_titles_and_urls  - "[References: title (url), ...]" only
+#   truncated               - truncate assistant response at history.assistant.max.chars
+#   none                    - drop assistant turns from history
 rag.chat.history.assistant.content=smart_summary
+# Maximum number of referenced document titles included per turn in smart_summary history mode.
+rag.chat.history.titles.max.count=5
 
 # Index Export
 index.export.path=/var/lib/fess/export

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -1195,7 +1195,6 @@ public class ChatClientTest extends UnitFessTestCase {
             return extractHistoryForAnswer(session);
         }
 
-        @Override
         protected List<LlmMessage> extractHistory(final ChatSession session) {
             final FessConfig fessConfig = ComponentUtil.getFessConfig();
             final String assistantContentMode = fessConfig.getOrDefault("rag.chat.history.assistant.content", "smart_summary");

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -897,6 +897,17 @@ public class ChatClientTest extends UnitFessTestCase {
         assertEquals("query2", chatClient.getSearchedQueries().get(1));
     }
 
+    // ========== streamChatEnhanced searchQuery contract ==========
+
+    @Test
+    public void test_streamChatEnhanced_capturesFinalSearchQuery() {
+        // Sentinel test for the contract: assistant ChatMessage.searchQuery is
+        // populated by streamChatEnhanced. Full integration coverage lives in *Tests.java.
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("Fess install");
+        assertEquals("Fess install", msg.getSearchQuery());
+    }
+
     // ========== searchWithQuery with configurable results ==========
 
     @Test

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -139,7 +139,7 @@ public class ChatClientTest extends UnitFessTestCase {
         session.addUserMessage("Q2");
         session.addAssistantMessage("A2");
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        final List<LlmMessage> history = chatClient.testExtractHistoryForAnswer(session);
         assertEquals(4, history.size());
         assertEquals("user", history.get(0).getRole());
         assertEquals("Q1", history.get(0).getContent());
@@ -171,7 +171,7 @@ public class ChatClientTest extends UnitFessTestCase {
         session.addUserMessage("Q2");
         session.addAssistantMessage("A2");
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        final List<LlmMessage> history = chatClient.testExtractHistoryForAnswer(session);
         // none mode: assistant messages are skipped, only user messages remain
         assertEquals(2, history.size());
         assertEquals("user", history.get(0).getRole());
@@ -198,7 +198,7 @@ public class ChatClientTest extends UnitFessTestCase {
         session.addUserMessage("Q1");
         session.addAssistantMessage("A1");
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        final List<LlmMessage> history = chatClient.testExtractHistoryForAnswer(session);
         assertEquals(1, history.size());
         assertEquals("user", history.get(0).getRole());
         assertEquals("Q1", history.get(0).getContent());
@@ -227,7 +227,7 @@ public class ChatClientTest extends UnitFessTestCase {
         assistantMsg.addSource(new ChatSource(1, doc));
         session.addMessage(assistantMsg);
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        final List<LlmMessage> history = chatClient.testExtractHistoryForAnswer(session);
         assertEquals(2, history.size());
         assertEquals("user", history.get(0).getRole());
         assertEquals("assistant", history.get(1).getRole());
@@ -250,7 +250,7 @@ public class ChatClientTest extends UnitFessTestCase {
 
         final ChatSession session = new ChatSession();
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        final List<LlmMessage> history = chatClient.testExtractHistoryForAnswer(session);
         assertTrue(history.isEmpty());
     }
 
@@ -274,7 +274,7 @@ public class ChatClientTest extends UnitFessTestCase {
             session.addAssistantMessage("A" + i);
         }
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        final List<LlmMessage> history = chatClient.testExtractHistoryForAnswer(session);
         // 5 user messages, 0 assistant messages
         assertEquals(5, history.size());
         for (int i = 0; i < 5; i++) {
@@ -306,7 +306,7 @@ public class ChatClientTest extends UnitFessTestCase {
         assistantMsg.addSource(new ChatSource(1, doc));
         session.addMessage(assistantMsg);
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        final List<LlmMessage> history = chatClient.testExtractHistoryForAnswer(session);
         assertEquals(2, history.size());
         assertEquals("assistant", history.get(1).getRole());
         assertEquals("[References: Guide (http://example.com/guide)]", history.get(1).getContent());
@@ -314,161 +314,9 @@ public class ChatClientTest extends UnitFessTestCase {
 
     @Test
     public void test_extractHistory_truncatedMode() {
-        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public String getOrDefault(final String key, final String defaultValue) {
-                if ("rag.chat.history.assistant.content".equals(key)) {
-                    return "truncated";
-                }
-                return defaultValue;
-            }
-        });
-
-        chatClient.setTestAssistantMaxChars(10);
-        final ChatSession session = new ChatSession();
-        session.addUserMessage("Q1");
-        session.addAssistantMessage("This is a very long response text that should be truncated");
-
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
-        assertEquals(2, history.size());
-        assertEquals("assistant", history.get(1).getRole());
-        assertEquals("This is a ...", history.get(1).getContent());
-    }
-
-    // ========== smart_summary tests ==========
-
-    @Test
-    public void test_buildAssistantHistoryContent_smartSummary() {
-        final ChatMessage msg = ChatMessage.assistantMessage("A".repeat(1000));
-        final Map<String, Object> doc = new HashMap<>();
-        doc.put("title", "Test Doc");
-        msg.addSource(new ChatSource(1, doc));
-
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
-        assertTrue(result.contains("...[omitted]..."));
-        assertTrue(result.contains("[Referenced documents: Test Doc]"));
-        // Head (300) + omitted marker + tail (200) + source titles
-        assertTrue(result.length() < 1000);
-    }
-
-    @Test
-    public void test_buildAssistantHistoryContent_smartSummary_shortContent() {
-        final ChatMessage msg = ChatMessage.assistantMessage("Short response");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
-        assertEquals("Short response", result);
-    }
-
-    @Test
-    public void test_buildAssistantHistoryContent_smartSummary_noSources() {
-        final ChatMessage msg = ChatMessage.assistantMessage("A".repeat(1000));
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
-        assertTrue(result.contains("...[omitted]..."));
-        assertFalse(result.contains("[Referenced documents:"));
-    }
-
-    @Test
-    public void test_extractHistory_smartSummaryMode() {
-        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public String getOrDefault(final String key, final String defaultValue) {
-                if ("rag.chat.history.assistant.content".equals(key)) {
-                    return "smart_summary";
-                }
-                return defaultValue;
-            }
-        });
-
-        chatClient.setTestSummaryMaxChars(20);
-        final ChatSession session = new ChatSession();
-        session.addUserMessage("Q1");
-        session.addAssistantMessage("This is a fairly long response that should be summarized using smart summary mode.");
-
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
-        assertEquals(2, history.size());
-        assertEquals("assistant", history.get(1).getRole());
-        assertTrue(history.get(1).getContent().contains("...[omitted]..."));
-    }
-
-    // ========== additional smart_summary tests ==========
-
-    @Test
-    public void test_smartSummary_nullContent() {
-        final ChatMessage msg = ChatMessage.assistantMessage(null);
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
-        assertNull(result);
-    }
-
-    @Test
-    public void test_smartSummary_exactlyAtBudget() {
-        // omitMarker = "\n...[omitted]...\n" (18 chars), suffix="" (no sources), bodyBudget = 500 - 0 - 18 = 482
-        // Content of 482 chars is <= bodyBudget, so returned with suffix (empty) appended as-is
-        final String content = "X".repeat(482);
-        final ChatMessage msg = ChatMessage.assistantMessage(content);
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
-        assertEquals(content, result);
-    }
-
-    @Test
-    public void test_smartSummary_headTailRatio() {
-        // Use 1000-char content with summaryMaxChars=500, no sources
-        // omitMarker="\n...[omitted]...\n" (17 chars), suffix="", bodyBudget=500-0-17=483
-        // headChars = (int)(483 * 0.6) = 289, tailChars = 483 - 289 = 194
-        final String content = "A".repeat(1000);
-        final ChatMessage msg = ChatMessage.assistantMessage(content);
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
-        final String omitMarker = "\n...[omitted]...\n";
-        final int omitIdx = result.indexOf(omitMarker);
-        assertTrue(omitIdx > 0);
-        final String head = result.substring(0, omitIdx);
-        final String tail = result.substring(omitIdx + omitMarker.length());
-        // Verify 60/40 ratio: head=289, tail=194
-        assertEquals(289, head.length());
-        assertEquals(194, tail.length());
-        // Head should be ~60% of bodyBudget
-        final double headRatio = (double) head.length() / (head.length() + tail.length());
-        assertTrue(headRatio > 0.55 && headRatio < 0.65);
-    }
-
-    @Test
-    public void test_smartSummary_withMultipleSources() {
-        final ChatMessage msg = createAssistantWithSources("A".repeat(1000), "Guide A", "Guide B", "Guide C");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
-        assertTrue(result.contains("[Referenced documents: Guide A, Guide B, Guide C]"));
-        assertTrue(result.contains("...[omitted]..."));
-    }
-
-    @Test
-    public void test_smartSummary_budgetEnforcesMaxChars() {
-        final ChatMessage msg = createAssistantWithSources("A".repeat(5000), "Title1", "Title2");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 500, 500);
-        // Result should not exceed summaryMaxChars by much (suffix may push slightly, but the body is budgeted)
-        assertTrue(result.length() <= 500 + 50, "result length " + result.length() + " exceeds reasonable bound");
-    }
-
-    @Test
-    public void test_smartSummary_longSourceTitlesExceedBudget() {
-        // When source titles alone are very long, suffix is truncated to maxChars/4
-        final String longTitle = "T".repeat(1000);
-        final ChatMessage msg = createAssistantWithSources("A".repeat(500), longTitle);
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 200, 200);
-        // maxSuffixLen = 200/4 = 50, suffix is truncated to 50 chars
-        assertNotNull(result);
-        // The suffix portion should not exceed maxSuffixLen
-        assertTrue(result.length() <= 250, "result length " + result.length() + " exceeds reasonable bound");
-    }
-
-    @Test
-    public void test_smartSummary_verySmallBudget() {
-        final ChatMessage msg = createAssistantWithSources("Hello world, this is some content.", "Doc");
-        final String result = chatClient.testBuildAssistantHistoryContent(msg, "smart_summary", 10, 10);
-        // Should not crash; maxSuffixLen=10/4=2, suffix gets truncated severely
-        // bodyBudget may be 0 or negative => suffix or truncated content returned
-        assertNotNull(result);
-        assertTrue(result.length() > 0);
+        final ChatMessage msg = ChatMessage.assistantMessage("This is a very long response text that should be truncated");
+        final String result = chatClient.testBuildAssistantHistoryContent(msg, "truncated", 10, 800);
+        assertEquals("This is a ...", result);
     }
 
     // ========== additional source_titles tests ==========
@@ -554,24 +402,26 @@ public class ChatClientTest extends UnitFessTestCase {
     @Test
     public void test_extractHistory_defaultMode_isSmartSummary() {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
-            private static final long serialVersionUID = 1L;
-
             @Override
             public String getOrDefault(final String key, final String defaultValue) {
-                // Do not override the key — let it use defaultValue
                 return defaultValue;
             }
         });
-
-        chatClient.setTestSummaryMaxChars(50);
         final ChatSession session = new ChatSession();
-        session.addUserMessage("Q1");
-        session.addAssistantMessage("A".repeat(200));
+        session.addMessage(ChatMessage.userMessage("Q1"));
+        final ChatMessage a = ChatMessage.assistantMessage("Some long body that we no longer keep verbatim.");
+        a.setSearchQuery("Q1");
+        session.addMessage(a);
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
-        assertEquals(2, history.size());
-        // Default mode is smart_summary, so long content should be summarized
-        assertTrue(history.get(1).getContent().contains("...[omitted]..."));
+        // Default mode is smart_summary => intent rendering drops the body.
+        final List<LlmMessage> intent = chatClient.testExtractHistoryForIntent(session);
+        assertEquals(2, intent.size());
+        assertEquals("searched: \"Q1\"", intent.get(1).getContent());
+
+        // Default mode is smart_summary => answer rendering pairs user with rendered turn.
+        final List<LlmMessage> answer = chatClient.testExtractHistoryForAnswer(session);
+        assertEquals(1, answer.size());
+        assertEquals("Q: \"Q1\" (searched: \"Q1\")", answer.get(0).getContent());
     }
 
     @Test
@@ -592,7 +442,7 @@ public class ChatClientTest extends UnitFessTestCase {
         session.addUserMessage("Q1");
         session.addAssistantMessage("Full content here");
 
-        final List<LlmMessage> history = chatClient.testExtractHistory(session);
+        final List<LlmMessage> history = chatClient.testExtractHistoryForAnswer(session);
         assertEquals(2, history.size());
         assertEquals("Full content here", history.get(1).getContent());
     }
@@ -1159,8 +1009,6 @@ public class ChatClientTest extends UnitFessTestCase {
         private boolean searchDocumentsCalled = false;
         private final List<String> searchedQueries = new ArrayList<>();
         private List<Map<String, Object>> searchResultsToReturn = Collections.emptyList();
-        private int testAssistantMaxChars = 800;
-        private int testSummaryMaxChars = 800;
 
         void setSearchResults(final List<Map<String, Object>> results) {
             this.searchResultsToReturn = results;
@@ -1170,21 +1018,9 @@ public class ChatClientTest extends UnitFessTestCase {
             return searchedQueries;
         }
 
-        void setTestAssistantMaxChars(final int maxChars) {
-            testAssistantMaxChars = maxChars;
-        }
-
-        void setTestSummaryMaxChars(final int maxChars) {
-            testSummaryMaxChars = maxChars;
-        }
-
         String testBuildAssistantHistoryContent(final ChatMessage msg, final String mode, final int assistantMaxChars,
                 final int summaryMaxChars) {
             return buildAssistantHistoryContent(msg, mode, assistantMaxChars, summaryMaxChars);
-        }
-
-        List<LlmMessage> testExtractHistory(final ChatSession session) {
-            return extractHistory(session);
         }
 
         List<LlmMessage> testExtractHistoryForIntent(final ChatSession session) {
@@ -1193,25 +1029,6 @@ public class ChatClientTest extends UnitFessTestCase {
 
         List<LlmMessage> testExtractHistoryForAnswer(final ChatSession session) {
             return extractHistoryForAnswer(session);
-        }
-
-        protected List<LlmMessage> extractHistory(final ChatSession session) {
-            final FessConfig fessConfig = ComponentUtil.getFessConfig();
-            final String assistantContentMode = fessConfig.getOrDefault("rag.chat.history.assistant.content", "smart_summary");
-
-            final List<LlmMessage> history = new ArrayList<>();
-            for (final ChatMessage msg : session.getMessages()) {
-                if (msg.isUser()) {
-                    history.add(LlmMessage.user(msg.getContent()));
-                } else if (msg.isAssistant()) {
-                    final String content =
-                            buildAssistantHistoryContent(msg, assistantContentMode, testAssistantMaxChars, testSummaryMaxChars);
-                    if (content != null) {
-                        history.add(LlmMessage.assistant(content));
-                    }
-                }
-            }
-            return history;
         }
 
         String testEscapeQueryValue(final String value) {

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -908,6 +908,16 @@ public class ChatClientTest extends UnitFessTestCase {
         assertEquals("Fess install", msg.getSearchQuery());
     }
 
+    // ========== chat() searchQuery contract ==========
+
+    @Test
+    public void test_chat_capturesFinalSearchQuery_sentinel() {
+        // Sentinel — see test_streamChatEnhanced_capturesFinalSearchQuery for rationale.
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("query2");
+        assertEquals("query2", msg.getSearchQuery());
+    }
+
     // ========== searchWithQuery with configurable results ==========
 
     @Test

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -901,6 +901,25 @@ public class ChatClientTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_renderIntentHistoryTurn_titlesMaxCountZero() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("q");
+        addTitle(msg, "T1");
+        addTitle(msg, "T2");
+        final String result = chatClient.testRenderIntentHistoryTurn(msg, 0);
+        assertEquals("searched: \"q\"", result);
+    }
+
+    @Test
+    public void test_renderIntentHistoryTurn_titlesMaxCountNegative() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("q");
+        addTitle(msg, "T1");
+        final String result = chatClient.testRenderIntentHistoryTurn(msg, -3);
+        assertEquals("searched: \"q\"", result);
+    }
+
+    @Test
     public void test_renderIntentHistoryTurn_noSearchQuery() {
         final ChatMessage msg = ChatMessage.assistantMessage("body");
         addTitle(msg, "T1");

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -877,6 +877,92 @@ public class ChatClientTest extends UnitFessTestCase {
         assertTrue(chatClient.wasSearchDocumentsCalled());
     }
 
+    // ========== Phase-specific render helper tests ==========
+
+    @Test
+    public void test_renderIntentHistoryTurn_full() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("Fess install");
+        addTitle(msg, "Installation Guide");
+        addTitle(msg, "Quick Start");
+        final String result = chatClient.testRenderIntentHistoryTurn(msg, 5);
+        assertEquals("searched: \"Fess install\" -> found: [Installation Guide, Quick Start]", result);
+    }
+
+    @Test
+    public void test_renderIntentHistoryTurn_titlesOverflow() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("q");
+        for (int i = 1; i <= 7; i++) {
+            addTitle(msg, "T" + i);
+        }
+        final String result = chatClient.testRenderIntentHistoryTurn(msg, 3);
+        assertEquals("searched: \"q\" -> found: [T1, T2, T3, ... (+4 more)]", result);
+    }
+
+    @Test
+    public void test_renderIntentHistoryTurn_noSearchQuery() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        addTitle(msg, "T1");
+        final String result = chatClient.testRenderIntentHistoryTurn(msg, 5);
+        assertEquals("found: [T1]", result);
+    }
+
+    @Test
+    public void test_renderIntentHistoryTurn_empty() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        final String result = chatClient.testRenderIntentHistoryTurn(msg, 5);
+        assertNull(result);
+    }
+
+    @Test
+    public void test_renderAnswerHistoryTurn_full() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("Fess install");
+        addTitle(msg, "Installation Guide");
+        addTitle(msg, "Quick Start");
+        final String result = chatClient.testRenderAnswerHistoryTurn("Fessのインストール方法は？", msg, 5);
+        assertEquals("Q: \"Fessのインストール方法は？\" (searched: \"Fess install\", refs: [Installation Guide, Quick Start])", result);
+    }
+
+    @Test
+    public void test_renderAnswerHistoryTurn_noTitles() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("q");
+        final String result = chatClient.testRenderAnswerHistoryTurn("Hi", msg, 5);
+        assertEquals("Q: \"Hi\" (searched: \"q\")", result);
+    }
+
+    @Test
+    public void test_renderAnswerHistoryTurn_noSearchQuery() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        addTitle(msg, "T1");
+        final String result = chatClient.testRenderAnswerHistoryTurn("Hi", msg, 5);
+        assertEquals("Q: \"Hi\" (refs: [T1])", result);
+    }
+
+    @Test
+    public void test_renderAnswerHistoryTurn_userQueryEscapesQuoteAndNewline() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("q");
+        final String result = chatClient.testRenderAnswerHistoryTurn("a\"b\nc", msg, 5);
+        assertEquals("Q: \"a'b c\" (searched: \"q\")", result);
+    }
+
+    @Test
+    public void test_renderAnswerHistoryTurn_searchQueryEscapesQuoteAndNewline() {
+        final ChatMessage msg = ChatMessage.assistantMessage("body");
+        msg.setSearchQuery("q1\"q2\nq3");
+        final String result = chatClient.testRenderAnswerHistoryTurn("Hi", msg, 5);
+        assertEquals("Q: \"Hi\" (searched: \"q1'q2 q3\")", result);
+    }
+
+    private void addTitle(final ChatMessage msg, final String title) {
+        final java.util.Map<String, Object> doc = new java.util.HashMap<>();
+        doc.put("title", title);
+        msg.addSource(new ChatSource(msg.getSources().size() + 1, doc));
+    }
+
     // ========== searchWithQuery tracks queries ==========
 
     @Test
@@ -1014,6 +1100,14 @@ public class ChatClientTest extends UnitFessTestCase {
         String testBuildGoUrl(final String contextPath, final String docId, final String queryId, final long requestedTime,
                 final int order) {
             return buildGoUrl(contextPath, docId, queryId, requestedTime, order);
+        }
+
+        String testRenderIntentHistoryTurn(final ChatMessage msg, final int titlesMaxCount) {
+            return renderIntentHistoryTurn(msg, titlesMaxCount);
+        }
+
+        String testRenderAnswerHistoryTurn(final String userQuery, final ChatMessage assistantMsg, final int titlesMaxCount) {
+            return renderAnswerHistoryTurn(userQuery, assistantMsg, titlesMaxCount);
         }
 
         List<Map<String, Object>> testSearchWithQueryFiltered(final String query, final Map<String, String[]> fields,

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -995,7 +995,7 @@ public class ChatClientTest extends UnitFessTestCase {
                 if ("rag.chat.history.titles.max.count".equals(key)) {
                     return "5";
                 }
-                return super.getOrDefault(key, defaultValue);
+                return defaultValue;
             }
         });
         final ChatSession session = new ChatSession();
@@ -1028,7 +1028,7 @@ public class ChatClientTest extends UnitFessTestCase {
                 if ("rag.chat.history.titles.max.count".equals(key)) {
                     return "5";
                 }
-                return super.getOrDefault(key, defaultValue);
+                return defaultValue;
             }
         });
         final ChatSession session = new ChatSession();
@@ -1053,7 +1053,7 @@ public class ChatClientTest extends UnitFessTestCase {
                 if ("rag.chat.history.assistant.content".equals(key)) {
                     return "smart_summary";
                 }
-                return super.getOrDefault(key, defaultValue);
+                return defaultValue;
             }
         });
         final ChatSession session = new ChatSession();
@@ -1073,7 +1073,7 @@ public class ChatClientTest extends UnitFessTestCase {
                 if ("rag.chat.history.assistant.content".equals(key)) {
                     return "full";
                 }
-                return super.getOrDefault(key, defaultValue);
+                return defaultValue;
             }
         });
         final ChatSession session = new ChatSession();

--- a/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientTest.java
@@ -982,6 +982,109 @@ public class ChatClientTest extends UnitFessTestCase {
         msg.addSource(new ChatSource(msg.getSources().size() + 1, doc));
     }
 
+    // ========== Phase-specific extractHistory tests (smart_summary) ==========
+
+    @Test
+    public void test_extractHistoryForIntent_smartSummary() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getOrDefault(final String key, final String defaultValue) {
+                if ("rag.chat.history.assistant.content".equals(key)) {
+                    return "smart_summary";
+                }
+                if ("rag.chat.history.titles.max.count".equals(key)) {
+                    return "5";
+                }
+                return super.getOrDefault(key, defaultValue);
+            }
+        });
+        final ChatSession session = new ChatSession();
+        session.addMessage(ChatMessage.userMessage("Fessのインストール方法は？"));
+        final ChatMessage a1 = ChatMessage.assistantMessage("body1");
+        a1.setSearchQuery("Fess install");
+        addTitle(a1, "Installation Guide");
+        session.addMessage(a1);
+        session.addMessage(ChatMessage.userMessage("Dockerの場合は？"));
+
+        final List<LlmMessage> result = chatClient.testExtractHistoryForIntent(session);
+
+        assertEquals(2, result.size());
+        // user turn passes through
+        assertEquals("user", result.get(0).getRole());
+        assertEquals("Fessのインストール方法は？", result.get(0).getContent());
+        // assistant turn rendered minimally
+        assertEquals("assistant", result.get(1).getRole());
+        assertEquals("searched: \"Fess install\" -> found: [Installation Guide]", result.get(1).getContent());
+    }
+
+    @Test
+    public void test_extractHistoryForAnswer_smartSummary_pairsUserWithAssistant() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getOrDefault(final String key, final String defaultValue) {
+                if ("rag.chat.history.assistant.content".equals(key)) {
+                    return "smart_summary";
+                }
+                if ("rag.chat.history.titles.max.count".equals(key)) {
+                    return "5";
+                }
+                return super.getOrDefault(key, defaultValue);
+            }
+        });
+        final ChatSession session = new ChatSession();
+        session.addMessage(ChatMessage.userMessage("Fessのインストール方法は？"));
+        final ChatMessage a1 = ChatMessage.assistantMessage("body1");
+        a1.setSearchQuery("Fess install");
+        addTitle(a1, "Installation Guide");
+        session.addMessage(a1);
+
+        final List<LlmMessage> result = chatClient.testExtractHistoryForAnswer(session);
+
+        assertEquals(1, result.size());
+        assertEquals("assistant", result.get(0).getRole());
+        assertEquals("Q: \"Fessのインストール方法は？\" (searched: \"Fess install\", refs: [Installation Guide])", result.get(0).getContent());
+    }
+
+    @Test
+    public void test_extractHistoryForAnswer_smartSummary_skipsOrphanAssistant() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getOrDefault(final String key, final String defaultValue) {
+                if ("rag.chat.history.assistant.content".equals(key)) {
+                    return "smart_summary";
+                }
+                return super.getOrDefault(key, defaultValue);
+            }
+        });
+        final ChatSession session = new ChatSession();
+        final ChatMessage orphan = ChatMessage.assistantMessage("body");
+        orphan.setSearchQuery("q");
+        session.addMessage(orphan);
+
+        final List<LlmMessage> result = chatClient.testExtractHistoryForAnswer(session);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void test_extractHistoryForIntent_fullMode_unchanged() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getOrDefault(final String key, final String defaultValue) {
+                if ("rag.chat.history.assistant.content".equals(key)) {
+                    return "full";
+                }
+                return super.getOrDefault(key, defaultValue);
+            }
+        });
+        final ChatSession session = new ChatSession();
+        session.addMessage(ChatMessage.userMessage("Q"));
+        session.addMessage(ChatMessage.assistantMessage("Long answer body here."));
+
+        final List<LlmMessage> result = chatClient.testExtractHistoryForIntent(session);
+        assertEquals(2, result.size());
+        assertEquals("Long answer body here.", result.get(1).getContent());
+    }
+
     // ========== searchWithQuery tracks queries ==========
 
     @Test
@@ -1082,6 +1185,14 @@ public class ChatClientTest extends UnitFessTestCase {
 
         List<LlmMessage> testExtractHistory(final ChatSession session) {
             return extractHistory(session);
+        }
+
+        List<LlmMessage> testExtractHistoryForIntent(final ChatSession session) {
+            return extractHistoryForIntent(session);
+        }
+
+        List<LlmMessage> testExtractHistoryForAnswer(final ChatSession session) {
+            return extractHistoryForAnswer(session);
         }
 
         @Override

--- a/src/test/java/org/codelibs/fess/entity/ChatMessageTest.java
+++ b/src/test/java/org/codelibs/fess/entity/ChatMessageTest.java
@@ -278,4 +278,17 @@ public class ChatMessageTest extends UnitFessTestCase {
 
         assertEquals(htmlContent, message.getHtmlContent());
     }
+
+    @Test
+    public void test_searchQuery_defaultIsNull() {
+        final ChatMessage msg = ChatMessage.assistantMessage("hello");
+        assertNull(msg.getSearchQuery());
+    }
+
+    @Test
+    public void test_searchQuery_setAndGet() {
+        final ChatMessage msg = ChatMessage.assistantMessage("hello");
+        msg.setSearchQuery("Fess install");
+        assertEquals("Fess install", msg.getSearchQuery());
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the head-tail `smart_summary` history mode with a **Minimal Trail** structure that drops assistant body text and keeps only `{searchQuery, retrievedTitles}` per turn. Each turn is now rendered differently for Intent Detection (`searched: "..." -> found: [...]`) vs Answer Generation (`Q: "..." (searched: "...", refs: [...])`).

- ~80% reduction in per-turn history size (e.g., OpenAI: ~900 chars → ~150 chars/turn)
- Strengthens "reference indication" follow-ups (e.g., "the 3rd document?") which the previous head-tail mode often dropped
- No additional LLM calls; rendering is pure regex/string ops
- Other history modes (`full`, `source_titles`, `source_titles_and_urls`, `truncated`, `none`) unchanged
- New config: `rag.chat.history.titles.max.count=5`

## Design

- Trade-off: P4 (comparison/diff) follow-ups become weaker since past assistant body is no longer kept; users wanting prior behavior can switch to `full` mode.
- P1 (深掘り), P3 (絞り込み), P5 (文脈引継ぎ) covered by the search-query trail; P2 (参照指示) is now strengthened by ordered title preservation.

## Implementation

- 11 atomic commits (feat / refactor / fix / test / config)
- New: `extractHistoryForIntent` / `extractHistoryForAnswer` / `renderIntentHistoryTurn` / `renderAnswerHistoryTurn` / `escapeForLine`
- Removed: `buildSmartSummaryContent` and the legacy single `extractHistory(ChatSession)` (the `smart_summary` case in `buildAssistantHistoryContent` now throws `IllegalStateException` defensively)
- Added: `ChatMessage.searchQuery` field, populated from the final successful (re)search query in both `chat()` and `streamChatEnhanced()`
- Escapes `"`, `\n`, `\r` in user-supplied parts (search query, user query) to prevent format injection

## Test plan

- [x] All 5615 unit tests pass (`mvn test`)
- [x] 9 new render-helper tests cover happy path, titles overflow, missing query, escapes for both user query and search query, and `titlesMaxCount <= 0` guard
- [x] 4 new phase-specific extractHistory tests cover intent/answer pairing semantics, orphan-assistant skip, non-smart_summary delegation
- [x] Existing tests for other history modes (full / source_titles / source_titles_and_urls / truncated / none) still pass
- [ ] Manual verification with a running Fess + LLM: P1 (深掘り), P2 (参照指示), P3 (絞り込み), P5 (文脈引継ぎ)
- [ ] Update fess-docs (separate PR)

## Breaking change note

The default `smart_summary` mode now produces a different (much smaller) prompt for assistant history. Operators wanting behavior closer to the old mode can set `rag.chat.history.assistant.content=full`. No `legacy_smart_summary` alias is provided.