### PR TITLE
fix: show favorite star and count for all users in static themes

### DIFF
--- a/src/main/webapp/js/search.js
+++ b/src/main/webapp/js/search.js
@@ -168,6 +168,17 @@ $(function() {
               return;
             }
             $favorite.attr("href", "#" + docId);
+            // 401: adding a favorite requires login (FavoritePostHandler's
+            // AUTH_REQUIRED gate). 403 after the token refresh above: the CSRF
+            // gate rejects a session-bound token before the auth check runs, so
+            // a guest whose session rotated after page load surfaces as 403
+            // instead of 401. Logging in issues a fresh session + token, so
+            // send both to the login page — same spec as the static themes,
+            // which open the login modal here.
+            if (jqXHR && (jqXHR.status === 401 || jqXHR.status === 403)) {
+              window.location.href = contextPath + "/login/";
+              return;
+            }
             console.error("Failed to add favorite:", textStatus, errorThrown);
           });
       };
@@ -215,6 +226,12 @@ $(function() {
         }
       })
       .fail(function(jqXHR, textStatus, errorThrown) {
+        // 401: guest session — favorites are per-user, so a guest has nothing
+        // to sync. The star itself stays visible (write requires login and
+        // redirects to the login page on click), matching the static themes.
+        if (jqXHR && jqXHR.status === 401) {
+          return;
+        }
         console.error("Failed to load favorites:", textStatus, errorThrown);
       });
   }

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1925,15 +1925,6 @@ function renderPagination(env) {
   }
 }
 
-async function refreshFavorite(docId, btn) {
-  try {
-    const env = await api.get("/documents/" + encodeURIComponent(docId) + "/favorite");
-    setFavoriteUi(btn, !!env.favorite, env.count || 0);
-  } catch (e) {
-    if (e.code === "AUTH_REQUIRED" || e.httpStatus === 401) btn.classList.add("d-none");
-  }
-}
-
 function setFavoriteUi(btn, on, count) {
   btn.setAttribute("aria-pressed", on ? "true" : "false");
   btn.setAttribute("aria-label", on ? t("result.favorite_remove") : t("result.favorite_add"));
@@ -1961,7 +1952,12 @@ async function toggleFavorite(docId, btn, queryId) {
     const env = await api.post("/documents/" + encodeURIComponent(docId) + "/favorite", { query_id: queryId || "" });
     setFavoriteUi(btn, !!env.favorite, env.count || 0);
   } catch (e) {
-    if (e.code === "AUTH_REQUIRED" || e.httpStatus === 401) {
+    // 401/AUTH_REQUIRED: adding a favorite requires login (FavoritePostHandler gate).
+    // 403: the CSRF gate rejects a stale session-bound token (e.g. the guest session
+    // expired between page load and the click) *before* the auth check runs, so a
+    // guest click can surface as 403 instead of 401. Logging in through the modal
+    // issues a fresh session + token, so treat both the same.
+    if (e.code === "AUTH_REQUIRED" || e.httpStatus === 401 || e.httpStatus === 403) {
       if (!window.bootstrap || !bootstrap.Modal) {
         console.warn("[fess] bootstrap not loaded; skipping modal show");
       } else {

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -303,8 +303,13 @@ function buildResultCard(d, queryId, order) {
 
   // favorite button (theme extra; same .info row). Config flag is features.user_favorite
   // (searchResults.jsp favoriteSupport / FessConfig.isUserFavorite), not features.favorite.
-  // Favorites are per-user — only show for authenticated users (guests would 401).
-  if (features.user_favorite && api.isAuthenticated()) {
+  // The star + favorite count are shown to EVERYONE (guests included) when the feature is on
+  // — matching the legacy searchResults.jsp, which renders the star purely on ${favoriteSupport}
+  // — so the count acts as a popularity / social-proof signal. Adding a favorite, however,
+  // requires login: a guest click hits FavoritePostHandler's AUTH_REQUIRED gate and
+  // toggleFavorite() opens the login modal. So gate display only on features.user_favorite; do
+  // NOT add an api.isAuthenticated() check here (that would hide the count from guests).
+  if (features.user_favorite) {
     // Spacer before the star (searchResults.jsp puts an &nbsp; before the favorite).
     appendNbspSpacer();
     const favBtn = el("button", {
@@ -566,9 +571,11 @@ function renderResults(env) {
     if (!btn || !docId) return;
     btn.addEventListener("click", () => toggleFavorite(docId, btn, li.dataset.queryId || ""));
   });
-  // Bulk-sync favorites for all result cards in one request (Feature 5). Only when the
-  // user_favorite feature is enabled AND the user is authenticated — otherwise
-  // GET /favorites returns 400 (feature off) or 401 (guest session).
+  // Bulk-sync the *per-user* favorited state (solid vs outline star) for all result cards in
+  // one request (Feature 5). Only logged-in users can own favorites (adding requires login),
+  // so gate this on api.isAuthenticated() — a guest has nothing to sync. The star itself and
+  // its count are still rendered for guests above; this only flips already-favorited stars to
+  // the solid icon for the signed-in user.
   const favEnabled = !!(api.getConfig()?.features?.user_favorite) && api.isAuthenticated();
   if (favEnabled && env.query_id) syncFavorites(env.query_id);
 }


### PR DESCRIPTION
## Summary

The favorite (お気に入り) star is not shown in search results when the `docuforge` (or bootstrap) static theme is active.

After enabling the favorite log in General Settings and running a search, the ☆ star never appears for a **guest (non-logged-in)** visitor. The legacy `searchResults.jsp` renders the star purely on `${favoriteSupport}` (no login gate), so the static-theme SPA was inconsistent.

## Spec

Decided behavior (display vs. write are separated):

- **Display (star + favorite count): shown to everyone** — guests included — when the `user.favorite` feature is enabled. The count is a popularity / social-proof signal, matching the legacy JSP which always renders the star.
- **Adding a favorite (write): requires login.** A guest click hits `FavoritePostHandler`'s existing `AUTH_REQUIRED` gate; `toggleFavorite()` then opens the login modal. This keeps `favorite_count` trustworthy — an anonymous, session-rotating client cannot inflate it.

This intentionally keeps the backend `FavoritePostHandler` login requirement **unchanged** (no API behavior change); only the theme rendering is adjusted.

## Changes

- **`themes/bootstrap/assets/search.js`**:
  - Gate the favorite star/count **render** only on `features.user_favorite` (drop the `api.isAuthenticated()` check) so guests see the star and the count.
  - Keep the **per-user favorited-state bulk sync** (`GET /api/v2/favorites`, solid vs outline star) gated on `api.isAuthenticated()` — only logged-in users own favorites, so a guest has nothing to sync.
  - Remove the unused `refreshFavorite()` — it still implemented the old hide-the-star-on-401 policy and would silently reintroduce this bug if it were ever wired up again.
  - `toggleFavorite()` now treats **403 like 401** (opens the login modal): a stale session-bound CSRF token is rejected before the auth check, so a guest click whose session expired after page load could otherwise fail silently.

No backend / API change.

> Note: the `docuforge` theme lives in [`codelibs/fess-themes`](https://github.com/codelibs/fess-themes) and gets the identical `search.js` change in a companion PR (codelibs/fess-themes#1).

## Test

No automated test change (backend unchanged). Manual verification recommended:
- As a **guest**: enable the favorite log, search → the ☆ star and the favorite count appear; clicking the star opens the login modal.
- As a **logged-in user**: the star toggles and already-favorited results show the solid star.
