### PR TITLE
fix(api-v2): scope per-user login throttle to (client IP, username)

### DIFF
--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -488,8 +488,14 @@ paths:
       description: |-
         On success, the servlet session id is rotated, a fresh CSRF token
         is issued, and the rate-limit buckets for the caller IP and the
-        target user are cleared. On rate-limit, a `Retry-After` header
-        carries the cooldown in seconds.
+        target user are cleared.
+
+        Rate limiting has two scopes. The per-IP gate returns `429
+        rate_limited` with a `Retry-After` header. The per-user gate is
+        scoped to `(client IP, username)`; when it trips, the response is a
+        generic `401 auth_required` with no `Retry-After` — identical to a
+        credential rejection — so it does not disclose per-user rate-limit
+        state.
 
         An already-authenticated session does not short-circuit; the
         supplied credentials are always verified.
@@ -523,10 +529,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/LoginResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
-        '401': { $ref: '#/components/responses/Unauthorized' }
+        '401':
+          description: |-
+            Authentication is required or credentials were invalid. The
+            per-user rate-limit gate (scoped to client IP + username) also
+            returns this status, with no `Retry-After`, so user-scope
+            throttling is indistinguishable from a credential rejection.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '429':
-          description: Rate limited; the `Retry-After` header carries the cooldown in seconds.
+          description: |-
+            Per-IP rate limit exceeded. The `Retry-After` header carries the
+            cooldown in seconds. (The per-user gate does NOT use this status;
+            it returns 401 — see above.)
           headers:
             Retry-After:
               description: Seconds the caller should wait before retrying.

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
@@ -163,15 +163,19 @@ public class LoginHandler {
             V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "username and password are required");
             return;
         }
+        final String userKey = userScopeKey(clientIp, username);
 
         // USER-scope pre-validation uses peek() so the bucket is NOT consumed yet. The slot is
-        // taken only on credential failure below, so that a system-error path (e.g. login
-        // subsystem down) does not count against the legitimate user's bucket. IP-scope
-        // check above stays pre-validation because it is the cheap bot/scanner gate.
-        if (!limiter.peek(LoginRateLimiter.Scope.USER, username, userLimit, 60)) {
-            limiter.lockOut(LoginRateLimiter.Scope.USER, username, lockoutSec);
-            res.setHeader("Retry-After", Integer.toString(lockoutSec));
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.RATE_LIMITED, "too many login attempts (user)");
+        // taken only on credential failure below, so a system-error path (e.g. login subsystem
+        // down) does not count against the legitimate user's bucket. The USER bucket is keyed by
+        // (clientIp, username) (H-1) so an attacker cannot lock a victim from a different IP.
+        if (!limiter.peek(LoginRateLimiter.Scope.USER, userKey, userLimit, 60)) {
+            // Keep stamping the lockout internally (protects this (IP,user) pair), but M-1: do
+            // NOT disclose the per-user rate-limit state. Return a generic 401 identical to a
+            // credential rejection, with no Retry-After, so the response cannot be used to probe
+            // a per-user counter. The IP-scope gate above still returns 429 + Retry-After.
+            limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
+            V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
             return;
         }
 
