### PR TITLE
fix(cors): restrict credentialed CORS to allow-listed origins

### DIFF
--- a/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
@@ -302,6 +302,13 @@ public class SearchEngineApiManager extends BaseApiManager {
 
     @Override
     protected void writeHeaders(final HttpServletResponse response) {
-        ComponentUtil.getFessConfig().getApiDashboardResponseHeaderList().forEach(e -> response.setHeader(e.getFirst(), e.getSecond()));
+        // Vary is merged (addHeader) so it does not clobber CorsFilter's `Vary: Origin`.
+        ComponentUtil.getFessConfig().getApiDashboardResponseHeaderList().forEach(e -> {
+            if ("Vary".equalsIgnoreCase(e.getFirst())) {
+                response.addHeader(e.getFirst(), e.getSecond());
+            } else {
+                response.setHeader(e.getFirst(), e.getSecond());
+            }
+        });
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -561,6 +561,13 @@ public class SearchApiV2Manager extends BaseApiManager {
         // apply uniformly across both v1 and v2 JSON responses. V2EnvelopeWriter only sets the
         // Content-Type / charset; security-baseline headers must be applied here so they reach
         // every response that flows through write(...) → writeHeaders(...).
-        ComponentUtil.getFessConfig().getApiJsonResponseHeaderList().forEach(e -> response.setHeader(e.getFirst(), e.getSecond()));
+        // Vary is merged (addHeader) so it does not clobber CorsFilter's `Vary: Origin`.
+        ComponentUtil.getFessConfig().getApiJsonResponseHeaderList().forEach(e -> {
+            if ("Vary".equalsIgnoreCase(e.getFirst())) {
+                response.addHeader(e.getFirst(), e.getSecond());
+            } else {
+                response.setHeader(e.getFirst(), e.getSecond());
+            }
+        });
     }
 }

--- a/src/main/java/org/codelibs/fess/cors/CorsHandler.java
+++ b/src/main/java/org/codelibs/fess/cors/CorsHandler.java
@@ -62,6 +62,21 @@ public abstract class CorsHandler {
     protected static final String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";
 
     /**
+     * Literal value returned in {@code Access-Control-Allow-Origin} for wildcard (non-credentialed) CORS.
+     */
+    protected static final String ALLOW_ORIGIN_ALL = "*";
+
+    /**
+     * HTTP {@code Vary} response header name.
+     */
+    protected static final String VARY = "Vary";
+
+    /**
+     * HTTP {@code Origin} header name. Appended to {@code Vary} for every origin-bearing request.
+     */
+    protected static final String ORIGIN = "Origin";
+
+    /**
      * Processes the CORS request by setting appropriate headers.
      *
      * @param origin the origin of the request

--- a/src/main/java/org/codelibs/fess/cors/CorsHandler.java
+++ b/src/main/java/org/codelibs/fess/cors/CorsHandler.java
@@ -80,9 +80,10 @@ public abstract class CorsHandler {
      * Processes the CORS request by setting appropriate headers.
      *
      * @param origin the origin of the request
+     * @param matchType how the origin matched the allow list (EXACT reflects the origin and may send credentials; WILDCARD returns literal "*")
      * @param request the servlet request
      * @param response the servlet response
      */
-    public abstract void process(String origin, ServletRequest request, ServletResponse response);
+    public abstract void process(String origin, CorsMatchType matchType, ServletRequest request, ServletResponse response);
 
 }

--- a/src/main/java/org/codelibs/fess/cors/CorsHandlerFactory.java
+++ b/src/main/java/org/codelibs/fess/cors/CorsHandlerFactory.java
@@ -68,4 +68,24 @@ public class CorsHandlerFactory {
         }
         return handerMap.get("*");
     }
