### PR TITLE
fix(api-v2): enforce CSRF unconditionally and remove theme.api.csrf.required

### DIFF
--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -21,7 +21,7 @@ info:
     State-changing endpoints (`POST` / `PUT` / `DELETE`) require the
     `X-Fess-CSRF-Token` header. Acquire the token from
     `POST /auth/login` (in the `csrf_token` field) or from
-    `GET /ui/config` when `csrf_required=true`. The token rotates on
+    `GET /ui/config`. The token rotates on
     login, logout, and password change.
 
     CSRF verification runs **before** authentication, so a state-changing
@@ -917,8 +917,7 @@ components:
       in: header
       description: |-
         CSRF token issued by `POST /auth/login` or `GET /ui/config`.
-        Required for all state-changing requests when
-        `theme.api.csrf.required=true` (the default).
+        Required for all state-changing requests.
       required: true
       schema: { type: string }
 
@@ -1438,8 +1437,8 @@ components:
                 csrf_token:
                   type: string
                   description: |-
-                    Empty string when `csrf_required` is `false`; otherwise a
-                    fresh token bound to the current session.
+                    A fresh CSRF token bound to the current session
+                    (`csrf_required` is always `true`).
 
     # --- Auth --------------------------------------------------------
     AuthMeResponse:

--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -41,6 +41,7 @@ import org.codelibs.fess.api.v2.handlers.FavoritesListHandler;
 import org.codelibs.fess.api.v2.handlers.LoginHandler;
 import org.codelibs.fess.api.v2.handlers.LogoutHandler;
 import org.codelibs.fess.api.v2.handlers.MeHandler;
+import org.codelibs.fess.api.v2.handlers.OriginValidator;
 import org.codelibs.fess.api.v2.handlers.PasswordChangeHandler;
 import org.codelibs.fess.api.v2.handlers.RelatedContentHandler;
 import org.codelibs.fess.api.v2.handlers.RelatedQueriesHandler;
