### PR TITLE
feat(rag): use highlighted passages for large documents in answer generation

### DIFF
--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -473,7 +473,8 @@ public class ChatClient {
                         // Phase 4: Fetch full content
                         phaseStartTime = System.currentTimeMillis();
                         callback.onPhaseStart(ChatPhaseCallback.PHASE_FETCH, "Retrieving document content...");
-                        final List<Map<String, Object>> fullDocs = fetchFullContent(evalResult.getRelevantDocIds());
+                        final List<Map<String, Object>> fullDocs = ComponentUtil.getChatContentFetcher()
+                                .fetchContent(new ChatContentRequest(evalResult.getRelevantDocIds(), searchResults, finalSearchQuery));
                         callback.onPhaseComplete(ChatPhaseCallback.PHASE_FETCH);
                         sources = fullDocs;
 
@@ -926,58 +927,17 @@ public class ChatClient {
     }
 
     /**
-     * Fetches full document content for the given document IDs.
+     * Fetches full document content for the given doc ids.
+     *
+     * <p>Delegates to {@link ChatContentFetcher}. With a blank query the fetcher
+     * resolves every document to its full content, preserving the original
+     * behavior of this method.</p>
      *
      * @param docIds the document IDs to fetch
-     * @return list of documents with full content
+     * @return list of documents with full content, in docIds order
      */
     protected List<Map<String, Object>> fetchFullContent(final List<String> docIds) {
-        if (docIds.isEmpty()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("[RAG] Fetch full content called with empty docIds.");
-            }
-            return Collections.emptyList();
-        }
-
-        final long startTime = System.currentTimeMillis();
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final String[] fields = fessConfig.getRagChatContentFields().split(",");
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("[RAG] Fetching full content. docIds={}, fields={}", docIds, String.join(",", fields));
-        }
-
-        try {
-            final List<Map<String, Object>> results = ComponentUtil.getSearchHelper()
-                    .getDocumentListByDocIds(docIds.toArray(new String[0]), fields, OptionalThing.empty(),
-                            SearchRequestParams.SearchRequestType.JSON);
-
-            // Reorder results to match original docIds order (preserve search score order)
-            final Map<String, Map<String, Object>> resultMap = new LinkedHashMap<>();
-            for (final Map<String, Object> doc : results) {
-                final String docId = (String) doc.get("doc_id");
-                if (docId != null) {
-                    resultMap.put(docId, doc);
-                }
-            }
-            final List<Map<String, Object>> orderedResults = new ArrayList<>();
-            for (final String docId : docIds) {
-                final Map<String, Object> doc = resultMap.get(docId);
-                if (doc != null) {
-                    orderedResults.add(doc);
-                }
-            }
-
-            if (logger.isDebugEnabled()) {
-                logger.debug("[RAG] Full content fetched. docIdCount={}, fetchedCount={}, elapsedTime={}ms", docIds.size(),
-                        orderedResults.size(), System.currentTimeMillis() - startTime);
-            }
-            return orderedResults;
-        } catch (final Exception e) {
-            logger.warn("Failed to fetch full content for docIds={}. error={}, elapsedTime={}ms", docIds, e.getMessage(),
-                    System.currentTimeMillis() - startTime);
-            return Collections.emptyList();
-        }
+        return ComponentUtil.getChatContentFetcher().fetchContent(new ChatContentRequest(docIds, Collections.emptyList(), null));
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -19,7 +19,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/src/main/java/org/codelibs/fess/chat/ChatContentFetcher.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatContentFetcher.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.chat;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves the content of relevant documents for the LLM answer context.
+ *
+ * <p>Implementations decide, per document, whether to use the full content or
+ * query-relevant highlighted passages (e.g. based on document size), so that
+ * large documents do not crowd out the answer context. The default
+ * implementation is {@link DefaultChatContentFetcher}; replace the
+ * {@code chatContentFetcher} DI component to override the behavior.</p>
+ */
+public interface ChatContentFetcher {
+
+    /**
+     * Resolves the LLM-context content for the given relevant documents.
+     *
+     * @param request the fetch request (doc ids, search results, query)
+     * @return document maps in the same order as {@code request.getDocIds()},
+     *         each with the {@code content} field set to the text to send to the LLM
+     */
+    List<Map<String, Object>> fetchContent(ChatContentRequest request);
+}

--- a/src/main/java/org/codelibs/fess/chat/ChatContentRequest.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatContentRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.chat;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Request object for {@link ChatContentFetcher}. Carries the relevant document
+ * ids (in search-score order), the search-phase result maps (which contain
+ * {@code content_length} and highlight snippets), and the query used to
+ * highlight large documents.
+ */
+public class ChatContentRequest {
+
+    /** Relevant document ids, in search-score order. */
+    protected final List<String> docIds;
+
+    /** Search-phase result maps (with content_length); may be empty for the summary path. */
+    protected final List<Map<String, Object>> searchResults;
+
+    /** Query used to highlight large documents; blank/null disables highlighting (full fetch). */
+    protected final String query;
+
+    /**
+     * Creates a new request.
+     *
+     * @param docIds relevant document ids in score order
+     * @param searchResults search-phase result maps (may be empty)
+     * @param query query used to highlight large documents (may be null/blank)
+     */
+    public ChatContentRequest(final List<String> docIds, final List<Map<String, Object>> searchResults, final String query) {
+        this.docIds = docIds;
+        this.searchResults = searchResults;
+        this.query = query;
+    }
+
+    /**
+     * Returns the relevant document ids.
+     *
+     * @return the document ids
+     */
+    public List<String> getDocIds() {
+        return docIds;
+    }
+
+    /**
+     * Returns the search-phase result maps.
+     *
+     * @return the search results (may be empty)
+     */
+    public List<Map<String, Object>> getSearchResults() {
+        return searchResults;
+    }
+
+    /**
+     * Returns the highlight query.
+     *
+     * @return the query (may be null/blank)
+     */
+    public String getQuery() {
+        return query;
+    }
+}

--- a/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
+++ b/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
@@ -37,7 +37,9 @@ import org.dbflute.optional.OptionalThing;
  * {@code content_length}: small documents are fetched in full (existing
  * behavior), large documents use query-relevant highlighted passages so the
  * relevant section reaches the LLM. Highlight snippets are normalized into the
