### PR TITLE
chore(deps): prepare 15.7.0 release (bump kopf to 15.7.0, EOL 2027-12-01)

### DIFF
--- a/deps.xml
+++ b/deps.xml
@@ -6,7 +6,7 @@
 	<property name="suggest.dir" value="${basedir}/src/main/webapp/WEB-INF/env/suggest" />
 	<property name="thumbnail.dir" value="${basedir}/src/main/webapp/WEB-INF/env/thumbnail" />
 	<property name="site.dir" value="${basedir}/src/main/webapp/WEB-INF/site" />
-	<property name="kopf.version" value="15.6.0" />
+	<property name="kopf.version" value="15.7.0" />
 	<property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/tags/v${kopf.version}.zip" />
 	<!-- property name="kopf.version" value="main" / -->
 	<!-- property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/heads/${kopf.version}.zip" / -->

--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -174,7 +174,7 @@ public class SystemHelper {
             logger.debug("Initializing {}", this.getClass().getSimpleName());
         }
         final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        cal.set(2027, 10 - 1, 1); // EOL Date
+        cal.set(2027, 12 - 1, 1); // EOL Date
         eolTime = cal.getTimeInMillis();
         if (isEoled()) {
             logger.error("Your system is out of support. See https://fess.codelibs.org/eol.html");


### PR DESCRIPTION
## Summary

Release preparation for **Fess 15.7.0** (analogous to #3113, the 15.6.0 prep).

- `deps.xml`: switch `kopf.version` from `15.6.0` to the tagged **`15.7.0`** release (`refs/tags/v15.7.0`).
- `SystemHelper.java`: extend the EOL date from `2027-10-01` to **`2027-12-01`** (the established +2-month-per-minor cadence).

OpenSearch plugins (`module.xml` / `plugin.xml`) are already at `3.7.0`, so no change is needed there (unlike #3113 which still did the OpenSearch bump).

## Note on sequencing

`deps.xml` downloads `https://github.com/codelibs/fess-kopf/archive/refs/tags/v15.7.0.zip`, so this PR's build/CI requires the **`fess-kopf` `v15.7.0` tag to exist first**. Merge the fess-kopf 15.7.0 release PR and push the `v15.7.0` tag before merging this one.