### PR TITLE
fix(theme): align user menu profile label with password change page

### DIFF
--- a/src/main/webapp/themes/bootstrap/i18n/messages.de.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.de.json
@@ -143,7 +143,7 @@
   "facet.remove": "Entfernen",
   "help.title": "Hilfe",
   "nav.help": "Hilfe",
-  "nav.profile": "Profil",
+  "nav.profile": "Passwort ändern",
   "nav.administration": "Administration",
   "nav.eol_warning": "Dieses Produkt hat das Ende der Lebensdauer erreicht",
   "nav.dev_mode_warning": "Entwicklungsmodus aktiv",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.en.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.en.json
@@ -143,7 +143,7 @@
   "facet.remove": "Remove",
   "help.title": "Help",
   "nav.help": "Help",
-  "nav.profile": "Profile",
+  "nav.profile": "Change Password",
   "nav.administration": "Administration",
   "nav.eol_warning": "This product has reached end-of-life",
   "nav.dev_mode_warning": "Development mode active",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.es.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.es.json
@@ -143,7 +143,7 @@
   "facet.remove": "Eliminar",
   "help.title": "Ayuda",
   "nav.help": "Ayuda",
-  "nav.profile": "Perfil",
+  "nav.profile": "Cambiar contraseña",
   "nav.administration": "Administración",
   "nav.eol_warning": "Este producto ha llegado al fin de su vida útil",
   "nav.dev_mode_warning": "Modo de desarrollo activo",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.fr.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.fr.json
@@ -143,7 +143,7 @@
   "facet.remove": "Supprimer",
   "help.title": "Aide",
   "nav.help": "Aide",
-  "nav.profile": "Profil",
+  "nav.profile": "Changer le mot de passe",
   "nav.administration": "Administration",
   "nav.eol_warning": "Ce produit a atteint la fin de vie",
   "nav.dev_mode_warning": "Mode développement actif",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.hi.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.hi.json
@@ -143,7 +143,7 @@
   "facet.remove": "हटाएं",
   "help.title": "सहायता",
   "nav.help": "सहायता",
-  "nav.profile": "प्रोफाइल",
+  "nav.profile": "पासवर्ड बदलें",
   "nav.administration": "प्रशासन",
   "nav.eol_warning": "यह उत्पाद जीवन के अंत तक पहुंच गया है",
   "nav.dev_mode_warning": "विकास मोड सक्रिय",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.id.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.id.json
@@ -143,7 +143,7 @@
   "facet.remove": "Hapus",
   "help.title": "Bantuan",
   "nav.help": "Bantuan",
-  "nav.profile": "Profil",
+  "nav.profile": "Ubah Kata Sandi",
   "nav.administration": "Administrasi",
   "nav.eol_warning": "Produk ini telah mencapai akhir masa pakai",
   "nav.dev_mode_warning": "Mode pengembangan aktif",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.it.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.it.json
@@ -143,7 +143,7 @@
   "facet.remove": "Rimuovi",
   "help.title": "Aiuto",
   "nav.help": "Aiuto",
-  "nav.profile": "Profilo",
+  "nav.profile": "Cambia password",
   "nav.administration": "Amministrazione",
   "nav.eol_warning": "Questo prodotto ha raggiunto il fine vita",
   "nav.dev_mode_warning": "Modalità sviluppo attiva",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.ja.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.ja.json
@@ -143,7 +143,7 @@
   "facet.remove": "解除",
   "help.title": "ヘルプ",
   "nav.help": "ヘルプ",
-  "nav.profile": "プロファイル",
+  "nav.profile": "パスワード変更",
   "nav.administration": "管理",
   "nav.eol_warning": "このプロダクトはサポート終了しています",
   "nav.dev_mode_warning": "開発モードで動作中",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.ko.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.ko.json
@@ -143,7 +143,7 @@
   "facet.remove": "제거",
   "help.title": "도움말",
   "nav.help": "도움말",
-  "nav.profile": "프로필",
+  "nav.profile": "비밀번호 변경",
   "nav.administration": "관리",
   "nav.eol_warning": "이 제품은 지원 종료(EOL)에 도달했습니다",
   "nav.dev_mode_warning": "개발 모드 활성",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.nl.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.nl.json