@@ -156,6 +157,10 @@ public class SearchApiV2Manager extends BaseApiManager {
     @Resource
     protected RelatedContentHandler relatedContentHandler;
 
+    /** Validates the request origin for the baseline CSRF Origin layer (unsafe methods). */
+    @Resource
+    protected OriginValidator originValidator;
+
     /**
      * Constructor — pins the path prefix to {@code /api/v2}.
      */
@@ -204,7 +209,18 @@ public class SearchApiV2Manager extends BaseApiManager {
         // servlet spec; headers set here are preserved.
         writeHeaders(response);
         final String sub = subPath(request);
-        if (ComponentUtil.getFessConfig().isThemeApiCsrfRequired() && CsrfRequirement.requiresCsrf(sub, request.getMethod())) {
+
+        // Layer 1: baseline Origin check (always applied). Rejects browser-driven
+        // cross-site state-changing requests before any handler runs. A missing
+        // Origin/Referer is allowed (non-browser API client compatibility); see
+        // OriginValidator.
+        if (CsrfRequirement.isUnsafeMethod(request.getMethod()) && !originValidator.isAllowed(request)) {
+            V2EnvelopeWriter.writeError(response, V2ErrorCode.FORBIDDEN, "cross-site request blocked");
+            return;
+        }
+
+        // Layer 2: session-bound CSRF token verification (always applied).
+        if (CsrfRequirement.requiresCsrf(sub, request.getMethod())) {
             final HttpSession session = request.getSession(false);
             final String header = request.getHeader("X-Fess-CSRF-Token");
             final SessionCsrfTokenManager csrf = ComponentUtil.getSessionCsrfTokenManager();

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/CsrfRequirement.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/CsrfRequirement.java
@@ -99,4 +99,26 @@ public final class CsrfRequirement {
         // it inherits CSRF enforcement rather than being silently exempt.
         return true;
     }
+
+    /**
+     * Returns whether the given HTTP method is a state-changing ("unsafe") method
+     * for the purposes of the baseline Origin check.
+     *
+     * <p>{@code GET}, {@code HEAD}, and {@code OPTIONS} are safe (idempotent, no
+     * state change) and therefore not subject to the Origin check; every other
+     * method ({@code POST}, {@code PUT}, {@code DELETE}, {@code PATCH}, …) is
+     * unsafe. Unlike {@link #requiresCsrf}, this does NOT exempt
+     * {@code /auth/login}: the Origin layer covers login CSRF as well (a missing
+     * Origin still allows the request, preserving non-browser auto-login).</p>
+     *
+     * @param method the HTTP method (case-insensitive); {@code null} is treated as safe
+     * @return {@code true} if the method is state-changing and must pass the Origin check
+     */
+    public static boolean isUnsafeMethod(final String method) {
+        if (method == null) {
+            return false;
+        }
+        final String m = method.toUpperCase(Locale.ROOT);
+        return !"GET".equals(m) && !"HEAD".equals(m) && !"OPTIONS".equals(m);
+    }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/OriginValidator.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/OriginValidator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.cors.CorsMatchType;
+import org.codelibs.fess.cors.CorsResolution;
+import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.fess.util.OriginUtil;
+
+import jakarta.annotation.Resource;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Baseline same-origin / allow-listed-origin decision for the v2 CSRF Origin
+ * check. Registered as a Lasta DI component ({@code originValidator}) so the
+ * policy is replaceable; the trusted self-origin set is resolved through the
+ * injected {@link TargetOriginResolver} and the CORS allow list is consulted via
+ * {@link ComponentUtil}.
+ */
+public class OriginValidator {
+
+    private static final Logger logger = LogManager.getLogger(OriginValidator.class);
+
+    /** Resolves the canonical self-origin set used for the same-origin comparison. */
+    @Resource
+    protected TargetOriginResolver targetOriginResolver;
+
+    /**
+     * Default constructor. The validator is stateless and intended to be
+     * instantiated once by the DI container and shared across concurrent requests.
+     */
+    public OriginValidator() {
+        // no-op
+    }
+
+    /**
+     * Validates the source origin of a state-changing request.
+     *
+     * <p>Algorithm:</p>
+     * <ol>
+     * <li>Resolve the trusted self-origin set via {@link TargetOriginResolver#resolve}.</li>
+     * <li>Read the {@code Origin} header. If non-blank, it is the source — the
+     * {@code Referer} is NOT consulted as a fallback (a same-origin Referer must
+     * not rescue a cross-site Origin). If {@code Origin} is blank/absent, read
+     * {@code Referer} as the source.</li>
+     * <li>Canonicalize the source via {@link OriginUtil#canonicalize}. If the
+     * result is {@code null} (both headers absent or unparseable) → allow
+     * (non-browser API client compatibility; browser-driven cross-site state
+     * changes always carry an Origin).</li>
+     * <li>If the trusted self-origin set contains the canonical source → allow.</li>
+     * <li>If the CORS allow list resolves the source to an {@link CorsMatchType#EXACT}
+     * match → allow. {@code resolve()} is used (never {@code get()}) so a {@code "*"}
+     * wildcard fallback is never silently trusted.</li>
+     * <li>Otherwise (cross-site, {@code Origin: null}, malformed value) → reject.</li>
+     * </ol>
+     *
+     * @param request the request; only the {@code Origin}/{@code Referer} headers are read
+     * @return {@code true} if the request may proceed, {@code false} if it is blocked as cross-site
+     */
+    public boolean isAllowed(final HttpServletRequest request) {
+        final Set<String> trustedSameOrigins = targetOriginResolver.resolve(request);
+
+        final String origin = request.getHeader("Origin");
+        final String rawSource;
+        final boolean fromOrigin;
+        if (StringUtil.isNotBlank(origin)) {
+            // Origin present (non-blank): do NOT fall back to Referer. A same-origin
+            // Referer must not rescue a cross-site Origin.
+            rawSource = origin;
+            fromOrigin = true;
+        } else {
+            // A blank/absent Origin is treated as absent; consult the Referer.
+            rawSource = request.getHeader("Referer");
+            fromOrigin = false;
+        }
+
+        final String source = OriginUtil.canonicalize(rawSource);
+        if (source == null) {
+            if (fromOrigin) {
+                // A non-blank Origin that fails to canonicalize is a present but
+                // malformed/opaque origin ("null", multi-value, control chars,
+                // unparseable). This is a cross-site signal from a real browser, not
+                // a missing header — reject.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("v2 origin check: blocked request with present but unusable Origin header");
+                }
+                return false;
+            }
+            // Origin absent/blank and Referer absent or unparseable. Browser-driven
+            // cross-site state changes always carry an Origin, so a missing source is
+            // a non-browser API client; allow for compatibility.
+            if (logger.isDebugEnabled()) {
+                logger.debug("v2 origin check: no usable source origin; allowing (non-browser client)");
+            }
+            return true;
+        }
+
+        if (trustedSameOrigins.contains(source)) {
+            return true;
+        }
+
+        final CorsResolution resolution = ComponentUtil.getCorsHandlerFactory().resolve(source);
+        if (resolution != null && resolution.getMatchType() == CorsMatchType.EXACT) {
+            // Explicit allow-listed origin (credentialed SPA). WILDCARD is never trusted.
+            return true;
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("v2 origin check: blocked cross-site request (source present, not trusted)");
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/TargetOriginResolver.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/TargetOriginResolver.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.fess.util.OriginUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Builds the canonical self-origin set ({@code trustedSameOrigins}) for the v2
+ * CSRF Origin check. The trust boundary for forwarded headers is
+ * enforced here. Registered as a Lasta DI component
+ * ({@code targetOriginResolver}) so the resolution strategy is replaceable per
+ * deployment.
+ *
+ * <p>Resolution priority:</p>
+ * <ol>
+ * <li>If {@code theme.api.csrf.server.origins} is configured, canonicalize each
+ * value and return that set. This is header-independent and the hardest option —
+ * the recommended setting behind reverse proxies.</li>
+ * <li>Otherwise, only when {@code request.getRemoteAddr()} is a trusted proxy
+ * ({@code rate.limit.trusted.proxies}), reconstruct the origin from the
+ * {@code X-Forwarded-Proto} / {@code X-Forwarded-Host} (+ optional
+ * {@code X-Forwarded-Port}) headers. A comma-separated {@code X-Forwarded-Host}
+ * uses the first value. Forwarded headers from an untrusted source are never
+ * trusted (spoof prevention).</li>
+ * <li>Otherwise, reconstruct from the servlet request
+ * ({@code getScheme}/{@code getServerName}/{@code getServerPort}).</li>
+ * </ol>
+ *
+ * <p>The reconstructed origin is always canonicalized so default ports are
+ * normalized consistently with the source origin.</p>
+ */
+public class TargetOriginResolver {
+
+    /**
+     * Default constructor. The resolver is stateless and intended to be
+     * instantiated once by the DI container and shared across concurrent requests.
+     */
+    public TargetOriginResolver() {
+        // no-op
+    }
+
+    /**
+     * Resolves the set of canonical origins that are considered same-origin for
+     * this request.
+     *
+     * @param request the current request (forwarded headers consulted only for trusted proxies)
+     * @return a non-null set of canonical origins (may be empty if every configured value was invalid)
+     */
+    public Set<String> resolve(final HttpServletRequest request) {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+
+        // (1) Explicit, header-independent configuration takes precedence.
+        final Set<String> configured = fessConfig.getThemeApiCsrfServerOriginsAsSet();
+        if (configured != null && !configured.isEmpty()) {
+            final Set<String> result = new LinkedHashSet<>();
+            for (final String value : configured) {
+                final String canonical = OriginUtil.canonicalize(value);
+                if (canonical != null) {
+                    result.add(canonical);
+                }
+            }
+            return result;
+        }
+
+        // (2) Forwarded headers are trusted only when the immediate peer is a trusted proxy.
+        final String remoteAddr = request.getRemoteAddr();
+        if (remoteAddr != null && fessConfig.getRateLimitTrustedProxiesAsSet().contains(remoteAddr)) {
+            final String forwarded = reconstructFromForwardedHeaders(request);
+            if (forwarded != null) {
+                return Collections.singleton(forwarded);
+            }
+        }
+
+        // (3) Fall back to the servlet-observed scheme/host/port.
+        final String canonical =
+                OriginUtil.canonicalize(buildOrigin(request.getScheme(), request.getServerName(), request.getServerPort()));
+        if (canonical != null) {
+            return Collections.singleton(canonical);
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * Reconstructs the canonical origin from {@code X-Forwarded-*} headers, or
+     * {@code null} when the required proto/host are absent or unusable. Only call
+     * after verifying the request came from a trusted proxy.
+     */
+    private static String reconstructFromForwardedHeaders(final HttpServletRequest request) {
+        final String proto = firstValue(request.getHeader("X-Forwarded-Proto"));
+        final String host = firstValue(request.getHeader("X-Forwarded-Host"));
+        if (StringUtil.isBlank(proto) || StringUtil.isBlank(host)) {
+            return null;
+        }
+        // X-Forwarded-Host may already include a port (host:port); if a separate
+        // X-Forwarded-Port is supplied and the host lacks one, append it.
+        final String trimmedHost = host.trim();
+        String origin = proto.trim() + "://" + trimmedHost;
+        if (!hasPort(trimmedHost)) {
+            final String port = firstValue(request.getHeader("X-Forwarded-Port"));
+            if (StringUtil.isNotBlank(port)) {
+                origin = origin + ":" + port.trim();
+            }
+        }
+        return OriginUtil.canonicalize(origin);
+    }
+
+    /**
+     * Returns whether the host already carries a port. For a bracketed IPv6 literal
+     * (e.g. {@code [::1]} or {@code [::1]:8443}) the port separator is the {@code ':'}
+     * after the closing {@code ']'}; the inner colons of the address must not be
+     * mistaken for a port separator. For a non-bracketed host any {@code ':'}
+     * indicates a port.
+     */
+    private static boolean hasPort(final String host) {
+        if (host.startsWith("[")) {
+            final int closing = host.lastIndexOf(']');
+            // Bracketed literal: a port exists only if a ':' follows the closing ']'.
+            return closing >= 0 && host.indexOf(':', closing + 1) >= 0;
+        }
+        return host.indexOf(':') >= 0;
+    }
+
+    /**
+     * Returns the first value of a possibly comma-separated header value, trimmed,
+     * or {@code null} when the input is blank.
+     */
+    private static String firstValue(final String headerValue) {
+        if (StringUtil.isBlank(headerValue)) {
+            return null;
+        }
+        final int comma = headerValue.indexOf(',');
+        final String first = comma >= 0 ? headerValue.substring(0, comma) : headerValue;
+        final String trimmed = first.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static String buildOrigin(final String scheme, final String host, final int port) {
+        if (StringUtil.isBlank(scheme) || StringUtil.isBlank(host)) {
+            return null;
+        }
+        final StringBuilder buf = new StringBuilder();
+        buf.append(scheme).append("://").append(host);
+        if (port > 0) {
+            buf.append(':').append(port);
+        }
+        return buf.toString();
+    }
+}

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/UiConfigHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/UiConfigHandler.java
@@ -136,10 +136,10 @@ public class UiConfigHandler {
      * <p>Rejects non-{@code GET} methods with {@link V2ErrorCode#METHOD_NOT_ALLOWED}.
      * Otherwise assembles the SPA bootstrap payload — site name, login
      * requirement, supported locales, active theme descriptor, feature flags,
-     * paging defaults, and (when {@code theme.api.csrf.required=true}) a
-     * freshly-issued CSRF token bound to the session — and writes it via the
-     * standard v2 envelope. Any unexpected exception is caught and emitted as
-     * a structured {@code internal_error} envelope.</p>
+     * paging defaults, and a freshly-issued CSRF token bound to the session
+     * (always required now) — and writes it via the standard v2 envelope. Any
+     * unexpected exception is caught and emitted as a structured
+     * {@code internal_error} envelope.</p>
      *
      * @param req the incoming HTTP request
      * @param res the HTTP response to write to
@@ -292,21 +292,14 @@ public class UiConfigHandler {
             // Server-wide supported language list, surfaced as plain JSON array of codes.
             final String[] langs = cfg.getSupportedLanguagesAsArray();
 
-            // m-14: expose whether CSRF is required so the SPA can decide whether to
-            // send the X-Fess-CSRF-Token header. When csrf_required=false the SPA MAY
-            // omit the header; when true it MUST include it for all state-changing
-            // requests. The csrf_token field is only populated when csrf_required=true
-            // (empty string otherwise) to avoid issuing a session-bound token that the
-            // SPA will never use.
-            final boolean csrfRequired = cfg.isThemeApiCsrfRequired();
-            String csrfToken = "";
-            if (csrfRequired) {
-                // Issue (or echo) a CSRF token so the SPA can immediately POST. Using
-                // getSession(true) ensures the session exists even on the very first request.
-                final HttpSession session = req.getSession(true);
-                final SessionCsrfTokenManager csrf = ComponentUtil.getComponent(SessionCsrfTokenManager.class);
-                csrfToken = csrf == null ? "" : csrf.issue(session);
-            }
+            // The CSRF token is always required for v2 state-changing requests, so the SPA
+            // MUST include the X-Fess-CSRF-Token header. The csrf_required/csrf_token fields
+            // are retained for SPA backward compatibility; csrf_required is now always true
+            // and a freshly-issued session-bound token is always returned. Using
+            // getSession(true) ensures the session exists even on the very first request.
+            final HttpSession session = req.getSession(true);
+            final SessionCsrfTokenManager csrf = ComponentUtil.getComponent(SessionCsrfTokenManager.class);
+            final String csrfToken = csrf == null ? "" : csrf.issue(session);
 
             // sort_options: conditionally include click_count and favorite_count entries.
             final List<Map<String, Object>> sortOptions = buildSortOptions(searchLogEnabled, userFavoriteEnabled);
@@ -387,7 +380,7 @@ public class UiConfigHandler {
             payload.put("notifications", notifications);
             payload.put("facet_views", facetViews);
             payload.put("filetype_options", buildFiletypeOptions());
-            payload.put("csrf_required", csrfRequired);
+            payload.put("csrf_required", true);
             payload.put("csrf_token", csrfToken);
             V2EnvelopeWriter.writeSuccess(res, payload);
         } catch (final Exception e) {

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -2088,8 +2088,8 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. true */
     String THEME_ASSETS_PRECOMPRESSED = "theme.assets.precompressed";
 
-    /** The key of the configuration. e.g. true */
-    String THEME_API_CSRF_REQUIRED = "theme.api.csrf.required";
+    /** The key of the configuration. e.g.  */
+    String THEME_API_CSRF_SERVER_ORIGINS = "theme.api.csrf.server.origins";
 
     /** The key of the configuration. e.g. 10 */
     String THEME_API_LOGIN_RATE_LIMIT_PER_IP_PER_MINUTE = "theme.api.login.rate.limit.per.ip.per.minute";
@@ -10015,18 +10015,11 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     boolean isThemeAssetsPrecompressed();
 
     /**
-     * Get the value for the key 'theme.api.csrf.required'. <br>
-     * The value is, e.g. true <br>
+     * Get the value for the key 'theme.api.csrf.server.origins'. <br>
+     * The value is, e.g.  <br>
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
-    String getThemeApiCsrfRequired();
-
-    /**
-     * Is the property for the key 'theme.api.csrf.required' true? <br>
-     * The value is, e.g. true <br>
-     * @return The determination, true or false. (if not found, exception but basically no way)
-     */
-    boolean isThemeApiCsrfRequired();
+    String getThemeApiCsrfServerOrigins();
 
     /**
      * Get the value for the key 'theme.api.login.rate.limit.per.ip.per.minute'. <br>
@@ -13840,12 +13833,8 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return is(FessConfig.THEME_ASSETS_PRECOMPRESSED);
         }
 
-        public String getThemeApiCsrfRequired() {
-            return get(FessConfig.THEME_API_CSRF_REQUIRED);
-        }
-
-        public boolean isThemeApiCsrfRequired() {
-            return is(FessConfig.THEME_API_CSRF_REQUIRED);
+        public String getThemeApiCsrfServerOrigins() {
+            return get(FessConfig.THEME_API_CSRF_SERVER_ORIGINS);
         }
 
         public String getThemeApiLoginRateLimitPerIpPerMinute() {
@@ -14524,7 +14513,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.THEME_ALLOWED_ARCHIVE_EXTENSIONS, "zip");
             defaultMap.put(FessConfig.THEME_ASSETS_CACHE_MAX_AGE, "86400");
             defaultMap.put(FessConfig.THEME_ASSETS_PRECOMPRESSED, "true");
-            defaultMap.put(FessConfig.THEME_API_CSRF_REQUIRED, "true");
+            defaultMap.put(FessConfig.THEME_API_CSRF_SERVER_ORIGINS, "");
             defaultMap.put(FessConfig.THEME_API_LOGIN_RATE_LIMIT_PER_IP_PER_MINUTE, "10");
             defaultMap.put(FessConfig.THEME_API_LOGIN_RATE_LIMIT_PER_USER_PER_MINUTE, "5");
             defaultMap.put(FessConfig.THEME_API_LOGIN_LOCKOUT_SECONDS, "900");

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -2417,6 +2417,21 @@ public interface FessProp {
         return set;
     }
 
+    String THEME_API_CSRF_SERVER_ORIGINS_SET = "themeApiCsrfServerOriginsSet";
+
+    String getThemeApiCsrfServerOrigins();
+
+    default Set<String> getThemeApiCsrfServerOriginsAsSet() {
+        @SuppressWarnings("unchecked")
+        Set<String> set = (Set<String>) propMap.get(THEME_API_CSRF_SERVER_ORIGINS_SET);
+        if (set == null) {
+            set = split(getThemeApiCsrfServerOrigins(), "[\\n,]")
+                    .get(stream -> stream.map(String::trim).filter(StringUtil::isNotEmpty).collect(Collectors.toSet()));
+            propMap.put(THEME_API_CSRF_SERVER_ORIGINS_SET, set);
+        }
+        return set;
+    }
+
     /**
      * Resolves {@code api.v2.chat.rate.limit.per.user.per.minute} from the system
      * properties, defaulting to {@code 30} on absence or parse failure. A return

--- a/src/main/java/org/codelibs/fess/util/OriginUtil.java
+++ b/src/main/java/org/codelibs/fess/util/OriginUtil.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.util;
+
+import java.net.URI;
+import java.util.Locale;
+
+/**
+ * Single source of truth for origin canonicalization used by the v2 CSRF Origin
+ * check. Pure, side-effect-free static helper.
+ *
+ * <p>Normalizes an {@code Origin} header value or a full URL (e.g. {@code Referer})
+ * into a canonical {@code "scheme://host[:port]"} string. The scheme and host are
+ * lower-cased, the default port for the scheme is stripped ({@code https:443} /
+ * {@code http:80}), and any path, query, or fragment is discarded.</p>
+ *
+ * <p>Invalid inputs all map to {@code null}: {@code null}, blank, the literal
+ * string {@code "null"} (the value browsers send for opaque origins), values that
+ * contain whitespace or control characters (CR/LF/TAB/etc.), values carrying
+ * multiple space-separated tokens, values missing a scheme or host, and anything
+ * that cannot be parsed. Parsing never throws — failures are caught and reported
+ * as {@code null} so callers can treat {@code null} uniformly as "unusable".</p>
+ */
+public final class OriginUtil {
+
+    private OriginUtil() {
+    }
+
+    /**
+     * Canonicalizes an {@code Origin} header value or URL into
+     * {@code "scheme://host[:port]"}.
+     *
+     * <p>Examples: {@code https://App.Example.com:443/path?x} →
+     * {@code https://app.example.com}; {@code http://example.com:80} →
+     * {@code http://example.com}.</p>
+     *
+     * <p>Note: hosts containing an underscore (e.g. {@code https://my_host}) canonicalize
+     * to {@code null} because {@link java.net.URI#getHost()} returns {@code null} for them,
+     * so such origins fail closed (are not treated as same-origin). Operators with such
+     * internal hostnames should set {@code theme.api.csrf.server.origins} explicitly.</p>
+     *
+     * @param originOrUrl the raw Origin header value or URL (may be {@code null})
+     * @return the canonical origin, or {@code null} if the input is missing,
+     *         malformed, or otherwise unusable
+     */
+    public static String canonicalize(final String originOrUrl) {
+        if (originOrUrl == null) {
+            return null;
+        }
+        // Strip only surrounding ASCII spaces. Do NOT use String.trim() here: trim()
+        // also removes trailing CR/LF/TAB, which would let an injected
+        // "https://example.com\r\n..." slip through as a clean origin. Edge CR/LF/TAB
+        // must be detected by the control-char scan below and rejected.
+        final String value = stripSpaces(originOrUrl);
+        if (value.isEmpty()) {
+            return null;
+        }
+        // Browsers emit the literal "null" for opaque origins (e.g. sandboxed
+        // iframes, data: URLs). It is never a trustworthy same-origin value.
+        if ("null".equalsIgnoreCase(value)) {
+            return null;
+        }
+        // Reject any remaining whitespace or control character. A well-formed
+        // Origin/URL is a single token without spaces; embedded space/CR/LF/TAB
+        // indicate header injection or a multi-valued header and must not be
+        // normalized away.
+        for (int i = 0; i < value.length(); i++) {
+            final char c = value.charAt(i);
+            if (c <= ' ' || Character.isWhitespace(c) || Character.isISOControl(c)) {
+                return null;
+            }
+        }
+        try {
+            final URI uri = new URI(value);
+            final String scheme = uri.getScheme();
+            if (scheme == null) {
+                return null;
+            }
+            final String host = uri.getHost();
+            if (host == null || host.isEmpty()) {
+                return null;
+            }
+            final String lowerScheme = scheme.toLowerCase(Locale.ROOT);
+            final String lowerHost = host.toLowerCase(Locale.ROOT);
+            final int port = uri.getPort();
+            final StringBuilder buf = new StringBuilder();
+            buf.append(lowerScheme).append("://").append(lowerHost);
+            if (port != -1 && !isDefaultPort(lowerScheme, port)) {
+                buf.append(':').append(port);
+            }
+            return buf.toString();
+        } catch (final Exception e) {
+            // URISyntaxException or any other parse failure — treat as unusable.
+            return null;
+        }
+    }
+
+    private static boolean isDefaultPort(final String scheme, final int port) {
+        return ("https".equals(scheme) && port == 443) || ("http".equals(scheme) && port == 80);
+    }
+
+    /**
+     * Removes only leading/trailing ASCII space (0x20) characters. Unlike
+     * {@link String#trim()}, this deliberately preserves CR/LF/TAB and other
+     * control characters so the caller's control-char scan can reject them.
+     */
+    private static String stripSpaces(final String value) {
+        int start = 0;
+        int end = value.length();
+        while (start < end && value.charAt(start) == ' ') {
+            start++;
+        }
+        while (end > start && value.charAt(end - 1) == ' ') {
+            end--;
+        }
+        return value.substring(start, end);
+    }
+}

--- a/src/main/resources/fess_api.xml
+++ b/src/main/resources/fess_api.xml
@@ -27,6 +27,8 @@
 	<component name="loginHandler" class="org.codelibs.fess.api.v2.handlers.LoginHandler"/>
 	<component name="relatedQueriesHandler" class="org.codelibs.fess.api.v2.handlers.RelatedQueriesHandler"/>
 	<component name="relatedContentHandler" class="org.codelibs.fess.api.v2.handlers.RelatedContentHandler"/>
+	<component name="targetOriginResolver" class="org.codelibs.fess.api.v2.handlers.TargetOriginResolver"/>
+	<component name="originValidator" class="org.codelibs.fess.api.v2.handlers.OriginValidator"/>
 
 	<component name="searchApiV2Manager" class="org.codelibs.fess.api.v2.SearchApiV2Manager">
 	</component>

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1673,7 +1673,12 @@ theme.upload.attic.retention.days=7
 theme.allowed.archive.extensions=zip
 theme.assets.cache.max.age=86400
 theme.assets.precompressed=true
-theme.api.csrf.required=true
+# Optional: canonical external origin(s) of this Fess instance (comma/newline separated),
+# e.g. https://fess.example.com. When set, these are treated as same-origin for the v2 CSRF
+# Origin check WITHOUT trusting forwarded headers. Recommended behind reverse proxies that are
+# not listed in rate.limit.trusted.proxies. When empty, the target origin is reconstructed from
+# trusted-proxy X-Forwarded-* headers, then from the servlet request.
+theme.api.csrf.server.origins=
 theme.api.login.rate.limit.per.ip.per.minute=10
 theme.api.login.rate.limit.per.user.per.minute=5
 theme.api.login.lockout.seconds=900

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerCsrfTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerCsrfTest.java
@@ -53,11 +53,9 @@ import jakarta.servlet.http.Part;
  * available — we only assert that the gate did <em>not</em> emit a
  * {@code "forbidden"} envelope, not that the downstream handler succeeded.</p>
  *
- * <p>TODO: the spec §7.3 "csrf-required=false" scenario is intentionally deferred
- * to an integration test. {@link UnitFessTestCase}'s {@code FessConfig} is loaded
- * from {@code fess_config.properties} on disk and overriding
- * {@code theme.api.csrf.required} requires injecting a fake config component,
- * which is heavier than the value this case adds at the unit level.</p>
+ * <p>The token layer is always applied to state-changing requests (there is no
+ * enable/disable flag), so every unsafe request to a CSRF-gated path without a
+ * valid token is rejected.</p>
  */
 public class SearchApiV2ManagerCsrfTest extends UnitFessTestCase {
 

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerOriginCheckTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerOriginCheckTest.java
@@ -1,0 +1,804 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codelibs.fess.cors.CorsHandlerFactory;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
+
+/**
+ * Integration tests for the two-layer CSRF gate wired into
+ * {@link SearchApiV2Manager#process}. Both layers are always applied to unsafe
+ * methods (there are no enable/disable flags).
+ *
+ * <p>The gate fires before path dispatch, so blocked scenarios do not need the
+ * downstream handler. Both layers emit the same {@code "forbidden"} envelope
+ * code; the layers are distinguished by message ({@code "cross-site request
+ * blocked"} for the Origin layer, {@code "invalid csrf token"} for the token
+ * layer).</p>
+ *
+ * <p>The same-origin reconstruction for the stub request is
+ * {@code http://localhost:8080} (its {@code getScheme}/{@code getServerName}/
+ * {@code getServerPort} defaults); {@code getRemoteAddr} returns an untrusted
+ * peer so the servlet reconstruction path is exercised without forwarded-header
+ * trust. The manager's {@code originValidator} is wired by
+ * {@link SearchApiV2ManagerTestSupport} with a real {@code TargetOriginResolver}
+ * that drives off these servlet defaults.</p>
+ */
+public class SearchApiV2ManagerOriginCheckTest extends UnitFessTestCase {
+
+    private static final String SAME_ORIGIN = "http://localhost:8080";
+
+    @BeforeEach
+    public void registerComponents() {
+        final SessionCsrfTokenManager manager = new SessionCsrfTokenManager();
+        ComponentUtil.register(manager, "sessionCsrfTokenManager");
+        ComponentUtil.register(manager, SessionCsrfTokenManager.class.getCanonicalName());
+        ComponentUtil.register(new CorsHandlerFactory(), "corsHandlerFactory");
+    }
+
+    // Origin layer: cross-site is blocked regardless of token
+
+    @Test
+    public void test_crossSiteOrigin_blockedEvenWithValidToken() throws Exception {
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final StubSession session = new StubSession();
+        session.setAttribute(SessionCsrfTokenManager.SESSION_ATTR, "good-token");
+        final CapturingResponse res = new CapturingResponse();
+        final StubRequest req = new StubRequest("/api/v2/click").withMethod("POST")
+                .withSession(session)
+                .withHeader("X-Fess-CSRF-Token", "good-token")
+                .withHeader("Origin", "https://evil.example.com");
+        m.process(req, res, new NopChain());
+        assertEquals(403, res.status, res.body());
+        assertTrue(res.body().contains("\"code\":\"forbidden\""), res.body());
+        assertTrue(res.body().contains("cross-site request blocked"), res.body());
+    }
+
+    // Token layer: missing token on a state-changing path is blocked
+
+    @Test
+    public void test_sameOrigin_missingToken_blockedByTokenLayer() throws Exception {
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final CapturingResponse res = new CapturingResponse();
+        // Same-origin passes the Origin layer; the token layer still rejects the missing token.
+        final StubRequest req = new StubRequest("/api/v2/click").withMethod("POST").withHeader("Origin", SAME_ORIGIN);
+        m.process(req, res, new NopChain());
+        assertEquals(403, res.status, res.body());
+        assertTrue(res.body().contains("invalid csrf token"), res.body());
+    }
+
+    // same-origin + valid token passes both gates
+
+    @Test
+    public void test_sameOriginAndValidToken_passesGate() throws Exception {
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final StubSession session = new StubSession();
+        session.setAttribute(SessionCsrfTokenManager.SESSION_ATTR, "good-token");
+        final CapturingResponse res = new CapturingResponse();
+        final StubRequest req = new StubRequest("/api/v2/click").withMethod("POST")
+                .withSession(session)
+                .withHeader("X-Fess-CSRF-Token", "good-token")
+                .withHeader("Origin", SAME_ORIGIN);
+        m.process(req, res, new NopChain());
+        // The gate must NOT emit a forbidden envelope; dispatch proceeds into the click handler.
+        assertFalse(res.body().contains("cross-site request blocked"), res.body());
+        assertFalse(res.body().contains("invalid csrf token"), res.body());
+    }
+
+    @Test
+    public void test_missingOriginAndValidToken_passesGate() throws Exception {
+        // Non-browser client (no Origin/Referer) with a valid token: Origin layer allows
+        // (missing source), token layer allows (valid token).
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final StubSession session = new StubSession();
+        session.setAttribute(SessionCsrfTokenManager.SESSION_ATTR, "good-token");
+        final CapturingResponse res = new CapturingResponse();
+        final StubRequest req =
+                new StubRequest("/api/v2/click").withMethod("POST").withSession(session).withHeader("X-Fess-CSRF-Token", "good-token");
+        m.process(req, res, new NopChain());
+        assertFalse(res.body().contains("cross-site request blocked"), res.body());
+        assertFalse(res.body().contains("invalid csrf token"), res.body());
+    }
+
+    // safe method skips both layers
+
+    @Test
+    public void test_getRequest_skipsBothLayers_evenCrossSiteOrigin() throws Exception {
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final CapturingResponse res = new CapturingResponse();
+        // GET is a safe method: neither the Origin layer nor the token layer applies,
+        // even with a cross-site Origin and no token.
+        final StubRequest req = new StubRequest("/api/v2/auth/me").withHeader("Origin", "https://evil.example.com");
+        m.process(req, res, new NopChain());
+        assertFalse(res.body().contains("cross-site request blocked"), res.body());
+        assertFalse(res.body().contains("invalid csrf token"), res.body());
+    }
+
+    @Test
+    public void test_loginPost_crossSiteOrigin_blockedByOriginLayer() throws Exception {
+        // /auth/login is exempt from the token layer, but the Origin layer still covers
+        // it (login CSRF defense). A cross-site Origin must be blocked.
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final CapturingResponse res = new CapturingResponse();
+        final StubRequest req = new StubRequest("/api/v2/auth/login").withMethod("POST").withHeader("Origin", "https://evil.example.com");
+        m.process(req, res, new NopChain());
+        assertEquals(403, res.status, res.body());
+        assertTrue(res.body().contains("cross-site request blocked"), res.body());
+    }
+
+    // stubs
+
+    /** A FilterChain that does nothing — the v2 manager never delegates further. */
+    private static class NopChain implements FilterChain {
+        @Override
+        public void doFilter(final ServletRequest request, final ServletResponse response) {
+            // no-op
+        }
+    }
+
+    /** Minimal HttpServletResponse stub capturing status and writer output. */
+    private static class CapturingResponse implements HttpServletResponse {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter writer = new PrintWriter(sw);
+        int status = 200;
+        String contentType;
+
+        String body() {
+            writer.flush();
+            return sw.toString();
+        }
+
+        @Override
+        public void setStatus(final int sc) {
+            this.status = sc;
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        @Override
+        public void setContentType(final String type) {
+            this.contentType = type;
+        }
+
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return writer;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public void setCharacterEncoding(final String s) {
+        }
+
+        @Override
+        public jakarta.servlet.ServletOutputStream getOutputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setContentLength(final int len) {
+        }
+
+        @Override
+        public void setContentLengthLong(final long len) {
+        }
+
+        @Override
+        public void setBufferSize(final int size) {
+        }
+
+        @Override
+        public int getBufferSize() {
+            return 0;
+        }
+
+        @Override
+        public void flushBuffer() {
+        }
+
+        @Override
+        public void resetBuffer() {
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void setLocale(final java.util.Locale loc) {
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public void addCookie(final jakarta.servlet.http.Cookie cookie) {
+        }
+
+        @Override
+        public boolean containsHeader(final String name) {
+            return false;
+        }
+
+        @Override
+        public String encodeURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeRedirectURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public void sendError(final int sc, final String msg) {
+        }
+
+        @Override
+        public void sendError(final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void setDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void addDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void setHeader(final String name, final String value) {
+        }
+
+        @Override
+        public void addHeader(final String name, final String value) {
+        }
+
+        @Override
+        public void setIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public void addIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return null;
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaders(final String name) {
+            return java.util.Collections.emptyList();
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaderNames() {
+            return java.util.Collections.emptyList();
+        }
+    }
+
+    /** Minimal HttpServletRequest stub with per-name headers, method, session, and servlet origin defaults. */
+    private static class StubRequest implements HttpServletRequest {
+        private final String uri;
+        private final Map<String, Object> attrs = new HashMap<>();
+        private final Map<String, String> headers = new HashMap<>();
+        private String method = "GET";
+        private HttpSession session;
+
+        StubRequest(final String uri) {
+            this.uri = uri;
+        }
+
+        StubRequest withMethod(final String m) {
+            this.method = m;
+            return this;
+        }
+
+        StubRequest withHeader(final String name, final String value) {
+            this.headers.put(name, value);
+            return this;
+        }
+
+        StubRequest withSession(final HttpSession s) {
+            this.session = s;
+            return this;
+        }
+
+        @Override
+        public String getServletPath() {
+            return uri;
+        }
+
+        @Override
+        public String getMethod() {
+            return method;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return uri;
+        }
+
+        @Override
+        public String getContextPath() {
+            return "";
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return headers.get(name);
+        }
+
+        @Override
+        public String getScheme() {
+            return "http";
+        }
+
+        @Override
+        public String getServerName() {
+            return "localhost";
+        }
+
+        @Override
+        public int getServerPort() {
+            return 8080;
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            // An untrusted peer so forwarded headers are never trusted and the servlet
+            // reconstruction path (http://localhost:8080) is used for same-origin.
+            return "203.0.113.9";
+        }
+
+        @Override
+        public HttpSession getSession(final boolean create) {
+            if (session == null && create) {
+                session = new StubSession();
+            }
+            return session;
+        }
+
+        @Override
+        public HttpSession getSession() {
+            return getSession(true);
+        }
+
+        @Override
+        public Object getAttribute(final String name) {
+            return attrs.get(name);
+        }
+
+        @Override
+        public void setAttribute(final String name, final Object value) {
+            if (value == null) {
+                attrs.remove(name);
+            } else {
+                attrs.put(name, value);
+            }
+        }
+
+        @Override
+        public void removeAttribute(final String name) {
+            attrs.remove(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attrs.keySet());
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(final String name) {
+            final String v = headers.get(name);
+            return v == null ? Collections.emptyEnumeration() : Collections.enumeration(Collections.singletonList(v));
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            return Collections.enumeration(headers.keySet());
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(final String path) {
+            return null;
+        }
+
+        @Override
+        public String getParameter(final String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public String[] getParameterValues(final String name) {
+            return null;
+        }
+
+        @Override
+        public String getQueryString() {
+            return null;
+        }
+
+        // unsupported remainder
+
+        @Override
+        public String getAuthType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.servlet.http.Cookie[] getCookies() {
+            return null;
+        }
+
+        @Override
+        public long getDateHeader(final String name) {
+            return -1L;
+        }
+
+        @Override
+        public int getIntHeader(final String name) {
+            return -1;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isUserInRole(final String role) {
+            return false;
+        }
+
+        @Override
+        public java.security.Principal getUserPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return null;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return new StringBuffer("http://localhost:8080").append(uri);
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return false;
+        }
+
+        @Override
+        public boolean authenticate(final HttpServletResponse response) {
+            return false;
+        }
+
+        @Override
+        public void login(final String username, final String password) {
+        }
+
+        @Override
+        public void logout() {
+        }
+
+        @Override
+        public java.util.Collection<Part> getParts() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Part getPart(final String name) {
+            return null;
+        }
+
+        @Override
+        public <T extends HttpUpgradeHandler> T upgrade(final Class<T> handlerClass) {
+            return null;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public void setCharacterEncoding(final String env) {
+        }
+
+        @Override
+        public int getContentLength() {
+            return 0;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return 0L;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getProtocol() {
+            return "HTTP/1.1";
+        }
+
+        @Override
+        public java.io.BufferedReader getReader() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return "client";
+        }
+
+        @Override
+        public int getRemotePort() {
+            return 0;
+        }
+
+        @Override
+        public String getLocalName() {
+            return "localhost";
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public int getLocalPort() {
+            return 8080;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return null;
+        }
+
+        @Override
+        public AsyncContext startAsync() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public AsyncContext startAsync(final ServletRequest req, final ServletResponse res) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return false;
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return false;
+        }
+
+        @Override
+        public AsyncContext getAsyncContext() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public DispatcherType getDispatcherType() {
+            return DispatcherType.REQUEST;
+        }
+
+        @Override
+        public String getRequestId() {
+            return "req";
+        }
+
+        @Override
+        public String getProtocolRequestId() {
+            return "";
+        }
+
+        @Override
+        public jakarta.servlet.ServletConnection getServletConnection() {
+            return null;
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public Enumeration<java.util.Locale> getLocales() {
+            return Collections.enumeration(Collections.singletonList(java.util.Locale.ROOT));
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return null;
+        }
+    }
+
+    /** Minimal HttpSession stub holding a single CSRF token attribute. */
+    private static class StubSession implements HttpSession {
+        private final Map<String, Object> attrs = new HashMap<>();
+
+        @Override
+        public Object getAttribute(final String name) {
+            return attrs.get(name);
+        }
+
+        @Override
+        public void setAttribute(final String name, final Object value) {
+            attrs.put(name, value);
+        }
+
+        @Override
+        public void removeAttribute(final String name) {
+            attrs.remove(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attrs.keySet());
+        }
+
+        @Override
+        public long getCreationTime() {
+            return 0L;
+        }
+
+        @Override
+        public String getId() {
+            return "stub-session";
+        }
+
+        @Override
+        public long getLastAccessedTime() {
+            return 0L;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return null;
+        }
+
+        @Override
+        public void setMaxInactiveInterval(final int interval) {
+        }
+
+        @Override
+        public int getMaxInactiveInterval() {
+            return 0;
+        }
+
+        @Override
+        public void invalidate() {
+            attrs.clear();
+        }
+
+        @Override
+        public boolean isNew() {
+            return false;
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTestSupport.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTestSupport.java
@@ -25,10 +25,14 @@ import org.codelibs.fess.api.v2.handlers.FavoritePostHandler;
 import org.codelibs.fess.api.v2.handlers.LoginHandler;
 import org.codelibs.fess.api.v2.handlers.LogoutHandler;
 import org.codelibs.fess.api.v2.handlers.MeHandler;
+import org.codelibs.fess.api.v2.handlers.OriginValidator;
 import org.codelibs.fess.api.v2.handlers.PasswordChangeHandler;
 import org.codelibs.fess.api.v2.handlers.ScrollSearchHandler;
 import org.codelibs.fess.api.v2.handlers.SearchHandler;
+import org.codelibs.fess.api.v2.handlers.TargetOriginResolver;
 import org.codelibs.fess.api.v2.handlers.UiConfigHandler;
+import org.codelibs.fess.cors.CorsHandlerFactory;
+import org.codelibs.fess.util.ComponentUtil;
 
 /**
  * Test support factory for {@link SearchApiV2Manager}.
@@ -58,6 +62,13 @@ final class SearchApiV2ManagerTestSupport {
      * @return a fully initialised {@code SearchApiV2Manager} ready for unit testing
      */
     static SearchApiV2Manager newManagerWithHandlers() {
+        // The v2 CSRF Origin layer (SearchApiV2Manager.process) resolves the CORS
+        // allow list via ComponentUtil.getCorsHandlerFactory() for unsafe methods.
+        // The unit container does not auto-register it, so mirror the DI wiring with
+        // an empty factory (no EXACT/wildcard entries) unless a test registered its own.
+        if (!ComponentUtil.hasComponent("corsHandlerFactory")) {
+            ComponentUtil.register(new CorsHandlerFactory(), "corsHandlerFactory");
+        }
         final SearchApiV2Manager m = new SearchApiV2Manager();
         m.searchHandler = new SearchHandler();
         m.scrollSearchHandler = new ScrollSearchHandler();
@@ -73,6 +84,30 @@ final class SearchApiV2ManagerTestSupport {
         m.chatSessionClearHandler = new ChatSessionClearHandler();
         m.cacheHandler = new CacheHandler();
         m.loginHandler = new LoginHandler();
+        // The Origin layer (SearchApiV2Manager.process) calls originValidator.isAllowed(...)
+        // for unsafe methods. Mirror the DI wiring: a real OriginValidator whose
+        // targetOriginResolver reconstructs the same-origin set from the servlet request
+        // (server.origins empty + untrusted peer in the unit harness).
+        m.originValidator = newOriginValidator();
         return m;
+    }
+
+    /**
+     * Builds an {@link OriginValidator} with a {@link TargetOriginResolver} injected,
+     * mirroring the Lasta DI {@code @Resource} wiring for unit tests that construct the
+     * validator outside the container.
+     *
+     * @return a fully wired {@code OriginValidator}
+     */
+    static OriginValidator newOriginValidator() {
+        final OriginValidator validator = new OriginValidator();
+        try {
+            final java.lang.reflect.Field field = OriginValidator.class.getDeclaredField("targetOriginResolver");
+            field.setAccessible(true);
+            field.set(validator, new TargetOriginResolver());
+        } catch (final ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to wire TargetOriginResolver into OriginValidator", e);
+        }
+        return validator;
     }
 }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/CsrfRequirementTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/CsrfRequirementTest.java
@@ -86,4 +86,35 @@ public class CsrfRequirementTest {
         assertTrue(CsrfRequirement.requiresCsrf("/unknown/endpoint", "PUT"));
         assertTrue(CsrfRequirement.requiresCsrf("/another/new/path", "DELETE"));
     }
+
+    // isUnsafeMethod: safe (GET/HEAD/OPTIONS) vs unsafe (state-changing) methods
+
+    @Test
+    public void test_isUnsafeMethod_safeMethodsAreFalse() {
+        assertFalse(CsrfRequirement.isUnsafeMethod("GET"));
+        assertFalse(CsrfRequirement.isUnsafeMethod("HEAD"));
+        assertFalse(CsrfRequirement.isUnsafeMethod("OPTIONS"));
+    }
+
+    @Test
+    public void test_isUnsafeMethod_stateChangingMethodsAreTrue() {
+        assertTrue(CsrfRequirement.isUnsafeMethod("POST"));
+        assertTrue(CsrfRequirement.isUnsafeMethod("PUT"));
+        assertTrue(CsrfRequirement.isUnsafeMethod("DELETE"));
+        assertTrue(CsrfRequirement.isUnsafeMethod("PATCH"));
+    }
+
+    @Test
+    public void test_isUnsafeMethod_isCaseInsensitive() {
+        assertFalse(CsrfRequirement.isUnsafeMethod("get"));
+        assertFalse(CsrfRequirement.isUnsafeMethod("Head"));
+        assertFalse(CsrfRequirement.isUnsafeMethod("options"));
+        assertTrue(CsrfRequirement.isUnsafeMethod("post"));
+        assertTrue(CsrfRequirement.isUnsafeMethod("Delete"));
+    }
+
+    @Test
+    public void test_isUnsafeMethod_nullIsFalse() {
+        assertFalse(CsrfRequirement.isUnsafeMethod(null));
+    }
 }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/OriginValidatorTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/OriginValidatorTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.codelibs.fess.cors.CorsHandler;
+import org.codelibs.fess.cors.CorsHandlerFactory;
+import org.codelibs.fess.cors.CorsMatchType;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequestImpl;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Unit tests for the {@link OriginValidator} component. A stub
+ * {@link TargetOriginResolver} is injected so the trusted self-origin set is
+ * controlled directly, and a real {@link CorsHandlerFactory} (populated with an
+ * EXACT origin and a {@code "*"} wildcard) is registered via {@link ComponentUtil}
+ * to pin EXACT-vs-WILDCARD trust. Extends {@link UnitFessTestCase} so UTFlute mock
+ * requests are available for exercising {@code Origin}/{@code Referer} headers.
+ */
+public class OriginValidatorTest extends UnitFessTestCase {
+
+    private static final String SELF = "https://fess.example.com";
+
+    /** Allow-listed (EXACT) cross-origin SPA. */
+    private static final String ALLOWED_ORIGIN = "https://spa.example.com";
+
+    /**
+     * Builds an {@link OriginValidator} whose {@link TargetOriginResolver} always
+     * returns the single {@link #SELF} origin, and registers a CORS allow list with
+     * one EXACT origin plus a {@code "*"} wildcard fallback.
+     */
+    private OriginValidator validator() {
+        final CorsHandlerFactory factory = new CorsHandlerFactory();
+        // EXACT allow-listed origin and a wildcard fallback. The wildcard must NOT be
+        // treated as trusted for CSRF.
+        factory.add(ALLOWED_ORIGIN, new NopCorsHandler());
+        factory.add("*", new NopCorsHandler());
+        ComponentUtil.register(factory, "corsHandlerFactory");
+
+        final OriginValidator validator = new OriginValidator();
+        validator.targetOriginResolver = new TargetOriginResolver() {
+            @Override
+            public Set<String> resolve(final HttpServletRequest request) {
+                return Collections.singleton(SELF);
+            }
+        };
+        return validator;
+    }
+
+    private MockletHttpServletRequest newRequest() {
+        final ServletContext ctx = getMockRequest().getServletContext();
+        return new MockletHttpServletRequestImpl(ctx, "/api/v2/click");
+    }
+
+    private boolean allowed(final MockletHttpServletRequest request) {
+        return validator().isAllowed(request);
+    }
+
+    // same-origin
+
+    @Test
+    public void test_sameOriginAllowed() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", SELF);
+        assertTrue(allowed(req));
+    }
+
+    @Test
+    public void test_sameOriginWithDefaultPortNormalizedAllowed() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "https://fess.example.com:443");
+        assertTrue(allowed(req));
+    }
+
+    // cross-site Origin
+
+    @Test
+    public void test_crossSiteOriginRejected() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "https://evil.example.com");
+        assertFalse(allowed(req));
+    }
+
+    // Origin priority over Referer
+
+    @Test
+    public void test_crossSiteOriginWithSameOriginRefererStillRejected() {
+        // Origin is present and cross-site; a same-origin Referer must NOT rescue it.
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "https://evil.example.com");
+        req.addHeader("Referer", SELF + "/search");
+        assertFalse(allowed(req));
+    }
+
+    // Referer fallback
+
+    @Test
+    public void test_originAbsentSameOriginRefererAllowed() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Referer", SELF + "/search?q=x");
+        assertTrue(allowed(req));
+    }
+
+    @Test
+    public void test_originAbsentCrossSiteRefererRejected() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Referer", "https://evil.example.com/page");
+        assertFalse(allowed(req));
+    }
+
+    // CORS allow list
+
+    @Test
+    public void test_corsExactAllowed() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", ALLOWED_ORIGIN);
+        assertTrue(allowed(req));
+    }
+
+    @Test
+    public void test_wildcardNotTrusted() {
+        // An origin that only matches via the "*" wildcard must be rejected for CSRF.
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "https://random-unlisted.example.org");
+        assertFalse(allowed(req));
+    }
+
+    // missing source
+
+    @Test
+    public void test_bothMissingAllowed() {
+        // No Origin and no Referer → non-browser API client → allow.
+        final MockletHttpServletRequest req = newRequest();
+        assertTrue(allowed(req));
+    }
+
+    // malformed Origin values
+
+    @Test
+    public void test_originLiteralNullRejected() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "null");
+        assertFalse(allowed(req));
+    }
+
+    @Test
+    public void test_originEmptyFallsBackToRefererAndAllowsWhenSameOrigin() {
+        // An empty Origin is blank → fall back to Referer (same-origin) → allow.
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "");
+        req.addHeader("Referer", SELF + "/x");
+        assertTrue(allowed(req));
+    }
+
+    @Test
+    public void test_originEmptyAndNoRefererAllowed() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "");
+        assertTrue(allowed(req));
+    }
+
+    @Test
+    public void test_originMultiValueRejected() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "https://a.example.com https://b.example.com");
+        assertFalse(allowed(req));
+    }
+
+    @Test
+    public void test_originControlCharRejected() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "https://evil.example.com\r\nX: y");
+        assertFalse(allowed(req));
+    }
+
+    @Test
+    public void test_originUnparseableRejected() {
+        final MockletHttpServletRequest req = newRequest();
+        req.addHeader("Origin", "httpsexample");
+        assertFalse(allowed(req));
+    }
+
+    /** No-op CORS handler used only to populate the allow-list registry. */
+    private static final class NopCorsHandler extends CorsHandler {
+        @Override
+        public void process(final String origin, final CorsMatchType matchType, final ServletRequest request,
+                final ServletResponse response) {
+            // no-op
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/TargetOriginResolverTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/TargetOriginResolverTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.util.Set;
+
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequestImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.ServletContext;
+
+/**
+ * Unit tests for the {@link TargetOriginResolver} component. The trust boundary
+ * for forwarded headers is the security-critical behavior pinned here.
+ *
+ * <p>{@link FessConfig.SimpleImpl} is sub-classed inline to control
+ * {@code theme.api.csrf.server.origins} and {@code rate.limit.trusted.proxies}
+ * without booting the container; the chosen config is installed via
+ * {@link ComponentUtil#setFessConfig} so the component picks it up through
+ * {@code ComponentUtil.getFessConfig()}.</p>
+ */
+public class TargetOriginResolverTest extends UnitFessTestCase {
+
+    private static final String TRUSTED_PROXY = "10.0.0.5";
+
+    private static final String UNTRUSTED_PEER = "203.0.113.9";
+
+    private final TargetOriginResolver resolver = new TargetOriginResolver();
+
+    /** Installs a {@link FessConfig} whose CSRF/trusted-proxy raw values are fixed for the test. */
+    private void useConfig(final String serverOrigins, final String trustedProxies) {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getThemeApiCsrfServerOrigins() {
+                return serverOrigins;
+            }
+
+            @Override
+            public String getRateLimitTrustedProxies() {
+                return trustedProxies;
+            }
+        });
+    }
+
+    @AfterEach
+    public void resetFessConfig() {
+        ComponentUtil.setFessConfig(null);
+    }
+
+    private MockletHttpServletRequest newRequest(final String remoteAddr) {
+        final ServletContext ctx = getMockRequest().getServletContext();
+        final MockletHttpServletRequestImpl req = new MockletHttpServletRequestImpl(ctx, "/api/v2/click");
+        req.setRemoteAddr(remoteAddr);
+        return req;
+    }
+
+    // (1) explicit server.origins wins over forwarded headers
+
+    @Test
+    public void test_serverOriginsConfigured_ignoresForwardedHeaders() {
+        useConfig("https://fess.example.com", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(TRUSTED_PROXY);
+        // These spoofed/legitimate forwarded headers must be ignored when server.origins is set.
+        req.addHeader("X-Forwarded-Proto", "https");
+        req.addHeader("X-Forwarded-Host", "evil.example.com");
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://fess.example.com"), origins.toString());
+        assertFalse(origins.contains("https://evil.example.com"), origins.toString());
+        assertEquals(1, origins.size());
+    }
+
+    @Test
+    public void test_serverOriginsMultiValueCanonicalized() {
+        useConfig("https://a.example.com:443, http://b.example.com:80", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(TRUSTED_PROXY);
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://a.example.com"), origins.toString());
+        assertTrue(origins.contains("http://b.example.com"), origins.toString());
+        assertEquals(2, origins.size());
+    }
+
+    // (2) trusted-proxy forwarded reconstruction
+
+    @Test
+    public void test_trustedProxy_reconstructsFromForwardedHeaders() {
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(TRUSTED_PROXY);
+        req.addHeader("X-Forwarded-Proto", "https");
+        req.addHeader("X-Forwarded-Host", "public.example.com");
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://public.example.com"), origins.toString());
+        assertEquals(1, origins.size());
+    }
+
+    @Test
+    public void test_trustedProxy_forwardedPortAppliedAndDefaultNormalized() {
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(TRUSTED_PROXY);
+        req.addHeader("X-Forwarded-Proto", "https");
+        req.addHeader("X-Forwarded-Host", "public.example.com");
+        req.addHeader("X-Forwarded-Port", "443");
+
+        // Default https port must be normalized away by canonicalization.
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://public.example.com"), origins.toString());
+    }
+
+    @Test
+    public void test_trustedProxy_forwardedNonDefaultPortKept() {
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(TRUSTED_PROXY);
+        req.addHeader("X-Forwarded-Proto", "https");
+        req.addHeader("X-Forwarded-Host", "public.example.com");
+        req.addHeader("X-Forwarded-Port", "8443");
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://public.example.com:8443"), origins.toString());
+    }
+
+    @Test
+    public void test_trustedProxy_forwardedHostCommaListUsesFirst() {
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(TRUSTED_PROXY);
+        req.addHeader("X-Forwarded-Proto", "https");
+        req.addHeader("X-Forwarded-Host", "public.example.com, internal.example.com");
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://public.example.com"), origins.toString());
+        assertFalse(origins.contains("https://internal.example.com"), origins.toString());
+    }
+
+    @Test
+    public void test_trustedProxy_bracketedIPv6HostWithoutPort_appliesForwardedPort() {
+        // A bracketed IPv6 literal has inner colons but no port; X-Forwarded-Port must
+        // still be appended (regression for the IPv6 port-detection bug).
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(TRUSTED_PROXY);
+        req.addHeader("X-Forwarded-Proto", "https");
+        req.addHeader("X-Forwarded-Host", "[::1]");
+        req.addHeader("X-Forwarded-Port", "8443");
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://[::1]:8443"), origins.toString());
+    }
+
+    @Test
+    public void test_trustedProxy_bracketedIPv6HostWithPort_doesNotDoubleAppend() {
+        // Already-ported bracketed IPv6 literal: the existing port wins and a differing
+        // X-Forwarded-Port must not be appended a second time.
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(TRUSTED_PROXY);
+        req.addHeader("X-Forwarded-Proto", "https");
+        req.addHeader("X-Forwarded-Host", "[::1]:8443");
+        req.addHeader("X-Forwarded-Port", "9999");
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://[::1]:8443"), origins.toString());
+        assertFalse(origins.contains("https://[::1]:9999"), origins.toString());
+    }
+
+    // (2 negative) untrusted peer cannot spoof via forwarded headers
+
+    @Test
+    public void test_untrustedPeer_forwardedHeadersIgnored_fallsBackToServlet() {
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(UNTRUSTED_PEER);
+        // Spoofed forwarded headers from an untrusted source must be ignored.
+        req.addHeader("X-Forwarded-Proto", "https");
+        req.addHeader("X-Forwarded-Host", "evil.example.com");
+        req.setScheme("http");
+        req.setServerName("realhost.internal");
+        req.setServerPort(8080);
+
+        final Set<String> origins = resolver.resolve(req);
+        assertFalse(origins.contains("https://evil.example.com"), origins.toString());
+        assertTrue(origins.contains("http://realhost.internal:8080"), origins.toString());
+    }
+
+    // (3) servlet reconstruction with port normalization
+
+    @Test
+    public void test_noForwarded_reconstructsFromServletWithDefaultPortNormalized() {
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(UNTRUSTED_PEER);
+        req.setScheme("https");
+        req.setServerName("fess.example.com");
+        req.setServerPort(443);
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("https://fess.example.com"), origins.toString());
+        assertEquals(1, origins.size());
+    }
+
+    @Test
+    public void test_noForwarded_reconstructsFromServletWithNonDefaultPort() {
+        useConfig("", TRUSTED_PROXY);
+        final MockletHttpServletRequest req = newRequest(UNTRUSTED_PEER);
+        req.setScheme("http");
+        req.setServerName("localhost");
+        req.setServerPort(8080);
+
+        final Set<String> origins = resolver.resolve(req);
+        assertTrue(origins.contains("http://localhost:8080"), origins.toString());
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/UiConfigHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/UiConfigHandlerTest.java
@@ -99,10 +99,9 @@ public class UiConfigHandlerTest extends UnitFessTestCase {
     }
 
     /**
-     * m-14: when {@code theme.api.csrf.required=true} (default), the response must
-     * include both {@code csrf_required:true} and a non-empty {@code csrf_token}.
-     * When false, {@code csrf_required:false} must be present and {@code csrf_token}
-     * must be empty string.
+     * The token is always required now: the response must include
+     * {@code csrf_required:true} and a non-empty {@code csrf_token} bound to the
+     * session.
      *
      * <p>The unit harness returns the FessConfig default value. We register a VirtualHostHelper
      * and ThemeRegistry stub so the handler reaches the payload-assembly section.</p>
@@ -123,11 +122,10 @@ public class UiConfigHandlerTest extends UnitFessTestCase {
         assertTrue(res.status == 200 || res.status == 500, "unexpected status: " + res.status + " body=" + res.body());
         if (res.status == 200) {
             final String body = res.body();
-            // csrf_required field must always be present (m-14).
-            assertTrue(body.contains("\"csrf_required\""), "csrf_required field missing in: " + body);
-            // The value is a boolean — check for true or false.
-            assertTrue(body.contains("\"csrf_required\":true") || body.contains("\"csrf_required\":false"),
-                    "csrf_required must be a boolean in: " + body);
+            // csrf_required is always true now.
+            assertTrue(body.contains("\"csrf_required\":true"), "csrf_required must be true in: " + body);
+            // A fresh session-bound token is always issued, so csrf_token must be non-empty.
+            assertFalse(body.contains("\"csrf_token\":\"\""), "csrf_token must not be empty in: " + body);
         }
     }
 

--- a/src/test/java/org/codelibs/fess/util/OriginUtilTest.java
+++ b/src/test/java/org/codelibs/fess/util/OriginUtilTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link OriginUtil#canonicalize}: origin normalization and
+ * rejection of malformed/unusable inputs. Pure function; no container required.
+ */
+public class OriginUtilTest {
+
+    // normalization
+
+    @Test
+    public void test_simpleOriginIsPreserved() {
+        assertEquals("https://example.com", OriginUtil.canonicalize("https://example.com"));
+    }
+
+    @Test
+    public void test_hostIsLowerCased() {
+        assertEquals("https://app.example.com", OriginUtil.canonicalize("https://App.Example.COM"));
+    }
+
+    @Test
+    public void test_schemeIsLowerCased() {
+        assertEquals("https://example.com", OriginUtil.canonicalize("HTTPS://example.com"));
+    }
+
+    @Test
+    public void test_defaultHttpsPortIsStripped() {
+        assertEquals("https://example.com", OriginUtil.canonicalize("https://example.com:443"));
+    }
+
+    @Test
+    public void test_defaultHttpPortIsStripped() {
+        assertEquals("http://example.com", OriginUtil.canonicalize("http://example.com:80"));
+    }
+
+    @Test
+    public void test_nonDefaultPortIsKept() {
+        assertEquals("https://example.com:8443", OriginUtil.canonicalize("https://example.com:8443"));
+        assertEquals("http://example.com:8080", OriginUtil.canonicalize("http://example.com:8080"));
+    }
+
+    @Test
+    public void test_pathQueryFragmentAreStripped() {
+        assertEquals("https://example.com", OriginUtil.canonicalize("https://example.com/path/to?x=1&y=2#frag"));
+    }
+
+    @Test
+    public void test_fullUrlWithEverythingNormalized() {
+        // lower-cased host, default port stripped, path/query discarded
+        assertEquals("https://app.example.com", OriginUtil.canonicalize("https://App.Example.com:443/path?x"));
+    }
+
+    @Test
+    public void test_leadingTrailingWhitespaceIsTrimmedButInnerRejected() {
+        assertEquals("https://example.com", OriginUtil.canonicalize("  https://example.com  "));
+    }
+
+    // invalid inputs -> null
+
+    @Test
+    public void test_nullInput() {
+        assertNull(OriginUtil.canonicalize(null));
+    }
+
+    @Test
+    public void test_emptyInput() {
+        assertNull(OriginUtil.canonicalize(""));
+    }
+
+    @Test
+    public void test_blankInput() {
+        assertNull(OriginUtil.canonicalize("   "));
+    }
+
+    @Test
+    public void test_literalNullStringInput() {
+        assertNull(OriginUtil.canonicalize("null"));
+        assertNull(OriginUtil.canonicalize("NULL"));
+    }
+
+    @Test
+    public void test_multipleSpaceSeparatedValues() {
+        assertNull(OriginUtil.canonicalize("https://a.example.com https://b.example.com"));
+    }
+
+    @Test
+    public void test_carriageReturnRejected() {
+        assertNull(OriginUtil.canonicalize("https://example.com\r"));
+    }
+
+    @Test
+    public void test_lineFeedRejected() {
+        assertNull(OriginUtil.canonicalize("https://example.com\n"));
+    }
+
+    @Test
+    public void test_crlfInjectionRejected() {
+        assertNull(OriginUtil.canonicalize("https://example.com\r\nSet-Cookie: x=1"));
+    }
+
+    @Test
+    public void test_tabRejected() {
+        assertNull(OriginUtil.canonicalize("https://example.com\t"));
+    }
+
+    @Test
+    public void test_innerControlCharRejected() {
+        assertNull(OriginUtil.canonicalize("https://exa\u0000mple.com"));
+    }
+
+    @Test
+    public void test_missingSchemeRejected() {
+        assertNull(OriginUtil.canonicalize("example.com"));
+        assertNull(OriginUtil.canonicalize("//example.com"));
+    }
+
+    @Test
+    public void test_missingHostRejected() {
+        // A scheme with no authority component yields no host.
+        assertNull(OriginUtil.canonicalize("https:///path"));
+        assertNull(OriginUtil.canonicalize("mailto:user@example.com"));
+    }
+
+    @Test
+    public void test_unparseableRejected() {
+        assertNull(OriginUtil.canonicalize("httpsexample"));
+        assertNull(OriginUtil.canonicalize("http://[invalid"));
+    }
+}


### PR DESCRIPTION
## Summary

v2 CSRF protection was controlled by a single config key `theme.api.csrf.required`.
Setting it to `false` disabled both token issuance (`/ui/config`) and verification at
once, leaving every state-changing endpoint with no CSRF protection (fail-open).

This removes the flag entirely and applies two independent CSRF layers
**unconditionally** to unsafe methods — there is no longer a single switch that turns
CSRF protection off.

## Changes

- **Origin layer (always on)** — the request `Origin` (with `Referer` fallback) is
  canonicalized and accepted only if same-origin or an **EXACT** CORS allow-list match.
  `*` is never trusted. Missing `Origin`/`Referer` is allowed (non-browser API clients).
  `/auth/login` is covered (login CSRF).
- **Token layer (always on)** — the existing session-bound `X-Fess-CSRF-Token` check
  for state-changing paths (login exempt), now unconditional.
- **DI components** — the Origin check is implemented as Lasta DI components
  (`OriginValidator`, `TargetOriginResolver`, registered in `fess_api.xml`) so policy
  and self-origin resolution are replaceable per deployment; canonicalization is a pure
  util at `org.codelibs.fess.util.OriginUtil`.
- **Trusted self-origin** — resolved from the optional `theme.api.csrf.server.origins`,
  or from `X-Forwarded-Proto/Host/Port` only when the peer is a trusted proxy
  (`rate.limit.trusted.proxies`), otherwise from the servlet request.
- **`/ui/config`** always issues a token and returns `csrf_required=true` (field
  retained for SPA compatibility). OpenAPI updated. The `theme.api.csrf.required` config
  key and its `FessConfig` getters are removed.

## Breaking change

`theme.api.csrf.required` is removed; token verification can no longer be disabled.
Deployments that ran with `theme.api.csrf.required=false` must send the
`X-Fess-CSRF-Token` (already returned by `POST /auth/login`) on state-changing v2
requests. The bootstrap SPA already does this.

## Tests

Origin canonicalization (malformed/`null`/control-char/IPv6 inputs), origin decisions
(same-origin, cross-site, Referer fallback, wildcard-not-trusted, missing→allow),
forwarded-header trust (trusted-proxy reconstruction + untrusted-spoof rejection), and
the `SearchApiV2Manager` gate. v2 regression: 445 tests, 0 failures.