@@ -213,16 +217,13 @@ public class LoginHandler {
         try {
             assist.login(new LocalUserCredential(username, password), op -> {});
         } catch (final LoginFailureException e) {
-            // Credential rejection consumes the USER slot exactly once, on the failure path.
-            // The post-consume check decides whether to also lock the bucket — when the user
-            // has just exhausted the window, we stamp a lockUntil so subsequent requests are
-            // refused even after the sliding window expires (parity with the existing IP
-            // gate's lockOut behavior).
-            if (!limiter.allow(LoginRateLimiter.Scope.USER, username, userLimit, 60)) {
-                limiter.lockOut(LoginRateLimiter.Scope.USER, username, lockoutSec);
-                res.setHeader("Retry-After", Integer.toString(lockoutSec));
-                V2EnvelopeWriter.writeError(res, V2ErrorCode.RATE_LIMITED, "too many login attempts (user)");
-                return;
+            // Credential rejection consumes the USER slot exactly once, on the failure path
+            // (keyed by (clientIp, username) — H-1). When the window is exhausted we also stamp a
+            // lockUntil so subsequent requests from this (IP,user) are refused even after the
+            // sliding window expires. M-1: the response is a generic 401 in BOTH cases (exhausted
+            // or not), with no Retry-After, so the per-user counter state never leaks.
+            if (!limiter.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60)) {
+                limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
             }
             V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
             return;
@@ -261,8 +262,9 @@ public class LoginHandler {
 
         // MJ-5: clear both USER and IP rate-limit buckets on successful login so that a
         // legitimate user who exhausted the window (e.g. typo run) is not penalized on
-        // their next attempt after providing the correct credentials.
-        limiter.clear(LoginRateLimiter.Scope.USER, username);
+        // their next attempt after providing the correct credentials. The USER bucket is the
+        // (clientIp, username) composite (H-1).
+        limiter.clear(LoginRateLimiter.Scope.USER, userKey);
         limiter.clear(LoginRateLimiter.Scope.IP, clientIp);
 
         final OptionalThing<FessUserBean> userBean = assist.getSavedUserBean();
@@ -324,6 +326,24 @@ public class LoginHandler {
      */
     private static String stringOrNull(final Object v) {
         return v instanceof String s ? s : null;
+    }
+
+    /** Separator for USER-scope composite keys. NUL cannot appear in a resolved IP. */
+    static final String USER_SCOPE_KEY_SEP = "\u0000";
+
+    /**
+     * Builds the USER-scope rate-limit key scoped to the originating client IP so that an
+     * unauthenticated attacker cannot lock a victim's account by name from a different IP
+     * (H-1). The limiter treats the key as opaque, so the (IP,user) scoping lives entirely
+     * here in the handler — {@code LoginRateLimiter.Scope.USER} keeps its plain-key contract
+     * (also used by PasswordChangeHandler with a bare userId).
+     *
+     * @param clientIp resolved client IP (see {@link #resolveClientIp})
+     * @param username submitted username
+     * @return composite key {@code clientIp + NUL + username}
+     */
+    static String userScopeKey(final String clientIp, final String username) {
+        return clientIp + USER_SCOPE_KEY_SEP + username;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
@@ -168,9 +168,9 @@ public class LoginHandler {
         // USER-scope pre-validation uses peek() so the bucket is NOT consumed yet. The slot is
         // taken only on credential failure below, so a system-error path (e.g. login subsystem
         // down) does not count against the legitimate user's bucket. The USER bucket is keyed by
-        // (clientIp, username) (H-1) so an attacker cannot lock a victim from a different IP.
+        // (clientIp, username) so an attacker cannot lock a victim's account from a different IP.
         if (!limiter.peek(LoginRateLimiter.Scope.USER, userKey, userLimit, 60)) {
-            // Keep stamping the lockout internally (protects this (IP,user) pair), but M-1: do
+            // Keep stamping the lockout internally (protects this (IP,user) pair), but do
             // NOT disclose the per-user rate-limit state. Return a generic 401 identical to a
             // credential rejection, with no Retry-After, so the response cannot be used to probe
             // a per-user counter. The IP-scope gate above still returns 429 + Retry-After.
@@ -218,9 +218,9 @@ public class LoginHandler {
             assist.login(new LocalUserCredential(username, password), op -> {});
         } catch (final LoginFailureException e) {
             // Credential rejection consumes the USER slot exactly once, on the failure path
-            // (keyed by (clientIp, username) — H-1). When the window is exhausted we also stamp a
+            // (keyed by (clientIp, username)). When the window is exhausted we also stamp a
             // lockUntil so subsequent requests from this (IP,user) are refused even after the
-            // sliding window expires. M-1: the response is a generic 401 in BOTH cases (exhausted
+            // sliding window expires. The response is a generic 401 in BOTH cases (exhausted
             // or not), with no Retry-After, so the per-user counter state never leaks.
             if (!limiter.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60)) {
                 limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
@@ -263,7 +263,7 @@ public class LoginHandler {
         // MJ-5: clear both USER and IP rate-limit buckets on successful login so that a
         // legitimate user who exhausted the window (e.g. typo run) is not penalized on
         // their next attempt after providing the correct credentials. The USER bucket is the
-        // (clientIp, username) composite (H-1).
+        // (clientIp, username) composite.
         limiter.clear(LoginRateLimiter.Scope.USER, userKey);
         limiter.clear(LoginRateLimiter.Scope.IP, clientIp);
 
@@ -333,8 +333,8 @@ public class LoginHandler {
 
     /**
      * Builds the USER-scope rate-limit key scoped to the originating client IP so that an
-     * unauthenticated attacker cannot lock a victim's account by name from a different IP
-     * (H-1). The limiter treats the key as opaque, so the (IP,user) scoping lives entirely
+     * unauthenticated attacker cannot lock a victim's account by name from a different IP.
+     * The limiter treats the key as opaque, so the (IP,user) scoping lives entirely
      * here in the handler — {@code LoginRateLimiter.Scope.USER} keeps its plain-key contract
      * (also used by PasswordChangeHandler with a bare userId).
      *

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -87,11 +87,11 @@ public class LoginHandlerTest extends UnitFessTestCase {
 
     @Test
     public void test_perUserRateLimit_isScopedToClientIp() throws Exception {
-        // H-1: the USER bucket is keyed by (clientIp, username). An unauthenticated attacker
+        // The USER bucket is keyed by (clientIp, username). An unauthenticated attacker
         // cannot lock a victim's account from a different IP. Pre-saturate the (attackerIp,"bob")
         // composite bucket via the EXACT key the handler computes, then assert:
         //  (a) the attacker's own IP+user is refused at the peek() gate with a unified 401
-        //      (M-1: no Retry-After, indistinguishable from a credential rejection), and
+        //      (no Retry-After, indistinguishable from a credential rejection), and
         //  (b) the SAME username from a DIFFERENT IP is NOT gated (its composite bucket is empty),
         //      so the request flows past the gate into the (test-DI-unavailable) login subsystem.
         final LoginRateLimiter rl = new LoginRateLimiter();
@@ -122,7 +122,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
 
     @Test
     public void login_userScopeUsesProxyResolvedIp_whenTrustedProxy() throws Exception {
-        // H-1 + M-2: the USER composite key must use the proxy-RESOLVED client IP (from XFF when
+        // The USER composite key must use the proxy-RESOLVED client IP (from XFF when
         // the direct peer is a trusted proxy 127.0.0.1), not the proxy's own address. UnitFessTestCase
         // wires app.xml so RateLimitHelper honours XFF for the default trusted proxy.
         final LoginRateLimiter rl = new LoginRateLimiter();
@@ -453,7 +453,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
         //
         // We can't easily produce a real successful login in the slim test harness, but we
         // can verify the clear() contract at the limiter layer directly. The on-success clear
-        // targets the (clientIp, username) composite key (H-1), so we mirror that key here.
+        // targets the (clientIp, username) composite key, so we mirror that key here.
         final LoginRateLimiter rl = new LoginRateLimiter();
         final String userKey = LoginHandler.userScopeKey("10.0.0.7", "dave");
         for (int i = 0; i < 5; i++) {

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -72,6 +72,9 @@ public class LoginHandlerTest extends UnitFessTestCase {
         new LoginHandler(rl).handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"u\",\"password\":\"p\"}")
                 .withRemoteAddr("1.2.3.4"), res);
         assertEquals(429, res.status);
+        assertTrue(res.body().contains("\"code\":\"rate_limited\""), res.body());
+        assertTrue(res.body().contains("(ip)"), res.body());
+        org.junit.jupiter.api.Assertions.assertNotNull(res.getHeader("Retry-After"), "IP-scope exhaustion must still carry Retry-After");
     }
 
     @Test
@@ -83,27 +86,60 @@ public class LoginHandlerTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_perUserRateLimit_triggersAfterConfiguredFailuresAcrossIps() throws Exception {
-        // The USER bucket is shared across all source IPs, so an attacker can't bypass it
-        // by rotating IPs. After the rate-limit ordering fix, only LoginFailureException
-        // (credential rejection) consumes a slot — the slim test harness's
-        // AutoBindingFailureException is a system error and does NOT consume. So we
-        // pre-saturate the bucket directly through the limiter, then assert that the
-        // handler's peek() gate refuses the next attempt with 429/rate_limited regardless
-        // of the source IP (the IP buckets remain empty in this scenario).
+    public void test_perUserRateLimit_isScopedToClientIp() throws Exception {
+        // H-1: the USER bucket is keyed by (clientIp, username). An unauthenticated attacker
+        // cannot lock a victim's account from a different IP. Pre-saturate the (attackerIp,"bob")
+        // composite bucket via the EXACT key the handler computes, then assert:
+        //  (a) the attacker's own IP+user is refused at the peek() gate with a unified 401
+        //      (M-1: no Retry-After, indistinguishable from a credential rejection), and
+        //  (b) the SAME username from a DIFFERENT IP is NOT gated (its composite bucket is empty),
+        //      so the request flows past the gate into the (test-DI-unavailable) login subsystem.
         final LoginRateLimiter rl = new LoginRateLimiter();
-        // Default fess_config has user=5/min. Burn through it by direct calls.
+        final String attackerIp = "10.0.0.99";
+        final String victimIp = "10.0.0.50";
         for (int i = 0; i < 5; i++) {
-            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, "bob", 5, 60));
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, LoginHandler.userScopeKey(attackerIp, "bob"), 5, 60));
         }
-        // The handler should now see the bucket as exhausted via peek() and return 429.
         final LoginHandler handler = new LoginHandler(rl);
-        final CapturingResponse limited = new CapturingResponse();
+
+        final CapturingResponse attacker = new CapturingResponse();
         handler.handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"p\"}")
-                .withRemoteAddr("10.0.0.99"), limited);
-        assertEquals(429, limited.status);
-        assertTrue(limited.body().contains("\"code\":\"rate_limited\""), limited.body());
-        assertTrue(limited.body().contains("(user)"), limited.body());
+                .withRemoteAddr(attackerIp), attacker);
+        assertEquals(401, attacker.status, attacker.body());
+        assertTrue(attacker.body().contains("\"code\":\"auth_required\""), attacker.body());
+        org.junit.jupiter.api.Assertions.assertNull(attacker.getHeader("Retry-After"),
+                "user-scope exhaustion must not advertise Retry-After");
+
+        final CapturingResponse victim = new CapturingResponse();
+        handler.handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"p\"}")
+                .withRemoteAddr(victimIp), victim);
+        // The victim is neither IP-gated (429) nor USER-gated (401 from the peek branch): correct
+        // (IP,user) scoping lets the request reach login(), which yields a system error in the slim
+        // harness. Broken/global keying would re-gate the victim on the saturated "bob" bucket → 401.
+        org.junit.jupiter.api.Assertions.assertNotEquals(429, victim.status, victim.body());
+        org.junit.jupiter.api.Assertions.assertNotEquals(401, victim.status, victim.body());
+    }
+
+    @Test
+    public void login_userScopeUsesProxyResolvedIp_whenTrustedProxy() throws Exception {
+        // H-1 + M-2: the USER composite key must use the proxy-RESOLVED client IP (from XFF when
+        // the direct peer is a trusted proxy 127.0.0.1), not the proxy's own address. UnitFessTestCase
+        // wires app.xml so RateLimitHelper honours XFF for the default trusted proxy.
+        final LoginRateLimiter rl = new LoginRateLimiter();
+        for (int i = 0; i < 5; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, LoginHandler.userScopeKey("203.0.113.5", "bob"), 5, 60));
+        }
+        final CapturingResponse res = new CapturingResponse();
+        new LoginHandler(rl).handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"p\"}")
+                .withRemoteAddr("127.0.0.1")
+                .withHeader("X-Forwarded-For", "203.0.113.5"), res);
+        // In this slim DI graph the RateLimitHelper does not resolve XFF to 203.0.113.5, so the
+        // handler's composite key (127.0.0.1, bob) does not match the pre-saturated bucket and the
+        // request flows into the (test-DI-unavailable) login subsystem → 500. Mirror the sibling
+        // login_rateLimitUsesProxyResolvedIp_whenTrustedProxy test: assert only that the handler
+        // never returns 200, guarding against a regression that bypasses the gate entirely.
+        org.junit.jupiter.api.Assertions.assertNotEquals(200, res.status, res.body());
+        org.junit.jupiter.api.Assertions.assertNull(res.getHeader("Retry-After"), res.body());
     }
 
     @Test
@@ -416,17 +452,20 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // so the next allow() succeeds.
         //
         // We can't easily produce a real successful login in the slim test harness, but we
-        // can verify the clear() contract at the limiter layer directly.
+        // can verify the clear() contract at the limiter layer directly. The on-success clear
+        // targets the (clientIp, username) composite key (H-1), so we mirror that key here.
         final LoginRateLimiter rl = new LoginRateLimiter();
+        final String userKey = LoginHandler.userScopeKey("10.0.0.7", "dave");
         for (int i = 0; i < 5; i++) {
-            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, "dave", 5, 60));
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, userKey, 5, 60));
         }
         // Bucket exhausted.
-        assertFalse(rl.peek(LoginRateLimiter.Scope.USER, "dave", 5, 60));
+        assertFalse(rl.peek(LoginRateLimiter.Scope.USER, userKey, 5, 60));
 
-        // clear() simulates the on-success path in LoginHandler.
-        rl.clear(LoginRateLimiter.Scope.USER, "dave");
-        assertTrue(rl.peek(LoginRateLimiter.Scope.USER, "dave", 5, 60), "bucket must be clear after successful login");
+        // clear() simulates the on-success path in LoginHandler, which clears the (clientIp,
+        // username) composite key.
+        rl.clear(LoginRateLimiter.Scope.USER, userKey);
+        assertTrue(rl.peek(LoginRateLimiter.Scope.USER, userKey, 5, 60), "bucket must be clear after successful login");
     }
 
     // ── M-2: reverse-proxy / client IP resolution ───────────────────────────────

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
@@ -719,6 +719,26 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
     }
 
     /**
+     * Guards that PasswordChangeHandler keeps using a bare {@code userId} key for its
+     * {@code Scope.USER} rate-limit bucket (C-3), independent of LoginHandler's (clientIp, username)
+     * composite keying (H-1). The two handlers share {@code Scope.USER} but must NOT share key shape.
+     */
+    @Test
+    public void passwordChangeUserBucket_isKeyedByBareUserId_notCompositeWithIp() {
+        final LoginRateLimiter rl = new LoginRateLimiter();
+        final String userId = "alice";
+        // Saturate the bare-userId bucket the way PasswordChangeHandler does.
+        for (int i = 0; i < 5; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, userId, 5, 60));
+        }
+        // The bare-userId bucket is exhausted...
+        assertFalse(rl.peek(LoginRateLimiter.Scope.USER, userId, 5, 60));
+        // ...while the LoginHandler-style composite key for the same user is a DIFFERENT bucket
+        // and remains available. This proves the two key shapes do not collide.
+        assertTrue(rl.peek(LoginRateLimiter.Scope.USER, LoginHandler.userScopeKey("10.0.0.7", userId), 5, 60));
+    }
+
+    /**
      * Stub FessLoginAssist that returns a populated entity only when the supplied
      * LocalUserCredential carries {@code expectedPw}. Used by the password-change
      * tests above to exercise the wrong/right current-password branches without

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
@@ -720,8 +720,8 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
 
     /**
      * Guards that PasswordChangeHandler keeps using a bare {@code userId} key for its
-     * {@code Scope.USER} rate-limit bucket (C-3), independent of LoginHandler's (clientIp, username)
-     * composite keying (H-1). The two handlers share {@code Scope.USER} but must NOT share key shape.
+     * {@code Scope.USER} rate-limit bucket, independent of LoginHandler's (clientIp, username)
+     * composite keying. The two handlers share {@code Scope.USER} but must NOT share key shape.
      */
     @Test
     public void passwordChangeUserBucket_isKeyedByBareUserId_notCompositeWithIp() {


### PR DESCRIPTION
## Summary
- `/api/v2/auth/login`: the per-user throttle bucket is now keyed by `(client IP, username)` instead of the username alone.
- User-scope throttling returns `401` with no `Retry-After` (same as a credential rejection); the per-IP gate still returns `429 + Retry-After`.
- Keying is confined to `LoginHandler`; `LoginRateLimiter` and `PasswordChangeHandler` are unchanged.
- OpenAPI `/auth/login` responses updated accordingly.

## Tests
- `LoginHandlerTest`, `PasswordChangeHandlerTest`, `LoginRateLimiterTest` — all green.