### PR TITLE
feat(crawler): include 403 and 410 in default failure URL status codes

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -430,7 +430,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. true */
     String CRAWLER_IGNORE_CONTENT_EXCEPTION = "crawler.ignore.content.exception";
 
-    /** The key of the configuration. e.g. 404 */
+    /** The key of the configuration. e.g. 404,403,410 */
     String CRAWLER_FAILURE_URL_STATUS_CODES = "crawler.failure.url.status.codes";
 
     /** The key of the configuration. e.g. 60 */
@@ -3459,7 +3459,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /**
      * Get the value for the key 'crawler.failure.url.status.codes'. <br>
-     * The value is, e.g. 404 <br>
+     * The value is, e.g. 404,403,410 <br>
      * comment: HTTP status codes considered as failure URLs.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
@@ -3467,7 +3467,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /**
      * Get the value for the key 'crawler.failure.url.status.codes' as {@link Integer}. <br>
-     * The value is, e.g. 404 <br>
+     * The value is, e.g. 404,403,410 <br>
      * comment: HTTP status codes considered as failure URLs.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      * @throws NumberFormatException When the property is not integer.
@@ -13478,7 +13478,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.CRAWLER_IGNORE_ROBOTS_TXT, "false");
             defaultMap.put(FessConfig.CRAWLER_IGNORE_ROBOTS_TAGS, "false");
             defaultMap.put(FessConfig.CRAWLER_IGNORE_CONTENT_EXCEPTION, "true");
-            defaultMap.put(FessConfig.CRAWLER_FAILURE_URL_STATUS_CODES, "404");
+            defaultMap.put(FessConfig.CRAWLER_FAILURE_URL_STATUS_CODES, "404,403,410");
             defaultMap.put(FessConfig.CRAWLER_SYSTEM_MONITOR_INTERVAL, "60");
             defaultMap.put(FessConfig.CRAWLER_HOTTHREAD_ignore_idle_threads, "true");
             defaultMap.put(FessConfig.CRAWLER_HOTTHREAD_INTERVAL, "500ms");

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -347,7 +347,7 @@ crawler.ignore.robots.tags=false
 # Whether to ignore content exceptions during crawling.
 crawler.ignore.content.exception=true
 # HTTP status codes considered as failure URLs.
-crawler.failure.url.status.codes=404
+crawler.failure.url.status.codes=404,403,410
 # Interval (seconds) for system monitor during crawling.
 crawler.system.monitor.interval=60
 # Whether to ignore idle threads in hot thread monitoring.


### PR DESCRIPTION
## Summary
Expand the default value of `crawler.failure.url.status.codes` from `404` to `404,403,410` so that `Forbidden` and `Gone` responses are treated as failure URLs out of the box, alongside `Not Found`.

## Changes Made
- `src/main/resources/fess_config.properties`: change default of `crawler.failure.url.status.codes` from `404` to `404,403,410`.
- `src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java`: regenerate the matching default and Javadoc/example comments for `CRAWLER_FAILURE_URL_STATUS_CODES`.

## Testing
- No behavior change beyond the default property value; existing tests around `FessConfig` defaults continue to apply. Operators who have overridden `crawler.failure.url.status.codes` are unaffected.

## Breaking Changes
- Existing installations that rely on the implicit default will now classify `403` and `410` responses as failure URLs as well. Sites that intentionally serve `403`/`410` for normal pages should override `crawler.failure.url.status.codes` back to `404` (or their preferred set).

## Additional Notes
- `403 Forbidden` and `410 Gone` are typically signals that a URL is no longer crawlable, so treating them as failure URLs by default aligns the shipped configuration with common operational expectations.