### PR TITLE
chore: prepare 15.7.0 release

### DIFF
--- a/dbflute.xml
+++ b/dbflute.xml
@@ -2,7 +2,7 @@
 <project name="dbflute" basedir=".">
 	<property name="mydbflute.dir" value="${basedir}/mydbflute" />
 	<property name="target.dir" value="${basedir}/target" />
-	<property name="branch.name" value="fess-15.5" />
+	<property name="branch.name" value="fess-15.7" />
 	<property name="mydbflute.url" value="https://github.com/lastaflute/lastaflute-example-waterfront/archive/${branch.name}.zip" />
 
 	<target name="mydbflute.check">

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.7.0-SNAPSHOT</version>
+		<version>15.7.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary
Prepares the project for the 15.7.0 release by finalizing version references in the build configuration.

## Changes Made
- `pom.xml`: bump the `fess-parent` version from `15.7.0-SNAPSHOT` to the release version `15.7.0`
- `dbflute.xml`: update the DBFlute example branch reference from `fess-15.5` to `fess-15.7`

## Testing
- No functional code changed; build configuration only. CI build should confirm the release parent resolves correctly.

## Breaking Changes
- None

## Additional Notes
- This is a release-preparation change. After release, the parent version is typically advanced to the next `-SNAPSHOT` on `master`.