### PR TITLE
refactor(api,crawler,llm): precompile regex patterns and tighten hot paths

### DIFF
--- a/src/main/java/org/codelibs/fess/api/BaseApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/BaseApiManager.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.fess.Constants;
@@ -35,6 +36,8 @@ import jakarta.servlet.http.HttpServletResponse;
 public abstract class BaseApiManager implements WebApiManager {
 
     private static final String API_FORMAT_TYPE = "apiFormatType";
+
+    private static final Pattern MULTIPLE_SLASHES = Pattern.compile("/+");
 
     /** Path prefix for API endpoints. */
     protected String pathPrefix;
@@ -67,7 +70,6 @@ public abstract class BaseApiManager implements WebApiManager {
      * Default constructor for BaseApiManager.
      */
     public BaseApiManager() {
-        // Default constructor
     }
 
     /**
@@ -111,7 +113,7 @@ public abstract class BaseApiManager implements WebApiManager {
         String value = request.getParameter("type");
         if (value == null) {
             final String servletPath = request.getServletPath();
-            final String[] values = servletPath.replaceAll("/+", "/").split("/");
+            final String[] values = MULTIPLE_SLASHES.split(servletPath);
             if (values.length > 2) {
                 value = values[2];
             }
@@ -119,34 +121,11 @@ public abstract class BaseApiManager implements WebApiManager {
         if (value == null) {
             return FormatType.SEARCH;
         }
-        final String type = value.toUpperCase(Locale.ROOT);
-        if (FormatType.SEARCH.name().equals(type)) {
-            return FormatType.SEARCH;
+        try {
+            return FormatType.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (final IllegalArgumentException e) {
+            return FormatType.OTHER;
         }
-        if (FormatType.LABEL.name().equals(type)) {
-            return FormatType.LABEL;
-        }
-        if (FormatType.POPULARWORD.name().equals(type)) {
-            return FormatType.POPULARWORD;
-        }
-        if (FormatType.FAVORITE.name().equals(type)) {
-            return FormatType.FAVORITE;
-        }
-        if (FormatType.FAVORITES.name().equals(type)) {
-            return FormatType.FAVORITES;
-        }
-        if (FormatType.PING.name().equals(type)) {
-            return FormatType.PING;
-        }
-        if (FormatType.SCROLL.name().equals(type)) {
-            return FormatType.SCROLL;
-        }
-        if (FormatType.SUGGEST.name().equals(type)) {
-            return FormatType.SUGGEST;
-        }
-
-        // default
-        return FormatType.OTHER;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/WebApiManagerFactory.java
+++ b/src/main/java/org/codelibs/fess/api/WebApiManagerFactory.java
@@ -15,9 +15,7 @@
  */
 package org.codelibs.fess.api;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Arrays;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,7 +35,6 @@ public class WebApiManagerFactory {
      * Default constructor.
      */
     public WebApiManagerFactory() {
-        // Default constructor
     }
 
     /**
@@ -54,10 +51,9 @@ public class WebApiManagerFactory {
         if (logger.isDebugEnabled()) {
             logger.debug("Adding WebApiManager. class={}", webApiManager.getClass().getSimpleName());
         }
-        final List<WebApiManager> list = new ArrayList<>();
-        Collections.addAll(list, webApiManagers);
-        list.add(webApiManager);
-        webApiManagers = list.toArray(new WebApiManager[list.size()]);
+        final WebApiManager[] updated = Arrays.copyOf(webApiManagers, webApiManagers.length + 1);
+        updated[webApiManagers.length] = webApiManager;
+        webApiManagers = updated;
         if (logger.isDebugEnabled()) {
             logger.debug("WebApiManager added. totalManagers={}", webApiManagers.length);
         }

--- a/src/main/java/org/codelibs/fess/api/WebApiRequest.java
+++ b/src/main/java/org/codelibs/fess/api/WebApiRequest.java
@@ -48,7 +48,8 @@ public class WebApiRequest extends HttpServletRequestWrapper {
      */
     @Override
     public String getServletPath() {
-        if (getQueryString() != null && getQueryString().indexOf("SAStruts.method") != -1) {
+        final String queryString = getQueryString();
+        if (queryString != null && queryString.contains("SAStruts.method")) {
             return super.getServletPath();
         }
         return servletPath;

--- a/src/main/java/org/codelibs/fess/api/chat/ChatApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/chat/ChatApiManager.java
@@ -72,7 +72,6 @@ public class ChatApiManager extends BaseApiManager {
      * Default constructor.
      */
     public ChatApiManager() {
-        // Default constructor
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
@@ -21,7 +21,9 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.apache.catalina.connector.ClientAbortException;
 import org.apache.logging.log4j.LogManager;
@@ -57,6 +59,16 @@ public class SearchEngineApiManager extends BaseApiManager {
     private static final String ADMIN_SERVER = "/admin/server_";
 
     private static final Logger logger = LogManager.getLogger(SearchEngineApiManager.class);
+
+    private static final Pattern DOTS = Pattern.compile("\\.\\.+");
+
+    private static final Pattern MULTIPLE_SLASHES = Pattern.compile("/+");
+
+    private static final Map<String, String> EXTENSION_CONTENT_TYPES = Map.ofEntries(Map.entry(".html", "text/html;charset=utf-8"),
+            Map.entry(".css", "text/css"), Map.entry(".eot", "application/vnd.ms-fontobject"),
+            Map.entry(".ico", "image/vnd.microsoft.icon"), Map.entry(".js", "text/javascript"), Map.entry(".json", "application/json"),
+            Map.entry(".otf", "font/otf"), Map.entry(".svg", "image/svg+xml"), Map.entry(".ttf", "font/ttf"),
+            Map.entry(".txt", "text/plain"), Map.entry(".woff", "font/woff"), Map.entry(".woff2", "font/woff2"));
 
     /** Roles that are allowed to access the search engine API */
     protected String[] acceptedRoles = { "admin" };
@@ -214,36 +226,20 @@ public class SearchEngineApiManager extends BaseApiManager {
     protected void processPluginRequest(final HttpServletRequest request, final HttpServletResponse response, final String path) {
         if (StringUtil.isNotBlank(path)) {
             final String lowerPath = path.toLowerCase(Locale.ROOT);
-            if (lowerPath.endsWith(".html")) {
+            if (lowerPath.endsWith("/")) {
                 response.setContentType("text/html;charset=utf-8");
-            } else if (lowerPath.endsWith(".css")) {
-                response.setContentType("text/css");
-            } else if (lowerPath.endsWith(".eot")) {
-                response.setContentType("application/vnd.ms-fontobject");
-            } else if (lowerPath.endsWith(".ico")) {
-                response.setContentType("image/vnd.microsoft.icon");
-            } else if (lowerPath.endsWith(".js")) {
-                response.setContentType("text/javascript");
-            } else if (lowerPath.endsWith(".json")) {
-                response.setContentType("application/json");
-            } else if (lowerPath.endsWith(".otf")) {
-                response.setContentType("font/otf");
-            } else if (lowerPath.endsWith(".svg")) {
-                response.setContentType("image/svg+xml");
-            } else if (lowerPath.endsWith(".ttf")) {
-                response.setContentType("font/ttf");
-            } else if (lowerPath.endsWith(".txt")) {
-                response.setContentType("text/plain");
-            } else if (lowerPath.endsWith(".woff")) {
-                response.setContentType("font/woff");
-            } else if (lowerPath.endsWith(".woff2")) {
-                response.setContentType("font/woff2");
-            } else if (lowerPath.endsWith("/")) {
-                response.setContentType("text/html;charset=utf-8");
+            } else {
+                final int dot = lowerPath.lastIndexOf('.');
+                if (dot >= 0) {
+                    final String contentType = EXTENSION_CONTENT_TYPES.get(lowerPath.substring(dot));
+                    if (contentType != null) {
+                        response.setContentType(contentType);
+                    }
+                }
             }
         }
 
-        Path filePath = ResourceUtil.getSitePath(path.replaceAll("\\.\\.+", StringUtil.EMPTY).replaceAll("/+", "/").split("/"));
+        Path filePath = ResourceUtil.getSitePath(MULTIPLE_SLASHES.split(DOTS.matcher(path).replaceAll(StringUtil.EMPTY)));
         if (Files.isDirectory(filePath)) {
             filePath = filePath.resolve("index.html");
         }

--- a/src/main/java/org/codelibs/fess/api/json/SearchApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/json/SearchApiManager.java
@@ -21,23 +21,26 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URLDecoder;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.core.CoreLibConstants;
 import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
@@ -117,6 +120,13 @@ public class SearchApiManager extends BaseApiManager {
      */
     protected String mimeType = "application/json";
 
+    private static final DateTimeFormatter ISO_8601_EXTEND_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.ROOT);
+
+    private static final Pattern MULTIPLE_SLASHES = Pattern.compile("/+");
+
+    private static final Pattern CALLBACK_NAME_INVALID_CHARS = Pattern.compile("[^0-9a-zA-Z_$.]");
+
     /**
      * Constructor.
      */
@@ -138,7 +148,7 @@ public class SearchApiManager extends BaseApiManager {
     @Override
     protected FormatType detectFormatType(final HttpServletRequest request) {
         final String servletPath = request.getServletPath();
-        final String[] values = servletPath.replaceAll("/+", "/").split("/");
+        final String[] values = MULTIPLE_SLASHES.split(servletPath);
         final String value = values.length > 3 ? values[3] : null;
         if (value == null) {
             return FormatType.SEARCH;
@@ -417,10 +427,10 @@ public class SearchApiManager extends BaseApiManager {
             buf.append(escapeJson(searchQuery));
             buf.append(",\"requested_time\":");
             buf.append(requestedTime);
-            final String[] relatedQueries = relatedQueryHelper.getRelatedQueries(params.getQuery());
+            final String[] relatedQueries = relatedQueryHelper.getRelatedQueries(query);
             buf.append(",\"related_query\":");
             buf.append(escapeJson(relatedQueries));
-            final String[] relatedContents = relatedContentHelper.getRelatedContents(params.getQuery());
+            final String[] relatedContents = relatedContentHelper.getRelatedContents(query);
             buf.append(",\"related_contents\":");
             buf.append(escapeJson(relatedContents));
             buf.append(',');
@@ -703,14 +713,7 @@ public class SearchApiManager extends BaseApiManager {
                             throw new WebApiException(HttpServletResponse.SC_BAD_REQUEST, "URL is null.");
                         }
 
-                        boolean found = false;
-                        for (final String id : docIds) {
-                            if (docId.equals(id)) {
-                                found = true;
-                                break;
-                            }
-                        }
-                        if (!found) {
+                        if (!ArrayUtils.contains(docIds, docId)) {
                             throw new WebApiException(HttpServletResponse.SC_NOT_FOUND, "Not found: " + favoriteUrl);
                         }
 
@@ -800,11 +803,11 @@ public class SearchApiManager extends BaseApiManager {
                     urlList.add(urlObj);
                 }
             }
-            urlList = favoriteLogService.getUrlList(userCode, urlList);
-            final List<String> docIdList = new ArrayList<>(urlList.size());
+            final Set<String> favoriteUrls = new HashSet<>(favoriteLogService.getUrlList(userCode, urlList));
+            final List<String> docIdList = new ArrayList<>(favoriteUrls.size());
             for (final Map<String, Object> doc : docList) {
                 final String urlObj = DocumentUtil.getValue(doc, fessConfig.getIndexFieldUrl(), String.class);
-                if (urlObj != null && urlList.contains(urlObj)) {
+                if (urlObj != null && favoriteUrls.contains(urlObj)) {
                     final String docIdObj = DocumentUtil.getValue(doc, fessConfig.getIndexFieldDocId(), String.class);
                     if (docIdObj != null) {
                         docIdList.add(docIdObj);
@@ -1352,7 +1355,7 @@ public class SearchApiManager extends BaseApiManager {
      * @return The escaped callback name.
      */
     protected String escapeCallbackName(final String callbackName) {
-        return "/**/" + callbackName.replaceAll("[^0-9a-zA-Z_\\$\\.]", StringUtil.EMPTY);
+        return "/**/" + CALLBACK_NAME_INVALID_CHARS.matcher(callbackName).replaceAll(StringUtil.EMPTY);
     }
 
     /**
@@ -1407,8 +1410,10 @@ public class SearchApiManager extends BaseApiManager {
         } else if (obj instanceof Boolean) {
             buf.append(obj.toString());
         } else if (obj instanceof Date) {
-            final SimpleDateFormat sdf = new SimpleDateFormat(CoreLibConstants.DATE_FORMAT_ISO_8601_EXTEND, Locale.ROOT);
-            buf.append('\"').append(StringEscapeUtils.escapeJson(sdf.format(obj))).append('\"');
+            buf.append('\"')
+                    .append(StringEscapeUtils
+                            .escapeJson(ISO_8601_EXTEND_FORMATTER.withZone(ZoneId.systemDefault()).format(((Date) obj).toInstant())))
+                    .append('\"');
         } else {
             buf.append('\"').append(StringEscapeUtils.escapeJson(obj.toString())).append('\"');
         }

--- a/src/main/java/org/codelibs/fess/crawler/FessCrawlerThread.java
+++ b/src/main/java/org/codelibs/fess/crawler/FessCrawlerThread.java
@@ -90,12 +90,6 @@ public class FessCrawlerThread extends CrawlerThread {
     /** Configuration key for crawler clients used in parameter maps */
     protected static final String CRAWLER_CLIENTS = "crawlerClients";
 
-    /** HTTP status code for Not Found */
-    private static final int HTTP_STATUS_NOT_FOUND = 404;
-
-    /** HTTP status code for OK */
-    private static final int HTTP_STATUS_OK = 200;
-
     /**
      * Cache for client rules mapping client names to their corresponding URL patterns.
      * This cache improves performance by avoiding repeated parsing of client configuration rules.
@@ -195,24 +189,24 @@ public class FessCrawlerThread extends CrawlerThread {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Accessing document: url={}, status={}", url, httpStatusCode);
                 }
-                if (httpStatusCode == HTTP_STATUS_NOT_FOUND) {
+                if (httpStatusCode == Constants.NOT_FOUND_STATUS_CODE) {
                     storeChildUrlsToQueue(urlQueue, getAnchorSet(document.get(fessConfig.getIndexFieldAnchor())));
                     if (!indexingHelper.deleteDocument(searchEngineClient, id)) {
-                        logger.debug("Failed to delete document: status={}, url={}", HTTP_STATUS_NOT_FOUND, url);
+                        logger.debug("Failed to delete document: status={}, url={}", Constants.NOT_FOUND_STATUS_CODE, url);
                     }
                     return false;
                 }
                 if (responseData.getLastModified() == null) {
                     return true;
                 }
-                if (responseData.getLastModified().getTime() <= lastModified.getTime() && httpStatusCode == HTTP_STATUS_OK) {
+                if (responseData.getLastModified().getTime() <= lastModified.getTime() && httpStatusCode == Constants.OK_STATUS_CODE) {
 
                     log(logHelper, LogType.NOT_MODIFIED, crawlerContext, urlQueue);
 
                     responseData.setExecutionTime(systemHelper.getCurrentTimeAsLong() - startTime);
                     responseData.setParentUrl(urlQueue.getParentUrl());
                     responseData.setSessionId(crawlerContext.getSessionId());
-                    responseData.setHttpStatusCode(org.codelibs.fess.crawler.Constants.NOT_MODIFIED_STATUS);
+                    responseData.setHttpStatusCode(Constants.NOT_MODIFIED_STATUS);
                     processResponse(urlQueue, responseData);
 
                     storeChildUrlsToQueue(urlQueue, getAnchorSet(document.get(fessConfig.getIndexFieldAnchor())));

--- a/src/main/java/org/codelibs/fess/crawler/interval/FessIntervalController.java
+++ b/src/main/java/org/codelibs/fess/crawler/interval/FessIntervalController.java
@@ -119,29 +119,21 @@ public class FessIntervalController extends DefaultIntervalController {
      */
     @Override
     protected void delayForWaitingNewUrl() {
-        try {
-            ComponentUtil.getSystemHelper().calibrateCpuLoad();
-        } catch (final Exception e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Failed to calibrate CPU load", e);
-            }
-        }
-
-        try {
+        runQuietly("calibrate CPU load", () -> ComponentUtil.getSystemHelper().calibrateCpuLoad());
+        runQuietly("apply interval control rules", () -> {
             final IntervalControlHelper intervalControlHelper = ComponentUtil.getIntervalControlHelper();
             intervalControlHelper.checkCrawlerStatus();
             intervalControlHelper.delayByRules();
-        } catch (final Exception e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Failed to apply interval control rules", e);
-            }
-        }
+        });
+        runQuietly("execute parent delay logic", super::delayForWaitingNewUrl);
+    }
 
+    private void runQuietly(final String description, final Runnable action) {
         try {
-            super.delayForWaitingNewUrl();
+            action.run();
         } catch (final Exception e) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Failed to execute parent delay logic", e);
+                logger.debug("Failed to {}", description, e);
             }
         }
     }

--- a/src/main/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformer.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -73,6 +74,12 @@ public abstract class AbstractFessFileTransformer extends AbstractTransformer im
     }
 
     private static final Logger logger = LogManager.getLogger(AbstractFessFileTransformer.class);
+
+    private static final Pattern CACHE_WHITESPACE_PATTERN = Pattern.compile("[ \\t\\x0B\\f]+");
+
+    private static final Pattern TRAILING_SLASHES_PATTERN = Pattern.compile("/+$");
+
+    private static final Pattern SMB_SCHEME_PREFIX_PATTERN = Pattern.compile("^smb.?:/+");
 
     /**
      * The mapping for meta content.
@@ -261,7 +268,7 @@ public abstract class AbstractFessFileTransformer extends AbstractTransformer im
             if (responseData.getContentLength() > 0
                     && responseData.getContentLength() <= fessConfig.getCrawlerDocumentCacheMaxSizeAsInteger().longValue()) {
 
-                final String cache = content.trim().replaceAll("[ \\t\\x0B\\f]+", " ");
+                final String cache = CACHE_WHITESPACE_PATTERN.matcher(content.trim()).replaceAll(" ");
 
                 // text cache
                 putResultDataBody(dataMap, fessConfig.getIndexFieldCache(), cache);
@@ -422,18 +429,15 @@ public abstract class AbstractFessFileTransformer extends AbstractTransformer im
      * @return The parameters for extraction.
      */
     protected Map<String, String> createExtractParams(final ResponseData responseData, final CrawlingConfig crawlingConfig) {
-        final Map<String, String> params = new HashMap<>(crawlingConfig.getConfigParameterMap(ConfigName.CONFIG));
+        final Map<String, String> configParam = crawlingConfig.getConfigParameterMap(ConfigName.CONFIG);
+        final Map<String, String> params = new HashMap<>(configParam);
         params.put(ExtractData.RESOURCE_NAME_KEY, getResourceName(responseData));
         params.put(ExtractData.CONTENT_TYPE, responseData.getMimeType());
         params.put(ExtractData.CONTENT_ENCODING, responseData.getCharSet());
         params.put(ExtractData.URL, responseData.getUrl());
-        final Map<String, String> configParam = crawlingConfig.getConfigParameterMap(ConfigName.CONFIG);
-        if (configParam != null) {
-            final String keepOriginalBody = configParam.get(Config.KEEP_ORIGINAL_BODY);
-            if (StringUtil.isNotBlank(keepOriginalBody)) {
-                params.put(TikaExtractor.NORMALIZE_TEXT,
-                        Constants.TRUE.equalsIgnoreCase(keepOriginalBody) ? Constants.FALSE : Constants.TRUE);
-            }
+        final String keepOriginalBody = configParam.get(Config.KEEP_ORIGINAL_BODY);
+        if (StringUtil.isNotBlank(keepOriginalBody)) {
+            params.put(TikaExtractor.NORMALIZE_TEXT, Constants.TRUE.equalsIgnoreCase(keepOriginalBody) ? Constants.FALSE : Constants.TRUE);
         }
         return params;
     }
@@ -472,7 +476,7 @@ public abstract class AbstractFessFileTransformer extends AbstractTransformer im
             return null;
         }
 
-        name = name.replaceAll("/+$", StringUtil.EMPTY);
+        name = TRAILING_SLASHES_PATTERN.matcher(name).replaceAll(StringUtil.EMPTY);
         final int idx = name.lastIndexOf('/');
         if (idx >= 0) {
             name = name.substring(idx + 1);
@@ -553,7 +557,7 @@ public abstract class AbstractFessFileTransformer extends AbstractTransformer im
             return abbreviateSite(value);
         }
         if (url.startsWith("smb:") || url.startsWith("smb1:")) {
-            final String value = url.replaceFirst("^smb.?:/+", StringUtil.EMPTY);
+            final String value = SMB_SCHEME_PREFIX_PATTERN.matcher(url).replaceFirst(StringUtil.EMPTY);
             return abbreviateSite("\\\\" + value.replace('/', '\\'));
         }
 

--- a/src/main/java/org/codelibs/fess/crawler/transformer/FessXpathTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/FessXpathTransformer.java
@@ -32,7 +32,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -134,10 +136,13 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
     protected boolean useGoogleOffOn = true;
 
     /** Map storing field pruning rules */
-    protected Map<String, Boolean> fieldPrunedRuleMap = new HashMap<>();
+    protected Map<String, Boolean> fieldPrunedRuleMap = new ConcurrentHashMap<>();
 
     /** Cache for storing parsed pruned tags by configuration ID */
-    protected Map<String, PrunedTag[]> prunedTagsCache = new HashMap<>();
+    protected Map<String, PrunedTag[]> prunedTagsCache = new ConcurrentHashMap<>();
+
+    /** Compiled regex cache for {@link #convertUrlMap} entries */
+    private final Map<String, Pattern> convertUrlPatternCache = new ConcurrentHashMap<>();
 
     /**
      * Default constructor.
@@ -277,52 +282,18 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
      * @param document the parsed HTML document
      */
     protected void processMetaRobots(final ResponseData responseData, final ResultData resultData, final Document document) {
-        final Map<String, String> configMap = getConfigPrameterMap(responseData, ConfigName.CONFIG);
-        final String ignore = configMap.get(Config.IGNORE_ROBOTS_TAGS);
-        if (ignore == null) {
-            if (fessConfig.isCrawlerIgnoreRobotsTags()) {
-                return;
-            }
-        } else if (Boolean.parseBoolean(ignore)) {
+        if (isRobotsTagsIgnored(responseData)) {
             return;
         }
 
-        // meta tag
         try {
             final Node value = getXPathAPI().selectSingleNode(document, META_NAME_ROBOTS_CONTENT);
             if (value != null) {
-                boolean noindex = false;
-                boolean nofollow = false;
-                final String content = value.getTextContent().toLowerCase(Locale.ROOT);
-                if (content.contains(ROBOTS_TAG_NONE)) {
-                    noindex = true;
-                    nofollow = true;
-                } else {
-                    if (content.contains(ROBOTS_TAG_NOINDEX)) {
-                        noindex = true;
-                    }
-                    if (content.contains(ROBOTS_TAG_NOFOLLOW)) {
-                        nofollow = true;
-                    }
-                }
-                if (noindex && nofollow) {
-                    logger.info("META(robots=noindex,nofollow): {}", responseData.getUrl());
-                    throw new ChildUrlsException(Collections.emptySet(), "#processMetaRobots");
-                }
-                if (noindex) {
-                    logger.info("META(robots=noindex): {}", responseData.getUrl());
-                    storeChildUrls(responseData, resultData);
-                    throw new ChildUrlsException(resultData.getChildUrlSet(), "#processMetaRobots");
-                }
-                if (nofollow) {
-                    logger.info("META(robots=nofollow): {}", responseData.getUrl());
-                    responseData.setNoFollow(true);
-                }
+                applyRobotsDirective(value.getTextContent(), "META", "#processMetaRobots", responseData, resultData);
             }
         } catch (final XPathExpressionException e) {
             logger.warn("Could not parse a value of {}", META_NAME_ROBOTS_CONTENT, e);
         }
-
     }
 
     /**
@@ -333,50 +304,55 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
      * @param resultData the result data to store processed information
      */
     protected void processXRobotsTag(final ResponseData responseData, final ResultData resultData) {
-        final Map<String, String> configMap = getConfigPrameterMap(responseData, ConfigName.CONFIG);
-        final String ignore = configMap.get(Config.IGNORE_ROBOTS_TAGS);
-        if (ignore == null) {
-            if (fessConfig.isCrawlerIgnoreRobotsTags()) {
-                return;
-            }
-        } else if (Boolean.parseBoolean(ignore)) {
+        if (isRobotsTagsIgnored(responseData)) {
             return;
         }
 
-        // X-Robots-Tag
         responseData.getMetaDataMap()
                 .entrySet()
                 .stream()
                 .filter(e -> X_ROBOTS_TAG.equalsIgnoreCase(e.getKey()) && e.getValue() != null)
-                .forEach(e -> {
-                    boolean noindex = false;
-                    boolean nofollow = false;
-                    final String value = e.getValue().toString().toLowerCase(Locale.ROOT);
-                    if (value.contains(ROBOTS_TAG_NONE)) {
-                        noindex = true;
-                        nofollow = true;
-                    } else {
-                        if (value.contains(ROBOTS_TAG_NOINDEX)) {
-                            noindex = true;
-                        }
-                        if (value.contains(ROBOTS_TAG_NOFOLLOW)) {
-                            nofollow = true;
-                        }
-                    }
-                    if (noindex && nofollow) {
-                        logger.info("HEADER(robots=noindex,nofollow): {}", responseData.getUrl());
-                        throw new ChildUrlsException(Collections.emptySet(), "#processXRobotsTag");
-                    }
-                    if (noindex) {
-                        logger.info("HEADER(robots=noindex): {}", responseData.getUrl());
-                        storeChildUrls(responseData, resultData);
-                        throw new ChildUrlsException(resultData.getChildUrlSet(), "#processXRobotsTag");
-                    }
-                    if (nofollow) {
-                        logger.info("HEADER(robots=nofollow): {}", responseData.getUrl());
-                        responseData.setNoFollow(true);
-                    }
-                });
+                .forEach(e -> applyRobotsDirective(e.getValue().toString(), "HEADER", "#processXRobotsTag", responseData, resultData));
+    }
+
+    private boolean isRobotsTagsIgnored(final ResponseData responseData) {
+        final Map<String, String> configMap = getConfigPrameterMap(responseData, ConfigName.CONFIG);
+        final String ignore = configMap.get(Config.IGNORE_ROBOTS_TAGS);
+        if (ignore == null) {
+            return fessConfig.isCrawlerIgnoreRobotsTags();
+        }
+        return Boolean.parseBoolean(ignore);
+    }
+
+    private void applyRobotsDirective(final String rawValue, final String label, final String source, final ResponseData responseData,
+            final ResultData resultData) {
+        final String content = rawValue.toLowerCase(Locale.ROOT);
+        boolean noindex = false;
+        boolean nofollow = false;
+        if (content.contains(ROBOTS_TAG_NONE)) {
+            noindex = true;
+            nofollow = true;
+        } else {
+            if (content.contains(ROBOTS_TAG_NOINDEX)) {
+                noindex = true;
+            }
+            if (content.contains(ROBOTS_TAG_NOFOLLOW)) {
+                nofollow = true;
+            }
+        }
+        if (noindex && nofollow) {
+            logger.info("{}(robots=noindex,nofollow): {}", label, responseData.getUrl());
+            throw new ChildUrlsException(Collections.emptySet(), source);
+        }
+        if (noindex) {
+            logger.info("{}(robots=noindex): {}", label, responseData.getUrl());
+            storeChildUrls(responseData, resultData);
+            throw new ChildUrlsException(resultData.getChildUrlSet(), source);
+        }
+        if (nofollow) {
+            logger.info("{}(robots=nofollow): {}", label, responseData.getUrl());
+            responseData.setNoFollow(true);
+        }
     }
 
     /**
@@ -865,26 +841,24 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
      * @return the pruned node
      */
     protected Node pruneNode(final Node node, final CrawlingConfig crawlingConfig) {
-        PrunedTag[] prunedTags = null;
+        final PrunedTag[] prunedTags;
         if (crawlingConfig != null) {
-            final String configId = crawlingConfig.getConfigId();
-            prunedTags = prunedTagsCache.get(configId);
-            if (prunedTags == null) {
-                final Map<String, String> configMap = crawlingConfig.getConfigParameterMap(ConfigName.CONFIG);
-                final String value = configMap.get(CrawlingConfig.Param.Config.HTML_PRUNED_TAGS);
-                if (StringUtil.isNotBlank(value)) {
-                    prunedTags = PrunedTag.parse(value);
-                }
-                if (prunedTags == null) {
-                    prunedTags = fessConfig.getCrawlerDocumentHtmlPrunedTagsAsArray();
-                }
-                prunedTagsCache.put(configId, prunedTags);
-            }
-        }
-        if (prunedTags == null) {
+            prunedTags = prunedTagsCache.computeIfAbsent(crawlingConfig.getConfigId(), id -> resolvePrunedTags(crawlingConfig));
+        } else {
             prunedTags = fessConfig.getCrawlerDocumentHtmlPrunedTagsAsArray();
         }
         return pruneNodeByTags(node, prunedTags);
+    }
+
+    private PrunedTag[] resolvePrunedTags(final CrawlingConfig crawlingConfig) {
+        final String value = crawlingConfig.getConfigParameterMap(ConfigName.CONFIG).get(CrawlingConfig.Param.Config.HTML_PRUNED_TAGS);
+        if (StringUtil.isNotBlank(value)) {
+            final PrunedTag[] parsed = PrunedTag.parse(value);
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+        return fessConfig.getCrawlerDocumentHtmlPrunedTagsAsArray();
     }
 
     /**
@@ -1050,7 +1024,8 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
             for (final RequestData requestData : urlList) {
                 String url = requestData.getUrl();
                 for (final Map.Entry<String, String> entry : convertUrlMap.entrySet()) {
-                    url = url.replaceAll(entry.getKey(), entry.getValue());
+                    final Pattern pattern = convertUrlPatternCache.computeIfAbsent(entry.getKey(), Pattern::compile);
+                    url = pattern.matcher(url).replaceAll(entry.getValue());
                 }
                 url = pathMappingHelper.replaceUrl(url);
                 requestData.setUrl(replaceDuplicateHost(url));

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -69,6 +70,10 @@ public abstract class AbstractLlmClient implements LlmClient {
 
     /** Buffer size reserved when truncating context to fit within max chars limit. */
     protected static final int CONTEXT_TRUNCATION_BUFFER = 100;
+
+    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^>]+>");
+
+    private static final Pattern CONTROL_WHITESPACE_PATTERN = Pattern.compile("[\\r\\n\\t]");
 
     /** The HTTP client used for API communication. */
     protected CloseableHttpClient httpClient;
@@ -1128,7 +1133,8 @@ public abstract class AbstractLlmClient implements LlmClient {
             final LlmStreamCallback callback) {
         final LlmChatRequest request = new LlmChatRequest();
 
-        final String sanitizedUrl = sanitizeDocumentContent(documentUrl != null ? documentUrl.replaceAll("[\\r\\n\\t]", "") : "");
+        final String sanitizedUrl =
+                sanitizeDocumentContent(documentUrl != null ? CONTROL_WHITESPACE_PATTERN.matcher(documentUrl).replaceAll("") : "");
         final String resolvedPrompt =
                 resolveLanguageInstruction(getDocumentNotFoundSystemPrompt().replace("{{documentUrl}}", sanitizedUrl));
         if (logger.isDebugEnabled()) {
@@ -1262,8 +1268,10 @@ public abstract class AbstractLlmClient implements LlmClient {
      * @return the wrapped user input
      */
     protected String wrapUserInput(final String userMessage) {
-        final String escaped = userMessage.replace("</user_input>", "&lt;/user_input&gt;");
-        return "<user_input>" + escaped + "</user_input>";
+        if (userMessage.indexOf("</user_input>") < 0) {
+            return "<user_input>" + userMessage + "</user_input>";
+        }
+        return "<user_input>" + userMessage.replace("</user_input>", "&lt;/user_input&gt;") + "</user_input>";
     }
 
     /**
@@ -1355,7 +1363,7 @@ public abstract class AbstractLlmClient implements LlmClient {
         if (StringUtil.isBlank(text)) {
             return text;
         }
-        return text.replaceAll("<[^>]+>", "");
+        return HTML_TAG_PATTERN.matcher(text).replaceAll("");
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/api/json/SearchApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/api/json/SearchApiManagerTest.java
@@ -15,6 +15,12 @@
  */
 package org.codelibs.fess.api.json;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.codelibs.core.CoreLibConstants;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -61,5 +67,49 @@ public class SearchApiManagerTest extends UnitFessTestCase {
         assertTrue(str.startsWith("H"));
         assertTrue(str.endsWith("o"));
         assertEquals(5, str.length());
+    }
+
+    /**
+     * Verifies that the {@link Date} branch of {@code escapeJson(Object)} keeps
+     * the legacy {@link SimpleDateFormat} (ISO-8601 extended) output. This guards
+     * against a regression introduced when the implementation was migrated to
+     * {@code java.time.format.DateTimeFormatter}.
+     */
+    @Test
+    public void test_escapeJson_dateMatchesLegacySimpleDateFormat() {
+        final SearchApiManager manager = new SearchApiManager();
+        // Cover several time zones to catch zone/offset formatting differences.
+        for (final String tzId : new String[] { "UTC", "Asia/Tokyo", "America/Los_Angeles", "Europe/Paris" }) {
+            final TimeZone original = TimeZone.getDefault();
+            try {
+                TimeZone.setDefault(TimeZone.getTimeZone(tzId));
+                for (final long epochMillis : new long[] { 0L, 1L, 1_700_000_000_000L, 1_736_000_000_123L, System.currentTimeMillis() }) {
+                    final Date date = new Date(epochMillis);
+                    final SimpleDateFormat sdf = new SimpleDateFormat(CoreLibConstants.DATE_FORMAT_ISO_8601_EXTEND, Locale.ROOT);
+                    final String expected = "\"" + sdf.format(date) + "\"";
+                    final String actual = manager.escapeJson(date);
+                    assertEquals("tz=" + tzId + ", epochMillis=" + epochMillis, expected, actual);
+                }
+            } finally {
+                TimeZone.setDefault(original);
+            }
+        }
+    }
+
+    /**
+     * The output of {@code escapeJson(Date)} must be a JSON string in
+     * yyyy-MM-dd'T'HH:mm:ss.SSS&#177;HHmm form, surrounded by double quotes.
+     */
+    @Test
+    public void test_escapeJson_dateFormatShape() {
+        final SearchApiManager manager = new SearchApiManager();
+        final String result = manager.escapeJson(new Date(0L));
+        assertNotNull(result);
+        assertTrue(result.startsWith("\""), "should be wrapped in quotes: " + result);
+        assertTrue(result.endsWith("\""), "should be wrapped in quotes: " + result);
+        // 1970-01-01T00:00:00.000+0000 plus surrounding quotes is 30 chars
+        // (length depends on offset, which is always 5 chars for the "Z" pattern letter).
+        final String inner = result.substring(1, result.length() - 1);
+        assertTrue(inner.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[+-]\\d{4}"), "unexpected ISO-8601 layout: " + inner);
     }
 }


### PR DESCRIPTION
## Summary
Cross-cutting cleanup across `api/`, `crawler/`, and `llm/` packages: hoist repeated regex calls into static `Pattern` constants, make a couple of crawler caches thread-safe, and migrate the `Date` branch of the JSON encoder from `SimpleDateFormat` to `java.time.format.DateTimeFormatter`. No behavior changes intended.

## Changes Made

### API layer (`org.codelibs.fess.api`)
- **BaseApiManager**: hoist `"/+"` to a static `Pattern` and replace the long `if/else` chain in `getFormatType` with `FormatType.valueOf(...)` plus an `IllegalArgumentException` fallback to `OTHER`.
- **WebApiManagerFactory**: grow the `webApiManagers` array via `Arrays.copyOf` instead of building an `ArrayList` per call.
- **WebApiRequest.getServletPath**: cache the `getQueryString()` result in a local and switch the substring check to `String.contains`.
- **SearchEngineApiManager**: pre-compile `"\\.\\.+"` and `"/+"` patterns; replace the chained extension `if/else` with a `Map.ofEntries` lookup keyed by lowercase extension.
- **SearchApiManager**:
  - Pre-compile `"/+"`, the JSONP callback sanitizer, and a shared ISO-8601 `DateTimeFormatter`.
  - Use the already-resolved `query` for `getRelatedQueries`/`getRelatedContents` instead of re-reading `params.getQuery()`.
  - Use `ArrayUtils.contains` for the docId scan and a `HashSet` for favorite URL lookups (O(1) `contains`).
  - Migrate the `Date` branch of `escapeJson` to `DateTimeFormatter` with `ZoneId.systemDefault()`.
- **ChatApiManager**: drop the redundant `// Default constructor` comment.

### Crawler (`org.codelibs.fess.crawler`)
- **FessCrawlerThread**: remove local `HTTP_STATUS_OK`/`HTTP_STATUS_NOT_FOUND` constants and reuse `Constants.OK_STATUS_CODE`, `Constants.NOT_FOUND_STATUS_CODE`, and `Constants.NOT_MODIFIED_STATUS`.
- **FessIntervalController**: extract a `runQuietly(description, action)` helper so each delay stage shares the same swallow-and-debug-log treatment.
- **AbstractFessFileTransformer**: pre-compile cache/whitespace, trailing-slash, and SMB-prefix regexes; reuse the resolved config-parameter map (it cannot be `null` at that point because it's already used to construct a `HashMap`).
- **FessXpathTransformer**:
  - Switch `fieldPrunedRuleMap` and `prunedTagsCache` to `ConcurrentHashMap` and use `computeIfAbsent`, addressing a latent race when crawler threads populate the caches in parallel.
  - Cache compiled `Pattern` instances for `convertUrlMap` entries.
  - Extract `isRobotsTagsIgnored` and `applyRobotsDirective` so the meta `<robots>` and `X-Robots-Tag` paths no longer duplicate the same parsing block.

### LLM (`org.codelibs.fess.llm`)
- **AbstractLlmClient**: pre-compile the HTML-tag and control-whitespace regexes; short-circuit `wrapUserInput` when the message contains no `</user_input>` to skip the unnecessary `String.replace` call.

## Testing
- `mvn formatter:format && mvn license:format` should be re-run before merge if any conventions changed.
- New `SearchApiManagerTest` cases:
  - `test_escapeJson_dateMatchesLegacySimpleDateFormat` cross-checks the new formatter against `SimpleDateFormat(CoreLibConstants.DATE_FORMAT_ISO_8601_EXTEND)` across `UTC`, `Asia/Tokyo`, `America/Los_Angeles`, and `Europe/Paris` for several epoch values, guarding against regression in the `SimpleDateFormat` → `DateTimeFormatter` migration.
  - `test_escapeJson_dateFormatShape` asserts the output stays a quoted `yyyy-MM-dd'T'HH:mm:ss.SSS±HHmm` string.
- Existing crawler/API tests should keep passing — none of these changes alter visible behavior.

## Breaking Changes
None.

## Additional Notes
- The `ConcurrentHashMap` switch in `FessXpathTransformer` is the only change with potential runtime behavior implications — it's intentionally there because the caches are populated lazily from multiple crawler threads, and previously `HashMap.put` could race with reads.
- `escapeJson(Date)` now uses `ZoneId.systemDefault()` to mirror the previous `SimpleDateFormat` (which also used the default JVM zone). The new tests pin this behavior.
- Reviewers may want to spot-check the `FormatType.valueOf` fallback in `BaseApiManager#getFormatType` — the previous chain rejected unknown values via the final `default` arm, the new code does the same via the `catch`.