- * {@code content} field so the downstream context builder is unchanged.
+ * {@code content} field so the downstream context builder is unchanged. A large
+ * document with no extractable highlight passage falls back to its full content
+ * truncated to the threshold; its short digest is never used as a passage.
  */
 public class DefaultChatContentFetcher implements ChatContentFetcher {
 
@@ -81,10 +83,15 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
         putByDocId(resultMap, fetchFullContent(fullIds));
         putByDocId(resultMap, fetchHighlightedContent(highlightIds, request.getQuery()));
 
-        // Reconcile: any requested doc still missing (e.g. highlight had no match) -> full fetch fallback.
-        final List<String> missingIds = docIds.stream().filter(id -> !resultMap.containsKey(id)).collect(Collectors.toList());
+        // Fallback for large documents that produced no highlight passage: fetch the full content
+        // and truncate it to the threshold so the document still contributes a leading excerpt
+        // without crowding out the answer context (its short digest is never used as a passage).
+        final List<String> missingIds = highlightIds.stream().filter(id -> !resultMap.containsKey(id)).collect(Collectors.toList());
         if (!missingIds.isEmpty()) {
-            putByDocId(resultMap, fetchFullContent(missingIds));
+            final long maxLength = getFulltextThreshold();
+            final List<Map<String, Object>> fallbackDocs = fetchFullContent(missingIds);
+            fallbackDocs.forEach(doc -> truncateContent(doc, maxLength));
+            putByDocId(resultMap, fallbackDocs);
         }
 
         // Reorder to preserve original docIds (search-score) order.
@@ -124,6 +131,22 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
     protected long getFulltextThreshold() {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         return Long.parseLong(fessConfig.getOrDefault("rag.chat.content.fulltext.max.length", "3000"));
+    }
+
+    /**
+     * Truncates the {@code content} field of a document to at most {@code maxLength}
+     * characters, keeping the leading portion. Used as the fallback for a large
+     * document that produced no highlight passage so it still contributes a leading
+     * excerpt without crowding out the answer context.
+     *
+     * @param doc the document map (modified in place)
+     * @param maxLength the maximum content length in characters
+     */
+    protected void truncateContent(final Map<String, Object> doc, final long maxLength) {
+        final Object value = doc.get("content");
+        if (value instanceof String && ((String) value).length() > maxLength) {
+            doc.put("content", ((String) value).substring(0, (int) maxLength));
+        }
     }
 
     /**
@@ -227,25 +250,44 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
     }
 
     /**
-     * Normalizes highlighted search results: copies the highlight snippet into the
-     * {@code content} field, and drops documents whose snippet is blank so the
-     * caller's reconciliation step re-fetches them with full content (the highlight
-     * search response does not include the full content field).
+     * Normalizes highlighted search results: copies the highlight passage into the
+     * {@code content} field, and drops documents that produced no highlight passage
+     * so the caller can fall back to their truncated full content.
+     *
+     * <p>The passage is read from the raw highlight field ({@code hl_content}), not
+     * from {@code content_description}. {@code content_description} is built by
+     * {@code ViewHelper#getContentDescription} from {@code hl_content,digest} and
+     * therefore falls back to the short crawl-time {@code digest} when there is no
+     * highlight match; relying on it would mask the "no passage" case and send the
+     * digest to the LLM instead of the truncated full-content fallback. Reading the
+     * highlight field directly keeps that case detectable.</p>
      *
      * @param docs the highlighted search result maps
-     * @return maps with non-blank snippets only, each with {@code content} set to the snippet
+     * @return maps that produced a highlight passage only, each with {@code content} set to it
      */
     protected List<Map<String, Object>> normalizeHighlightedDocs(final List<Map<String, Object>> docs) {
+        final String highlightField = getHighlightContentField();
         final List<Map<String, Object>> normalized = new ArrayList<>();
         for (final Map<String, Object> doc : docs) {
-            final String snippet = (String) doc.get("content_description");
+            final String snippet = (String) doc.get(highlightField);
             if (StringUtil.isNotBlank(snippet)) {
                 doc.put("content", snippet); // normalize: buildContext is content-first
                 normalized.add(doc);
             }
-            // blank snippet -> omit so reconciliation re-fetches full content
+            // no highlight passage -> drop so the caller falls back to truncated full content
         }
         return normalized;
+    }
+
+    /**
+     * Returns the document-map key that holds the highlight passage for the content
+     * field (the highlight prefix joined with the content field name, e.g.
+     * {@code hl_content}).
+     *
+     * @return the highlight content field key
+     */
+    protected String getHighlightContentField() {
+        return ComponentUtil.getQueryHelper().getHighlightPrefix() + ComponentUtil.getFessConfig().getIndexFieldContent();
     }
 
     private void putByDocId(final Map<String, Map<String, Object>> target, final List<Map<String, Object>> docs) {
@@ -263,7 +305,8 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
      * display-oriented {@code rag.chat.highlight.*}.
      */
     protected static class AnswerHighlightSearchParams extends ChatClient.ChatSearchRequestParams {
-        private final FessConfig fessConfig;
+        private final int fragmentSize;
+        private final int numOfFragments;
 
         /**
          * Creates answer-highlight search params.
@@ -276,14 +319,15 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
         public AnswerHighlightSearchParams(final String query, final int pageSize, final FessConfig fessConfig,
                 final String[] extraQueries) {
             super(query, pageSize, fessConfig, Collections.emptyMap(), extraQueries);
-            this.fessConfig = fessConfig;
+            // Resolve once; getHighlightInfo() may be called repeatedly during search execution.
+            this.fragmentSize = Integer.parseInt(fessConfig.getOrDefault("rag.chat.answer.highlight.fragment.size", "1000"));
+            this.numOfFragments = Integer.parseInt(fessConfig.getOrDefault("rag.chat.answer.highlight.number.of.fragments", "5"));
         }
 
         @Override
         public HighlightInfo getHighlightInfo() {
-            return new HighlightInfo()
-                    .fragmentSize(Integer.parseInt(fessConfig.getOrDefault("rag.chat.answer.highlight.fragment.size", "1000")))
-                    .numOfFragments(Integer.parseInt(fessConfig.getOrDefault("rag.chat.answer.highlight.number.of.fragments", "5")))
+            return new HighlightInfo().fragmentSize(fragmentSize)
+                    .numOfFragments(numOfFragments)
                     .preTags(StringUtil.EMPTY)
                     .postTags(StringUtil.EMPTY);
         }

--- a/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
+++ b/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.chat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.entity.HighlightInfo;
+import org.codelibs.fess.entity.SearchRenderData;
+import org.codelibs.fess.entity.SearchRequestParams;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
+
+/**
+ * Default {@link ChatContentFetcher}. Dispatches per document by
+ * {@code content_length}: small documents are fetched in full (existing
+ * behavior), large documents use query-relevant highlighted passages so the
+ * relevant section reaches the LLM. Highlight snippets are normalized into the
+ * {@code content} field so the downstream context builder is unchanged.
+ */
+public class DefaultChatContentFetcher implements ChatContentFetcher {
+
+    private static final Logger logger = LogManager.getLogger(DefaultChatContentFetcher.class);
+
+    /** Per-document content resolution strategy. */
+    protected enum Strategy {
+        /** Fetch the full content (small documents / fallback). */
+        FULL,
+        /** Fetch query-relevant highlighted passages (large documents). */
+        HIGHLIGHT;
+    }
+
+    /**
+     * Default constructor.
+     */
+    public DefaultChatContentFetcher() {
+        // Default constructor
+    }
+
+    @Override
+    public List<Map<String, Object>> fetchContent(final ChatContentRequest request) {
+        final List<String> docIds = request.getDocIds();
+        if (docIds == null || docIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final Map<String, Long> sizeByDocId = buildSizeMap(request.getSearchResults());
+
+        final List<String> fullIds = new ArrayList<>();
+        final List<String> highlightIds = new ArrayList<>();
+        for (final String docId : docIds) {
+            if (decideStrategy(docId, sizeByDocId.get(docId), request) == Strategy.HIGHLIGHT) {
+                highlightIds.add(docId);
+            } else {
+                fullIds.add(docId);
+            }
+        }
+
+        final Map<String, Map<String, Object>> resultMap = new LinkedHashMap<>();
+        putByDocId(resultMap, fetchFullContent(fullIds));
+        putByDocId(resultMap, fetchHighlightedContent(highlightIds, request.getQuery()));
+
+        // Reconcile: any requested doc still missing (e.g. highlight had no match) -> full fetch fallback.
+        final List<String> missingIds = docIds.stream().filter(id -> !resultMap.containsKey(id)).collect(Collectors.toList());
+        if (!missingIds.isEmpty()) {
+            putByDocId(resultMap, fetchFullContent(missingIds));
+        }
+
+        // Reorder to preserve original docIds (search-score) order.
+        final List<Map<String, Object>> ordered = new ArrayList<>();
+        for (final String docId : docIds) {
+            final Map<String, Object> doc = resultMap.get(docId);
+            if (doc != null) {
+                ordered.add(doc);
+            }
+        }
+        return ordered;
+    }
+
+    /**
+     * Decides the fetch strategy for a document.
+     *
+     * @param docId the document id
+     * @param contentLength the indexed content length (null if unknown)
+     * @param request the fetch request
+     * @return {@link Strategy#HIGHLIGHT} for large documents, otherwise {@link Strategy#FULL}
+     */
+    protected Strategy decideStrategy(final String docId, final Long contentLength, final ChatContentRequest request) {
+        if (StringUtil.isBlank(request.getQuery())) {
+            return Strategy.FULL; // no query to highlight with
+        }
+        if (contentLength == null) {
+            return Strategy.FULL; // unknown size (e.g. summary path) -> full, no regression
+        }
+        return contentLength.longValue() > getFulltextThreshold() ? Strategy.HIGHLIGHT : Strategy.FULL;
+    }
+
+    /**
+     * Returns the content_length threshold above which highlighted passages are used.
+     *
+     * @return the threshold in characters
+     */
+    protected long getFulltextThreshold() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        return Long.parseLong(fessConfig.getOrDefault("rag.chat.content.fulltext.max.length", "3000"));
+    }
+
+    /**
+     * Builds a doc_id -&gt; content_length map from the search-phase results.
+     *
+     * @param searchResults the search-phase result maps (may be null)
+     * @return the size map (empty when searchResults is null/empty)
+     */
+    protected Map<String, Long> buildSizeMap(final List<Map<String, Object>> searchResults) {
+        final Map<String, Long> map = new LinkedHashMap<>();
+        if (searchResults == null) {
+            return map;
+        }
+        for (final Map<String, Object> doc : searchResults) {
+            final String docId = (String) doc.get("doc_id");
+            if (docId != null) {
+                map.put(docId, toLong(doc.get("content_length")));
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Converts a value to Long, tolerating Number and numeric String.
+     *
+     * @param value the value
+     * @return the Long value, or null if not convertible
+     */
+    protected Long toLong(final Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String && StringUtil.isNotBlank((String) value)) {
+            try {
+                return Long.valueOf((String) value);
+            } catch (final NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Fetches full content for the given document ids via doc_id lookup (no highlighting).
+     *
+     * @param docIds the document ids
+     * @return document maps (unordered)
+     */
+    protected List<Map<String, Object>> fetchFullContent(final List<String> docIds) {
+        if (docIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        final long startTime = System.currentTimeMillis();
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final String[] fields = fessConfig.getRagChatContentFields().split(",");
+        try {
+            return ComponentUtil.getSearchHelper()
+                    .getDocumentListByDocIds(docIds.toArray(new String[0]), fields, OptionalThing.empty(),
+                            SearchRequestParams.SearchRequestType.JSON);
+        } catch (final Exception e) {
+            logger.warn("Failed to fetch full content for docIds={}. error={}, elapsedTime={}ms", docIds, e.getMessage(),
+                    System.currentTimeMillis() - startTime);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Fetches query-relevant highlighted passages for large documents via a
+     * doc_id-restricted highlighted search, normalizing the snippet into the
+     * {@code content} field. Returns empty on failure (callers fall back to full).
+     *
+     * @param docIds the large-document ids
+     * @param query the highlight query
+     * @return document maps with {@code content} set to the highlighted snippet
+     */
+    protected List<Map<String, Object>> fetchHighlightedContent(final List<String> docIds, final String query) {
+        if (docIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        final long startTime = System.currentTimeMillis();
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        try {
+            final String docIdQuery =
+                    docIds.stream().map(id -> fessConfig.getIndexFieldDocId() + ":" + id).collect(Collectors.joining(" OR ", "(", ")"));
+            final SearchRenderData data = new SearchRenderData();
+            final AnswerHighlightSearchParams params =
+                    new AnswerHighlightSearchParams(query, docIds.size(), fessConfig, new String[] { docIdQuery });
+            ComponentUtil.getSearchHelper().search(params, data, OptionalThing.empty());
+
+            @SuppressWarnings("unchecked")
+            final List<Map<String, Object>> docs = (List<Map<String, Object>>) data.getDocumentItems();
+            if (docs == null) {
+                return Collections.emptyList();
+            }
+            for (final Map<String, Object> doc : docs) {
+                final String snippet = (String) doc.get("content_description");
+                if (StringUtil.isNotBlank(snippet)) {
+                    doc.put("content", snippet); // normalize: buildContext is content-first
+                }
+            }
+            return docs;
+        } catch (final Exception e) {
+            logger.warn("Failed to fetch highlighted content for docIds={}. Falling back to full. error={}, elapsedTime={}ms", docIds,
+                    e.getMessage(), System.currentTimeMillis() - startTime);
+            return Collections.emptyList();
+        }
+    }
+
+    private void putByDocId(final Map<String, Map<String, Object>> target, final List<Map<String, Object>> docs) {
+        for (final Map<String, Object> doc : docs) {
+            final String docId = (String) doc.get("doc_id");
+            if (docId != null) {
+                target.put(docId, doc);
+            }
+        }
+    }
+
+    /**
+     * Chat search params restricted to specific doc ids, using the answer-specific
+     * highlight settings ({@code rag.chat.answer.highlight.*}) instead of the
+     * display-oriented {@code rag.chat.highlight.*}.
+     */
+    protected static class AnswerHighlightSearchParams extends ChatClient.ChatSearchRequestParams {
+        private final FessConfig fessConfig;
+
+        /**
+         * Creates answer-highlight search params.
+         *
+         * @param query the highlight query
+         * @param pageSize the page size (number of large documents)
+         * @param fessConfig the configuration
+         * @param extraQueries the doc_id restriction clause
+         */
+        public AnswerHighlightSearchParams(final String query, final int pageSize, final FessConfig fessConfig,
+                final String[] extraQueries) {
+            super(query, pageSize, fessConfig, Collections.emptyMap(), extraQueries);
+            this.fessConfig = fessConfig;
+        }
+
+        @Override
+        public HighlightInfo getHighlightInfo() {
+            return new HighlightInfo()
+                    .fragmentSize(Integer.parseInt(fessConfig.getOrDefault("rag.chat.answer.highlight.fragment.size", "1000")))
+                    .numOfFragments(Integer.parseInt(fessConfig.getOrDefault("rag.chat.answer.highlight.number.of.fragments", "5")))
+                    .preTags(StringUtil.EMPTY)
+                    .postTags(StringUtil.EMPTY);
+        }
+    }
+}

--- a/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
+++ b/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
@@ -184,7 +184,7 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
                     .getDocumentListByDocIds(docIds.toArray(new String[0]), fields, OptionalThing.empty(),
                             SearchRequestParams.SearchRequestType.JSON);
         } catch (final Exception e) {
-            logger.warn("Failed to fetch full content for docIds={}. error={}, elapsedTime={}ms", docIds, e.getMessage(),
+            logger.warn("[RAG] Failed to fetch full content for docIds={}. error={}, elapsedTime={}ms", docIds, e.getMessage(),
                     System.currentTimeMillis() - startTime);
             return Collections.emptyList();
         }
@@ -218,18 +218,34 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
             if (docs == null) {
                 return Collections.emptyList();
             }
-            for (final Map<String, Object> doc : docs) {
-                final String snippet = (String) doc.get("content_description");
-                if (StringUtil.isNotBlank(snippet)) {
-                    doc.put("content", snippet); // normalize: buildContext is content-first
-                }
-            }
-            return docs;
+            return normalizeHighlightedDocs(docs);
         } catch (final Exception e) {
-            logger.warn("Failed to fetch highlighted content for docIds={}. Falling back to full. error={}, elapsedTime={}ms", docIds,
+            logger.warn("[RAG] Failed to fetch highlighted content for docIds={}. Falling back to full. error={}, elapsedTime={}ms", docIds,
                     e.getMessage(), System.currentTimeMillis() - startTime);
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * Normalizes highlighted search results: copies the highlight snippet into the
+     * {@code content} field, and drops documents whose snippet is blank so the
+     * caller's reconciliation step re-fetches them with full content (the highlight
+     * search response does not include the full content field).
+     *
+     * @param docs the highlighted search result maps
+     * @return maps with non-blank snippets only, each with {@code content} set to the snippet
+     */
+    protected List<Map<String, Object>> normalizeHighlightedDocs(final List<Map<String, Object>> docs) {
+        final List<Map<String, Object>> normalized = new ArrayList<>();
+        for (final Map<String, Object> doc : docs) {
+            final String snippet = (String) doc.get("content_description");
+            if (StringUtil.isNotBlank(snippet)) {
+                doc.put("content", snippet); // normalize: buildContext is content-first
+                normalized.add(doc);
+            }
+            // blank snippet -> omit so reconciliation re-fetches full content
+        }
+        return normalized;
     }
 
     private void putByDocId(final Map<String, Map<String, Object>> target, final List<Map<String, Object>> docs) {

--- a/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
+++ b/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
@@ -129,8 +129,7 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
      * @return the threshold in characters
      */
     protected long getFulltextThreshold() {
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        return Long.parseLong(fessConfig.getOrDefault("rag.chat.content.fulltext.max.length", "3000"));
+        return ComponentUtil.getFessConfig().getRagChatContentFulltextMaxLengthAsInteger().longValue();
     }
 
     /**
@@ -320,8 +319,8 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
                 final String[] extraQueries) {
             super(query, pageSize, fessConfig, Collections.emptyMap(), extraQueries);
             // Resolve once; getHighlightInfo() may be called repeatedly during search execution.
-            this.fragmentSize = Integer.parseInt(fessConfig.getOrDefault("rag.chat.answer.highlight.fragment.size", "1000"));
-            this.numOfFragments = Integer.parseInt(fessConfig.getOrDefault("rag.chat.answer.highlight.number.of.fragments", "5"));
+            this.fragmentSize = fessConfig.getRagChatAnswerHighlightFragmentSizeAsInteger();
+            this.numOfFragments = fessConfig.getRagChatAnswerHighlightNumberOfFragmentsAsInteger();
         }
 
         @Override

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -2007,6 +2007,15 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. 3 */
     String RAG_CHAT_HIGHLIGHT_NUMBER_OF_FRAGMENTS = "rag.chat.highlight.number.of.fragments";
 
+    /** The key of the configuration. e.g. 3000 */
+    String RAG_CHAT_CONTENT_FULLTEXT_MAX_LENGTH = "rag.chat.content.fulltext.max.length";
+
+    /** The key of the configuration. e.g. 1000 */
+    String RAG_CHAT_ANSWER_HIGHLIGHT_FRAGMENT_SIZE = "rag.chat.answer.highlight.fragment.size";
+
+    /** The key of the configuration. e.g. 5 */
+    String RAG_CHAT_ANSWER_HIGHLIGHT_NUMBER_OF_FRAGMENTS = "rag.chat.answer.highlight.number.of.fragments";
+
     /** The key of the configuration. e.g. smart_summary */
     String RAG_CHAT_HISTORY_ASSISTANT_CONTENT = "rag.chat.history.assistant.content";
 
@@ -9610,6 +9619,61 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     Integer getRagChatHighlightNumberOfFragmentsAsInteger();
 
     /**
+     * Get the value for the key 'rag.chat.content.fulltext.max.length'. <br>
+     * The value is, e.g. 3000 <br>
+     * comment: <br>
+     * Large-document handling for answer generation.<br>
+     * Documents whose content_length exceeds this value use highlighted passages<br>
+     * instead of full content in the answer context.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getRagChatContentFulltextMaxLength();
+
+    /**
+     * Get the value for the key 'rag.chat.content.fulltext.max.length' as {@link Integer}. <br>
+     * The value is, e.g. 3000 <br>
+     * comment: <br>
+     * Large-document handling for answer generation.<br>
+     * Documents whose content_length exceeds this value use highlighted passages<br>
+     * instead of full content in the answer context.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getRagChatContentFulltextMaxLengthAsInteger();
+
+    /**
+     * Get the value for the key 'rag.chat.answer.highlight.fragment.size'. <br>
+     * The value is, e.g. 1000 <br>
+     * comment: Highlight settings used when extracting passages from large documents for the answer context.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getRagChatAnswerHighlightFragmentSize();
+
+    /**
+     * Get the value for the key 'rag.chat.answer.highlight.fragment.size' as {@link Integer}. <br>
+     * The value is, e.g. 1000 <br>
+     * comment: Highlight settings used when extracting passages from large documents for the answer context.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getRagChatAnswerHighlightFragmentSizeAsInteger();
+
+    /**
+     * Get the value for the key 'rag.chat.answer.highlight.number.of.fragments'. <br>
+     * The value is, e.g. 5 <br>
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getRagChatAnswerHighlightNumberOfFragments();
+
+    /**
+     * Get the value for the key 'rag.chat.answer.highlight.number.of.fragments' as {@link Integer}. <br>
+     * The value is, e.g. 5 <br>
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getRagChatAnswerHighlightNumberOfFragmentsAsInteger();
+
+    /**
      * Get the value for the key 'rag.chat.history.assistant.content'. <br>
      * The value is, e.g. smart_summary <br>
      * comment: <br>
@@ -13584,6 +13648,30 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return getAsInteger(FessConfig.RAG_CHAT_HIGHLIGHT_NUMBER_OF_FRAGMENTS);
         }
 
+        public String getRagChatContentFulltextMaxLength() {
+            return get(FessConfig.RAG_CHAT_CONTENT_FULLTEXT_MAX_LENGTH);
+        }
+
+        public Integer getRagChatContentFulltextMaxLengthAsInteger() {
+            return getAsInteger(FessConfig.RAG_CHAT_CONTENT_FULLTEXT_MAX_LENGTH);
+        }
+
+        public String getRagChatAnswerHighlightFragmentSize() {
+            return get(FessConfig.RAG_CHAT_ANSWER_HIGHLIGHT_FRAGMENT_SIZE);
+        }
+
+        public Integer getRagChatAnswerHighlightFragmentSizeAsInteger() {
+            return getAsInteger(FessConfig.RAG_CHAT_ANSWER_HIGHLIGHT_FRAGMENT_SIZE);
+        }
+
+        public String getRagChatAnswerHighlightNumberOfFragments() {
+            return get(FessConfig.RAG_CHAT_ANSWER_HIGHLIGHT_NUMBER_OF_FRAGMENTS);
+        }
+
+        public Integer getRagChatAnswerHighlightNumberOfFragmentsAsInteger() {
+            return getAsInteger(FessConfig.RAG_CHAT_ANSWER_HIGHLIGHT_NUMBER_OF_FRAGMENTS);
+        }
+
         public String getRagChatHistoryAssistantContent() {
             return get(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_CONTENT);
         }
@@ -14408,6 +14496,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.RAG_CHAT_MESSAGE_MAX_LENGTH, "4000");
             defaultMap.put(FessConfig.RAG_CHAT_HIGHLIGHT_FRAGMENT_SIZE, "500");
             defaultMap.put(FessConfig.RAG_CHAT_HIGHLIGHT_NUMBER_OF_FRAGMENTS, "3");
+            defaultMap.put(FessConfig.RAG_CHAT_CONTENT_FULLTEXT_MAX_LENGTH, "3000");
+            defaultMap.put(FessConfig.RAG_CHAT_ANSWER_HIGHLIGHT_FRAGMENT_SIZE, "1000");
+            defaultMap.put(FessConfig.RAG_CHAT_ANSWER_HIGHLIGHT_NUMBER_OF_FRAGMENTS, "5");
             defaultMap.put(FessConfig.RAG_CHAT_HISTORY_ASSISTANT_CONTENT, "smart_summary");
             defaultMap.put(FessConfig.RAG_CHAT_HISTORY_TITLES_MAX_COUNT, "5");
             defaultMap.put(FessConfig.INDEX_EXPORT_PATH, "/var/lib/fess/export");

--- a/src/main/java/org/codelibs/fess/util/ComponentUtil.java
+++ b/src/main/java/org/codelibs/fess/util/ComponentUtil.java
@@ -30,6 +30,7 @@ import org.codelibs.fess.api.v2.SessionCsrfTokenManager;
 import org.codelibs.fess.api.v2.handlers.LoginRateLimiter;
 import org.codelibs.fess.auth.AuthenticationManager;
 import org.codelibs.fess.chat.ChatClient;
+import org.codelibs.fess.chat.ChatContentFetcher;
 import org.codelibs.fess.chat.ChatSessionManager;
 import org.codelibs.fess.cors.CorsHandlerFactory;
 import org.codelibs.fess.crawler.client.CrawlerClientCreator;
@@ -258,6 +259,8 @@ public final class ComponentUtil {
     private static final String CHAT_SESSION_MANAGER = "chatSessionManager";
 
     private static final String CHAT_CLIENT = "chatClient";
+
+    private static final String CHAT_CONTENT_FETCHER = "chatContentFetcher";
 
     private static final String CHAT_API_HELPER = "chatApiHelper";
 
@@ -944,6 +947,15 @@ public final class ComponentUtil {
      */
     public static ChatClient getChatClient() {
         return getComponent(CHAT_CLIENT);
+    }
+
+    /**
+     * Gets the chat content fetcher component.
+     *
+     * @return the chat content fetcher
+     */
+    public static ChatContentFetcher getChatContentFetcher() {
+        return getComponent(CHAT_CONTENT_FETCHER);
     }
 
     /**

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1621,6 +1621,13 @@ rag.chat.message.max.length=4000
 # Highlight settings for RAG search.
 rag.chat.highlight.fragment.size=500
 rag.chat.highlight.number.of.fragments=3
+# Large-document handling for answer generation.
+# Documents whose content_length exceeds this value use highlighted passages
+# instead of full content in the answer context.
+rag.chat.content.fulltext.max.length=3000
+# Highlight settings used when extracting passages from large documents for the answer context.
+rag.chat.answer.highlight.fragment.size=1000
+rag.chat.answer.highlight.number.of.fragments=5
 # History content mode for assistant messages.
 #   smart_summary           - drop assistant body, keep only past search query + referenced titles per turn (default, recommended)
 #   full                    - send the whole assistant response

--- a/src/main/resources/fess_llm.xml
+++ b/src/main/resources/fess_llm.xml
@@ -9,6 +9,10 @@
 	<component name="chatClient" class="org.codelibs.fess.chat.ChatClient">
 	</component>
 
+	<!-- Resolves document content for the answer context (size-based full/highlight dispatch) -->
+	<component name="chatContentFetcher" class="org.codelibs.fess.chat.DefaultChatContentFetcher">
+	</component>
+
 	<!-- Shared helper for v2 chat API handlers -->
 	<component name="chatApiHelper" class="org.codelibs.fess.helper.ChatApiHelper">
 	</component>

--- a/src/test/java/org/codelibs/fess/chat/DefaultChatContentFetcherTest.java
+++ b/src/test/java/org/codelibs/fess/chat/DefaultChatContentFetcherTest.java
@@ -123,6 +123,25 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_normalizeHighlightedDocs_setsContentAndDropsBlank() {
+        final TestableFetcher f = new TestableFetcher();
+        final Map<String, Object> withSnippet = new LinkedHashMap<>();
+        withSnippet.put("doc_id", "a");
+        withSnippet.put("content_description", "snippet-a");
+        final Map<String, Object> blankSnippet = new LinkedHashMap<>();
+        blankSnippet.put("doc_id", "b");
+        blankSnippet.put("content_description", "");
+        final Map<String, Object> noSnippet = new LinkedHashMap<>();
+        noSnippet.put("doc_id", "c");
+
+        final List<Map<String, Object>> out = f.normalizeHighlightedDocs(new ArrayList<>(List.of(withSnippet, blankSnippet, noSnippet)));
+
+        assertEquals(1, out.size());
+        assertEquals("a", out.get(0).get("doc_id"));
+        assertEquals("snippet-a", out.get(0).get("content"));
+    }
+
+    @Test
     public void test_fetchContent_missingReconciledToFull() {
         final TestableFetcher f = new TestableFetcher() {
             @Override

--- a/src/test/java/org/codelibs/fess/chat/DefaultChatContentFetcherTest.java
+++ b/src/test/java/org/codelibs/fess/chat/DefaultChatContentFetcherTest.java
@@ -34,11 +34,30 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
         return m;
     }
 
-    /** Stubs the two engine-touching fetches so dispatch/order can be tested without a search engine. */
+    private static Map<String, Object> contentDoc(final String docId, final String content) {
+        final Map<String, Object> m = new LinkedHashMap<>();
+        m.put("doc_id", docId);
+        m.put("content", content);
+        return m;
+    }
+
+    /**
+     * Stubs the two engine-touching fetches so dispatch/order can be tested without a search engine.
+     * Behavior is configurable via fields so individual tests need no anonymous subclasses:
+     * <ul>
+     * <li>{@code highlightResult} / {@code fullResult}: when set, returned verbatim (e.g. an empty
+     * list to simulate a highlight miss or an empty full fetch).</li>
+     * <li>{@code fullContent}: when set (and {@code fullResult} is null), generated full docs carry
+     * this content instead of the default {@code "FULL:<id>"} (used to exercise truncation).</li>
+     * </ul>
+     */
     private static class TestableFetcher extends DefaultChatContentFetcher {
         long threshold = 3000L;
         final List<String> fullCalledWith = new ArrayList<>();
         final List<String> highlightCalledWith = new ArrayList<>();
+        List<Map<String, Object>> highlightResult;
+        List<Map<String, Object>> fullResult;
+        String fullContent;
 
         @Override
         protected long getFulltextThreshold() {
@@ -46,14 +65,19 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
         }
 
         @Override
+        protected String getHighlightContentField() {
+            return "hl_content";
+        }
+
+        @Override
         protected List<Map<String, Object>> fetchFullContent(final List<String> docIds) {
             fullCalledWith.addAll(docIds);
+            if (fullResult != null) {
+                return new ArrayList<>(fullResult);
+            }
             final List<Map<String, Object>> r = new ArrayList<>();
             for (final String id : docIds) {
-                final Map<String, Object> m = new LinkedHashMap<>();
-                m.put("doc_id", id);
-                m.put("content", "FULL:" + id);
-                r.add(m);
+                r.add(contentDoc(id, fullContent != null ? fullContent : "FULL:" + id));
             }
             return r;
         }
@@ -61,12 +85,12 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
         @Override
         protected List<Map<String, Object>> fetchHighlightedContent(final List<String> docIds, final String query) {
             highlightCalledWith.addAll(docIds);
+            if (highlightResult != null) {
+                return new ArrayList<>(highlightResult);
+            }
             final List<Map<String, Object>> r = new ArrayList<>();
             for (final String id : docIds) {
-                final Map<String, Object> m = new LinkedHashMap<>();
-                m.put("doc_id", id);
-                m.put("content", "HL:" + id);
-                r.add(m);
+                r.add(contentDoc(id, "HL:" + id));
             }
             return r;
         }
@@ -86,6 +110,16 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
         final TestableFetcher f = new TestableFetcher();
         final ChatContentRequest req = new ChatContentRequest(List.of("a"), List.of(), "");
         assertEquals(DefaultChatContentFetcher.Strategy.FULL, f.decideStrategy("a", 999999L, req));
+    }
+
+    @Test
+    public void test_decideStrategy_atThresholdIsFull() {
+        final TestableFetcher f = new TestableFetcher();
+        f.threshold = 3000L;
+        final ChatContentRequest req = new ChatContentRequest(List.of("a"), List.of(), "q");
+        // The dispatch uses a strict ">" comparison, so content_length equal to the
+        // threshold is treated as a small document (FULL), not a large one (HIGHLIGHT).
+        assertEquals(DefaultChatContentFetcher.Strategy.FULL, f.decideStrategy("a", 3000L, req));
     }
 
     @Test
@@ -114,6 +148,15 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_fetchContent_nullDocIdsReturnsEmpty() {
+        final TestableFetcher f = new TestableFetcher();
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(null, List.of(), "q"));
+        assertTrue(out.isEmpty());
+        assertTrue(f.fullCalledWith.isEmpty());
+        assertTrue(f.highlightCalledWith.isEmpty());
+    }
+
+    @Test
     public void test_toLong() {
         final TestableFetcher f = new TestableFetcher();
         assertEquals(Long.valueOf(5L), f.toLong(Integer.valueOf(5)));
@@ -123,16 +166,68 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_truncateContent() {
+        final TestableFetcher f = new TestableFetcher();
+        final Map<String, Object> longDoc = new LinkedHashMap<>();
+        longDoc.put("content", "0123456789");
+        f.truncateContent(longDoc, 4L);
+        assertEquals("0123", longDoc.get("content"));
+
+        final Map<String, Object> shortDoc = new LinkedHashMap<>();
+        shortDoc.put("content", "ab");
+        f.truncateContent(shortDoc, 4L);
+        assertEquals("ab", shortDoc.get("content")); // shorter than max -> unchanged
+
+        final Map<String, Object> noContent = new LinkedHashMap<>();
+        f.truncateContent(noContent, 4L);
+        assertNull(noContent.get("content")); // missing content -> no-op
+    }
+
+    @Test
+    public void test_truncateContent_lengthEqualsMaxIsUnchanged() {
+        final TestableFetcher f = new TestableFetcher();
+        final Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("content", "0123"); // length 4 == maxLength
+        f.truncateContent(doc, 4L);
+        // Only content strictly longer than maxLength is cut; equal length stays intact.
+        assertEquals("0123", doc.get("content"));
+    }
+
+    @Test
+    public void test_truncateContent_nonStringContentIsNoOp() {
+        final TestableFetcher f = new TestableFetcher();
+        final Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("content", Integer.valueOf(123456789)); // non-String value
+        f.truncateContent(doc, 4L);
+        // A non-String content value is left untouched.
+        assertEquals(Integer.valueOf(123456789), doc.get("content"));
+    }
+
+    @Test
+    public void test_truncateContent_zeroMaxLengthYieldsEmpty() {
+        final TestableFetcher f = new TestableFetcher();
+        final Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("content", "abc");
+        f.truncateContent(doc, 0L);
+        // maxLength 0 truncates a non-empty string to the empty string.
+        assertEquals("", doc.get("content"));
+    }
+
+    @Test
     public void test_normalizeHighlightedDocs_setsContentAndDropsBlank() {
         final TestableFetcher f = new TestableFetcher();
         final Map<String, Object> withSnippet = new LinkedHashMap<>();
         withSnippet.put("doc_id", "a");
-        withSnippet.put("content_description", "snippet-a");
+        withSnippet.put("hl_content", "snippet-a");
         final Map<String, Object> blankSnippet = new LinkedHashMap<>();
         blankSnippet.put("doc_id", "b");
-        blankSnippet.put("content_description", "");
+        blankSnippet.put("hl_content", "");
         final Map<String, Object> noSnippet = new LinkedHashMap<>();
         noSnippet.put("doc_id", "c");
+        // No highlight passage, but content_description falls back to the short digest at the
+        // search layer. The digest must NOT be treated as a passage; this doc must be dropped so
+        // the caller falls back to its truncated full content.
+        noSnippet.put("content_description", "digest-c");
 
         final List<Map<String, Object>> out = f.normalizeHighlightedDocs(new ArrayList<>(List.of(withSnippet, blankSnippet, noSnippet)));
 
@@ -142,17 +237,200 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_fetchContent_missingReconciledToFull() {
-        final TestableFetcher f = new TestableFetcher() {
-            @Override
-            protected List<Map<String, Object>> fetchHighlightedContent(final List<String> docIds, final String query) {
-                highlightCalledWith.addAll(docIds);
-                return new ArrayList<>(); // highlight had no match
-            }
-        };
+    public void test_normalizeHighlightedDocs_multipleKeepsOrderOfPassagesOnly() {
+        final TestableFetcher f = new TestableFetcher();
+        final Map<String, Object> a = new LinkedHashMap<>();
+        a.put("doc_id", "a");
+        a.put("hl_content", "snippet-a");
+        final Map<String, Object> b = new LinkedHashMap<>();
+        b.put("doc_id", "b");
+        b.put("hl_content", ""); // blank -> dropped
+        final Map<String, Object> c = new LinkedHashMap<>();
+        c.put("doc_id", "c");
+        c.put("hl_content", "snippet-c");
+        final Map<String, Object> d = new LinkedHashMap<>();
+        d.put("doc_id", "d"); // no hl_content -> dropped
+
+        final List<Map<String, Object>> out = f.normalizeHighlightedDocs(new ArrayList<>(List.of(a, b, c, d)));
+
+        // Only docs with a non-blank passage survive, in their original order.
+        assertEquals(2, out.size());
+        assertEquals("a", out.get(0).get("doc_id"));
+        assertEquals("snippet-a", out.get(0).get("content"));
+        assertEquals("c", out.get(1).get("doc_id"));
+        assertEquals("snippet-c", out.get(1).get("content"));
+    }
+
+    @Test
+    public void test_fetchContent_highlightMissFallsBackToTruncatedFull() {
+        final TestableFetcher f = new TestableFetcher();
+        f.threshold = 4L;
+        f.highlightResult = new ArrayList<>(); // highlight had no match
+        f.fullContent = "0123456789"; // length 10, exceeds the threshold
         final ChatContentRequest req = new ChatContentRequest(List.of("big"), List.of(doc("big", 99999L)), "q");
         final List<Map<String, Object>> out = f.fetchContent(req);
+        // A large doc with no passage falls back to full content truncated to the threshold.
         assertEquals(1, out.size());
-        assertEquals("FULL:big", out.get(0).get("content"));
+        assertEquals("big", out.get(0).get("doc_id"));
+        assertEquals("0123", out.get(0).get("content"));
+        assertEquals(List.of("big"), f.highlightCalledWith);
+        assertEquals(List.of("big"), f.fullCalledWith);
+    }
+
+    @Test
+    public void test_fetchContent_mixedHighlightMissFallsBackToFull() {
+        final TestableFetcher f = new TestableFetcher();
+        f.highlightResult = new ArrayList<>(); // highlight had no match for the large doc
+        final List<String> docIds = List.of("small", "big");
+        final List<Map<String, Object>> searchResults = List.of(doc("small", 100L), doc("big", 99999L));
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(docIds, searchResults, "q"));
+        // Small doc kept; large doc falls back to full content (short here, so not truncated).
+        assertEquals(2, out.size());
+        assertEquals("small", out.get(0).get("doc_id"));
+        assertEquals("FULL:small", out.get(0).get("content"));
+        assertEquals("big", out.get(1).get("doc_id"));
+        assertEquals("FULL:big", out.get(1).get("content"));
+    }
+
+    @Test
+    public void test_fetchContent_unknownContentLengthIsFull() {
+        final TestableFetcher f = new TestableFetcher();
+        // doc_id "x" is absent from searchResults, so its content_length is unknown (null).
+        final List<Map<String, Object>> searchResults = List.of(doc("other", 100L));
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(List.of("x"), searchResults, "q"));
+
+        // Unknown size falls back to FULL; highlight is never attempted.
+        assertEquals(1, out.size());
+        assertEquals("x", out.get(0).get("doc_id"));
+        assertEquals("FULL:x", out.get(0).get("content"));
+        assertEquals(List.of("x"), f.fullCalledWith);
+        assertTrue(f.highlightCalledWith.isEmpty());
+    }
+
+    @Test
+    public void test_fetchContent_allLargeWithPassagesNoFullFallback() {
+        final TestableFetcher f = new TestableFetcher();
+        final List<String> docIds = List.of("big1", "big2");
+        final List<Map<String, Object>> searchResults = List.of(doc("big1", 99999L), doc("big2", 88888L));
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(docIds, searchResults, "q"));
+
+        // Every large doc produced a passage, so no full-content fallback is fetched.
+        assertEquals(List.of("big1", "big2"), f.highlightCalledWith);
+        assertTrue(f.fullCalledWith.isEmpty());
+        assertEquals(2, out.size());
+        assertEquals("big1", out.get(0).get("doc_id"));
+        assertEquals("HL:big1", out.get(0).get("content"));
+        assertEquals("big2", out.get(1).get("doc_id"));
+        assertEquals("HL:big2", out.get(1).get("content"));
+    }
+
+    @Test
+    public void test_fetchContent_partialHighlightHitMixesPassageAndTruncatedFull() {
+        // Highlight returns a passage for "big1" only; "big2" misses and must fall back
+        // to its truncated full content while preserving the original docIds order.
+        final TestableFetcher f = new TestableFetcher();
+        f.threshold = 4L;
+        f.highlightResult = new ArrayList<>(List.of(contentDoc("big1", "HL:big1"))); // only big1 returned
+        f.fullContent = "0123456789"; // length 10, exceeds the threshold
+        final List<String> docIds = List.of("big1", "big2");
+        final List<Map<String, Object>> searchResults = List.of(doc("big1", 99999L), doc("big2", 88888L));
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(docIds, searchResults, "q"));
+
+        assertEquals(List.of("big1", "big2"), f.highlightCalledWith);
+        assertEquals(List.of("big2"), f.fullCalledWith); // only the miss is reconciled via full
+        assertEquals(2, out.size());
+        assertEquals("big1", out.get(0).get("doc_id"));
+        assertEquals("HL:big1", out.get(0).get("content")); // hit keeps its passage
+        assertEquals("big2", out.get(1).get("doc_id"));
+        assertEquals("0123", out.get(1).get("content")); // miss -> truncated full
+    }
+
+    @Test
+    public void test_fetchContent_allLargeMissFallBackToTruncatedFull() {
+        final TestableFetcher f = new TestableFetcher();
+        f.threshold = 4L;
+        f.highlightResult = new ArrayList<>(); // every large doc misses
+        f.fullContent = "0123456789"; // length 10, exceeds the threshold
+        final List<String> docIds = List.of("big1", "big2");
+        final List<Map<String, Object>> searchResults = List.of(doc("big1", 99999L), doc("big2", 88888L));
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(docIds, searchResults, "q"));
+
+        assertEquals(List.of("big1", "big2"), f.highlightCalledWith);
+        assertEquals(List.of("big1", "big2"), f.fullCalledWith); // all misses reconciled via full
+        assertEquals(2, out.size());
+        assertEquals("big1", out.get(0).get("doc_id"));
+        assertEquals("0123", out.get(0).get("content"));
+        assertEquals("big2", out.get(1).get("doc_id"));
+        assertEquals("0123", out.get(1).get("content"));
+    }
+
+    @Test
+    public void test_fetchContent_reconciledDocKeepsOriginalPosition() {
+        // The large doc sits in the middle of the docIds order. After missing the
+        // highlight phase it is reconciled via full content, and must still land at its
+        // original middle position in the output (not appended at the end).
+        final TestableFetcher f = new TestableFetcher();
+        f.highlightResult = new ArrayList<>(); // the large doc misses
+        final List<String> docIds = List.of("small1", "big", "small2");
+        final List<Map<String, Object>> searchResults = List.of(doc("small1", 100L), doc("big", 99999L), doc("small2", 200L));
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(docIds, searchResults, "q"));
+
+        assertEquals(List.of("big"), f.highlightCalledWith);
+        // Full is called once for the small docs and once for the reconciled large doc.
+        assertEquals(List.of("small1", "small2", "big"), f.fullCalledWith);
+        assertEquals(3, out.size());
+        assertEquals("small1", out.get(0).get("doc_id"));
+        assertEquals("FULL:small1", out.get(0).get("content"));
+        assertEquals("big", out.get(1).get("doc_id")); // reconciled doc stays in the middle
+        assertEquals("FULL:big", out.get(1).get("content"));
+        assertEquals("small2", out.get(2).get("doc_id"));
+        assertEquals("FULL:small2", out.get(2).get("content"));
+    }
+
+    @Test
+    public void test_fetchContent_blankQueryAllFull() {
+        final TestableFetcher f = new TestableFetcher();
+        final List<String> docIds = List.of("big1", "big2");
+        final List<Map<String, Object>> searchResults = List.of(doc("big1", 99999L), doc("big2", 88888L));
+        // Blank query disables highlighting, so even large docs are fetched in full.
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(docIds, searchResults, ""));
+
+        assertTrue(f.highlightCalledWith.isEmpty());
+        assertEquals(List.of("big1", "big2"), f.fullCalledWith);
+        assertEquals(2, out.size());
+        assertEquals("FULL:big1", out.get(0).get("content"));
+        assertEquals("FULL:big2", out.get(1).get("content"));
+    }
+
+    @Test
+    public void test_fetchContent_unresolvedSmallDocIsExcludedNotRetried() {
+        // A small doc whose full fetch returns nothing is excluded. Reconciliation is scoped to
+        // large docs (highlight misses) only, so a failed small-doc fetch is not retried.
+        final TestableFetcher f = new TestableFetcher();
+        f.fullResult = new ArrayList<>(); // engine returned nothing for the requested doc
+        final List<String> docIds = List.of("small");
+        final List<Map<String, Object>> searchResults = List.of(doc("small", 100L));
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(docIds, searchResults, "q"));
+
+        assertTrue(out.isEmpty());
+        assertEquals(List.of("small"), f.fullCalledWith); // fetched once, not retried
+        assertTrue(f.highlightCalledWith.isEmpty());
+    }
+
+    @Test
+    public void test_fetchContent_emptySearchResultsAndNullQueryAllFull() {
+        final TestableFetcher f = new TestableFetcher();
+        final List<String> docIds = List.of("a", "b");
+        // Mirrors the ChatClient.fetchFullContent path: no search results (unknown sizes)
+        // and a null query. Every doc resolves to FULL with no highlight attempt.
+        final List<Map<String, Object>> out = f.fetchContent(new ChatContentRequest(docIds, List.of(), null));
+
+        assertTrue(f.highlightCalledWith.isEmpty());
+        assertEquals(List.of("a", "b"), f.fullCalledWith);
+        assertEquals(2, out.size());
+        assertEquals("a", out.get(0).get("doc_id"));
+        assertEquals("FULL:a", out.get(0).get("content"));
+        assertEquals("b", out.get(1).get("doc_id"));
+        assertEquals("FULL:b", out.get(1).get("content"));
     }
 }

--- a/src/test/java/org/codelibs/fess/chat/DefaultChatContentFetcherTest.java
+++ b/src/test/java/org/codelibs/fess/chat/DefaultChatContentFetcherTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.chat;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+public class DefaultChatContentFetcherTest extends UnitFessTestCase {
+
+    private static Map<String, Object> doc(final String docId, final Object contentLength) {
+        final Map<String, Object> m = new LinkedHashMap<>();
+        m.put("doc_id", docId);
+        if (contentLength != null) {
+            m.put("content_length", contentLength);
+        }
+        return m;
+    }
+
+    /** Stubs the two engine-touching fetches so dispatch/order can be tested without a search engine. */
+    private static class TestableFetcher extends DefaultChatContentFetcher {
+        long threshold = 3000L;
+        final List<String> fullCalledWith = new ArrayList<>();
+        final List<String> highlightCalledWith = new ArrayList<>();
+
+        @Override
+        protected long getFulltextThreshold() {
+            return threshold;
+        }
+
+        @Override
+        protected List<Map<String, Object>> fetchFullContent(final List<String> docIds) {
+            fullCalledWith.addAll(docIds);
+            final List<Map<String, Object>> r = new ArrayList<>();
+            for (final String id : docIds) {
+                final Map<String, Object> m = new LinkedHashMap<>();
+                m.put("doc_id", id);
+                m.put("content", "FULL:" + id);
+                r.add(m);
+            }
+            return r;
+        }
+
+        @Override
+        protected List<Map<String, Object>> fetchHighlightedContent(final List<String> docIds, final String query) {
+            highlightCalledWith.addAll(docIds);
+            final List<Map<String, Object>> r = new ArrayList<>();
+            for (final String id : docIds) {
+                final Map<String, Object> m = new LinkedHashMap<>();
+                m.put("doc_id", id);
+                m.put("content", "HL:" + id);
+                r.add(m);
+            }
+            return r;
+        }
+    }
+
+    @Test
+    public void test_decideStrategy_bySize() {
+        final TestableFetcher f = new TestableFetcher();
+        final ChatContentRequest req = new ChatContentRequest(List.of("a"), List.of(), "q");
+        assertEquals(DefaultChatContentFetcher.Strategy.FULL, f.decideStrategy("a", 2999L, req));
+        assertEquals(DefaultChatContentFetcher.Strategy.HIGHLIGHT, f.decideStrategy("a", 3001L, req));
+        assertEquals(DefaultChatContentFetcher.Strategy.FULL, f.decideStrategy("a", null, req));
+    }
+
+    @Test
+    public void test_decideStrategy_blankQuery_isFull() {
+        final TestableFetcher f = new TestableFetcher();
+        final ChatContentRequest req = new ChatContentRequest(List.of("a"), List.of(), "");
+        assertEquals(DefaultChatContentFetcher.Strategy.FULL, f.decideStrategy("a", 999999L, req));
+    }
+
+    @Test
+    public void test_fetchContent_dispatchAndOrder() {
+        final TestableFetcher f = new TestableFetcher();
+        final List<String> docIds = List.of("small", "big", "small2");
+        final List<Map<String, Object>> searchResults = List.of(doc("small", 100L), doc("big", 99999L), doc("small2", 200L));
+        final ChatContentRequest req = new ChatContentRequest(docIds, searchResults, "q");
+
+        final List<Map<String, Object>> out = f.fetchContent(req);
+
+        assertEquals(List.of("big"), f.highlightCalledWith);
+        assertEquals(List.of("small", "small2"), f.fullCalledWith);
+        assertEquals(3, out.size());
+        assertEquals("small", out.get(0).get("doc_id"));
+        assertEquals("FULL:small", out.get(0).get("content"));
+        assertEquals("big", out.get(1).get("doc_id"));
+        assertEquals("HL:big", out.get(1).get("content"));
+        assertEquals("small2", out.get(2).get("doc_id"));
+    }
+
+    @Test
+    public void test_fetchContent_emptyDocIds() {
+        final TestableFetcher f = new TestableFetcher();
+        assertTrue(f.fetchContent(new ChatContentRequest(List.of(), List.of(), "q")).isEmpty());
+    }
+
+    @Test
+    public void test_toLong() {
+        final TestableFetcher f = new TestableFetcher();
+        assertEquals(Long.valueOf(5L), f.toLong(Integer.valueOf(5)));
+        assertEquals(Long.valueOf(7L), f.toLong("7"));
+        assertNull(f.toLong("x"));
+        assertNull(f.toLong(null));
+    }
+
+    @Test
+    public void test_fetchContent_missingReconciledToFull() {
+        final TestableFetcher f = new TestableFetcher() {
+            @Override
+            protected List<Map<String, Object>> fetchHighlightedContent(final List<String> docIds, final String query) {
+                highlightCalledWith.addAll(docIds);
+                return new ArrayList<>(); // highlight had no match
+            }
+        };
+        final ChatContentRequest req = new ChatContentRequest(List.of("big"), List.of(doc("big", 99999L)), "q");
+        final List<Map<String, Object>> out = f.fetchContent(req);
+        assertEquals(1, out.size());
+        assertEquals("FULL:big", out.get(0).get("content"));
+    }
+}


### PR DESCRIPTION
## Summary

Improves RAG (AI search) answer generation for **large documents**. Previously, after relevance evaluation the answer phase re-fetched each document's **full** `content` by `doc_id` and naively truncated the concatenated context at a character limit. For large documents this meant the query-relevant passage (often in the middle/end of the document) never reached the LLM, so the answer could not be produced — the root cause reported in [discuss.codelibs.org: "AI search with large documents"](https://discuss.codelibs.org/t/ai-search-with-large-documents/2747).

This PR introduces an overridable `ChatContentFetcher` that dispatches **per document by `content_length`**:

- **Small documents** (`content_length` ≤ threshold) → full content, exactly as before.
- **Large documents** (`content_length` > threshold) → query-relevant **highlighted passages** fetched via a `doc_id`-restricted highlighted search, normalized into the `content` field.

`AbstractLlmClient.buildContext` is unchanged (content-first), so the downstream answer/summary/FAQ paths transparently receive either full content or passages.

## Design

- The size decision uses `content_length` from the **search-phase** results (where it is always present), not from the re-fetched documents.
- Highlighted passages use new **answer-specific** highlight settings (separate from the display-oriented `rag.chat.highlight.*`).
- Snippets are written into `content`; documents whose highlight snippet is blank are dropped so the reconciliation step re-fetches them with full content.
- **No regression:** blank/null query, unknown `content_length`, the SUMMARY path, and highlight failures all fall back to full content. Any exception or empty highlight result reconciles to a full fetch, so the worst case is identical to today's behavior.

## Overridability

- `ChatContentFetcher` is an interface registered as the `chatContentFetcher` DI component (`fess_llm.xml`), accessible via `ComponentUtil.getChatContentFetcher()`.
- `DefaultChatContentFetcher` exposes `decideStrategy` / `fetchFullContent` / `fetchHighlightedContent` / `getFulltextThreshold` as `protected`.
- Override the whole component by redefining `chatContentFetcher` in a later-loaded DI XML, or subclass `DefaultChatContentFetcher` to change just the dispatch threshold, fetch strategy, or provider-aware budget.

## New configuration (`fess_config.properties`)

| Key | Default | Purpose |
|-----|---------|---------|
| `rag.chat.content.fulltext.max.length` | `3000` | `content_length` above which highlighted passages are used instead of full content |
| `rag.chat.answer.highlight.fragment.size` | `1000` | Highlight fragment size for the answer context |
| `rag.chat.answer.highlight.number.of.fragments` | `5` | Number of highlight fragments for the answer context |

These are read via `getOrDefault`, so `FessConfig` is not regenerated.

## Changes

- **New:** `ChatContentRequest`, `ChatContentFetcher`, `DefaultChatContentFetcher` (`org.codelibs.fess.chat`).
- **Modified:** `ChatClient` routes content fetching through `ChatContentFetcher` (SEARCH/FAQ passes search results + query; SUMMARY path behavior preserved); `ComponentUtil` accessor; `fess_llm.xml` registration; `fess_config.properties` keys.

## Testing

- New `DefaultChatContentFetcherTest` (7 tests): size-based dispatch, original-order preservation, reconciliation-to-full, blank-snippet drop, `toLong` conversion.
- Full `org.codelibs.fess.chat` suite green: **111 tests, 0 failures**.

> Note: the runtime behavior of the `doc_id`-restricted highlighted search is best verified against a live OpenSearch; the full-content reconciliation fallback guarantees correctness even if highlighting yields nothing.
