### PR TITLE
fix(theme): trigger search suggestions from a single character

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -706,7 +706,7 @@ function renderSuggestItems(items) {
 async function showSuggest(q) {
   const dropdown = document.getElementById("suggest-dropdown");
   const inp = document.getElementById("query");
-  if (!q || q.length < 2) {
+  if (!q || q.length < 1) {
     dropdown.classList.add("d-none");
     while (dropdown.firstChild) dropdown.removeChild(dropdown.firstChild);
     if (inp) inp.setAttribute("aria-expanded", "false");


### PR DESCRIPTION
## Summary
Lowers the minimum query length for the bootstrap theme's search suggest dropdown from 2 characters to 1, so suggestions appear immediately after the first keystroke.

## Changes Made
- `src/main/webapp/themes/bootstrap/assets/search.js`: changed the guard in `showSuggest()` from `q.length < 2` to `q.length < 1`, so a single-character query now triggers the suggest request instead of being suppressed.

## Testing
- Manual: type a single character into the search box and confirm the suggest dropdown appears with results; clearing the box still hides the dropdown.

## Breaking Changes
- None.

## Additional Notes
- This only affects the bundled bootstrap reference theme. Reviewers may want to confirm the suggest backend returns useful results for single-character queries and that the extra request volume is acceptable.