@@ -143,7 +143,7 @@
   "facet.remove": "Verwijderen",
   "help.title": "Hulp",
   "nav.help": "Hulp",
-  "nav.profile": "Profiel",
+  "nav.profile": "Wachtwoord wijzigen",
   "nav.administration": "Beheer",
   "nav.eol_warning": "Dit product heeft het einde van de levensduur bereikt",
   "nav.dev_mode_warning": "Ontwikkelingsmodus actief",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.pl.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.pl.json
@@ -143,7 +143,7 @@
   "facet.remove": "Usuń",
   "help.title": "Pomoc",
   "nav.help": "Pomoc",
-  "nav.profile": "Profil",
+  "nav.profile": "Zmień hasło",
   "nav.administration": "Administracja",
   "nav.eol_warning": "Ten produkt osiągnął koniec okresu wsparcia",
   "nav.dev_mode_warning": "Tryb programisty aktywny",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.pt-BR.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.pt-BR.json
@@ -143,7 +143,7 @@
   "facet.remove": "Remover",
   "help.title": "Ajuda",
   "nav.help": "Ajuda",
-  "nav.profile": "Perfil",
+  "nav.profile": "Alterar senha",
   "nav.administration": "Administração",
   "nav.eol_warning": "Este produto atingiu o fim da vida útil",
   "nav.dev_mode_warning": "Modo de desenvolvimento ativo",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.ru.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.ru.json
@@ -143,7 +143,7 @@
   "facet.remove": "Удалить",
   "help.title": "Справка",
   "nav.help": "Справка",
-  "nav.profile": "Профиль",
+  "nav.profile": "Изменить пароль",
   "nav.administration": "Администрирование",
   "nav.eol_warning": "Этот продукт достиг конца срока поддержки",
   "nav.dev_mode_warning": "Режим разработчика активен",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.tr.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.tr.json
@@ -143,7 +143,7 @@
   "facet.remove": "Kaldır",
   "help.title": "Yardım",
   "nav.help": "Yardım",
-  "nav.profile": "Profil",
+  "nav.profile": "Şifre Değiştir",
   "nav.administration": "Yönetim",
   "nav.eol_warning": "Bu ürün kullanım ömrünün sonuna ulaştı",
   "nav.dev_mode_warning": "Geliştirici modu aktif",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.zh-CN.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.zh-CN.json
@@ -143,7 +143,7 @@
   "facet.remove": "移除",
   "help.title": "帮助",
   "nav.help": "帮助",
-  "nav.profile": "个人资料",
+  "nav.profile": "更改密码",
   "nav.administration": "管理",
   "nav.eol_warning": "此产品已达到生命周期终止",
   "nav.dev_mode_warning": "开发模式已激活",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.zh-TW.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.zh-TW.json
@@ -143,7 +143,7 @@
   "facet.remove": "移除",
   "help.title": "說明",
   "nav.help": "說明",
-  "nav.profile": "個人資料",
+  "nav.profile": "更改密碼",
   "nav.administration": "管理",
   "nav.eol_warning": "此產品已達到產品生命週期終止",
   "nav.dev_mode_warning": "開發模式已啟動",


### PR DESCRIPTION
## Summary
When logged in, the user dropdown menu on the search screen shows a different label depending on the UI: the default JSP view displays "Change Password" (`labels.profile`), while the bootstrap theme displays "Profile" (`nav.profile`). Both link to the same `/profile` page, which only provides password change functionality. This PR unifies the theme menu label with the default view.

## Changes Made
- Updated `nav.profile` in `src/main/webapp/themes/bootstrap/i18n/messages.*.json` (16 locales) to match the corresponding `labels.profile` translation in `fess_label_*.properties` (e.g. en: `Profile` -> `Change Password`, ja: `プロファイル` -> `パスワード変更`)
- No changes to the message key or `auth.js`; only the translated values were updated

## Testing
- Verified all 16 JSON files remain valid after the update
- Confirmed no tests rely on the previous "Profile" label text

## Breaking Changes
- None

## Additional Notes
- The "Change Password" wording follows the existing label introduced by #370, since the `/profile` page only implements password changes. The theme's own page title (`profile.title`) already uses "Change Password", so this also resolves an inconsistency within the theme itself.
- A companion PR applies the same fix to the docuforge theme in the fess-themes repository.