### PR TITLE
Reduce help page h2 font size in bootstrap static theme

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/styles.css
+++ b/src/main/webapp/themes/bootstrap/assets/styles.css
@@ -74,7 +74,7 @@ body { padding-top: 4.5rem; }
 .active-chip { display: inline-flex; align-items: center; gap: .35rem; background: var(--bs-primary-bg-subtle); color: var(--bs-body-color); font-size: .8rem; font-weight: 400; padding: .25rem .5rem; }
 .active-chip-remove { width: .65em; height: .65em; margin: 0; padding: 0; background-size: .65em; flex-shrink: 0; }
 .help-section { margin-bottom: 2rem; }
-.help-section h2 { border-bottom: 1px solid #dee2e6; padding-bottom: 0.5rem; }
+.help-section h2 { font-size: 1.5rem; border-bottom: 1px solid #dee2e6; padding-bottom: 0.5rem; }
 .help-section code { background: #f8f9fa; padding: 0.125rem 0.25rem; border-radius: 3px; }
 /* JSP parity (advance.jsp): the form lives in a full Bootstrap .container and uses a
    col-lg-3 label + col-lg-5 control grid — no narrow max-width cap, so label/control


### PR DESCRIPTION
## Summary

The help page (`/help`) in the bootstrap static theme renders its section headings (`基本的な検索`, `検索演算子`, etc.) using `.help-section h2`, which had no explicit `font-size`. As a result the headings inherited Bootstrap's default h2 size (~2rem at larger viewports), making them look oversized relative to the body text.

This sets an explicit `font-size: 1.5rem` on `.help-section h2` for a more balanced heading size.

## Changes

- `src/main/webapp/themes/bootstrap/assets/styles.css`: add `font-size: 1.5rem` to `.help-section h2`.

## Notes

- CSS-only change; no behavior or markup changes.
- The bottom border and padding on the headings are unchanged.