### PR TITLE
fix(api): resolve correct installation/EOL help URLs in UiConfigHandler

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/UiConfigHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/UiConfigHandler.java
@@ -223,9 +223,10 @@ public class UiConfigHandler {
             }
 
             // eol_link / installation_link — surfaced as resolved URLs. Derivation mirrors
-            // JSP runtime data registered by SystemHelper. Uses getHelpLink(name) for the
-            // installation URL (same base-link pattern); for eol_link, uses the raw config
-            // value since it is a full template URL rather than a guide-page name.
+            // the JSP runtime data registered by SystemHelper (setupSearchHtmlData /
+            // setupAdminHtmlData): the installation link resolves the online.help.installation
+            // template and the EOL link resolves the online.help.eol template, both via the
+            // shared SystemHelper#getHelpUrl locale/version substitution.
             // Falls back to empty string when SystemHelper / RequestManager are unavailable.
             String eolLink = "";
             String installationLink = "";
@@ -233,13 +234,13 @@ public class UiConfigHandler {
                 final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
                 if (systemHelper != null) {
                     try {
-                        installationLink = systemHelper.getHelpLink("installation");
+                        installationLink = systemHelper.getInstallationLink();
                     } catch (final Exception ignored) {
                         // RequestManager not bound in unit harness — leave empty.
                     }
                     if (eoled) {
                         try {
-                            eolLink = systemHelper.getHelpLink("eol");
+                            eolLink = systemHelper.getEolLink();
                         } catch (final Exception ignored) {
                             // RequestManager not bound in unit harness — leave empty.
                         }

--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -441,6 +441,24 @@ public class SystemHelper {
     }
 
     /**
+     * Gets the resolved online help link for the installation guide.
+     *
+     * @return The localized installation help URL.
+     */
+    public String getInstallationLink() {
+        return getHelpUrl(ComponentUtil.getFessConfig().getOnlineHelpInstallation());
+    }
+
+    /**
+     * Gets the resolved online help link for end-of-life information.
+     *
+     * @return The localized end-of-life help URL.
+     */
+    public String getEolLink() {
+        return getHelpUrl(ComponentUtil.getFessConfig().getOnlineHelpEol());
+    }
+
+    /**
      * Adds a design JSP file name to the map.
      *
      * @param key   The key for the JSP file.
@@ -658,14 +676,12 @@ public class SystemHelper {
     public void setupAdminHtmlData(final TypicalAction action, final ActionRuntime runtime) {
         runtime.registerData("developmentMode", ComponentUtil.getSearchEngineClient().isEmbedded());
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final String installationLink = fessConfig.getOnlineHelpInstallation();
-        runtime.registerData("installationLink", getHelpUrl(installationLink));
+        runtime.registerData("installationLink", getInstallationLink());
         runtime.registerData("storageEnabled", isStorageEnabled(fessConfig));
         final boolean eoled = isEoled();
         runtime.registerData("eoled", eoled);
         if (eoled) {
-            final String eolLink = fessConfig.getOnlineHelpEol();
-            runtime.registerData("eolLink", getHelpUrl(eolLink));
+            runtime.registerData("eolLink", getEolLink());
         }
     }
 
@@ -696,14 +712,11 @@ public class SystemHelper {
      */
     public void setupSearchHtmlData(final TypicalAction action, final ActionRuntime runtime) {
         runtime.registerData("developmentMode", ComponentUtil.getSearchEngineClient().isEmbedded());
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        final String installationLink = fessConfig.getOnlineHelpInstallation();
-        runtime.registerData("installationLink", getHelpUrl(installationLink));
+        runtime.registerData("installationLink", getInstallationLink());
         final boolean eoled = isEoled();
         runtime.registerData("eoled", eoled);
         if (eoled) {
-            final String eolLink = fessConfig.getOnlineHelpEol();
-            runtime.registerData("eolLink", getHelpUrl(eolLink));
+            runtime.registerData("eolLink", getEolLink());
         }
     }
 


### PR DESCRIPTION
## Problem

The development-mode warning link rendered by the static themes points to the wrong URL.

For example:
```
https://fess.codelibs.org/ja/15.7/admin/installation-guide.html   # actual (wrong)
https://fess.codelibs.org/ja/15.7/install/install.html            # expected
```

## Root cause

The static themes render this link from `features.installation_link`, served by the `/api/v2/ui/config` endpoint (`UiConfigHandler`). That handler built the URL via:

```java
installationLink = systemHelper.getHelpLink("installation");
```

`getHelpLink(name)` concatenates `online.help.base.link` (`.../{version}/admin/`) with `name + "-guide.html"`, producing `.../admin/installation-guide.html`.

The installation page actually has its own full-URL template, `online.help.installation` (`.../{version}/install/install.html`), which the legacy JSP path already resolves correctly in `SystemHelper#setupSearchHtmlData` / `setupAdminHtmlData`. In other words, the new API path and the JSP path had diverged.

The same divergence affected `eol_link`: `getHelpLink("eol")` produced `.../admin/eol-guide.html` instead of the configured `online.help.eol` value (`.../eol.html`).

## Fix

Centralize the link resolution in `SystemHelper` so both the API and JSP paths share one implementation:

- Add `SystemHelper#getInstallationLink()` and `#getEolLink()` (resolve `online.help.installation` / `online.help.eol` through the existing `getHelpUrl` locale/version substitution).
- Refactor `setupSearchHtmlData` / `setupAdminHtmlData` to use them.
- Update `UiConfigHandler` to call them instead of `getHelpLink(...)`.

The generic `getHelpLink(name)` is unchanged and still used for the many admin guide pages that legitimately follow the `{base}/{name}-guide.html` pattern.

## Verification

- `mvn -o compile` → BUILD SUCCESS
- `mvn -o test -Dtest=UiConfigHandlerTest` → 18 tests, 0 failures
- `mvn formatter:format license:format` → no further changes

https://claude.ai/code/session_017X3Vhm2U2pU7m12B8Q6JBw