### PR TITLE
fix(storage): enable storage features when using default GCS endpoint

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -71,6 +71,7 @@ import org.codelibs.fess.exception.FessSystemException;
 import org.codelibs.fess.mylasta.action.FessMessages;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.storage.StorageType;
 import org.codelibs.fess.timer.LoadControlMonitorTarget;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.util.GsaConfigParser;
@@ -659,14 +660,32 @@ public class SystemHelper {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final String installationLink = fessConfig.getOnlineHelpInstallation();
         runtime.registerData("installationLink", getHelpUrl(installationLink));
-        runtime.registerData("storageEnabled",
-                StringUtil.isNotBlank(fessConfig.getStorageEndpoint()) && StringUtil.isNotBlank(fessConfig.getStorageBucket()));
+        runtime.registerData("storageEnabled", isStorageEnabled(fessConfig));
         final boolean eoled = isEoled();
         runtime.registerData("eoled", eoled);
         if (eoled) {
             final String eolLink = fessConfig.getOnlineHelpEol();
             runtime.registerData("eolLink", getHelpUrl(eolLink));
         }
+    }
+
+    /**
+     * Determines whether object storage is enabled for the given configuration.
+     * Storage is considered enabled when a bucket is configured and either a
+     * custom endpoint is set or the storage type is {@link StorageType#GCS}
+     * (which has an implicit default endpoint).
+     *
+     * @param fessConfig the configuration to inspect (may be {@code null})
+     * @return {@code true} if storage is enabled, {@code false} otherwise
+     */
+    public boolean isStorageEnabled(final FessConfig fessConfig) {
+        if (fessConfig == null || StringUtil.isBlank(fessConfig.getStorageBucket())) {
+            return false;
+        }
+        if (StringUtil.isNotBlank(fessConfig.getStorageEndpoint())) {
+            return true;
+        }
+        return StorageType.GCS.name().equalsIgnoreCase(fessConfig.getStorageType());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/storage/GcsStorageClient.java
+++ b/src/main/java/org/codelibs/fess/storage/GcsStorageClient.java
@@ -19,6 +19,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -52,8 +53,20 @@ public class GcsStorageClient implements StorageClient {
 
     private static final Logger logger = LogManager.getLogger(GcsStorageClient.class);
 
+    private static final String DEFAULT_GCS_HOST = "storage.googleapis.com";
+
     private final Storage storage;
     private final String bucket;
+
+    /**
+     * Constructor for subclasses that customize behavior without initializing the GCS client.
+     * Subclasses using this constructor must override any method that depends on
+     * {@code storage} or {@code bucket}.
+     */
+    protected GcsStorageClient() {
+        this.storage = null;
+        this.bucket = null;
+    }
 
     /**
      * Creates a new GcsStorageClient instance.
@@ -72,7 +85,7 @@ public class GcsStorageClient implements StorageClient {
             builder.setProjectId(projectId);
         }
 
-        if (StringUtil.isNotBlank(endpoint)) {
+        if (StringUtil.isNotBlank(endpoint) && !isDefaultEndpoint(endpoint)) {
             // For fake-gcs-server or custom endpoint
             builder.setHost(endpoint);
             builder.setCredentials(NoCredentials.getInstance());
@@ -93,6 +106,28 @@ public class GcsStorageClient implements StorageClient {
         }
 
         this.storage = builder.build().getService();
+    }
+
+    /**
+     * Determines whether the given endpoint refers to the default GCS host
+     * ({@code storage.googleapis.com}). Subclasses may override this to
+     * recognize additional hosts as default.
+     *
+     * @param endpoint the endpoint to check (URL or host)
+     * @return {@code true} if the endpoint resolves to the default GCS host
+     */
+    protected boolean isDefaultEndpoint(final String endpoint) {
+        if (StringUtil.isBlank(endpoint)) {
+            return false;
+        }
+        final String value = endpoint.trim();
+        try {
+            final URI uri = URI.create(value.contains("://") ? value : "https://" + value);
+            return "https".equalsIgnoreCase(uri.getScheme()) && DEFAULT_GCS_HOST.equalsIgnoreCase(uri.getHost())
+                    && (uri.getPort() == -1 || uri.getPort() == 443);
+        } catch (final IllegalArgumentException e) {
+            return DEFAULT_GCS_HOST.equalsIgnoreCase(value);
+        }
     }
 
     @Override
@@ -243,6 +278,9 @@ public class GcsStorageClient implements StorageClient {
     public void close() {
         // GCS Storage client doesn't require explicit close
         // but we can try to close it if needed
+        if (storage == null) {
+            return;
+        }
         try {
             storage.close();
         } catch (final Exception e) {

--- a/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
@@ -123,6 +123,38 @@ public class SystemHelperTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_isStorageEnabled() {
+        assertTrue(systemHelper.isStorageEnabled(storageConfig("https://s3.example.com", "bucket", "s3")));
+        assertTrue(systemHelper.isStorageEnabled(storageConfig("", "bucket", "gcs")));
+        assertTrue(systemHelper.isStorageEnabled(storageConfig("", "bucket", "GCS")));
+
+        assertFalse(systemHelper.isStorageEnabled(storageConfig("", "bucket", "auto")));
+        assertFalse(systemHelper.isStorageEnabled(storageConfig("", "", "gcs")));
+        assertFalse(systemHelper.isStorageEnabled(null));
+    }
+
+    private FessConfig storageConfig(final String endpoint, final String bucket, final String type) {
+        return new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getStorageEndpoint() {
+                return endpoint;
+            }
+
+            @Override
+            public String getStorageBucket() {
+                return bucket;
+            }
+
+            @Override
+            public String getStorageType() {
+                return type;
+            }
+        };
+    }
+
+    @Test
     public void test_getForumLink() {
         getMockRequest().setLocale(Locale.ENGLISH);
         assertEquals("https://discuss.codelibs.org/c/FessEN/", systemHelper.getForumLink());

--- a/src/test/java/org/codelibs/fess/storage/GcsStorageClientTest.java
+++ b/src/test/java/org/codelibs/fess/storage/GcsStorageClientTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.storage;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+public class GcsStorageClientTest extends UnitFessTestCase {
+
+    private static final class TestableGcsStorageClient extends GcsStorageClient {
+        TestableGcsStorageClient() {
+            super();
+        }
+    }
+
+    @Test
+    public void test_isDefaultEndpoint() {
+        try (GcsStorageClient client = new TestableGcsStorageClient()) {
+            assertTrue(client.isDefaultEndpoint("https://storage.googleapis.com"));
+            assertTrue(client.isDefaultEndpoint("https://storage.googleapis.com/"));
+            assertTrue(client.isDefaultEndpoint("storage.googleapis.com"));
+            assertTrue(client.isDefaultEndpoint("https://storage.googleapis.com/storage/v1"));
+            assertTrue(client.isDefaultEndpoint("https://storage.googleapis.com:443"));
+
+            assertFalse(client.isDefaultEndpoint(""));
+            assertFalse(client.isDefaultEndpoint("http://storage.googleapis.com"));
+            assertFalse(client.isDefaultEndpoint("https://storage.googleapis.com:4443"));
+            assertFalse(client.isDefaultEndpoint("http://localhost:4443"));
+            assertFalse(client.isDefaultEndpoint("https://example.com/storage.googleapis.com"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The admin UI's `storageEnabled` flag previously required a non-blank `storage.endpoint`, which hid storage-dependent features (e.g. thumbnail/asset storage admin links) whenever GCS was used with the default `storage.googleapis.com` host. This change recognizes GCS-with-default-endpoint as a valid enabled configuration and stops `GcsStorageClient` from treating the default host as a custom endpoint.

## Changes Made
- `SystemHelper`: extracted a new `isStorageEnabled(FessConfig)` helper. Storage is now enabled when `storage.bucket` is set AND either `storage.endpoint` is non-blank or `storage.type` is `gcs` (case-insensitive). `setupStorageInfo` delegates to this helper.
- `GcsStorageClient`:
  - Added `isDefaultEndpoint(String)` to detect the default GCS host (`storage.googleapis.com`, HTTPS, default port). Custom-host/`NoCredentials` overrides are now skipped when the configured endpoint matches the default, so real Google credentials are used.
  - Added a protected no-arg constructor so subclasses can override behavior without instantiating the underlying GCS client; `close()` short-circuits when `storage` is null.
- Tests:
  - `SystemHelperTest#test_isStorageEnabled` covers S3-with-endpoint, GCS-without-endpoint (both cases), unrelated type, missing bucket, and null config.
  - New `GcsStorageClientTest#test_isDefaultEndpoint` covers bare host, scheme/path variants, explicit default port, plus negative cases (HTTP, non-default port, hostname embedded in path).

## Testing
- `mvn test -Dtest=SystemHelperTest`
- `mvn test -Dtest=GcsStorageClientTest`

## Breaking Changes
None. The previous behavior is preserved whenever an explicit endpoint is configured; only the GCS-default-endpoint case becomes "enabled" instead of "disabled".

## Additional Notes
- The default-endpoint detection deliberately matches only HTTPS on the default port so that fake-gcs-server / emulator configurations (typically HTTP and/or a custom port) continue to receive `NoCredentials` and the host override.
- `isStorageEnabled` is intentionally null-safe so callers don't have to guard against an uninitialized `FessConfig`.