### PR TITLE
fix(api/v2): default all /api/v2 responses to Cache-Control: no-store

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -187,6 +187,14 @@ public class SearchApiV2Manager extends BaseApiManager {
     @Override
     public void process(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain)
             throws IOException, ServletException {
+        // Default every v2 response to `no-store`: success envelopes can carry the session
+        // CSRF token (/ui/config), user identity (/auth/me, /auth/login) or role-filtered
+        // hits (/search, /favorites), none of which a shared cache may ever store. Without
+        // an explicit Cache-Control a 200 GET response is eligible for HTTP heuristic
+        // caching. Set BEFORE writeHeaders so an operator-configured Cache-Control in
+        // `api.json.response.headers` deliberately overrides this default; the error path
+        // (V2EnvelopeWriter.writeErrorWithDetails) re-asserts `no-store` independently.
+        response.setHeader("Cache-Control", "no-store");
         // Apply the configured `api.json.response.headers` (e.g. Referrer-Policy) at the very
         // top of dispatch so EVERY v2 response carries the security-baseline headers —
         // including CSRF rejections, NDJSON / SSE streams, and error envelopes. Unlike v1

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
@@ -489,6 +489,45 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
                 res.headers.get("Referrer-Policy"));
     }
 
+    @Test
+    public void test_process_setsNoStoreCacheControlOnSuccessResponses() throws Exception {
+        // Success envelopes can carry session-scoped data: the CSRF token on /ui/config,
+        // user identity on /auth/me and /auth/login, and role-filtered hits on /search.
+        // process() must therefore default every v2 response to Cache-Control: no-store
+        // before dispatch so shared proxies never store them. The error path already gets
+        // the header from V2EnvelopeWriter.writeErrorWithDetails, so this asserts the
+        // success path via a stub handler that does NOT set the header itself.
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final org.codelibs.fess.api.v2.handlers.LoginHandler stub =
+                new org.codelibs.fess.api.v2.handlers.LoginHandler(new org.codelibs.fess.api.v2.handlers.LoginRateLimiter()) {
+                    @Override
+                    public void handle(final jakarta.servlet.http.HttpServletRequest req,
+                            final jakarta.servlet.http.HttpServletResponse res) throws java.io.IOException {
+                        res.setContentType("application/json");
+                        res.setStatus(200);
+                        res.getWriter().write("{\"stub\":\"ok\"}");
+                    }
+                };
+        m.loginHandler = stub;
+        final CapturingResponse res = new CapturingResponse();
+        m.process(new StubRequest("/api/v2/auth/login").withMethod("POST"), res, new NopChain());
+        assertEquals(200, res.status);
+        assertEquals("v2 success responses must default to Cache-Control: no-store", "no-store", res.headers.get("Cache-Control"));
+    }
+
+    @Test
+    public void test_process_cacheControlDefaultPrecedesConfiguredHeaders() throws Exception {
+        // The no-store default must be set BEFORE writeHeaders applies the operator's
+        // api.json.response.headers, so a deployment can deliberately override the
+        // caching policy through configuration. With the default config (which only
+        // sets Referrer-Policy) both headers must be present on the same response.
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final CapturingResponse res = new CapturingResponse();
+        m.process(new StubRequest("/api/v2/does-not-exist"), res, new NopChain());
+        assertEquals("no-store", res.headers.get("Cache-Control"));
+        assertEquals("strict-origin-when-cross-origin", res.headers.get("Referrer-Policy"));
+    }
+
     /** A FilterChain that does nothing — the v2 manager never delegates further. */
     private static class NopChain implements FilterChain {
         @Override


### PR DESCRIPTION
## Summary

Security hardening follow-up to #3136 (unified `/api/v2` surface): every `/api/v2` response now defaults to `Cache-Control: no-store`.

## Problem

Success envelopes on `/api/v2` can carry session-scoped data:

- the session CSRF token issued by `GET /api/v2/ui/config`
- user identity from `POST /api/v2/auth/login` and `GET /api/v2/auth/me`
- role-filtered results from `/search`, `/favorites`, etc.

`V2EnvelopeWriter.writeSuccess()` only set the Content-Type, so these 200 responses carried no `Cache-Control` header and were eligible for HTTP heuristic caching — a shared proxy could store and replay a token- or identity-bearing body across users. (The error path already set `no-store` in `writeErrorWithDetails()`.)

## Fix

Set `Cache-Control: no-store` once at the top of `SearchApiV2Manager.process()`, covering every v2 response (success envelopes, CSRF rejections, SSE/NDJSON streams, error envelopes):

- placed **before** `writeHeaders()` so an operator-configured `Cache-Control` in `api.json.response.headers` deliberately overrides the default
- consistent with the existing `no-store` on the v2 error path and on `StaticThemeResponder.serveIndex()`

## Tests

- `test_process_setsNoStoreCacheControlOnSuccessResponses` — asserts the header on a 200 success response via a stub handler that does not set it itself
- `test_process_cacheControlDefaultPrecedesConfiguredHeaders` — asserts the default coexists with the configured `Referrer-Policy` baseline header

`mvn test -Dtest='org.codelibs.fess.api.v2.**'` — 354 tests, 0 failures.