### PR TITLE
fix(admin/theme): run validate() before verifyToken() and persist default theme

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/theme/AdminThemeAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/theme/AdminThemeAction.java
@@ -133,8 +133,11 @@ public class AdminThemeAction extends FessAdminAction {
     @Execute
     @Secured({ ROLE })
     public HtmlResponse reload(final ThemeListForm form) {
+        // validate must run before verifyToken: ThemeListForm carries validator annotations,
+        // so LastaFlute requires the validator call to precede token verification
+        // (otherwise DoubleSubmitVerifyTokenBeforeValidationException is raised).
+        validate(form, messages -> {}, () -> asListHtml(form));
         verifyToken(() -> asListHtml(form));
-        // validate is intentionally not called for reload — it has no form fields to validate
         try {
             themeRegistry.reload();
             saveInfo(m -> m.addSuccessReloadTheme(GLOBAL));
@@ -176,8 +179,8 @@ public class AdminThemeAction extends FessAdminAction {
     @Execute
     @Secured({ ROLE })
     public HtmlResponse upload(final ThemeUploadForm form) {
-        verifyToken(() -> asHtml(path_AdminTheme_AdminThemeUploadJsp));
         validate(form, messages -> {}, () -> asHtml(path_AdminTheme_AdminThemeUploadJsp));
+        verifyToken(() -> asHtml(path_AdminTheme_AdminThemeUploadJsp));
         // C-2: normalize null fileName (multipart parts without a filename= attribute return null
         // from getFileName()). Using the normalized local everywhere prevents a literal "null"
         // from appearing in error/success messages and prevents NPE in hasZipExtension.
@@ -298,8 +301,8 @@ public class AdminThemeAction extends FessAdminAction {
     @Execute
     @Secured({ ROLE })
     public HtmlResponse delete(final ThemeDeleteForm form) {
-        verifyToken(() -> asListHtml(new ThemeListForm()));
         validate(form, messages -> {}, () -> asListHtml(new ThemeListForm()));
+        verifyToken(() -> asListHtml(new ThemeListForm()));
         try {
             staticThemeInstaller.delete(form.name);
             saveInfo(m -> m.addSuccessDeleteTheme(GLOBAL, form.name));
@@ -349,8 +352,8 @@ public class AdminThemeAction extends FessAdminAction {
     @Execute
     @Secured({ ROLE })
     public HtmlResponse setdefault(final ThemeListForm form) {
-        verifyToken(() -> asListHtml(form));
         validate(form, messages -> {}, () -> asListHtml(form));
+        verifyToken(() -> asListHtml(form));
         final String name = form.defaultTheme == null ? "" : form.defaultTheme.trim();
         if (!name.isEmpty()) {
             // existence check — refuse to point the default theme at a missing theme
@@ -359,7 +362,9 @@ public class AdminThemeAction extends FessAdminAction {
             }
         }
         try {
-            ComponentUtil.getFessConfig().setDefaultTheme(name);
+            final FessConfig fessConfig = ComponentUtil.getFessConfig();
+            fessConfig.setDefaultTheme(name);
+            fessConfig.storeSystemProperties(); // setDefaultTheme only updates the in-memory value; persist it to system.properties
             themeRegistry.reload(); // re-resolve in case the new default needs to take effect immediately
             if (name.isEmpty()) {
                 saveInfo(m -> m.addSuccessClearDefaultTheme(GLOBAL));

--- a/src/test/java/org/codelibs/fess/app/web/admin/theme/AdminThemeActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/theme/AdminThemeActionTest.java
@@ -525,8 +525,8 @@ public class AdminThemeActionTest extends UnitFessTestCase {
     }
 
     /**
-     * Production path covered: {@code AdminThemeAction#upload} calls {@code verifyToken()},
-     * then {@code validate()}, then detects a non-zip extension via {@code hasZipExtension()}
+     * Production path covered: {@code AdminThemeAction#upload} calls {@code validate()},
+     * then {@code verifyToken()}, then detects a non-zip extension via {@code hasZipExtension()}
      * and calls {@code throwValidationError(addErrorsFileIsNotSupported)} before reading any
      * stream — confirming the pre-flight extension guard fires for a {@code .txt} file.
      */
@@ -582,8 +582,8 @@ public class AdminThemeActionTest extends UnitFessTestCase {
     }
 
     /**
-     * Production path covered: {@code AdminThemeAction#setdefault} calls {@code verifyToken()},
-     * then {@code validate()}, then checks {@code themeRegistry.getTheme(name).isEmpty()} for a
+     * Production path covered: {@code AdminThemeAction#setdefault} calls {@code validate()},
+     * then {@code verifyToken()}, then checks {@code themeRegistry.getTheme(name).isEmpty()} for a
      * non-empty name and calls {@code throwValidationError(addErrorsThemeNotFound)} when the
      * registry returns empty — which it does for any name not actually installed.
      */
@@ -607,9 +607,10 @@ public class AdminThemeActionTest extends UnitFessTestCase {
     }
 
     /**
-     * Production path covered: {@code AdminThemeAction#reload} calls {@code verifyToken()},
-     * then {@code themeRegistry.reload()}, then {@code saveInfo(addSuccessReloadTheme)},
-     * then {@code redirect(getClass())} — the full success flow exercised end-to-end.
+     * Production path covered: {@code AdminThemeAction#reload} calls {@code validate()},
+     * then {@code verifyToken()}, then {@code themeRegistry.reload()}, then
+     * {@code saveInfo(addSuccessReloadTheme)}, then {@code redirect(getClass())} — the full
+     * success flow exercised end-to-end.
      * A no-op {@code ThemeRegistry} subclass is used so the reload does not require the
      * filesystem/search-engine, mirroring the StaticThemeResponderTest injection style.
      */


### PR DESCRIPTION
## Summary
Fixes incorrect ordering of `validate()` and `verifyToken()` in `AdminThemeAction`, and ensures the default theme selection is actually persisted. These are follow-ups to the static theme system introduced in #3136.

## Changes Made
- **Validator/token ordering**: LastaFlute raises `DoubleSubmitVerifyTokenBeforeValidationException` when a form carrying validator annotations has `verifyToken()` invoked before `validate()`. The `reload`, `upload`, `delete`, and `setdefault` endpoints called these in the wrong order, so `validate()` now runs ahead of `verifyToken()` in each.
  - `reload()` previously skipped validation entirely; it now calls `validate()` explicitly to satisfy the contract before token verification.
- **Persist default theme**: `setDefaultTheme()` only updates the in-memory config value. `setdefault()` now calls `fessConfig.storeSystemProperties()` so the choice is written through to `system.properties` and survives restart.
- Updated the Javadoc in `AdminThemeActionTest` to reflect the corrected call order for the affected endpoints.

## Testing
- `mvn test -Dtest=AdminThemeActionTest`

## Breaking Changes
None.

## Additional Notes
The untracked `src/main/webapp/WEB-INF/view/bootstrap/` directory is intentionally not part of this PR — only the action and its test changes are included.