### PR TITLE
fix(theme/bootstrap): submit search when a home suggestion is clicked

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/app.js
+++ b/src/main/webapp/themes/bootstrap/assets/app.js
@@ -226,6 +226,9 @@ function attachHomeView() {
   if (input && homeSuggest && !input.dataset.suggestAttached) {
     input.dataset.suggestAttached = "1";
     search.attachSuggest(input, homeSuggest, {
+      // submitOnSelect: true — clicking a suggestion on the home page submits the search
+      // form immediately, matching default-JSP suggestor.js and results-page header behavior.
+      submitOnSelect: true,
       get lang() {
         // Home and results share the single #searchOptions drawer (JSP parity),
         // so the suggest lang filter reads the drawer's #langSearchOption select.

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -767,7 +767,11 @@ export function disableSubmitBriefly(btn) {
  *
  * @param {HTMLInputElement} input    - the text field to attach to
  * @param {HTMLElement}      dropdown - a <ul> that will be populated with <li> suggestions
- * @param {{ lang?: string[] | { length: number } }} [opts] - options; opts.lang can be a getter
+ * @param {{ lang?: string[] | { length: number }, submitOnSelect?: boolean }} [opts] - options;
+ *   opts.lang can be a getter; opts.submitOnSelect (opt-in) dispatches a submit event on the
+ *   input's form after selection — matches default-JSP suggestor.js and the results-page header
+ *   suggest (search.js mousedown handler).  Advanced search does NOT set this flag so it stays
+ *   fill-only (other fields would be empty on premature submit).
  */
 export function attachSuggest(input, dropdown, opts = {}) {
   if (!input || !dropdown) return;
@@ -777,7 +781,19 @@ export function attachSuggest(input, dropdown, opts = {}) {
     dropdown.classList.add("d-none");
     input.setAttribute("aria-expanded", "false");
   };
-  const choose = (text) => { input.value = text; clear(); input.focus(); };
+  const choose = (text) => {
+    input.value = text;
+    clear();
+    // submitOnSelect: opt-in flag — submit the form after filling the input, matching
+    // default-JSP suggestor.js and the results-page header suggest behavior.
+    // Advanced search does not pass this flag and keeps the fill-only path.
+    if (opts.submitOnSelect) {
+      const form = input.form || input.closest("form");
+      if (form) { form.dispatchEvent(new Event("submit")); }
+      return;
+    }
+    input.focus();
+  };
   const render = async (q) => {
     if (!q || q.length < 1) { clear(); return; }
     try {

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1231,4 +1231,47 @@ public class BundledBootstrapThemeTest {
             });
         }
     }
+
+    // ── Home suggest submit-on-select fix ──────────────────────────────────────
+
+    /**
+     * search.js attachSuggest() must support an opt-in submitOnSelect option so that
+     * callers can request the form to be submitted when a suggestion is chosen.
+     * This mirrors the default-JSP suggestor.js and the results-page header suggest
+     * (search.js ~line 1298: form.dispatchEvent(new Event("submit"))).
+     * Advanced search must NOT opt in — it stays fill-only.
+     */
+    @Test
+    public void test_searchJs_homeSuggestSubmitsOnSelectOptIn() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("submitOnSelect"),
+                "search.js attachSuggest() must support the submitOnSelect option so callers can opt in to submitting on suggestion click");
+        assertTrue(js.contains("opts.submitOnSelect"),
+                "search.js choose() must check opts.submitOnSelect to decide whether to submit the form");
+        assertTrue(js.contains("input.form"),
+                "search.js choose() must resolve the form via input.form (with fallback) for the submitOnSelect path");
+    }
+
+    /**
+     * app.js home wiring must enable submitOnSelect: true so that clicking a suggestion
+     * on the home page runs the search (matches default-JSP / results-page behavior).
+     */
+    @Test
+    public void test_appJs_homeSuggestEnablesSubmitOnSelect() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/app.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("submitOnSelect: true"),
+                "app.js home attachSuggest call must pass submitOnSelect: true so suggestion clicks submit the home search form");
+    }
+
+    /**
+     * advance.js must NOT pass submitOnSelect — it must remain fill-only so that
+     * clicking a suggestion only fills the all-words field without prematurely
+     * submitting the advanced search form (other fields would be empty).
+     */
+    @Test
+    public void test_advanceJs_keepsSuggestFillOnly() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/advance.js"), StandardCharsets.UTF_8);
+        assertFalse(js.contains("submitOnSelect"),
+                "advance.js must NOT pass submitOnSelect — advanced search suggestion clicks must remain fill-only");
+    }
 }


### PR DESCRIPTION
## Summary

In the bundled Bootstrap HTML theme, clicking a search suggestion on the **home (top) page** only filled the input without running the search — the user had to press the search button afterwards. Every other suggest path already submits:

- the default JSP suggestor (`js/suggestor.js`),
- the same theme's results-page header suggest (`search.js` `mousedown` handler), and
- keyboard accept (Enter/Tab) on the results page.

This was an inconsistency, not intended behavior: the home wiring comment even states it should reach "parity with index.jsp" (which submits). The root cause is that the shared `attachSuggest()` helper in `themes/bootstrap/assets/search.js` filled the input but never submitted the form.

## Why opt-in

`attachSuggest()` is also used by the **advanced search** form (`advance.js`, the "all words" input). There, auto-submitting when a single suggestion is clicked would be wrong because the other fields would still be empty. So submission is added as an **opt-in** `submitOnSelect` option that only the home page enables; advanced search stays fill-only.

## Changes

- `themes/bootstrap/assets/search.js` — `attachSuggest()` gains an opt-in `submitOnSelect` option. When set, after filling the input it dispatches a `submit` event on the input's form (`input.form` / `closest("form")`), mirroring the results-page header handler. Default behavior is unchanged (fill-only).
- `themes/bootstrap/assets/app.js` — the home search box now passes `submitOnSelect: true`. The existing `#home-search-form` submit handler navigates to `/search`, so dispatching submit runs the search.
- `advance.js` — unchanged (remains fill-only).
- `BundledBootstrapThemeTest` — 3 new assertions: home enables the opt-in (`app.js`), the submit logic exists (`search.js`), and advanced search stays fill-only (`advance.js`).

## Testing

`mvn test -Dtest=BundledBootstrapThemeTest` → 110 passed (2 new tests were red before the fix, green after).

Note: this repo has no JS unit-test framework, so verification uses the project's existing asset-content assertion style plus code review. A live browser run was not performed.