### PR TITLE
chore: update to OpenSearch 3.7.0

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -6,7 +6,7 @@
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://maven.codelibs.org" />
-	<property name="opensearch.version" value="3.6.0" />
+	<property name="opensearch.version" value="3.7.0" />
 
 	<target name="install.modules">
 		<mkdir dir="${target.dir}" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,8 +17,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-extension" />
-			<param name="plugin.version" value="3.6.0" />
-			<param name="plugin.zip.version" value="3.6.0" />
+			<param name="plugin.version" value="3.7.0" />
+			<param name="plugin.zip.version" value="3.7.0" />
 		</antcall>
 		<!-- analysis-fess -->
 		<antcall target="install.plugin">
@@ -26,8 +26,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-fess" />
-			<param name="plugin.version" value="3.6.0" />
-			<param name="plugin.zip.version" value="3.6.0" />
+			<param name="plugin.version" value="3.7.0" />
+			<param name="plugin.zip.version" value="3.7.0" />
 		</antcall>
 		<!-- configsync -->
 		<antcall target="install.plugin">
@@ -35,8 +35,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="configsync" />
-			<param name="plugin.version" value="3.6.0" />
-			<param name="plugin.zip.version" value="3.6.0" />
+			<param name="plugin.version" value="3.7.0" />
+			<param name="plugin.zip.version" value="3.7.0" />
 		</antcall>
 		<!-- minhash -->
 		<antcall target="install.plugin">
@@ -44,8 +44,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="minhash" />
-			<param name="plugin.version" value="3.6.0" />
-			<param name="plugin.zip.version" value="3.6.0" />
+			<param name="plugin.version" value="3.7.0" />
+			<param name="plugin.zip.version" value="3.7.0" />
 		</antcall>
 
 		<antcall target="remove.jars" />

--- a/src/test/java/org/codelibs/fess/helper/IndexingHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/IndexingHelperTest.java
@@ -359,8 +359,7 @@ public class IndexingHelperTest extends UnitFessTestCase {
 
         final Map<String, Object> document = indexingHelper.getDocument(client, "001", new String[] { "title", "content" });
         assertEquals("fess.update", resultMap.get("index"));
-        assertEquals(
-                "{\"query\":{\"ids\":{\"values\":[\"001\"],\"boost\":1.0}},\"_source\":{\"includes\":[\"title\",\"content\"],\"excludes\":[]}}",
+        assertEquals("{\"query\":{\"ids\":{\"values\":[\"001\"],\"boost\":1.0}},\"_source\":{\"includes\":[\"title\",\"content\"]}}",
                 resultMap.get("query"));
         assertEquals(3, document.size());
     }
@@ -387,7 +386,7 @@ public class IndexingHelperTest extends UnitFessTestCase {
                 indexingHelper.getDocumentListByPrefixId(client, "001", new String[] { "title", "content" });
         assertEquals("fess.update", resultMap.get("index"));
         assertEquals(
-                "{\"size\":1,\"query\":{\"prefix\":{\"_id\":{\"value\":\"001\",\"boost\":1.0}}},\"_source\":{\"includes\":[\"title\",\"content\"],\"excludes\":[]}}",
+                "{\"size\":1,\"query\":{\"prefix\":{\"_id\":{\"value\":\"001\",\"boost\":1.0}}},\"_source\":{\"includes\":[\"title\",\"content\"]}}",
                 resultMap.get("query"));
         assertEquals(1, documents.size());
     }
@@ -438,7 +437,7 @@ public class IndexingHelperTest extends UnitFessTestCase {
         final List<Map<String, Object>> documents = indexingHelper.getChildDocumentList(client, "001", new String[] { "title", "content" });
         assertEquals("fess.update", resultMap.get("index"));
         assertEquals(
-                "{\"size\":1,\"query\":{\"term\":{\"parent_id\":{\"value\":\"001\",\"boost\":1.0}}},\"_source\":{\"includes\":[\"title\",\"content\"],\"excludes\":[]}}",
+                "{\"size\":1,\"query\":{\"term\":{\"parent_id\":{\"value\":\"001\",\"boost\":1.0}}},\"_source\":{\"includes\":[\"title\",\"content\"]}}",
                 resultMap.get("query"));
         assertEquals(1, documents.size());
     }
@@ -465,7 +464,7 @@ public class IndexingHelperTest extends UnitFessTestCase {
                 indexingHelper.getDocumentListByQuery(client, QueryBuilders.idsQuery().addIds("001"), new String[] { "title", "content" });
         assertEquals("fess.update", resultMap.get("index"));
         assertEquals(
-                "{\"size\":1,\"query\":{\"ids\":{\"values\":[\"001\"],\"boost\":1.0}},\"_source\":{\"includes\":[\"title\",\"content\"],\"excludes\":[]}}",
+                "{\"size\":1,\"query\":{\"ids\":{\"values\":[\"001\"],\"boost\":1.0}},\"_source\":{\"includes\":[\"title\",\"content\"]}}",
                 resultMap.get("query"));
         assertEquals(1, documents.size());
     }


### PR DESCRIPTION
## Summary
Update Fess to OpenSearch 3.7.0: bump the bundled OpenSearch plugins/modules and fix test expectations that broke with the new version.

## Changes Made
- \`plugin.xml\`: opensearch-analysis-extension / analysis-fess / configsync / minhash 3.6.0 -> 3.7.0
- \`module.xml\`: \`opensearch.version\` 3.6.0 -> 3.7.0 (analysis-common, geo, lang-expression, lang-painless, mapper-extras, reindex, transport-netty4)
- \`IndexingHelperTest\`: removed \`,"excludes":[]\` from four expected \`_source\` JSON strings — OpenSearch 3.7.0 no longer serializes an empty \`excludes\` array in \`FetchSourceContext\`. Representation change only; query semantics are identical.

## Testing
- \`mvn antrun:run\`: all 3.7.0 plugin/module zips download successfully from Maven Central and maven.codelibs.org.
- \`mvn test -Dtest=IndexingHelperTest\`: 25 tests, 0 failures.
- Full workspace build with tests passed against fess-parent with OpenSearch 3.7.0.

## Breaking Changes
- None.

## Additional Notes
- Depends on the fess-parent update (codelibs/fess-parent#53); merge that first.