### PR TITLE
fix(theme/bootstrap): clear login form credentials on modal close

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/auth.js
+++ b/src/main/webapp/themes/bootstrap/assets/auth.js
@@ -256,8 +256,18 @@ export function attach() {
     }
   }
 
+  const modal = document.getElementById("login-modal");
   const form = document.getElementById("login-form");
   const err = document.getElementById("login-error");
+  if (modal && form) {
+    modal.addEventListener("hidden.bs.modal", () => {
+      form.reset();
+      if (err) {
+        err.classList.add("d-none");
+        err.textContent = "";
+      }
+    });
+  }
   if (form) {
     form.addEventListener("submit", async ev => {
       ev.preventDefault();


### PR DESCRIPTION
Reset the login form and hide the error banner whenever the login modal is closed, so that credentials entered in a previous session are not visible when the modal is reopened after logout.