+
+    /**
+     * Resolves the CORS handler and match type for the specified origin.
+     * An exact registration yields {@link CorsMatchType#EXACT}; a {@code "*"} fallback
+     * yields {@link CorsMatchType#WILDCARD}; no match yields {@code null}.
+     *
+     * @param origin the origin to look up
+     * @return the resolution, or {@code null} if neither an exact nor a wildcard handler is registered
+     */
+    public CorsResolution resolve(final String origin) {
+        final CorsHandler exact = handerMap.get(origin);
+        if (exact != null) {
+            return new CorsResolution(exact, CorsMatchType.EXACT);
+        }
+        final CorsHandler wildcard = handerMap.get("*");
+        if (wildcard != null) {
+            return new CorsResolution(wildcard, CorsMatchType.WILDCARD);
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/codelibs/fess/cors/CorsMatchType.java
+++ b/src/main/java/org/codelibs/fess/cors/CorsMatchType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.cors;
+
+/**
+ * Describes how a request {@code Origin} matched the configured CORS allow list.
+ */
+public enum CorsMatchType {
+
+    /** The Origin is an exact match of an allow-listed origin. Credentials and Origin reflection are permitted. */
+    EXACT,
+
+    /** No exact match, but {@code "*"} is configured. Literal {@code "*"} is returned and credentials are never sent. */
+    WILDCARD;
+}

--- a/src/main/java/org/codelibs/fess/cors/CorsResolution.java
+++ b/src/main/java/org/codelibs/fess/cors/CorsResolution.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.cors;
+
+/**
+ * Result of resolving a request {@code Origin} against the CORS allow list.
+ * Carries both the handler to invoke and the {@link CorsMatchType} that decides
+ * whether the Origin is reflected (EXACT) or a literal {@code "*"} is returned (WILDCARD).
+ */
+public class CorsResolution {
+
+    private final CorsHandler handler;
+
+    private final CorsMatchType matchType;
+
+    /**
+     * Creates a resolution.
+     *
+     * @param handler the handler to process the request
+     * @param matchType how the origin matched the allow list
+     */
+    public CorsResolution(final CorsHandler handler, final CorsMatchType matchType) {
+        this.handler = handler;
+        this.matchType = matchType;
+    }
+
+    /**
+     * Returns the handler to process the request.
+     *
+     * @return the CORS handler
+     */
+    public CorsHandler getHandler() {
+        return handler;
+    }
+
+    /**
+     * Returns how the origin matched the allow list.
+     *
+     * @return the match type
+     */
+    public CorsMatchType getMatchType() {
+        return matchType;
+    }
+}

--- a/src/main/java/org/codelibs/fess/cors/DefaultCorsHandler.java
+++ b/src/main/java/org/codelibs/fess/cors/DefaultCorsHandler.java
@@ -15,6 +15,8 @@
  */
 package org.codelibs.fess.cors;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
@@ -29,6 +31,8 @@ import jakarta.servlet.http.HttpServletResponse;
  * and applies standard CORS headers based on the application configuration.
  */
 public class DefaultCorsHandler extends CorsHandler {
+
+    private static final Logger logger = LogManager.getLogger(DefaultCorsHandler.class);
 
     /**
      * Creates a new instance of DefaultCorsHandler.
@@ -47,26 +51,41 @@ public class DefaultCorsHandler extends CorsHandler {
     public void register() {
         final CorsHandlerFactory factory = ComponentUtil.getCorsHandlerFactory();
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        fessConfig.getApiCorsAllowOriginList().forEach(s -> factory.add(s, this));
+        final java.util.List<String> origins = fessConfig.getApiCorsAllowOriginList();
+        origins.forEach(s -> factory.add(s, this));
+        if (origins.contains(ALLOW_ORIGIN_ALL) && fessConfig.isApiCorsAllowCredentials()) {
+            logger.warn("Credentials are NOT sent for the '*' entry in api.cors.allow.origin (a literal '*' is returned). "
+                    + "Credentials are honored only for an exact match of an explicit Origin. "
+                    + "To allow credentialed cross-origin access, set explicit origins in api.cors.allow.origin.");
+        }
     }
 
     /**
-     * Processes the CORS request by adding standard CORS headers to the response.
-     * Headers include allowed origin, methods, headers, max age, and credentials setting.
+     * Processes the CORS request by setting standard CORS headers on the response.
+     * For an EXACT origin match the request Origin is reflected and credentials may be sent;
+     * for a WILDCARD match a literal "*" is returned and credentials are never sent.
      *
      * @param origin the origin of the request
+     * @param matchType how the origin matched the allow list
      * @param request the servlet request
      * @param response the servlet response to add CORS headers to
      */
     @Override
-    public void process(final String origin, final ServletRequest request, final ServletResponse response) {
+    public void process(final String origin, final CorsMatchType matchType, final ServletRequest request, final ServletResponse response) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final HttpServletResponse httpResponse = (HttpServletResponse) response;
-        httpResponse.addHeader(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
-        httpResponse.addHeader(ACCESS_CONTROL_ALLOW_METHODS, fessConfig.getApiCorsAllowMethods());
-        httpResponse.addHeader(ACCESS_CONTROL_ALLOW_HEADERS, fessConfig.getApiCorsAllowHeaders());
-        httpResponse.addHeader(ACCESS_CONTROL_MAX_AGE, fessConfig.getApiCorsMaxAge());
-        httpResponse.addHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, fessConfig.getApiCorsAllowCredentials());
+        if (matchType == CorsMatchType.EXACT) {
+            httpResponse.setHeader(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+            if (fessConfig.isApiCorsAllowCredentials()) {
+                httpResponse.setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+            }
+        } else { // WILDCARD: never reflect, never send credentials
+            httpResponse.setHeader(ACCESS_CONTROL_ALLOW_ORIGIN, ALLOW_ORIGIN_ALL);
+        }
+        // Vary: Origin is emitted centrally by CorsFilter (avoid duplicates).
+        httpResponse.setHeader(ACCESS_CONTROL_ALLOW_METHODS, fessConfig.getApiCorsAllowMethods());
+        httpResponse.setHeader(ACCESS_CONTROL_ALLOW_HEADERS, fessConfig.getApiCorsAllowHeaders());
+        httpResponse.setHeader(ACCESS_CONTROL_MAX_AGE, fessConfig.getApiCorsMaxAge());
     }
 
 }

--- a/src/main/java/org/codelibs/fess/filter/CorsFilter.java
+++ b/src/main/java/org/codelibs/fess/filter/CorsFilter.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.cors.CorsHandler;
 import org.codelibs.fess.cors.CorsHandlerFactory;
+import org.codelibs.fess.cors.CorsResolution;
 import org.codelibs.fess.util.ComponentUtil;
 
 import jakarta.servlet.Filter;
@@ -52,27 +52,50 @@ public class CorsFilter implements Filter {
      */
     protected static final String OPTIONS = "OPTIONS";
 
+    /** Header name read to detect a genuine CORS preflight. */
+    protected static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
+
+    /** {@code Vary} response header name. */
+    protected static final String VARY = "Vary";
+
+    /** {@code Origin} value appended to {@code Vary}. */
+    protected static final String ORIGIN = "Origin";
+
     @Override
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
             throws IOException, ServletException {
         final HttpServletRequest httpRequest = (HttpServletRequest) request;
-        final String origin = httpRequest.getHeader("Origin");
-        if (StringUtil.isNotBlank(origin)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("HTTP Request: method={}", httpRequest.getMethod());
-            }
-            final CorsHandlerFactory factory = ComponentUtil.getCorsHandlerFactory();
-            final CorsHandler handler = factory.get(origin);
-            if (handler != null) {
-                handler.process(origin, request, response);
+        final String origin = httpRequest.getHeader(ORIGIN);
+        if (StringUtil.isBlank(origin)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("HTTP Request: method={}", httpRequest.getMethod());
+        }
+        final HttpServletResponse httpResponse = (HttpServletResponse) response;
+        // Append Origin to Vary for every origin-bearing request (cache-poisoning safe; single REQUEST dispatch).
+        httpResponse.addHeader(VARY, ORIGIN);
 
-                if (OPTIONS.equals(httpRequest.getMethod())) {
-                    final HttpServletResponse httpResponse = (HttpServletResponse) response;
-                    httpResponse.setStatus(HttpServletResponse.SC_ACCEPTED);
-                    return;
-                }
-            } else if (logger.isDebugEnabled()) {
+        final boolean preflight =
+                OPTIONS.equals(httpRequest.getMethod()) && StringUtil.isNotBlank(httpRequest.getHeader(ACCESS_CONTROL_REQUEST_METHOD));
+
+        final CorsHandlerFactory factory = ComponentUtil.getCorsHandlerFactory();
+        final CorsResolution resolution = factory.resolve(origin);
+        if (resolution != null) {
+            resolution.getHandler().process(origin, resolution.getMatchType(), request, response);
+            if (preflight) {
+                httpResponse.setStatus(HttpServletResponse.SC_ACCEPTED);
+                return;
+            }
+        } else {
+            if (logger.isDebugEnabled()) {
                 logger.debug("No CorsHandler: origin={}", origin);
+            }
+            if (preflight) {
+                // Disallowed genuine preflight: short-circuit with no CORS headers so the browser blocks it.
+                httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                return;
             }
         }
 

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -304,7 +304,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. 3600 */
     String API_CORS_MAX_AGE = "api.cors.max.age";
 
-    /** The key of the configuration. e.g. Origin, Content-Type, Accept, Authorization, X-Requested-With */
+    /** The key of the configuration. e.g. Origin, Content-Type, Accept, Authorization, X-Requested-With, X-Fess-CSRF-Token */
     String API_CORS_ALLOW_HEADERS = "api.cors.allow.headers";
 
     /** The key of the configuration. e.g. true */
@@ -2941,8 +2941,8 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /**
      * Get the value for the key 'api.cors.allow.headers'. <br>
-     * The value is, e.g. Origin, Content-Type, Accept, Authorization, X-Requested-With <br>
-     * comment: Allowed headers for CORS.
+     * The value is, e.g. Origin, Content-Type, Accept, Authorization, X-Requested-With, X-Fess-CSRF-Token <br>
+     * comment: Allowed request headers for CORS preflight. A static list is returned (Access-Control-Request-Headers is not reflected). Includes X-Fess-CSRF-Token for cross-origin SPAs sending the CSRF token.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getApiCorsAllowHeaders();
@@ -13956,7 +13956,8 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.API_CORS_ALLOW_ORIGIN, "*");
             defaultMap.put(FessConfig.API_CORS_ALLOW_METHODS, "GET, POST, OPTIONS, DELETE, PUT");
             defaultMap.put(FessConfig.API_CORS_MAX_AGE, "3600");
-            defaultMap.put(FessConfig.API_CORS_ALLOW_HEADERS, "Origin, Content-Type, Accept, Authorization, X-Requested-With");
+            defaultMap.put(FessConfig.API_CORS_ALLOW_HEADERS,
+                    "Origin, Content-Type, Accept, Authorization, X-Requested-With, X-Fess-CSRF-Token");
             defaultMap.put(FessConfig.API_CORS_ALLOW_CREDENTIALS, "true");
             defaultMap.put(FessConfig.API_JSONP_ENABLED, "false");
             defaultMap.put(FessConfig.API_PING_search_engine_FIELDS, "status,timed_out");

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -2094,17 +2094,34 @@ public interface FessProp {
 
     String getApiGsaResponseHeaders();
 
+    /**
+     * Parses a newline-separated {@code Name:Value} header configuration into pairs,
+     * excluding headers that control CORS / cross-origin disclosure. Excluded (silently,
+     * since an interface cannot hold a logger): any header whose name starts with
+     * {@code "access-control-"} (case-insensitive) and {@code "timing-allow-origin"}.
+     * CORS is controlled exclusively by {@code api.cors.*} / CorsFilter.
+     *
+     * @param value the raw configured header lines
+     * @return the sanitized list of header name/value pairs
+     */
+    private static List<Pair<String, String>> parseResponseHeaderList(final String value) {
+        return split(value, "\n").get(stream -> stream.filter(StringUtil::isNotBlank).map(s -> {
+            final String[] values = s.split(":", 2);
+            if (values.length == 2) {
+                return new Pair<>(values[0], values[1]);
+            }
+            return new Pair<>(values[0], StringUtil.EMPTY);
+        }).filter(pair -> {
+            final String name = pair.getFirst().trim().toLowerCase(Locale.ROOT);
+            return !name.startsWith("access-control-") && !"timing-allow-origin".equals(name);
+        }).collect(Collectors.toList()));
+    }
+
     default List<Pair<String, String>> getApiGsaResponseHeaderList() {
         @SuppressWarnings("unchecked")
         List<Pair<String, String>> list = (List<Pair<String, String>>) propMap.get(API_GSA_RESPONSE_HEADER_LIST);
         if (list == null) {
-            list = split(getApiGsaResponseHeaders(), "\n").get(stream -> stream.filter(StringUtil::isNotBlank).map(s -> {
-                final String[] values = s.split(":", 2);
-                if (values.length == 2) {
-                    return new Pair<>(values[0], values[1]);
-                }
-                return new Pair<>(values[0], StringUtil.EMPTY);
-            }).collect(Collectors.toList()));
+            list = parseResponseHeaderList(getApiGsaResponseHeaders());
             propMap.put(API_GSA_RESPONSE_HEADER_LIST, list);
         }
         return list;
@@ -2116,13 +2133,7 @@ public interface FessProp {
         @SuppressWarnings("unchecked")
         List<Pair<String, String>> list = (List<Pair<String, String>>) propMap.get(API_JSON_RESPONSE_HEADER_LIST);
         if (list == null) {
-            list = split(getApiJsonResponseHeaders(), "\n").get(stream -> stream.filter(StringUtil::isNotBlank).map(s -> {
-                final String[] values = s.split(":", 2);
-                if (values.length == 2) {
-                    return new Pair<>(values[0], values[1]);
-                }
-                return new Pair<>(values[0], StringUtil.EMPTY);
-            }).collect(Collectors.toList()));
+            list = parseResponseHeaderList(getApiJsonResponseHeaders());
             propMap.put(API_JSON_RESPONSE_HEADER_LIST, list);
         }
         return list;
@@ -2134,13 +2145,7 @@ public interface FessProp {
         @SuppressWarnings("unchecked")
         List<Pair<String, String>> list = (List<Pair<String, String>>) propMap.get(API_DASHBOARD_RESPONSE_HEADER_LIST);
         if (list == null) {
-            list = split(getApiDashboardResponseHeaders(), "\n").get(stream -> stream.filter(StringUtil::isNotBlank).map(s -> {
-                final String[] values = s.split(":", 2);
-                if (values.length == 2) {
-                    return new Pair<>(values[0], values[1]);
-                }
-                return new Pair<>(values[0], StringUtil.EMPTY);
-            }).collect(Collectors.toList()));
+            list = parseResponseHeaderList(getApiDashboardResponseHeaders());
             propMap.put(API_DASHBOARD_RESPONSE_HEADER_LIST, list);
         }
         return list;
@@ -2152,8 +2157,10 @@ public interface FessProp {
         @SuppressWarnings("unchecked")
         List<String> list = (List<String>) propMap.get(CORS_ALLOW_ORIGIN);
         if (list == null) {
-            list = split(getApiCorsAllowOrigin(), "\n")
-                    .get(stream -> stream.map(String::trim).filter(StringUtil::isNotEmpty).collect(Collectors.toList()));
+            list = split(getApiCorsAllowOrigin(), "[\\n,]").get(stream -> stream.map(String::trim)
+                    .filter(StringUtil::isNotEmpty)
+                    .filter(s -> !"null".equalsIgnoreCase(s))
+                    .collect(Collectors.toList()));
             propMap.put(CORS_ALLOW_ORIGIN, list);
         }
         return list;

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -2098,7 +2098,7 @@ public interface FessProp {
      * Parses a newline-separated {@code Name:Value} header configuration into pairs,
      * excluding headers that control CORS / cross-origin disclosure. Excluded (silently,
      * since an interface cannot hold a logger): any header whose name starts with
-     * {@code "access-control-"} (case-insensitive) and {@code "timing-allow-origin"}.
+     * {@code "access-control-"} (case-insensitive) or {@code "timing-allow-origin"}.
      * CORS is controlled exclusively by {@code api.cors.*} / CorsFilter.
      *
      * @param value the raw configured header lines

--- a/src/main/java/org/codelibs/fess/mylasta/direction/sponsor/FessActionAdjustmentProvider.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/sponsor/FessActionAdjustmentProvider.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -70,12 +71,24 @@ public class FessActionAdjustmentProvider implements ActionAdjustmentProvider {
 
         StreamUtil.split(value, "\n").of(stream -> stream.filter(StringUtil::isNotBlank).forEach(s -> {
             final String[] values = StringUtils.split(s, "=", 2);
+            if (values.length < 2) {
+                logger.warn("Unexpected value: value={}", s);
+                return;
+            }
+            final String[] keyValue = StringUtils.split(values[1], ":", 2);
+            final String headerName = keyValue.length >= 1 ? keyValue[0].trim() : StringUtil.EMPTY;
+            final String lowerName = headerName.toLowerCase(Locale.ROOT);
+            if (lowerName.startsWith("access-control-") || "timing-allow-origin".equals(lowerName)) {
+                logger.warn(
+                        "Ignoring CORS-control response header from response.headers (controlled by api.cors.* / CorsFilter): header={}, value={}",
+                        headerName, s);
+                return;
+            }
             List<Pair<String, String>> list = responseHeaderMap.get(values[0]);
             if (list == null) {
                 list = new ArrayList<>();
                 responseHeaderMap.put(values[0], list);
             }
-            final String[] keyValue = StringUtils.split(values[1], ":", 2);
             if (keyValue.length == 2) {
                 list.add(new Pair<>(keyValue[0].trim(), keyValue[1].trim()));
             } else if (keyValue.length == 1) {

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -233,25 +233,25 @@ api.admin.access.permissions=Radmin-api
 api.search.accept.referers=
 # Whether to enable scroll for API search.
 api.search.scroll=false
-# Headers for API JSON response.
+# Headers for API JSON response. Access-Control-* and Timing-Allow-Origin are ignored here (CORS is controlled by api.cors.* / CorsFilter). Do not set Vary.
 api.json.response.headers=Referrer-Policy:strict-origin-when-cross-origin
 # Whether to include exceptions in API JSON response.
 api.json.response.exception.included=false
-# Headers for API GSA response.
+# Headers for API GSA response. Access-Control-* and Timing-Allow-Origin are ignored here (CORS is controlled by api.cors.* / CorsFilter). Do not set Vary.
 api.gsa.response.headers=Referrer-Policy:strict-origin-when-cross-origin
 # Whether to include exceptions in API GSA response.
 api.gsa.response.exception.included=false
-# Headers for API dashboard response.
+# Headers for API dashboard response. Access-Control-* and Timing-Allow-Origin are ignored here (CORS is controlled by api.cors.* / CorsFilter). Do not set Vary.
 api.dashboard.response.headers=Referrer-Policy:strict-origin-when-cross-origin
-# Allowed origins for CORS.
+# Allowed origins for CORS. "*" returns a literal "*" (the request Origin is NOT reflected) and disables credentials. Set explicit origins (newline- or comma-separated) to allow credentialed cross-origin access.
 api.cors.allow.origin=*
 # Allowed HTTP methods for CORS.
 api.cors.allow.methods=GET, POST, OPTIONS, DELETE, PUT
 # Max age for CORS preflight requests.
 api.cors.max.age=3600
-# Allowed headers for CORS.
-api.cors.allow.headers=Origin, Content-Type, Accept, Authorization, X-Requested-With
-# Whether to allow credentials for CORS.
+# Allowed request headers for CORS preflight. A static list is returned (Access-Control-Request-Headers is not reflected). Includes X-Fess-CSRF-Token for cross-origin SPAs sending the CSRF token.
+api.cors.allow.headers=Origin, Content-Type, Accept, Authorization, X-Requested-With, X-Fess-CSRF-Token
+# Whether to allow credentials for CORS. Honored only for an exact match of an explicit Origin; ignored when api.cors.allow.origin is "*".
 api.cors.allow.credentials=true
 # Whether to enable JSONP for API.
 api.jsonp.enabled=false
@@ -574,7 +574,7 @@ response.max.site.path.length=100
 response.highlight.content_title.enabled=true
 # Inline MIME types for the response.
 response.inline.mimetypes=application/pdf,text/plain
-# HTTP headers for the response.
+# HTTP headers for the response. Access-Control-* and Timing-Allow-Origin are ignored (CORS is controlled by api.cors.* / CorsFilter). Do not set Vary here.
 response.headers=\
 text/html=X-XSS-Protection: 1; mode=block\n\
 text/html=Content-Security-Policy: reflected-xss block\n\

--- a/src/test/java/org/codelibs/fess/cors/CorsHandlerFactoryTest.java
+++ b/src/test/java/org/codelibs/fess/cors/CorsHandlerFactoryTest.java
@@ -263,6 +263,66 @@ public class CorsHandlerFactoryTest extends UnitFessTestCase {
         assertTrue(factory.handerMap.isEmpty());
     }
 
+    @Test
+    public void test_resolve_exactMatch() {
+        final String origin = "https://example.com";
+        final TestCorsHandler handler = new TestCorsHandler("exact-handler");
+        corsHandlerFactory.add(origin, handler);
+
+        final CorsResolution resolution = corsHandlerFactory.resolve(origin);
+
+        assertNotNull(resolution);
+        assertSame(handler, resolution.getHandler());
+        assertEquals(CorsMatchType.EXACT, resolution.getMatchType());
+    }
+
+    @Test
+    public void test_resolve_wildcardFallback() {
+        final TestCorsHandler wildcardHandler = new TestCorsHandler("wildcard-handler");
+        corsHandlerFactory.add("*", wildcardHandler);
+
+        final CorsResolution resolution = corsHandlerFactory.resolve("https://unknown.com");
+
+        assertNotNull(resolution);
+        assertSame(wildcardHandler, resolution.getHandler());
+        assertEquals(CorsMatchType.WILDCARD, resolution.getMatchType());
+    }
+
+    @Test
+    public void test_resolve_exactWinsOverWildcard() {
+        final String specific = "https://specific.com";
+        final TestCorsHandler specificHandler = new TestCorsHandler("specific-handler");
+        final TestCorsHandler wildcardHandler = new TestCorsHandler("wildcard-handler");
+        corsHandlerFactory.add(specific, specificHandler);
+        corsHandlerFactory.add("*", wildcardHandler);
+
+        final CorsResolution exact = corsHandlerFactory.resolve(specific);
+        assertEquals(CorsMatchType.EXACT, exact.getMatchType());
+        assertSame(specificHandler, exact.getHandler());
+
+        final CorsResolution wildcard = corsHandlerFactory.resolve("https://unknown.com");
+        assertEquals(CorsMatchType.WILDCARD, wildcard.getMatchType());
+        assertSame(wildcardHandler, wildcard.getHandler());
+    }
+
+    @Test
+    public void test_resolve_noMatchNoWildcard() {
+        corsHandlerFactory.add("https://example.com", new TestCorsHandler("h"));
+
+        assertNull(corsHandlerFactory.resolve("https://nonexistent.com"));
+    }
+
+    @Test
+    public void test_resolve_wildcardOriginExactKey() {
+        // A request whose Origin is literally "*" matches the "*" key EXACTly.
+        final TestCorsHandler wildcardHandler = new TestCorsHandler("wildcard-handler");
+        corsHandlerFactory.add("*", wildcardHandler);
+
+        final CorsResolution resolution = corsHandlerFactory.resolve("*");
+        assertEquals(CorsMatchType.EXACT, resolution.getMatchType());
+        assertSame(wildcardHandler, resolution.getHandler());
+    }
+
     // Test implementation of CorsHandler for testing purposes
     private static class TestCorsHandler extends CorsHandler {
         private final String name;

--- a/src/test/java/org/codelibs/fess/cors/CorsHandlerFactoryTest.java
+++ b/src/test/java/org/codelibs/fess/cors/CorsHandlerFactoryTest.java
@@ -332,7 +332,7 @@ public class CorsHandlerFactoryTest extends UnitFessTestCase {
         }
 
         @Override
-        public void process(String origin, ServletRequest request, ServletResponse response) {
+        public void process(String origin, CorsMatchType matchType, ServletRequest request, ServletResponse response) {
             // Test implementation - no operation
         }
 

--- a/src/test/java/org/codelibs/fess/cors/CorsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/cors/CorsHandlerTest.java
@@ -37,7 +37,6 @@ public class CorsHandlerTest extends UnitFessTestCase {
     private Map<String, List<String>> responseHeaders;
     private boolean processCalled;
     private String processOrigin;
-    private CorsMatchType processMatchType;
     private ServletRequest processRequest;
     private ServletResponse processResponse;
 
@@ -47,7 +46,6 @@ public class CorsHandlerTest extends UnitFessTestCase {
         responseHeaders = new HashMap<>();
         processCalled = false;
         processOrigin = null;
-        processMatchType = null;
         processRequest = null;
         processResponse = null;
 
@@ -57,7 +55,6 @@ public class CorsHandlerTest extends UnitFessTestCase {
             public void process(String origin, CorsMatchType matchType, ServletRequest request, ServletResponse response) {
                 processCalled = true;
                 processOrigin = origin;
-                processMatchType = matchType;
                 processRequest = request;
                 processResponse = response;
 

--- a/src/test/java/org/codelibs/fess/cors/CorsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/cors/CorsHandlerTest.java
@@ -37,6 +37,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
     private Map<String, List<String>> responseHeaders;
     private boolean processCalled;
     private String processOrigin;
+    private CorsMatchType processMatchType;
     private ServletRequest processRequest;
     private ServletResponse processResponse;
 
@@ -46,15 +47,17 @@ public class CorsHandlerTest extends UnitFessTestCase {
         responseHeaders = new HashMap<>();
         processCalled = false;
         processOrigin = null;
+        processMatchType = null;
         processRequest = null;
         processResponse = null;
 
         // Create a test implementation of CorsHandler
         corsHandler = new CorsHandler() {
             @Override
-            public void process(String origin, ServletRequest request, ServletResponse response) {
+            public void process(String origin, CorsMatchType matchType, ServletRequest request, ServletResponse response) {
                 processCalled = true;
                 processOrigin = origin;
+                processMatchType = matchType;
                 processRequest = request;
                 processResponse = response;
 
@@ -110,8 +113,8 @@ public class CorsHandlerTest extends UnitFessTestCase {
     @Test
     public void test_processMethodIsAbstract() throws Exception {
         try {
-            java.lang.reflect.Method processMethod =
-                    CorsHandler.class.getDeclaredMethod("process", String.class, ServletRequest.class, ServletResponse.class);
+            java.lang.reflect.Method processMethod = CorsHandler.class.getDeclaredMethod("process", String.class, CorsMatchType.class,
+                    ServletRequest.class, ServletResponse.class);
             assertTrue("process method should be abstract", Modifier.isAbstract(processMethod.getModifiers()));
             assertTrue("process method should be public", Modifier.isPublic(processMethod.getModifiers()));
         } catch (NoSuchMethodException e) {
@@ -124,7 +127,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
     public void test_constructor() {
         CorsHandler handler = new CorsHandler() {
             @Override
-            public void process(String origin, ServletRequest request, ServletResponse response) {
+            public void process(String origin, CorsMatchType matchType, ServletRequest request, ServletResponse response) {
                 // Test implementation
             }
         };
@@ -137,7 +140,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
         HttpServletRequest request = createMockRequest();
         HttpServletResponse response = createMockResponse();
 
-        corsHandler.process(null, request, response);
+        corsHandler.process(null, CorsMatchType.EXACT, request, response);
 
         assertTrue("process should be called", processCalled);
         assertNull(processOrigin, "origin should be null");
@@ -151,7 +154,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
         HttpServletRequest request = createMockRequest();
         HttpServletResponse response = createMockResponse();
 
-        corsHandler.process("", request, response);
+        corsHandler.process("", CorsMatchType.EXACT, request, response);
 
         assertTrue("process should be called", processCalled);
         assertEquals("", processOrigin);
@@ -166,7 +169,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
         HttpServletRequest request = createMockRequest();
         HttpServletResponse response = createMockResponse();
 
-        corsHandler.process(testOrigin, request, response);
+        corsHandler.process(testOrigin, CorsMatchType.EXACT, request, response);
 
         assertTrue("process should be called", processCalled);
         assertEquals(testOrigin, processOrigin);
@@ -191,7 +194,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
             HttpServletRequest request = createMockRequest();
             HttpServletResponse response = createMockResponse();
 
-            corsHandler.process(origin, request, response);
+            corsHandler.process(origin, CorsMatchType.EXACT, request, response);
 
             assertTrue("process should be called for origin: " + origin, processCalled);
             assertEquals(origin, processOrigin);
@@ -209,7 +212,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
         HttpServletRequest request = createMockRequest();
         HttpServletResponse response = createMockResponse();
 
-        corsHandler.process(wildcardOrigin, request, response);
+        corsHandler.process(wildcardOrigin, CorsMatchType.WILDCARD, request, response);
 
         assertTrue("process should be called", processCalled);
         assertEquals(wildcardOrigin, processOrigin);
@@ -226,7 +229,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
         HttpServletRequest request = createMockRequest();
         HttpServletResponse response = createMockResponse();
 
-        corsHandler.process(testOrigin, request, response);
+        corsHandler.process(testOrigin, CorsMatchType.EXACT, request, response);
 
         // Check all CORS headers are present
         assertNotNull(responseHeaders.get("Access-Control-Allow-Origin"), "Allow-Origin header should be set");
@@ -315,7 +318,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
             }
         };
 
-        corsHandler.process(testOrigin, request, response);
+        corsHandler.process(testOrigin, CorsMatchType.EXACT, request, response);
 
         assertTrue("process should be called", processCalled);
         assertEquals(testOrigin, processOrigin);
@@ -332,7 +335,7 @@ public class CorsHandlerTest extends UnitFessTestCase {
 
         for (String origin : origins) {
             processCalled = false;
-            corsHandler.process(origin, request, response);
+            corsHandler.process(origin, CorsMatchType.EXACT, request, response);
             assertTrue("process should be called for " + origin, processCalled);
             assertEquals(origin, processOrigin);
         }

--- a/src/test/java/org/codelibs/fess/cors/CorsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/cors/CorsHandlerTest.java
@@ -81,6 +81,9 @@ public class CorsHandlerTest extends UnitFessTestCase {
         assertEquals("Access-Control-Allow-Private-Network", CorsHandler.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK);
         assertEquals("Access-Control-Allow-Credentials", CorsHandler.ACCESS_CONTROL_ALLOW_CREDENTIALS);
         assertEquals("Access-Control-Max-Age", CorsHandler.ACCESS_CONTROL_MAX_AGE);
+        assertEquals("*", CorsHandler.ALLOW_ORIGIN_ALL);
+        assertEquals("Vary", CorsHandler.VARY);
+        assertEquals("Origin", CorsHandler.ORIGIN);
     }
 
     // Test that constants are protected static final

--- a/src/test/java/org/codelibs/fess/cors/CorsHeaderSingleSourceGuardTest.java
+++ b/src/test/java/org/codelibs/fess/cors/CorsHeaderSingleSourceGuardTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.cors;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guard test: verifies that CORS-control header name string literals appear ONLY in the
+ * designated single-source files (cors package + CorsFilter). Any other file emitting
+ * a quoted "Access-Control-" or "Timing-Allow-Origin" literal is a regression.
+ *
+ * Detection strategy: scan for the character sequences {@code "Access-Control-} and
+ * {@code "Timing-Allow-Origin} (opening double-quote + header prefix). This matches
+ * Java string literals but NOT unquoted occurrences in comments or Javadoc (e.g. the
+ * mention in FessConfig.java Javadoc does not start with a double-quote and is therefore
+ * not matched).
+ */
+public class CorsHeaderSingleSourceGuardTest extends UnitFessTestCase {
+
+    /** Quoted prefixes to detect CORS header string literals. */
+    private static final String[] NEEDLES = { "\"Access-Control-", "\"Timing-Allow-Origin" };
+
+    /** Path segment that identifies files in the allowed cors package. */
+    private static final String CORS_PKG = "/org/codelibs/fess/cors/";
+
+    /** Path suffix that identifies the allowed CorsFilter file. */
+    private static final String CORS_FILTER = "/org/codelibs/fess/filter/CorsFilter.java";
+
+    @Test
+    public void test_noStrayCorsHeaderEmitters() throws IOException {
+        final Path root = Paths.get("src/main/java");
+        assertTrue("src/main/java must exist (run from repos/fess root)", Files.isDirectory(root));
+
+        final List<String> offenders = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.filter(p -> p.toString().endsWith(".java")).forEach(p -> {
+                final String normalized = p.toString().replace('\\', '/');
+                // Skip files that are the legitimate single source of CORS headers.
+                if (normalized.contains(CORS_PKG) || normalized.endsWith(CORS_FILTER)) {
+                    return;
+                }
+                final String content;
+                try {
+                    content = Files.readString(p, StandardCharsets.UTF_8);
+                } catch (final IOException e) {
+                    throw new RuntimeException(e);
+                }
+                for (final String needle : NEEDLES) {
+                    if (content.contains(needle)) {
+                        offenders.add(normalized + " contains " + needle + "...");
+                        break;
+                    }
+                }
+            });
+        }
+
+        assertTrue("CORS-control header name literals must only appear in the cors package or CorsFilter. "
+                + "Stray emitters found (add them to the cors package or remove the literal): " + offenders, offenders.isEmpty());
+    }
+}

--- a/src/test/java/org/codelibs/fess/cors/DefaultCorsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/cors/DefaultCorsHandlerTest.java
@@ -26,7 +26,6 @@ import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class DefaultCorsHandlerTest extends UnitFessTestCase {

--- a/src/test/java/org/codelibs/fess/cors/DefaultCorsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/cors/DefaultCorsHandlerTest.java
@@ -15,51 +15,143 @@
  */
 package org.codelibs.fess.cors;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 public class DefaultCorsHandlerTest extends UnitFessTestCase {
+
+    private DefaultCorsHandler handler;
+    private Map<String, List<String>> headers;
 
     @Override
     protected void setUp(TestInfo testInfo) throws Exception {
         super.setUp(testInfo);
+        handler = new DefaultCorsHandler();
+        headers = new HashMap<>();
     }
 
     @Override
     protected void tearDown(TestInfo testInfo) throws Exception {
+        ComponentUtil.setFessConfig(null);
         super.tearDown(testInfo);
     }
 
-    // Basic test to verify test framework is working
-    @Test
-    public void test_basicAssertion() {
-        assertTrue(true);
-        assertFalse(false);
-        assertNotNull("test");
-        assertEquals(1, 1);
+    private void setupConfig(final boolean allowCredentials) {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public boolean isApiCorsAllowCredentials() {
+                return allowCredentials;
+            }
+
+            @Override
+            public String getApiCorsAllowCredentials() {
+                return Boolean.toString(allowCredentials);
+            }
+
+            @Override
+            public String getApiCorsAllowMethods() {
+                return "GET, POST, OPTIONS, DELETE, PUT";
+            }
+
+            @Override
+            public String getApiCorsAllowHeaders() {
+                return "Origin, Content-Type, Accept, Authorization, X-Requested-With, X-Fess-CSRF-Token";
+            }
+
+            @Override
+            public String getApiCorsMaxAge() {
+                return "3600";
+            }
+        });
     }
 
-    // Test placeholder for future implementation
     @Test
-    public void test_placeholder() {
-        // This test verifies the test class can be instantiated and run
-        String testValue = "test";
-        assertNotNull(testValue);
-        assertEquals("test", testValue);
+    public void test_process_exact_withCredentials() {
+        setupConfig(true);
+        final HttpServletResponse response = recordingResponse();
+
+        handler.process("https://app.example.com", CorsMatchType.EXACT, null, response);
+
+        assertEquals(List.of("https://app.example.com"), headers.get("Access-Control-Allow-Origin"));
+        assertEquals(List.of("true"), headers.get("Access-Control-Allow-Credentials"));
+        assertEquals(List.of("GET, POST, OPTIONS, DELETE, PUT"), headers.get("Access-Control-Allow-Methods"));
+        assertEquals(List.of("Origin, Content-Type, Accept, Authorization, X-Requested-With, X-Fess-CSRF-Token"),
+                headers.get("Access-Control-Allow-Headers"));
+        assertEquals(List.of("3600"), headers.get("Access-Control-Max-Age"));
+        // single value, no duplicate ACAO
+        assertEquals(1, headers.get("Access-Control-Allow-Origin").size());
     }
 
-    // Additional test for coverage
     @Test
-    public void test_additionalCoverage() {
-        int a = 5;
-        int b = 10;
-        int sum = a + b;
-        assertEquals(15, sum);
+    public void test_process_exact_withoutCredentials() {
+        setupConfig(false);
+        final HttpServletResponse response = recordingResponse();
 
-        String str = "Hello";
-        assertTrue(str.startsWith("H"));
-        assertTrue(str.endsWith("o"));
-        assertEquals(5, str.length());
+        handler.process("https://app.example.com", CorsMatchType.EXACT, null, response);
+
+        assertEquals(List.of("https://app.example.com"), headers.get("Access-Control-Allow-Origin"));
+        assertNull(headers.get("Access-Control-Allow-Credentials"));
+    }
+
+    @Test
+    public void test_process_wildcard_neverReflects_neverCredentials() {
+        setupConfig(true); // credentials enabled in config, but WILDCARD must NOT send them
+        final HttpServletResponse response = recordingResponse();
+
+        handler.process("https://evil.example", CorsMatchType.WILDCARD, null, response);
+
+        assertEquals(List.of("*"), headers.get("Access-Control-Allow-Origin"));
+        assertNull(headers.get("Access-Control-Allow-Credentials"));
+        assertEquals(List.of("GET, POST, OPTIONS, DELETE, PUT"), headers.get("Access-Control-Allow-Methods"));
+        assertEquals(1, headers.get("Access-Control-Allow-Origin").size());
+    }
+
+    @Test
+    public void test_process_doesNotEmitVary() {
+        // Vary is emitted by CorsFilter, not by the handler.
+        setupConfig(true);
+        final HttpServletResponse response = recordingResponse();
+
+        handler.process("https://app.example.com", CorsMatchType.EXACT, null, response);
+
+        assertNull(headers.get("Vary"));
+    }
+
+    private HttpServletResponse recordingResponse() {
+        return (HttpServletResponse) java.lang.reflect.Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class<?>[] { HttpServletResponse.class }, (proxy, method, args) -> {
+                    switch (method.getName()) {
+                    case "setHeader":
+                        final List<String> set = new ArrayList<>();
+                        set.add((String) args[1]);
+                        headers.put((String) args[0], set);
+                        return null;
+                    case "addHeader":
+                        headers.computeIfAbsent((String) args[0], k -> new ArrayList<>()).add((String) args[1]);
+                        return null;
+                    default:
+                        final Class<?> rt = method.getReturnType();
+                        if (rt == boolean.class) {
+                            return false;
+                        }
+                        if (rt == int.class) {
+                            return 0;
+                        }
+                        return null;
+                    }
+                });
     }
 }

--- a/src/test/java/org/codelibs/fess/filter/CorsFilterTest.java
+++ b/src/test/java/org/codelibs/fess/filter/CorsFilterTest.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 
 import org.codelibs.fess.cors.CorsHandler;
 import org.codelibs.fess.cors.CorsHandlerFactory;
+import org.codelibs.fess.cors.CorsMatchType;
+import org.codelibs.fess.cors.CorsResolution;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
@@ -71,7 +73,7 @@ public class CorsFilterTest extends UnitFessTestCase {
         corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         assertTrue(mockFilterChain.wasDoFilterCalled());
-        assertFalse(corsHandlerFactory.wasGetCalled());
+        assertFalse(corsHandlerFactory.wasResolveCalled());
     }
 
     // Test with blank Origin header
@@ -82,7 +84,7 @@ public class CorsFilterTest extends UnitFessTestCase {
         corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         assertTrue(mockFilterChain.wasDoFilterCalled());
-        assertFalse(corsHandlerFactory.wasGetCalled());
+        assertFalse(corsHandlerFactory.wasResolveCalled());
     }
 
     // Test with whitespace-only Origin header
@@ -93,7 +95,7 @@ public class CorsFilterTest extends UnitFessTestCase {
         corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         assertTrue(mockFilterChain.wasDoFilterCalled());
-        assertFalse(corsHandlerFactory.wasGetCalled());
+        assertFalse(corsHandlerFactory.wasResolveCalled());
     }
 
     // Test with valid Origin but no CorsHandler found
@@ -105,7 +107,7 @@ public class CorsFilterTest extends UnitFessTestCase {
         corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         assertTrue(mockFilterChain.wasDoFilterCalled());
-        assertTrue(corsHandlerFactory.wasGetCalled());
+        assertTrue(corsHandlerFactory.wasResolveCalled());
         assertEquals("http://example.com", corsHandlerFactory.getLastOrigin());
     }
 
@@ -121,7 +123,7 @@ public class CorsFilterTest extends UnitFessTestCase {
         corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         assertTrue(mockFilterChain.wasDoFilterCalled());
-        assertTrue(corsHandlerFactory.wasGetCalled());
+        assertTrue(corsHandlerFactory.wasResolveCalled());
         assertTrue(handler.wasProcessCalled());
         assertEquals(origin, handler.getLastOrigin());
         assertSame(mockRequest, handler.getLastRequest());
@@ -177,11 +179,12 @@ public class CorsFilterTest extends UnitFessTestCase {
         assertEquals(0, mockResponse.getStatus());
     }
 
-    // Test with OPTIONS request (preflight)
+    // Test with OPTIONS request (preflight) - with Access-Control-Request-Method
     @Test
     public void test_doFilter_withCorsHandler_options() throws IOException, ServletException {
         String origin = "http://example.com";
         mockRequest.setHeader("Origin", origin);
+        mockRequest.setHeader("Access-Control-Request-Method", "GET");
         mockRequest.setMethod("OPTIONS");
         TestCorsHandler handler = new TestCorsHandler();
         corsHandlerFactory.setHandler(handler);
@@ -189,25 +192,26 @@ public class CorsFilterTest extends UnitFessTestCase {
         corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         assertFalse(mockFilterChain.wasDoFilterCalled()); // Chain should not continue for OPTIONS
-        assertTrue(corsHandlerFactory.wasGetCalled());
+        assertTrue(corsHandlerFactory.wasResolveCalled());
         assertTrue(handler.wasProcessCalled());
         assertEquals(origin, handler.getLastOrigin());
         assertEquals(HttpServletResponse.SC_ACCEPTED, mockResponse.getStatus());
     }
 
-    // Test with OPTIONS request but no CorsHandler
+    // Test with OPTIONS request but no CorsHandler (genuine preflight with no handler -> 403)
     @Test
     public void test_doFilter_options_noCorsHandler() throws IOException, ServletException {
         String origin = "http://example.com";
         mockRequest.setHeader("Origin", origin);
+        mockRequest.setHeader("Access-Control-Request-Method", "GET");
         mockRequest.setMethod("OPTIONS");
         corsHandlerFactory.setHandler(null);
 
         corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        assertTrue(mockFilterChain.wasDoFilterCalled()); // Chain should continue if no handler
-        assertTrue(corsHandlerFactory.wasGetCalled());
-        assertEquals(0, mockResponse.getStatus()); // Status not set when no handler
+        assertFalse(mockFilterChain.wasDoFilterCalled()); // Chain should NOT continue for disallowed preflight
+        assertTrue(corsHandlerFactory.wasResolveCalled());
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, mockResponse.getStatus());
     }
 
     // Test with different origin formats
@@ -243,12 +247,131 @@ public class CorsFilterTest extends UnitFessTestCase {
         assertEquals("OPTIONS", CorsFilter.OPTIONS);
     }
 
+    // EXACT preflight: ACAO reflects origin, credentials present, Vary: Origin, 202
+    @Test
+    public void test_doFilter_preflight_exact() throws IOException, ServletException {
+        final String origin = "https://app.example.com";
+        mockRequest.setHeader("Origin", origin);
+        mockRequest.setHeader("Access-Control-Request-Method", "POST");
+        mockRequest.setMethod("OPTIONS");
+        final TestCorsHandler handler = new TestCorsHandler();
+        corsHandlerFactory.setHandler(handler);
+        corsHandlerFactory.setMatchType(CorsMatchType.EXACT);
+
+        corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        assertFalse(mockFilterChain.wasDoFilterCalled());
+        assertEquals(HttpServletResponse.SC_ACCEPTED, mockResponse.getStatus());
+        assertEquals(CorsMatchType.EXACT, handler.getLastMatchType());
+        assertEquals(java.util.List.of(origin), new java.util.ArrayList<>(mockResponse.getHeaders("Access-Control-Allow-Origin")));
+        assertEquals(java.util.List.of("true"), new java.util.ArrayList<>(mockResponse.getHeaders("Access-Control-Allow-Credentials")));
+        assertEquals(java.util.List.of("Origin"), new java.util.ArrayList<>(mockResponse.getHeaders("Vary")));
+        assertEquals(1, mockResponse.getHeaders("Access-Control-Allow-Origin").size());
+    }
+
+    // WILDCARD preflight: literal "*", no credentials, Vary: Origin, 202
+    @Test
+    public void test_doFilter_preflight_wildcard() throws IOException, ServletException {
+        mockRequest.setHeader("Origin", "https://anything.example");
+        mockRequest.setHeader("Access-Control-Request-Method", "GET");
+        mockRequest.setMethod("OPTIONS");
+        final TestCorsHandler handler = new TestCorsHandler();
+        corsHandlerFactory.setHandler(handler);
+        corsHandlerFactory.setMatchType(CorsMatchType.WILDCARD);
+
+        corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        assertFalse(mockFilterChain.wasDoFilterCalled());
+        assertEquals(HttpServletResponse.SC_ACCEPTED, mockResponse.getStatus());
+        assertEquals(java.util.List.of("*"), new java.util.ArrayList<>(mockResponse.getHeaders("Access-Control-Allow-Origin")));
+        assertNull(mockResponse.getHeader("Access-Control-Allow-Credentials"));
+        assertEquals(java.util.List.of("Origin"), new java.util.ArrayList<>(mockResponse.getHeaders("Vary")));
+    }
+
+    // NONE preflight: no handler -> no CORS headers, Vary: Origin present, 403, chain NOT called
+    @Test
+    public void test_doFilter_preflight_none_shortCircuits403() throws IOException, ServletException {
+        mockRequest.setHeader("Origin", "https://evil.example");
+        mockRequest.setHeader("Access-Control-Request-Method", "POST");
+        mockRequest.setMethod("OPTIONS");
+        corsHandlerFactory.setHandler(null); // resolve() -> null
+
+        corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        assertFalse(mockFilterChain.wasDoFilterCalled());
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, mockResponse.getStatus());
+        assertNull(mockResponse.getHeader("Access-Control-Allow-Origin"));
+        assertNull(mockResponse.getHeader("Access-Control-Allow-Credentials"));
+        assertEquals(java.util.List.of("Origin"), new java.util.ArrayList<>(mockResponse.getHeaders("Vary")));
+    }
+
+    // Non-preflight disallowed origin: no CORS headers, Vary present, chain continues
+    @Test
+    public void test_doFilter_nonPreflight_disallowedOrigin_continues() throws IOException, ServletException {
+        mockRequest.setHeader("Origin", "https://evil.example");
+        mockRequest.setMethod("GET");
+        corsHandlerFactory.setHandler(null);
+
+        corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        assertTrue(mockFilterChain.wasDoFilterCalled());
+        assertNull(mockResponse.getHeader("Access-Control-Allow-Origin"));
+        assertEquals(java.util.List.of("Origin"), new java.util.ArrayList<>(mockResponse.getHeaders("Vary")));
+    }
+
+    // Regression: evil origin under "*" must not be reflected and must not carry credentials
+    @Test
+    public void test_doFilter_evilOrigin_wildcard_notReflected() throws IOException, ServletException {
+        mockRequest.setHeader("Origin", "https://evil.example");
+        mockRequest.setMethod("GET");
+        final TestCorsHandler handler = new TestCorsHandler();
+        corsHandlerFactory.setHandler(handler);
+        corsHandlerFactory.setMatchType(CorsMatchType.WILDCARD);
+
+        corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        assertTrue(mockFilterChain.wasDoFilterCalled());
+        assertEquals("*", mockResponse.getHeader("Access-Control-Allow-Origin"));
+        assertNull(mockResponse.getHeader("Access-Control-Allow-Credentials"));
+    }
+
+    // Origin: null is a normal origin string; under "*" it is WILDCARD, never credentialed
+    @Test
+    public void test_doFilter_originNull_wildcard_noCredentials() throws IOException, ServletException {
+        mockRequest.setHeader("Origin", "null");
+        mockRequest.setMethod("GET");
+        final TestCorsHandler handler = new TestCorsHandler();
+        corsHandlerFactory.setHandler(handler);
+        corsHandlerFactory.setMatchType(CorsMatchType.WILDCARD);
+
+        corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        assertEquals("*", mockResponse.getHeader("Access-Control-Allow-Origin"));
+        assertNull(mockResponse.getHeader("Access-Control-Allow-Credentials"));
+    }
+
+    // No duplicate Vary on a single dispatch
+    @Test
+    public void test_doFilter_singleVaryHeader() throws IOException, ServletException {
+        mockRequest.setHeader("Origin", "https://app.example.com");
+        mockRequest.setMethod("GET");
+        final TestCorsHandler handler = new TestCorsHandler();
+        corsHandlerFactory.setHandler(handler);
+        corsHandlerFactory.setMatchType(CorsMatchType.EXACT);
+
+        corsFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        assertEquals(1, mockResponse.getHeaders("Vary").size());
+    }
+
     // Helper classes for testing
 
     private static class TestCorsHandlerFactory extends CorsHandlerFactory {
         private boolean getCalled = false;
+        private boolean resolveCalled = false;
         private String lastOrigin = null;
         private CorsHandler handler = null;
+        private CorsMatchType matchType = CorsMatchType.WILDCARD;
 
         @Override
         public CorsHandler get(String origin) {
@@ -257,12 +380,27 @@ public class CorsFilterTest extends UnitFessTestCase {
             return handler;
         }
 
+        @Override
+        public CorsResolution resolve(String origin) {
+            resolveCalled = true;
+            lastOrigin = origin;
+            return handler == null ? null : new CorsResolution(handler, matchType);
+        }
+
         public void setHandler(CorsHandler handler) {
             this.handler = handler;
         }
 
+        public void setMatchType(CorsMatchType matchType) {
+            this.matchType = matchType;
+        }
+
         public boolean wasGetCalled() {
             return getCalled;
+        }
+
+        public boolean wasResolveCalled() {
+            return resolveCalled;
         }
 
         public String getLastOrigin() {
@@ -273,15 +411,24 @@ public class CorsFilterTest extends UnitFessTestCase {
     private static class TestCorsHandler extends CorsHandler {
         private boolean processCalled = false;
         private String lastOrigin = null;
+        private CorsMatchType lastMatchType = null;
         private ServletRequest lastRequest = null;
         private ServletResponse lastResponse = null;
 
         @Override
-        public void process(String origin, ServletRequest request, ServletResponse response) {
+        public void process(String origin, CorsMatchType matchType, ServletRequest request, ServletResponse response) {
             processCalled = true;
             lastOrigin = origin;
+            lastMatchType = matchType;
             lastRequest = request;
             lastResponse = response;
+            final HttpServletResponse httpResponse = (HttpServletResponse) response;
+            if (matchType == CorsMatchType.EXACT) {
+                httpResponse.setHeader(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+                httpResponse.setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+            } else {
+                httpResponse.setHeader(ACCESS_CONTROL_ALLOW_ORIGIN, ALLOW_ORIGIN_ALL);
+            }
         }
 
         public boolean wasProcessCalled() {
@@ -290,6 +437,10 @@ public class CorsFilterTest extends UnitFessTestCase {
 
         public String getLastOrigin() {
             return lastOrigin;
+        }
+
+        public CorsMatchType getLastMatchType() {
+            return lastMatchType;
         }
 
         public ServletRequest getLastRequest() {
@@ -303,29 +454,23 @@ public class CorsFilterTest extends UnitFessTestCase {
 
     private static class TestHttpServletRequest implements HttpServletRequest {
         private String method = "GET";
-        private String originHeader = null;
+        private final java.util.Map<String, String> headerMap = new java.util.HashMap<>();
 
         public void setMethod(String method) {
             this.method = method;
         }
 
-        @Override
-        public String getMethod() {
-            return method;
-        }
-
         public void setHeader(String name, String value) {
-            if ("Origin".equals(name)) {
-                originHeader = value;
+            if (value == null) {
+                headerMap.remove(name);
+            } else {
+                headerMap.put(name, value);
             }
         }
 
         @Override
         public String getHeader(String name) {
-            if ("Origin".equals(name)) {
-                return originHeader;
-            }
-            return null;
+            return headerMap.get(name);
         }
 
         // Minimal implementations for other required methods
@@ -357,6 +502,11 @@ public class CorsFilterTest extends UnitFessTestCase {
         @Override
         public int getIntHeader(String name) {
             return -1;
+        }
+
+        @Override
+        public String getMethod() {
+            return method;
         }
 
         @Override
@@ -667,34 +817,54 @@ public class CorsFilterTest extends UnitFessTestCase {
 
     private static class TestHttpServletResponse implements HttpServletResponse {
         private int status = 0;
+        private final java.util.Map<String, java.util.List<String>> headers = new java.util.LinkedHashMap<>();
 
         @Override
         public void setStatus(int sc) {
             this.status = sc;
         }
 
+        @Override
         public int getStatus() {
             return status;
         }
 
         @Override
-        public java.util.Collection<String> getHeaderNames() {
-            return java.util.Collections.emptyList();
+        public void setHeader(String name, String value) {
+            final java.util.List<String> list = new java.util.ArrayList<>();
+            list.add(value);
+            headers.put(name, list);
+        }
+
+        @Override
+        public void addHeader(String name, String value) {
+            headers.computeIfAbsent(name, k -> new java.util.ArrayList<>()).add(value);
+        }
+
+        @Override
+        public boolean containsHeader(String name) {
+            return headers.containsKey(name);
+        }
+
+        @Override
+        public String getHeader(String name) {
+            final java.util.List<String> list = headers.get(name);
+            return list != null && !list.isEmpty() ? list.get(0) : null;
         }
 
         @Override
         public java.util.Collection<String> getHeaders(String name) {
-            return java.util.Collections.emptyList();
+            return headers.getOrDefault(name, java.util.Collections.emptyList());
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaderNames() {
+            return headers.keySet();
         }
 
         // Minimal implementations for other required methods
         @Override
         public void addCookie(jakarta.servlet.http.Cookie cookie) {
-        }
-
-        @Override
-        public boolean containsHeader(String name) {
-            return false;
         }
 
         @Override
@@ -732,24 +902,11 @@ public class CorsFilterTest extends UnitFessTestCase {
         }
 
         @Override
-        public void setHeader(String name, String value) {
-        }
-
-        @Override
-        public void addHeader(String name, String value) {
-        }
-
-        @Override
         public void setIntHeader(String name, int value) {
         }
 
         @Override
         public void addIntHeader(String name, int value) {
-        }
-
-        @Override
-        public String getHeader(String name) {
-            return null;
         }
 
         @Override

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessPropCorsTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessPropCorsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.mylasta.direction;
+
+import java.util.List;
+
+import org.codelibs.core.misc.Pair;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+public class FessPropCorsTest extends UnitFessTestCase {
+
+    private FessConfig jsonConfig(final String raw) {
+        return new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getApiJsonResponseHeaders() {
+                return raw;
+            }
+        };
+    }
+
+    private FessConfig originConfig(final String raw) {
+        return new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getApiCorsAllowOrigin() {
+                return raw;
+            }
+        };
+    }
+
+    @Test
+    public void test_jsonResponseHeaders_stripsCorsAndTimingAllow() {
+        final List<Pair<String, String>> list = jsonConfig("Referrer-Policy:strict-origin-when-cross-origin\n"
+                + "Access-Control-Allow-Origin:*\n" + "access-control-allow-credentials:true\n" + "Access-Control-Expose-Headers:X-Foo\n"
+                + "Timing-Allow-Origin:*\n" + " TIMING-ALLOW-ORIGIN : https://evil ").getApiJsonResponseHeaderList();
+
+        assertEquals(1, list.size());
+        assertEquals("Referrer-Policy", list.get(0).getFirst());
+    }
+
+    @Test
+    public void test_gsaResponseHeaders_stripsCors() {
+        final List<Pair<String, String>> list = new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getApiGsaResponseHeaders() {
+                return "X-Foo:bar\nAccess-Control-Allow-Methods:GET";
+            }
+        }.getApiGsaResponseHeaderList();
+        assertEquals(1, list.size());
+        assertEquals("X-Foo", list.get(0).getFirst());
+    }
+
+    @Test
+    public void test_dashboardResponseHeaders_stripsCors() {
+        final List<Pair<String, String>> list = new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getApiDashboardResponseHeaders() {
+                return "Access-Control-Allow-Origin:https://evil\nX-Bar:baz";
+            }
+        }.getApiDashboardResponseHeaderList();
+        assertEquals(1, list.size());
+        assertEquals("X-Bar", list.get(0).getFirst());
+    }
+
+    @Test
+    public void test_corsAllowOrigin_newlineAndCommaAndTrim() {
+        final List<String> list = originConfig("https://a.example\n https://b.example , https://c.example").getApiCorsAllowOriginList();
+        assertEquals(List.of("https://a.example", "https://b.example", "https://c.example"), list);
+    }
+
+    @Test
+    public void test_corsAllowOrigin_dropsLiteralNullCaseInsensitive() {
+        final List<String> list = originConfig("null\nNULL\nNull , https://ok.example").getApiCorsAllowOriginList();
+        assertEquals(List.of("https://ok.example"), list);
+    }
+
+    @Test
+    public void test_corsAllowOrigin_dropsEmptyEntries() {
+        final List<String> list = originConfig("\n , \nhttps://ok.example\n,").getApiCorsAllowOriginList();
+        assertEquals(List.of("https://ok.example"), list);
+    }
+
+    @Test
+    public void test_corsAllowOrigin_wildcardAndExplicitCoexist() {
+        final List<String> list = originConfig("*, https://app.example.com").getApiCorsAllowOriginList();
+        assertEquals(List.of("*", "https://app.example.com"), list);
+    }
+}

--- a/src/test/java/org/codelibs/fess/mylasta/direction/sponsor/FessActionAdjustmentProviderTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/sponsor/FessActionAdjustmentProviderTest.java
@@ -15,7 +15,9 @@
  */
 package org.codelibs.fess.mylasta.direction.sponsor;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -89,5 +91,48 @@ public class FessActionAdjustmentProviderTest extends UnitFessTestCase {
                 return text;
             }
         };
+    }
+
+    // --- CORS deny-set tests ---
+
+    @Test
+    public void test_parse_stripsCorsHeaders_global() {
+        final FessConfig fessConfig =
+                createFessConfigWithResponseHeaders("*=Access-Control-Allow-Origin:https://evil\n*=X-Custom:ok\n*=Timing-Allow-Origin:*");
+        final FessActionAdjustmentProvider provider = new FessActionAdjustmentProvider(fessConfig);
+        final List<String> emitted = collectHeaders(provider, "application/json");
+        assertEquals(List.of("X-Custom=ok"), emitted);
+    }
+
+    @Test
+    public void test_parse_stripsCorsHeaders_perMime() {
+        final FessConfig fessConfig = createFessConfigWithResponseHeaders(
+                "text/html=Access-Control-Allow-Credentials:true\ntext/html=X-Frame-Options:SAMEORIGIN");
+        final FessActionAdjustmentProvider provider = new FessActionAdjustmentProvider(fessConfig);
+        final List<String> emitted = collectHeaders(provider, "text/html");
+        assertEquals(List.of("X-Frame-Options=SAMEORIGIN"), emitted);
+    }
+
+    @Test
+    public void test_parse_keepsNonCorsHeaders() {
+        final FessConfig fessConfig = createFessConfigWithResponseHeaders("*=Referrer-Policy:strict-origin-when-cross-origin");
+        final FessActionAdjustmentProvider provider = new FessActionAdjustmentProvider(fessConfig);
+        final List<String> emitted = collectHeaders(provider, "application/json");
+        assertEquals(List.of("Referrer-Policy=strict-origin-when-cross-origin"), emitted);
+    }
+
+    @Test
+    public void test_parse_varyIsKept_forMergeByContainer() {
+        // Vary is NOT in the deny set; it is allowed through so the container merges it with CorsFilter's Vary: Origin.
+        final FessConfig fessConfig = createFessConfigWithResponseHeaders("*=Vary:Accept-Encoding");
+        final FessActionAdjustmentProvider provider = new FessActionAdjustmentProvider(fessConfig);
+        final List<String> emitted = collectHeaders(provider, "application/json");
+        assertEquals(List.of("Vary=Accept-Encoding"), emitted);
+    }
+
+    private List<String> collectHeaders(final FessActionAdjustmentProvider provider, final String mimeType) {
+        final List<String> emitted = new ArrayList<>();
+        provider.adjustActionResponseHeaders(mimeType, (k, v) -> emitted.add(k + "=" + v));
+        return emitted;
     }
 }


### PR DESCRIPTION
## Summary
Hardens CORS handling so credentialed cross-origin access is granted only to explicitly allow-listed origins.

- `Access-Control-Allow-Origin` reflects the request `Origin` only on an **exact** allow-list match; credentials are sent only then.
- With `api.cors.allow.origin=*`, the server returns a literal `*` and **never** sends `Access-Control-Allow-Credentials` (no origin reflection).
- Requests with no matching origin get no CORS headers; disallowed preflights are short-circuited with `403`.
- `Vary: Origin` is emitted for every origin-bearing response (cache-safety).
- `CorsFilter`/`DefaultCorsHandler` is the single source of `Access-Control-*`; `Access-Control-*` and `Timing-Allow-Origin` entries in `api.*.response.headers` / `response.headers` are now ignored (a guard test enforces this).
- `api.cors.allow.origin` accepts newline- or comma-separated origins; a literal `null` entry is rejected.
- `api.cors.allow.headers` default adds `X-Fess-CSRF-Token`.

## Compatibility
Behavior change: configurations that relied on `*` + credentials (reflected origin) no longer receive credentials. To keep credentialed cross-origin access, set explicit origins in `api.cors.allow.origin` and keep `api.cors.allow.credentials=true`.

## Tests
New/updated unit tests for the CORS handler, factory, filter, config parsing, and a guard test; full CORS suite green.
