### PR TITLE
docs(openapi): align v2 Chat API spec with implementation

### DIFF
--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -665,7 +665,6 @@ paths:
                 $ref: '#/components/schemas/ChatResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
         '403': { $ref: '#/components/responses/Forbidden' }
-        '404': { $ref: '#/components/responses/NotFound' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '413': { $ref: '#/components/responses/PayloadTooLarge' }
         '415': { $ref: '#/components/responses/UnsupportedMediaType' }
@@ -723,7 +722,7 @@ paths:
                 type: string
                 example: |
                   event: phase
-                  data: {"phase":"retrieval","status":"start"}
+                  data: {"phase":"search","status":"start","message":"Searching documents..."}
 
                   event: chunk
                   data: {"content":"Fess is "}
@@ -766,7 +765,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ChatClearResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
-        '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
@@ -1559,7 +1557,12 @@ components:
       type: object
       required: [message]
       properties:
-        message: { type: string }
+        message:
+          type: string
+          description: |-
+            The user message. The maximum length is bounded by
+            `rag.chat.message.max.length` (default 4000); exceeding it
+            returns `invalid_request` (HTTP 400).
         session_id: { type: string }
         fields:
           type: object


### PR DESCRIPTION
## Summary

Corrects the chat endpoints in the v2 OpenAPI user spec (`src/main/config/openapi/v2/openapi-user.yaml`) so the documented contract matches the actual handler behavior (`ChatHandler`, `ChatStreamHandler`, `ChatSessionClearHandler`).

## Changes

- **Remove HTTP 404 from `POST /chat`** — the handler never returns 404; a 404 is only produced by the router for unknown paths. The `POST /chat/stream` definition already omitted it, so this also fixes an internal inconsistency in the spec.
- **Remove HTTP 401 from `DELETE /chat/sessions/{session_id}`** — the handler resolves a guest user code and never returns 401 (unauthenticated/cross-user cases return 404, CSRF failures return 403).
- **Fix the SSE example phase** — the example used a non-existent `"retrieval"` phase. The real phase constants are `intent` / `search` / `evaluate` / `fetch` / `answer` (`ChatPhaseCallback`); the example now uses `"search"` with the `message` field actually emitted by `onPhaseStart`.
- **Document the `message` length limit** — bounded by `rag.chat.message.max.length` (default `4000`); exceeding it returns `invalid_request` (HTTP 400).

## Verification

- Spec parses cleanly as OpenAPI 3.0.3.
- Response codes now match the implementation:
  - `POST /chat` → 200/400/403/405/413/415/429/500
  - `POST /chat/stream` → 200/400/403/405/413/415/429/500
  - `DELETE /chat/sessions/{session_id}` → 200/400/403/404/405/429/500
- Consistent with the corresponding documentation update in the `fess-docs` repository.