### PR TITLE
Refactor v2 API helpers into DI components

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -16,47 +16,31 @@
 package org.codelibs.fess.api.v2;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.Constants;
 import org.codelibs.fess.api.BaseApiManager;
 import org.codelibs.fess.api.v2.handlers.CacheHandler;
 import org.codelibs.fess.api.v2.handlers.ChatHandler;
 import org.codelibs.fess.api.v2.handlers.ChatSessionClearHandler;
 import org.codelibs.fess.api.v2.handlers.ChatStreamHandler;
 import org.codelibs.fess.api.v2.handlers.ClickHandler;
-import org.codelibs.fess.api.v2.handlers.CsrfRequirement;
 import org.codelibs.fess.api.v2.handlers.FavoriteGetHandler;
 import org.codelibs.fess.api.v2.handlers.FavoritePostHandler;
 import org.codelibs.fess.api.v2.handlers.FavoritesListHandler;
+import org.codelibs.fess.api.v2.handlers.HealthHandler;
+import org.codelibs.fess.api.v2.handlers.LabelsHandler;
 import org.codelibs.fess.api.v2.handlers.LoginHandler;
 import org.codelibs.fess.api.v2.handlers.LogoutHandler;
 import org.codelibs.fess.api.v2.handlers.MeHandler;
 import org.codelibs.fess.api.v2.handlers.PasswordChangeHandler;
+import org.codelibs.fess.api.v2.handlers.PopularWordsHandler;
 import org.codelibs.fess.api.v2.handlers.RelatedContentHandler;
 import org.codelibs.fess.api.v2.handlers.RelatedQueriesHandler;
 import org.codelibs.fess.api.v2.handlers.ScrollSearchHandler;
 import org.codelibs.fess.api.v2.handlers.SearchHandler;
+import org.codelibs.fess.api.v2.handlers.SuggestWordsHandler;
 import org.codelibs.fess.api.v2.handlers.UiConfigHandler;
-import org.codelibs.fess.entity.PingResponse;
-import org.codelibs.fess.entity.SearchRequestParams;
-import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
-import org.codelibs.fess.helper.LabelTypeHelper;
-import org.codelibs.fess.helper.PopularWordHelper;
-import org.codelibs.fess.helper.SuggestHelper;
-import org.codelibs.fess.helper.VirtualHostHelper;
-import org.codelibs.fess.suggest.entity.SuggestItem;
-import org.codelibs.fess.suggest.request.suggest.SuggestRequestBuilder;
-import org.codelibs.fess.suggest.request.suggest.SuggestResponse;
 import org.codelibs.fess.util.ComponentUtil;
 
 import jakarta.annotation.PostConstruct;
@@ -70,13 +54,12 @@ import jakarta.servlet.http.HttpSession;
 /**
  * Web API manager for the {@code /api/v2} surface.
  *
- * <p>This skeleton registers itself under the {@code /api/v2} path prefix and
- * dispatches by sub-path to specific handlers. The {@code /health} endpoint is
- * wired up here; later batches add search, suggest, auth, and theme endpoints.</p>
+ * <p>This manager registers itself under the {@code /api/v2} path prefix and
+ * dispatches by sub-path to DI-managed handlers.</p>
  *
  * <p>All responses use {@link V2EnvelopeWriter} so the wire shape stays uniform:
- * a top-level {@code {"response": {...}}} envelope with {@code status} and
- * {@code version} fields plus either a payload or an {@code error} object.</p>
+ * a top-level {@code {"response": {...}}} envelope with {@code status} plus
+ * either a payload or an {@code error} object.</p>
  */
 public class SearchApiV2Manager extends BaseApiManager {
 
@@ -144,6 +127,22 @@ public class SearchApiV2Manager extends BaseApiManager {
     @Resource
     protected CacheHandler cacheHandler;
 
+    /** Handles {@code GET /api/v2/health}. */
+    @Resource
+    protected HealthHandler healthHandler;
+
+    /** Handles {@code GET /api/v2/suggest-words}. */
+    @Resource
+    protected SuggestWordsHandler suggestWordsHandler;
+
+    /** Handles {@code GET /api/v2/labels}. */
+    @Resource
+    protected LabelsHandler labelsHandler;
+
+    /** Handles {@code GET /api/v2/popular-words}. */
+    @Resource
+    protected PopularWordsHandler popularWordsHandler;
+
     /** Handles {@code POST /api/v2/auth/login}. */
     @Resource
     protected LoginHandler loginHandler;
@@ -193,7 +192,7 @@ public class SearchApiV2Manager extends BaseApiManager {
         // an explicit Cache-Control a 200 GET response is eligible for HTTP heuristic
         // caching. Set BEFORE writeHeaders so an operator-configured Cache-Control in
         // `api.json.response.headers` deliberately overrides this default; the error path
-        // (V2EnvelopeWriter.writeErrorWithDetails) re-asserts `no-store` independently.
+        // (ComponentUtil.getV2EnvelopeWriter().writeErrorWithDetails) re-asserts `no-store` independently.
         response.setHeader("Cache-Control", "no-store");
         // Apply the configured `api.json.response.headers` (e.g. Referrer-Policy) at the very
         // top of dispatch so EVERY v2 response carries the security-baseline headers —
@@ -204,12 +203,13 @@ public class SearchApiV2Manager extends BaseApiManager {
         // servlet spec; headers set here are preserved.
         writeHeaders(response);
         final String sub = subPath(request);
-        if (ComponentUtil.getFessConfig().isThemeApiCsrfRequired() && CsrfRequirement.requiresCsrf(sub, request.getMethod())) {
+        if (ComponentUtil.getFessConfig().isThemeApiCsrfRequired()
+                && ComponentUtil.getV2CsrfRequirement().requiresCsrf(sub, request.getMethod())) {
             final HttpSession session = request.getSession(false);
             final String header = request.getHeader("X-Fess-CSRF-Token");
             final SessionCsrfTokenManager csrf = ComponentUtil.getSessionCsrfTokenManager();
             if (session == null || !csrf.verify(session, header)) {
-                V2EnvelopeWriter.writeError(response, V2ErrorCode.FORBIDDEN, "invalid csrf token");
+                ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.FORBIDDEN, "invalid csrf token");
                 return;
             }
         }
@@ -246,16 +246,16 @@ public class SearchApiV2Manager extends BaseApiManager {
             // than the generic "endpoint not found" emitted by the switch default arm. This
             // closes the dispatch hole where /documents/abc/foo silently fell through.
             if (sub.startsWith("/documents/")) {
-                V2EnvelopeWriter.writeError(response, V2ErrorCode.NOT_FOUND, "unknown action on document: " + sub);
+                ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.NOT_FOUND, "unknown action on document: " + sub);
                 return;
             }
             switch (sub) {
-            case "/health" -> handleHealth(request, response);
+            case "/health" -> healthHandler.handle(request, response);
             case "/search" -> searchHandler.handle(request, response);
             case "/favorites" -> favoritesListHandler.handle(request, response);
-            case "/suggest-words" -> handleSuggestWords(request, response);
-            case "/labels" -> handleLabels(request, response);
-            case "/popular-words" -> handlePopularWords(request, response);
+            case "/suggest-words" -> suggestWordsHandler.handle(request, response);
+            case "/labels" -> labelsHandler.handle(request, response);
+            case "/popular-words" -> popularWordsHandler.handle(request, response);
             case "/auth/me" -> meHandler.handle(request, response);
             case "/auth/login" -> loginHandler.handle(request, response);
             case "/auth/logout" -> logoutHandler.handle(request, response);
@@ -266,7 +266,7 @@ public class SearchApiV2Manager extends BaseApiManager {
             case "/chat/stream" -> chatStreamHandler.handle(request, response);
             case "/related-queries" -> relatedQueriesHandler.handle(request, response);
             case "/related-content" -> relatedContentHandler.handle(request, response);
-            default -> V2EnvelopeWriter.writeError(response, V2ErrorCode.NOT_FOUND, "endpoint not found: " + sub);
+            default -> ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.NOT_FOUND, "endpoint not found: " + sub);
             }
         } catch (final IOException e) {
             // Streaming handlers can disconnect mid-write (broken pipe, client abort). Once
@@ -283,7 +283,7 @@ public class SearchApiV2Manager extends BaseApiManager {
                 throw e;
             }
             logger.warn("/api/v2 handler failed for {}", sub, e);
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INTERNAL_ERROR, "internal error");
         } catch (final Exception e) {
             if (response.isCommitted()) {
                 // SSE / NDJSON handlers have already started flushing; the v2 envelope can no
@@ -296,7 +296,7 @@ public class SearchApiV2Manager extends BaseApiManager {
             // Do not leak e.getMessage() to the wire — message content from upstream
             // libraries can include connection strings, stack-trace fragments, or other
             // information the SPA must not see.
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INTERNAL_ERROR, "internal error");
         }
     }
 
@@ -320,238 +320,6 @@ public class SearchApiV2Manager extends BaseApiManager {
             sub = sub.substring(0, sub.length() - 1);
         }
         return sub;
-    }
-
-    /**
-     * Returns a structured snapshot of the search engine's cluster health.
-     *
-     * <p>Mirrors the v1 ping endpoint, but emits the v2 envelope shape and exposes
-     * just the high-level fields most useful to monitoring tooling. If the engine
-     * is unreachable we still emit a structured error envelope rather than letting
-     * the exception escape.</p>
-     *
-     * @param request the incoming HTTP request
-     * @param response the HTTP response to write to
-     * @throws IOException if writing the envelope fails
-     */
-    private void handleHealth(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        if (!"GET".equalsIgnoreCase(request.getMethod())) {
-            response.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
-            return;
-        }
-        try {
-            final PingResponse ping = ComponentUtil.getSearchEngineClient().ping();
-            final String clusterStatus = ping.getClusterStatus();
-            final Map<String, Object> engine = new LinkedHashMap<>();
-            engine.put("cluster_name", ping.getClusterName());
-            engine.put("status", clusterStatus);
-            engine.put("ping_status", ping.getStatus());
-            // Envelope invariant: envelope.status>=1 iff HTTP>=400. A red cluster maps to
-            // HTTP 503, so it must emit a SERVICE_UNAVAILABLE error envelope (not the
-            // success envelope used for green/yellow). The engine details are surfaced
-            // through Map.of("engine", engine) in writeErrorWithDetails so monitoring
-            // tooling can still parse them out of error.details.
-            if ("red".equalsIgnoreCase(clusterStatus)) {
-                V2EnvelopeWriter.writeErrorWithDetails(response, V2ErrorCode.SERVICE_UNAVAILABLE, "search engine cluster is red",
-                        Map.of("engine", engine));
-            } else {
-                // yellow or green — both return 200; the engine.status field carries the detail.
-                V2EnvelopeWriter.writeSuccess(response, Map.of("engine", engine));
-            }
-        } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(response, e, logger, "/api/v2/health");
-        }
-    }
-
-    /**
-     * Handles the {@code /api/v2/suggest-words} endpoint.
-     *
-     * <p>Reads {@code q} (query), {@code num} (size), {@code fn} (suggest fields)
-     * and {@code lang} (language) query parameters, delegates to
-     * {@link SuggestHelper#suggester()} to obtain a
-     * {@link SuggestRequestBuilder}, then maps each
-     * {@link SuggestItem} into a snake_case payload. The wire shape is:</p>
-     *
-     * <pre>{@code
-     * { "q": "...", "page_size": <int>, "record_count": <int>,
-     *   "query_time": <long>, "suggest_words": [{"text":"...","types":[...]}] }
-     * }</pre>
-     *
-     * <p>Non-GET requests are rejected with {@link V2ErrorCode#INVALID_REQUEST}.
-     * Other failures emit {@link V2ErrorCode#INTERNAL_ERROR} so callers always
-     * see a structured envelope.</p>
-     *
-     * @param request the incoming HTTP request
-     * @param response the HTTP response to write to
-     * @throws IOException if writing the envelope fails
-     */
-    private void handleSuggestWords(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        if (!"GET".equalsIgnoreCase(request.getMethod())) {
-            response.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
-            return;
-        }
-        try {
-            final String q = request.getParameter("q");
-            final String numStr = request.getParameter("num");
-            final int num;
-            if (StringUtil.isNotBlank(numStr) && StringUtils.isNumeric(numStr)) {
-                num = Integer.parseInt(numStr);
-            } else {
-                num = 10;
-            }
-            final String[] fields = SearchRequestParams.getParamValueArray(request, "fn");
-            final String[] langs = SearchRequestParams.getParamValueArray(request, "lang");
-            final String[] tags = SearchRequestParams.getParamValueArray(request, "label");
-
-            final SuggestHelper suggestHelper = ComponentUtil.getSuggestHelper();
-            final SuggestRequestBuilder builder = suggestHelper.suggester().suggest();
-            if (q != null) {
-                builder.setQuery(q);
-            }
-            for (final String field : fields) {
-                builder.addField(field);
-            }
-            ComponentUtil.getRoleQueryHelper().build(SearchRequestType.SUGGEST).forEach(builder::addRole);
-            builder.setSize(num);
-            for (final String lang : langs) {
-                builder.addLang(lang);
-            }
-            for (final String tag : tags) {
-                builder.addTag(tag);
-            }
-            final VirtualHostHelper virtualHostHelper = ComponentUtil.getVirtualHostHelper();
-            final String virtualHostKey = virtualHostHelper.getVirtualHostKey();
-            if (StringUtil.isNotBlank(virtualHostKey)) {
-                builder.addTag(virtualHostKey);
-            }
-            builder.addKind(SuggestItem.Kind.USER.toString());
-            if (ComponentUtil.getFessConfig().isSuggestSearchLog()) {
-                builder.addKind(SuggestItem.Kind.QUERY.toString());
-            }
-            if (ComponentUtil.getFessConfig().isSuggestDocuments()) {
-                builder.addKind(SuggestItem.Kind.DOCUMENT.toString());
-            }
-
-            final SuggestResponse suggestResponse = builder.execute().getResponse();
-
-            final List<Map<String, Object>> items = new ArrayList<>(suggestResponse.getItems().size());
-            for (final SuggestItem item : suggestResponse.getItems()) {
-                final Map<String, Object> entry = new LinkedHashMap<>();
-                entry.put("text", item.getText());
-                final String[] itemTags = item.getTags();
-                entry.put("types", itemTags == null ? new ArrayList<String>() : List.of(itemTags));
-                items.add(entry);
-            }
-
-            final Map<String, Object> payload = new LinkedHashMap<>();
-            payload.put("q", q == null ? "" : q);
-            payload.put("page_size", suggestResponse.getNum());
-            payload.put("record_count", suggestResponse.getTotal());
-            payload.put("query_time", suggestResponse.getTookMs());
-            payload.put("suggest_words", items);
-            V2EnvelopeWriter.writeSuccess(response, payload);
-        } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(response, e, logger, "/api/v2/suggest-words");
-        }
-    }
-
-    /**
-     * Handles the {@code /api/v2/labels} endpoint.
-     *
-     * <p>Reads the {@code lang} parameter (only its presence in the request's
-     * {@link Locale} is consumed) and returns the configured label list. The
-     * wire shape is:</p>
-     *
-     * <pre>{@code
-     * { "record_count": <int>, "labels": [{"label":"...","value":"..."}] }
-     * }</pre>
-     *
-     * <p>The helper signature mirrors v1's {@link SearchRequestType#JSON} usage —
-     * the plan's reference to {@code JSON_API} predates the enum's current shape
-     * and {@code JSON_API} does not exist.</p>
-     *
-     * @param request the incoming HTTP request
-     * @param response the HTTP response to write to
-     * @throws IOException if writing the envelope fails
-     */
-    private void handleLabels(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        if (!"GET".equalsIgnoreCase(request.getMethod())) {
-            response.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
-            return;
-        }
-        try {
-            final LabelTypeHelper labelTypeHelper = ComponentUtil.getLabelTypeHelper();
-            final Locale locale = request.getLocale() == null ? Locale.ROOT : request.getLocale();
-            final List<Map<String, String>> items = labelTypeHelper.getLabelTypeItemList(SearchRequestType.JSON, locale);
-            final List<Map<String, Object>> labels = new ArrayList<>(items.size());
-            for (final Map<String, String> item : items) {
-                final Map<String, Object> entry = new LinkedHashMap<>();
-                entry.put("label", item.get(Constants.ITEM_LABEL));
-                entry.put("value", item.get(Constants.ITEM_VALUE));
-                labels.add(entry);
-            }
-            final Map<String, Object> payload = new LinkedHashMap<>();
-            payload.put("record_count", labels.size());
-            payload.put("labels", labels);
-            V2EnvelopeWriter.writeSuccess(response, payload);
-        } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(response, e, logger, "/api/v2/labels");
-        }
-    }
-
-    /**
-     * Handles the {@code /api/v2/popular-words} endpoint.
-     *
-     * <p>Reads {@code seed}, {@code label} (tags), and {@code field} (fields)
-     * parameters, then delegates to {@link PopularWordHelper#getWordList} to
-     * fetch a flat list of popular search terms. Roles are not forwarded — they
-     * come from the session-bound {@code RoleQueryHelper}. The wire shape is:</p>
-     *
-     * <pre>{@code
-     * { "record_count": <int>, "popular_words": ["..."] }
-     * }</pre>
-     *
-     * <p>When the feature is disabled via {@code web.api.popular.word=false}
-     * the response is an {@link V2ErrorCode#INVALID_REQUEST} envelope so the
-     * wire contract matches v1's "unsupported operation" semantics.</p>
-     *
-     * @param request the incoming HTTP request
-     * @param response the HTTP response to write to
-     * @throws IOException if writing the envelope fails
-     */
-    private void handlePopularWords(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        if (!"GET".equalsIgnoreCase(request.getMethod())) {
-            response.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
-            return;
-        }
-        if (!ComponentUtil.getFessConfig().isWebApiPopularWord()) {
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.INVALID_REQUEST, "unsupported operation");
-            return;
-        }
-        try {
-            final String seed = request.getParameter("seed");
-            // Honor v1's parameter name ("label") rather than the plan-level "tags" so
-            // existing clients keep working; v2 can introduce a new alias later if needed.
-            String[] tags = SearchRequestParams.getParamValueArray(request, "label");
-            final String virtualHostKey = ComponentUtil.getVirtualHostHelper().getVirtualHostKey();
-            if (StringUtil.isNotBlank(virtualHostKey)) {
-                tags = ArrayUtils.addAll(tags, virtualHostKey);
-            }
-            final String[] fields = request.getParameterValues("field");
-            final PopularWordHelper popularWordHelper = ComponentUtil.getPopularWordHelper();
-            final List<String> words =
-                    popularWordHelper.getWordList(SearchRequestType.JSON, seed, tags, null, fields, StringUtil.EMPTY_STRINGS);
-            final Map<String, Object> payload = new LinkedHashMap<>();
-            payload.put("record_count", words.size());
-            payload.put("popular_words", words);
-            V2EnvelopeWriter.writeSuccess(response, payload);
-        } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(response, e, logger, "/api/v2/popular-words");
-        }
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/api/v2/SessionCsrfTokenManager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SessionCsrfTokenManager.java
@@ -143,7 +143,7 @@ public class SessionCsrfTokenManager {
      * @param session the HTTP session whose id should be hashed; may be {@code null}
      * @return an 8-character lowercase hex prefix of {@code SHA-256(sessionId)}, or a literal placeholder
      */
-    static String redactSessionId(final HttpSession session) {
+    private String redactSessionId(final HttpSession session) {
         if (session == null) {
             return "(null)";
         }
@@ -167,7 +167,7 @@ public class SessionCsrfTokenManager {
         }
     }
 
-    private static boolean constantTimeEquals(final String a, final String b) {
+    private boolean constantTimeEquals(final String a, final String b) {
         if (a.length() != b.length()) {
             return false;
         }

--- a/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
@@ -40,7 +40,7 @@ import jakarta.servlet.http.HttpServletResponse;
  * to work. The {@code version} field is omitted from the envelope because
  * the API version is already encoded in the URL path ({@code /api/v2/...}).</p>
  */
-public final class V2EnvelopeWriter {
+public class V2EnvelopeWriter {
 
     /** Status value indicating a successful response. */
     public static final int STATUS_OK = 0;
@@ -51,11 +51,11 @@ public final class V2EnvelopeWriter {
     /** Status value indicating an unexpected server-side failure. */
     public static final int STATUS_SYSTEM_ERROR = 9;
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
     private static final String CONTENT_TYPE = "application/json; charset=UTF-8";
 
-    private V2EnvelopeWriter() {
-        // Utility class — no instances.
+    public V2EnvelopeWriter() {
+        // default constructor
     }
 
     /**
@@ -88,7 +88,7 @@ public final class V2EnvelopeWriter {
      * @throws IOException if writing to the response fails
      * @throws IllegalStateException if {@code payload} contains a reserved envelope key ({@code "status"})
      */
-    public static void writeSuccess(final HttpServletResponse res, final Map<String, Object> payload) throws IOException {
+    public void writeSuccess(final HttpServletResponse res, final Map<String, Object> payload) throws IOException {
         if (res.isCommitted()) {
             return;
         }
@@ -112,7 +112,7 @@ public final class V2EnvelopeWriter {
             envelope.putAll(payload);
         }
         final Map<String, Object> root = Map.of("response", envelope);
-        MAPPER.writeValue(res.getWriter(), root);
+        mapper.writeValue(res.getWriter(), root);
     }
 
     /**
@@ -134,7 +134,7 @@ public final class V2EnvelopeWriter {
      * @param message a human-readable message safe to expose to API callers
      * @throws IOException if writing to the response fails
      */
-    public static void writeError(final HttpServletResponse res, final V2ErrorCode code, final String message) throws IOException {
+    public void writeError(final HttpServletResponse res, final V2ErrorCode code, final String message) throws IOException {
         writeErrorWithDetails(res, code, message, null);
     }
 
@@ -157,7 +157,7 @@ public final class V2EnvelopeWriter {
      * @param details optional structured details merged under {@code error.details}; {@code null} omits the key
      * @throws IOException if writing to the response fails
      */
-    public static void writeErrorWithDetails(final HttpServletResponse res, final V2ErrorCode code, final String message,
+    public void writeErrorWithDetails(final HttpServletResponse res, final V2ErrorCode code, final String message,
             final Map<String, Object> details) throws IOException {
         if (res.isCommitted()) {
             return;
@@ -185,7 +185,7 @@ public final class V2EnvelopeWriter {
         envelope.put("status", statusValue);
         envelope.put("error", err);
         final Map<String, Object> root = Map.of("response", envelope);
-        MAPPER.writeValue(res.getWriter(), root);
+        mapper.writeValue(res.getWriter(), root);
     }
 
     /**
@@ -204,8 +204,8 @@ public final class V2EnvelopeWriter {
      * @param contextTag a brief tag identifying the call site (e.g. "/api/v2/health")
      * @throws IOException if writing the envelope fails
      */
-    public static void writeInternalError(final HttpServletResponse res, final Throwable cause, final Logger logger,
-            final String contextTag) throws IOException {
+    public void writeInternalError(final HttpServletResponse res, final Throwable cause, final Logger logger, final String contextTag)
+            throws IOException {
         if (cause != null) {
             logger.warn("v2 internal error: {}", contextTag, cause);
         } else {

--- a/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
@@ -54,6 +54,11 @@ public class V2EnvelopeWriter {
     private final ObjectMapper mapper = new ObjectMapper();
     private static final String CONTENT_TYPE = "application/json; charset=UTF-8";
 
+    /**
+     * Creates the v2 envelope writer. Registered as the DI component
+     * {@code v2EnvelopeWriter} and obtained via
+     * {@link org.codelibs.fess.util.ComponentUtil#getV2EnvelopeWriter()}.
+     */
     public V2EnvelopeWriter() {
         // default constructor
     }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/CacheHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/CacheHandler.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.helper.ViewHelper;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/CacheHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/CacheHandler.java
@@ -86,11 +86,11 @@ public class CacheHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res, final String docId) throws IOException {
         if (!"GET".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
-        if (!DocIdValidator.isValid(docId)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid doc_id");
+        if (!ComponentUtil.getV2DocIdValidator().isValid(docId)) {
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid doc_id");
             return;
         }
         // M-17: split DI-binding failure from "no user bean present". A genuine anonymous
@@ -103,7 +103,7 @@ public class CacheHandler {
             assist = ComponentUtil.getComponent(FessLoginAssist.class);
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/cache/{}: could not acquire FessLoginAssist", docId, e);
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/cache/" + docId);
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/cache/" + docId);
             return;
         }
         final OptionalThing<FessUserBean> userBean;
@@ -111,7 +111,7 @@ public class CacheHandler {
             userBean = assist.getSavedUserBean();
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/cache/{}: getSavedUserBean failed", docId, e);
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/cache/" + docId);
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/cache/" + docId);
             return;
         }
         // MJ-20: parity with v1 CacheAction:68-70 — honor app.login.required.
@@ -120,7 +120,7 @@ public class CacheHandler {
         try {
             final org.codelibs.fess.mylasta.direction.FessConfig fessConfig = ComponentUtil.getFessConfig();
             if (fessConfig.isLoginRequired() && !userBean.isPresent()) {
-                V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "login required");
+                ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "login required");
                 return;
             }
         } catch (final Exception e) {
@@ -135,7 +135,7 @@ public class CacheHandler {
             final OptionalEntity<Map<String, Object>> docOpt =
                     ComponentUtil.getSearchHelper().getDocumentByDocId(docId, qfc.getCacheResponseFields(), userBean);
             if (!docOpt.isPresent()) {
-                V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "doc not found: " + docId);
+                ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "doc not found: " + docId);
                 return;
             }
             final Map<String, Object> doc = docOpt.get();
@@ -143,12 +143,12 @@ public class CacheHandler {
             final String[] hq = req.getParameterValues("hq");
             final String content = ComponentUtil.getViewHelper().createCacheContent(doc, hq);
             if (content == null) {
-                V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "no cache for: " + docId);
+                ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "no cache for: " + docId);
                 return;
             }
-            V2EnvelopeWriter.writeSuccess(res, buildCachePayload(docId, content, doc));
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, buildCachePayload(docId, content, doc));
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/cache/" + docId);
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/cache/" + docId);
         }
     }
 
@@ -174,7 +174,7 @@ public class CacheHandler {
 
     // Note: RFC2045-quoted charset values (e.g. charset="UTF-8") are not unquoted here. This is
     // acceptable because crawler-indexed mimetypes store the charset unquoted (e.g. charset=UTF-8).
-    private static String parseCharset(final String mimetype) {
+    private String parseCharset(final String mimetype) {
         if (StringUtil.isNotBlank(mimetype)) {
             final int idx = mimetype.toLowerCase(java.util.Locale.ROOT).indexOf("charset=");
             if (idx >= 0) {

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatHandler.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.chat.ChatClient;
 import org.codelibs.fess.chat.ChatClient.ChatResult;
@@ -87,40 +86,40 @@ public class ChatHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"POST".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "POST");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         if (!fessConfig.isRagChatEnabled()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "chat is not enabled");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "chat is not enabled");
             return;
         }
 
         final Map<String, Object> raw;
         try {
-            raw = V2JsonBody.read(req, MAX_BODY_BYTES);
+            raw = ComponentUtil.getV2JsonBody().read(req, MAX_BODY_BYTES);
         } catch (final V2JsonBody.PayloadTooLargeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
             return;
         } catch (final V2JsonBody.UnsupportedMediaTypeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
             return;
         } catch (final V2JsonBody.MalformedJsonException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;
         }
 
         final int maxLen = ComponentUtil.getChatApiHelper().getMaxMessageLength(fessConfig);
         final ChatRequestBody body;
         try {
-            body = ChatRequestBody.from(raw, maxLen);
+            body = ComponentUtil.getChatApiHelper().parseRequestBody(raw, maxLen);
         } catch (final ChatRequestBody.MessageTooLongException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;
         }
 
         if (StringUtil.isBlank(body.message())) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "message is required");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "message is required");
             return;
         }
 
@@ -134,7 +133,7 @@ public class ChatHandler {
         } catch (final RuntimeException e) {
             // Limiter DI not available (e.g. slim test harness); log and surface as 500.
             logger.warn("[RAG] /api/v2/chat rate-limit lookup failed", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
@@ -144,7 +143,7 @@ public class ChatHandler {
         if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(userId)
                 && !limiter.allow(LoginRateLimiter.Scope.CHAT, userId, chatLimit, 60)) {
             res.setHeader("Retry-After", "60");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
             return;
         }
 
@@ -165,12 +164,12 @@ public class ChatHandler {
             payload.put("content", result.getMessage().getContent());
             final List<ChatSource> sources = result.getMessage().getSources();
             if (sources != null) {
-                payload.put("sources", toSourceMaps(sources));
+                payload.put("sources", ComponentUtil.getChatApiHelper().toSourceMaps(sources));
             }
-            V2EnvelopeWriter.writeSuccess(res, payload);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
         } catch (final Exception e) {
             logger.warn("[RAG] /api/v2/chat failed. error={}", e.getMessage(), e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "chat failed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "chat failed");
         }
     }
 
@@ -199,37 +198,4 @@ public class ChatHandler {
         return ComponentUtil.getChatClient();
     }
 
-    /**
-     * Converts a list of {@link ChatSource} objects to a list of snake_case maps
-     * suitable for JSON serialization. The Java field names on ChatSource are kept
-     * unchanged (v1 compatibility); only the output wire keys are snake_case.
-     *
-     * <p>Output keys: {@code rank}, {@code title}, {@code url}, {@code doc_id},
-     * {@code snippet}, {@code url_link}, {@code go_url}. A {@link LinkedHashMap}
-     * is used to guarantee key order.</p>
-     *
-     * @param sources list of chat sources to convert
-     * @return list of snake_case maps, one per source
-     */
-    static List<Map<String, Object>> toSourceMaps(final List<ChatSource> sources) {
-        final List<Map<String, Object>> result = new java.util.ArrayList<>(sources.size());
-        for (final ChatSource src : sources) {
-            final Map<String, Object> m = new LinkedHashMap<>();
-            m.put("rank", src.getIndex());
-            putIfNotNull(m, "title", src.getTitle());
-            putIfNotNull(m, "url", src.getUrl());
-            putIfNotNull(m, "doc_id", src.getDocId());
-            putIfNotNull(m, "snippet", src.getSnippet());
-            putIfNotNull(m, "url_link", src.getUrlLink());
-            putIfNotNull(m, "go_url", src.getGoUrl());
-            result.add(m);
-        }
-        return result;
-    }
-
-    private static void putIfNotNull(final Map<String, Object> map, final String key, final Object value) {
-        if (value != null) {
-            map.put(key, value);
-        }
-    }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatRequestBody.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatRequestBody.java
@@ -17,12 +17,8 @@ package org.codelibs.fess.api.v2.handlers;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.codelibs.fess.helper.ChatApiHelper;
-import org.codelibs.fess.util.ComponentUtil;
 
 /**
  * Parsed view of a chat request body shared by {@link ChatHandler} and
@@ -68,7 +64,7 @@ public final class ChatRequestBody {
      */
     private final Map<String, List<String>> warnings;
 
-    private ChatRequestBody(final String message, final String sessionId, final Map<String, String[]> fields, final String[] extraQueries,
+    public ChatRequestBody(final String message, final String sessionId, final Map<String, String[]> fields, final String[] extraQueries,
             final Map<String, List<String>> warnings) {
         this.message = message;
         this.sessionId = sessionId;
@@ -129,40 +125,6 @@ public final class ChatRequestBody {
     }
 
     /**
-     * Parses a raw JSON body map into a validated {@link ChatRequestBody}.
-     *
-     * <p>The {@code message} and {@code session_id} values are trimmed; blank
-     * inputs become {@code null}. Label filters and {@code extra_queries} are
-     * passed through the {@link ChatApiHelper} allowlist; rejected values are
-     * tracked in {@link #getWarnings()} but otherwise dropped.</p>
-     *
-     * @param raw the parsed JSON request body
-     * @param maxMessageLength upper bound on the {@code message} length, in characters
-     * @return a validated, immutable view of the request body
-     * @throws MessageTooLongException if {@code message} exceeds {@code maxMessageLength}
-     * @throws IOException if validation reports an unrecoverable error
-     */
-    public static ChatRequestBody from(final Map<String, Object> raw, final int maxMessageLength) throws IOException {
-        final String message = trimmedOrNull(raw.get("message"));
-        final String sessionId = trimmedOrNull(raw.get("session_id"));
-        if (message != null && message.length() > maxMessageLength) {
-            throw new MessageTooLongException("message exceeds max length: " + message.length() + " > " + maxMessageLength);
-        }
-        final Map<String, List<String>> warnings = new HashMap<>();
-        final ChatApiHelper chatApiHelper = ComponentUtil.getChatApiHelper();
-        final Map<String, String[]> fields = chatApiHelper.parseFieldFilters(raw, warnings);
-        final String[] extraQueries = chatApiHelper.parseExtraQueries(raw, warnings);
-        return new ChatRequestBody(message, sessionId, fields, extraQueries, warnings);
-    }
-
-    private static String trimmedOrNull(final Object v) {
-        if (v == null) {
-            return null;
-        }
-        final String s = v.toString().trim();
-        return s.isEmpty() ? null : s;
-    }
-
     /** Thrown when the request {@code message} exceeds {@code rag.chat.message.max.length}. */
     public static class MessageTooLongException extends IOException {
         private static final long serialVersionUID = 1L;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatRequestBody.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatRequestBody.java
@@ -32,7 +32,8 @@ import java.util.Map;
  * {@code /api/v2/chat/sessions/{session_id}}; the {@code clear} flag is no
  * longer accepted here.</p>
  *
- * <p>Length is enforced inside {@link #from(Map, int)} so the caller does not need
+ * <p>Length is enforced inside {@link org.codelibs.fess.helper.ChatApiHelper#parseRequestBody(Map, int)}
+ * so the caller does not need
  * a separate guard. Label and {@code extra_queries} validation uses the same allowlist
  * helpers v1 calls — {@code LabelTypeHelper} for labels and {@code ViewHelper}
  * for facet queries — to prevent query injection, delegated to the
@@ -64,6 +65,17 @@ public final class ChatRequestBody {
      */
     private final Map<String, List<String>> warnings;
 
+    /**
+     * Creates a parsed chat request body. Instances are normally produced by
+     * {@link org.codelibs.fess.helper.ChatApiHelper#parseRequestBody(Map, int)} after the
+     * raw body has been validated, so callers rarely invoke this constructor directly.
+     *
+     * @param message the trimmed {@code message} value, or {@code null} when omitted or blank
+     * @param sessionId the trimmed {@code session_id} value, or {@code null} for a fresh session
+     * @param fields the validated label-filter map; never {@code null}
+     * @param extraQueries the validated {@code extra_queries} array; never {@code null}
+     * @param warnings the map of rejected field values tracked for diagnostics; never {@code null}
+     */
     public ChatRequestBody(final String message, final String sessionId, final Map<String, String[]> fields, final String[] extraQueries,
             final Map<String, List<String>> warnings) {
         this.message = message;
@@ -124,7 +136,6 @@ public final class ChatRequestBody {
         return Collections.unmodifiableMap(warnings);
     }
 
-    /**
     /** Thrown when the request {@code message} exceeds {@code rag.chat.message.max.length}. */
     public static class MessageTooLongException extends IOException {
         private static final long serialVersionUID = 1L;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
@@ -89,19 +89,19 @@ public class ChatSessionClearHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res, final String sessionId) throws IOException {
         if (!"DELETE".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "DELETE");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
 
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         if (!fessConfig.isRagChatEnabled()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "chat is not enabled");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "chat is not enabled");
             return;
         }
 
         // Validate the session_id path segment before touching any backend state.
         if (sessionId == null || !SESSION_ID_PATTERN.matcher(sessionId).matches()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid session_id");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid session_id");
             return;
         }
 
@@ -114,7 +114,7 @@ public class ChatSessionClearHandler {
             limiter = ComponentUtil.getLoginRateLimiter();
         } catch (final RuntimeException e) {
             logger.warn("[RAG] /api/v2/chat/sessions DELETE rate-limit lookup failed", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
@@ -124,23 +124,23 @@ public class ChatSessionClearHandler {
         if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(userId)
                 && !limiter.allow(LoginRateLimiter.Scope.CHAT, userId, chatLimit, 60)) {
             res.setHeader("Retry-After", "60");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
             return;
         }
 
         try {
             final boolean cleared = ComponentUtil.getChatSessionManager().clearSession(sessionId, userId);
             if (!cleared) {
-                V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "session not found");
+                ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "session not found");
                 return;
             }
             final Map<String, Object> payload = new LinkedHashMap<>();
             payload.put("session_id", sessionId);
             payload.put("cleared", true);
-            V2EnvelopeWriter.writeSuccess(res, payload);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
         } catch (final Exception e) {
             logger.warn("[RAG] DELETE /api/v2/chat/sessions/{} failed. error={}", sessionId, e.getMessage(), e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
         }
     }
 

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
@@ -195,46 +195,46 @@ public class ChatStreamHandler {
      */
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         // --- Gate checks: ALL validation runs before any SSE headers are set. ---
-        // Pre-stream failures return proper HTTP status via V2EnvelopeWriter.writeError
+        // Pre-stream failures return proper HTTP status via ComponentUtil.getV2EnvelopeWriter().writeError
         // (application/json). SSE headers are only committed after every gate passes.
 
         if (!"POST".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "POST");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
 
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         if (!fessConfig.isRagChatEnabled()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "chat is not enabled");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "chat is not enabled");
             return;
         }
 
         final Map<String, Object> raw;
         try {
-            raw = V2JsonBody.read(req, MAX_BODY_BYTES);
+            raw = ComponentUtil.getV2JsonBody().read(req, MAX_BODY_BYTES);
         } catch (final V2JsonBody.PayloadTooLargeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
             return;
         } catch (final V2JsonBody.UnsupportedMediaTypeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
             return;
         } catch (final V2JsonBody.MalformedJsonException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;
         }
 
         final int maxLen = ComponentUtil.getChatApiHelper().getMaxMessageLength(fessConfig);
         final ChatRequestBody body;
         try {
-            body = ChatRequestBody.from(raw, maxLen);
+            body = ComponentUtil.getChatApiHelper().parseRequestBody(raw, maxLen);
         } catch (final ChatRequestBody.MessageTooLongException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;
         }
 
         if (StringUtil.isBlank(body.message())) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "message is required");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "message is required");
             return;
         }
 
@@ -246,7 +246,7 @@ public class ChatStreamHandler {
         } catch (final RuntimeException e) {
             // Limiter DI not available (e.g. slim test harness); log and surface as 500.
             logger.warn("[RAG] /api/v2/chat/stream rate-limit lookup failed", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
@@ -256,7 +256,7 @@ public class ChatStreamHandler {
         if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(userId)
                 && !limiter.allow(LoginRateLimiter.Scope.CHAT, userId, chatLimit, 60)) {
             res.setHeader("Retry-After", "60");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
             return;
         }
 
@@ -298,7 +298,7 @@ public class ChatStreamHandler {
             final List<ChatSource> sources = result.getMessage().getSources();
             if (sources != null && !sources.isEmpty()) {
                 synchronized (writeLock) {
-                    sendSseEvent(writer, "sources", Map.of("sources", ChatHandler.toSourceMaps(sources)));
+                    sendSseEvent(writer, "sources", Map.of("sources", ComponentUtil.getChatApiHelper().toSourceMaps(sources)));
                 }
             }
 
@@ -449,7 +449,7 @@ public class ChatStreamHandler {
      * @param res the HTTP response to set headers on
      */
     protected void setSseHeaders(final HttpServletResponse res) {
-        SseResponseHelper.applySseHeaders(res);
+        ComponentUtil.getSseResponseHelper().applySseHeaders(res);
     }
 
     /**
@@ -660,7 +660,7 @@ public class ChatStreamHandler {
      * @param key key
      * @param value value to add when non-null
      */
-    protected static void putIfNotNull(final Map<String, Object> data, final String key, final Object value) {
+    protected void putIfNotNull(final Map<String, Object> data, final String key, final Object value) {
         if (value != null) {
             data.put(key, value);
         }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ClickHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ClickHandler.java
@@ -98,11 +98,11 @@ public class ClickHandler {
      * @param epochMs epoch millis
      * @return UTC-anchored {@link LocalDateTime}
      */
-    static LocalDateTime epochMsToUtcLocalDateTime(final long epochMs) {
+    LocalDateTime epochMsToUtcLocalDateTime(final long epochMs) {
         return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMs), ZoneOffset.UTC);
     }
 
-    private static String stringOrNull(final Map<String, Object> body, final String key) {
+    private String stringOrNull(final Map<String, Object> body, final String key) {
         final Object v = body.get(key);
         if (v == null) {
             return null;
@@ -123,13 +123,13 @@ public class ClickHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"POST".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "POST");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         final FessConfig cfg = ComponentUtil.getFessConfig();
         if (!cfg.isSearchLog()) {
             // Feature disabled — succeed without doing anything (fire-and-forget contract).
-            V2EnvelopeWriter.writeSuccess(res, Map.of("ok", true, "logged", false));
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, Map.of("ok", true, "logged", false));
             return;
         }
         // m-15: check session BEFORE parsing the body so anonymous callers short-circuit
@@ -150,26 +150,26 @@ public class ClickHandler {
         if (userSessionId == null) {
             // Anonymous caller: a click log without a session id is meaningless,
             // so report success with logged:false rather than failing the request.
-            V2EnvelopeWriter.writeSuccess(res, Map.of("ok", true, "logged", false));
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, Map.of("ok", true, "logged", false));
             return;
         }
         final Map<String, Object> body;
         try {
-            body = V2JsonBody.read(req, MAX_BODY_BYTES);
+            body = ComponentUtil.getV2JsonBody().read(req, MAX_BODY_BYTES);
         } catch (final V2JsonBody.PayloadTooLargeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
             return;
         } catch (final V2JsonBody.UnsupportedMediaTypeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
             return;
         } catch (final V2JsonBody.MalformedJsonException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;
         }
         final String docId = stringOrNull(body, "doc_id");
         final String queryId = stringOrNull(body, "query_id");
-        if (!DocIdValidator.isValid(docId)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid doc_id");
+        if (!ComponentUtil.getV2DocIdValidator().isValid(docId)) {
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid doc_id");
             return;
         }
         try {
@@ -177,7 +177,7 @@ public class ClickHandler {
             final OptionalEntity<Map<String, Object>> docOpt = searchHelper.getDocumentByDocId(docId,
                     new String[] { cfg.getIndexFieldId(), cfg.getIndexFieldUrl() }, OptionalThing.empty());
             if (!docOpt.isPresent()) {
-                V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "doc not found: " + docId);
+                ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "doc not found: " + docId);
                 return;
             }
             final Map<String, Object> doc = docOpt.get();
@@ -206,9 +206,9 @@ public class ClickHandler {
             if (logger.isDebugEnabled()) {
                 logger.debug("logged click: docId={}, queryId={}, url={}", docId, queryId, url);
             }
-            V2EnvelopeWriter.writeSuccess(res, Map.of("ok", true, "logged", true));
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, Map.of("ok", true, "logged", true));
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/click");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/click");
         }
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ClickHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ClickHandler.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.helper.SearchHelper;
 import org.codelibs.fess.helper.SearchLogHelper;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/CsrfRequirement.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/CsrfRequirement.java
@@ -38,9 +38,10 @@ import java.util.Locale;
  * {@code CsrfRequirementCompleteCoverageTest} to pin the decision. Failing to do so is safe
  * (the new path is CSRF-required by default), but the coverage test will flag the omission.</p>
  */
-public final class CsrfRequirement {
+public class CsrfRequirement {
 
-    private CsrfRequirement() {
+    public CsrfRequirement() {
+        // default constructor
     }
 
     /**
@@ -59,7 +60,7 @@ public final class CsrfRequirement {
      * @param method the HTTP method (case-insensitive)
      * @return {@code true} if a valid CSRF token must accompany the request
      */
-    public static boolean requiresCsrf(final String subPath, final String method) {
+    public boolean requiresCsrf(final String subPath, final String method) {
         if (method == null) {
             return false;
         }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/CsrfRequirement.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/CsrfRequirement.java
@@ -40,6 +40,11 @@ import java.util.Locale;
  */
 public class CsrfRequirement {
 
+    /**
+     * Creates a CSRF requirement evaluator. Registered as the DI component
+     * {@code v2CsrfRequirement} and obtained via
+     * {@link org.codelibs.fess.util.ComponentUtil#getV2CsrfRequirement()}.
+     */
     public CsrfRequirement() {
         // default constructor
     }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/DocIdValidator.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/DocIdValidator.java
@@ -30,13 +30,13 @@ import org.codelibs.core.lang.StringUtil;
  * path-traversal-style abuse). Centralised here so the handlers share a single
  * compiled pattern instead of each declaring its own copy.</p>
  */
-final class DocIdValidator {
+public class DocIdValidator {
 
     /** Allowlist for {@code doc_id}: ASCII letters, digits, underscore and hyphen. */
     private static final Pattern DOC_ID_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
 
-    private DocIdValidator() {
-        // no instances
+    public DocIdValidator() {
+        // default constructor
     }
 
     /**
@@ -45,7 +45,7 @@ final class DocIdValidator {
      * @param docId the candidate document id
      * @return {@code true} if non-blank and composed only of allowed characters
      */
-    static boolean isValid(final String docId) {
+    public boolean isValid(final String docId) {
         return StringUtil.isNotBlank(docId) && DOC_ID_PATTERN.matcher(docId).matches();
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/DocIdValidator.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/DocIdValidator.java
@@ -35,6 +35,11 @@ public class DocIdValidator {
     /** Allowlist for {@code doc_id}: ASCII letters, digits, underscore and hyphen. */
     private static final Pattern DOC_ID_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
 
+    /**
+     * Creates a document-id validator. Registered as the DI component
+     * {@code v2DocIdValidator} and obtained via
+     * {@link org.codelibs.fess.util.ComponentUtil#getV2DocIdValidator()}.
+     */
     public DocIdValidator() {
         // default constructor
     }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoriteGetHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoriteGetHandler.java
@@ -93,16 +93,16 @@ public class FavoriteGetHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res, final String docId) throws IOException {
         if (!"GET".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
-        if (!DocIdValidator.isValid(docId)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid doc_id");
+        if (!ComponentUtil.getV2DocIdValidator().isValid(docId)) {
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid doc_id");
             return;
         }
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         if (!fessConfig.isUserFavorite()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "favorite feature is not available");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "favorite feature is not available");
             return;
         }
         try {
@@ -113,7 +113,7 @@ public class FavoriteGetHandler {
             final OptionalEntity<Map<String, Object>> docOpt = searchHelper.getDocumentByDocId(docId,
                     new String[] { fessConfig.getIndexFieldUrl(), fessConfig.getIndexFieldFavoriteCount() }, OptionalThing.empty());
             if (!docOpt.isPresent()) {
-                V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "doc not found: " + docId);
+                ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "doc not found: " + docId);
                 return;
             }
             final Map<String, Object> doc = docOpt.get();
@@ -133,9 +133,9 @@ public class FavoriteGetHandler {
             payload.put("doc_id", docId);
             payload.put("favorite", favorite);
             payload.put("count", count);
-            V2EnvelopeWriter.writeSuccess(res, payload);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite GET");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite GET");
         }
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoriteGetHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoriteGetHandler.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.service.FavoriteLogService;
 import org.codelibs.fess.helper.SearchHelper;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.service.FavoriteLogService;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
@@ -143,11 +143,11 @@ public class FavoritePostHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res, final String docId) throws IOException {
         if (!"POST".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "POST");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
-        if (!DocIdValidator.isValid(docId)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid doc_id");
+        if (!ComponentUtil.getV2DocIdValidator().isValid(docId)) {
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid doc_id");
             return;
         }
         // Auth check before body parsing — avoids spending CPU on the body for
@@ -162,7 +162,7 @@ public class FavoritePostHandler {
             assist = ComponentUtil.getComponent(FessLoginAssist.class);
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/documents/{}/favorite POST: could not acquire FessLoginAssist", docId, e);
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");
             return;
         }
         final OptionalThing<FessUserBean> userBean;
@@ -170,40 +170,40 @@ public class FavoritePostHandler {
             userBean = assist.getSavedUserBean();
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/documents/{}/favorite POST: getSavedUserBean failed", docId, e);
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");
             return;
         }
         if (!userBean.isPresent()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "login required");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "login required");
             return;
         }
         final FessConfig cfg = ComponentUtil.getFessConfig();
         if (!cfg.isUserFavorite()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "favorite feature is not available");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "favorite feature is not available");
             return;
         }
         final UserInfoHelper userInfoHelper = ComponentUtil.getUserInfoHelper();
         final String userCode = userInfoHelper.getUserCode();
         if (StringUtil.isBlank(userCode)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "no user session");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "no user session");
             return;
         }
         final Map<String, Object> body;
         try {
-            body = V2JsonBody.read(req, MAX_BODY_BYTES);
+            body = ComponentUtil.getV2JsonBody().read(req, MAX_BODY_BYTES);
         } catch (final V2JsonBody.PayloadTooLargeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
             return;
         } catch (final V2JsonBody.UnsupportedMediaTypeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
             return;
         } catch (final V2JsonBody.MalformedJsonException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;
         }
         final String queryId = (String) body.get("query_id");
         if (StringUtil.isBlank(queryId)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "query_id is required");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "query_id is required");
             return;
         }
 
@@ -216,15 +216,15 @@ public class FavoritePostHandler {
         try {
             docIds = userInfoHelper.getResultDocIds(queryId);
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid query_id");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "invalid query_id");
             return;
         }
         if (docIds == null) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "no searched urls");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "no searched urls");
             return;
         }
         if (!ArrayUtils.contains(docIds, docId)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "doc not in search result");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "doc not in search result");
             return;
         }
 
@@ -282,7 +282,7 @@ public class FavoritePostHandler {
                     });
         } catch (final DocNotFoundException e) {
             logger.warn("/api/v2/documents/{}/favorite POST: doc not found", docId, e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "doc not found: " + docId);
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "doc not found: " + docId);
             return;
         } catch (final AlreadyFavoritedException e) {
             // M-9: idempotent re-POST — return 200 with the full payload shape so the
@@ -297,14 +297,14 @@ public class FavoritePostHandler {
             idempotentPayload.put("favorite", true);
             idempotentPayload.put("count", favoriteCountHolder[0]);
             idempotentPayload.put("already_existed", true);
-            V2EnvelopeWriter.writeSuccess(res, idempotentPayload);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, idempotentPayload);
             return;
         } catch (final FavoriteAddFailedException e) {
             logger.warn("/api/v2/documents/{}/favorite POST: add failed", docId, e);
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");
             return;
         } catch (final RuntimeException e) {
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");
             return;
         }
 
@@ -313,6 +313,6 @@ public class FavoritePostHandler {
         successPayload.put("ok", true);
         successPayload.put("favorite", true);
         successPayload.put("count", favoriteCountHolder[0]);
-        V2EnvelopeWriter.writeSuccess(res, successPayload);
+        ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, successPayload);
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritesListHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritesListHandler.java
@@ -94,12 +94,12 @@ public class FavoritesListHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"GET".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         if (!fessConfig.isUserFavorite()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "favorite feature is not available");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "favorite feature is not available");
             return;
         }
         // query_id arrives as a query parameter; treat it as opaque (do not URL-decode).
@@ -107,7 +107,7 @@ public class FavoritesListHandler {
         // set previously cached in the session by the search handler.
         final String queryId = req.getParameter("query_id");
         if (StringUtil.isBlank(queryId)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "query_id is required");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "query_id is required");
             return;
         }
         // Resolve the session-bound user code BEFORE doing any expensive work — anonymous
@@ -115,7 +115,7 @@ public class FavoritesListHandler {
         final UserInfoHelper userInfoHelper = ComponentUtil.getUserInfoHelper();
         final String userCode = userInfoHelper == null ? null : userInfoHelper.getUserCode();
         if (StringUtil.isBlank(userCode)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "no user session");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "no user session");
             return;
         }
         try {
@@ -160,9 +160,9 @@ public class FavoritesListHandler {
             final Map<String, Object> payload = new LinkedHashMap<>();
             payload.put("record_count", data.size());
             payload.put("data", data);
-            V2EnvelopeWriter.writeSuccess(res, payload);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/favorites GET");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/favorites GET");
         }
     }
 
@@ -171,10 +171,10 @@ public class FavoritesListHandler {
      * {@code record_count: 0}. Used when the {@code query_id} matches no cached
      * result set in the session.
      */
-    private static void writeEmpty(final HttpServletResponse res) throws IOException {
+    private void writeEmpty(final HttpServletResponse res) throws IOException {
         final Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("record_count", 0);
         payload.put("data", new ArrayList<Map<String, Object>>());
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritesListHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritesListHandler.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.service.FavoriteLogService;
 import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codelibs.fess.api.v2.V2ErrorCode;
+import org.codelibs.fess.entity.PingResponse;
+import org.codelibs.fess.util.ComponentUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Handles the {@code /api/v2/health} endpoint.
+ */
+public class HealthHandler {
+
+    private static final Logger logger = LogManager.getLogger(HealthHandler.class);
+
+    /**
+     * Default constructor used by the DI container.
+     */
+    public HealthHandler() {
+        // default constructor
+    }
+
+    /**
+     * Processes one health check request.
+     *
+     * @param request the incoming HTTP request
+     * @param response the HTTP response to write to
+     * @throws IOException if writing the envelope fails
+     */
+    public void handle(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        if (!"GET".equalsIgnoreCase(request.getMethod())) {
+            response.setHeader("Allow", "GET");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            return;
+        }
+        try {
+            final PingResponse ping = ComponentUtil.getSearchEngineClient().ping();
+            final String clusterStatus = ping.getClusterStatus();
+            final Map<String, Object> engine = new LinkedHashMap<>();
+            engine.put("cluster_name", ping.getClusterName());
+            engine.put("status", clusterStatus);
+            engine.put("ping_status", ping.getStatus());
+            if ("red".equalsIgnoreCase(clusterStatus)) {
+                ComponentUtil.getV2EnvelopeWriter()
+                        .writeErrorWithDetails(response, V2ErrorCode.SERVICE_UNAVAILABLE, "search engine cluster is red",
+                                Map.of("engine", engine));
+            } else {
+                ComponentUtil.getV2EnvelopeWriter().writeSuccess(response, Map.of("engine", engine));
+            }
+        } catch (final Exception e) {
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2/health");
+        }
+    }
+}

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LabelsHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LabelsHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.api.v2.V2ErrorCode;
+import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
+import org.codelibs.fess.helper.LabelTypeHelper;
+import org.codelibs.fess.util.ComponentUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Handles the {@code /api/v2/labels} endpoint.
+ */
+public class LabelsHandler {
+
+    private static final Logger logger = LogManager.getLogger(LabelsHandler.class);
+
+    /**
+     * Default constructor used by the DI container.
+     */
+    public LabelsHandler() {
+        // default constructor
+    }
+
+    /**
+     * Processes one labels request.
+     *
+     * @param request the incoming HTTP request
+     * @param response the HTTP response to write to
+     * @throws IOException if writing the envelope fails
+     */
+    public void handle(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        if (!"GET".equalsIgnoreCase(request.getMethod())) {
+            response.setHeader("Allow", "GET");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            return;
+        }
+        try {
+            final LabelTypeHelper labelTypeHelper = ComponentUtil.getLabelTypeHelper();
+            final Locale locale = request.getLocale() == null ? Locale.ROOT : request.getLocale();
+            final List<Map<String, String>> items = labelTypeHelper.getLabelTypeItemList(SearchRequestType.JSON, locale);
+            final List<Map<String, Object>> labels = new ArrayList<>(items.size());
+            for (final Map<String, String> item : items) {
+                final Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("label", item.get(Constants.ITEM_LABEL));
+                entry.put("value", item.get(Constants.ITEM_VALUE));
+                labels.add(entry);
+            }
+            final Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("record_count", labels.size());
+            payload.put("labels", labels);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(response, payload);
+        } catch (final Exception e) {
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2/labels");
+        }
+    }
+}

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.api.v2.SessionCsrfTokenManager;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.app.web.base.login.LocalUserCredential;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
@@ -129,7 +129,7 @@ public class LoginHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"POST".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "POST");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         final LoginRateLimiter limiter = limiter();
@@ -142,25 +142,25 @@ public class LoginHandler {
         if (!limiter.allow(LoginRateLimiter.Scope.IP, clientIp, ipLimit, 60)) {
             limiter.lockOut(LoginRateLimiter.Scope.IP, clientIp, lockoutSec);
             res.setHeader("Retry-After", Integer.toString(lockoutSec));
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.RATE_LIMITED, "too many login attempts (ip)");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many login attempts (ip)");
             return;
         }
 
         final Map<String, Object> body;
         try {
-            body = V2JsonBody.read(req, MAX_BODY_BYTES);
+            body = ComponentUtil.getV2JsonBody().read(req, MAX_BODY_BYTES);
         } catch (final V2JsonBody.PayloadTooLargeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "payload too large");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "payload too large");
             return;
         } catch (final V2JsonBody.MalformedJsonException | V2JsonBody.UnsupportedMediaTypeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;
         }
         final String username = stringOrNull(body.get("username"));
         final String password = stringOrNull(body.get("password"));
         final String returnTo = stringOrNull(body.get("return_to"));
         if (StringUtil.isBlank(username) || StringUtil.isBlank(password)) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "username and password are required");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "username and password are required");
             return;
         }
         final String userKey = userScopeKey(clientIp, username);
@@ -175,7 +175,7 @@ public class LoginHandler {
             // credential rejection, with no Retry-After, so the response cannot be used to probe
             // a per-user counter. The IP-scope gate above still returns 429 + Retry-After.
             limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
             return;
         }
 
@@ -188,7 +188,7 @@ public class LoginHandler {
             assist = ComponentUtil.getComponent(FessLoginAssist.class);
         } catch (final RuntimeException e) {
             logger.warn("login failed unexpectedly: could not acquire FessLoginAssist", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
 
@@ -210,7 +210,7 @@ public class LoginHandler {
             prevUserId = existingBean.isPresent() ? existingBean.get().getUserId() : null;
         } catch (final RuntimeException e) {
             logger.warn("login: could not check existing session state", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
 
@@ -225,7 +225,7 @@ public class LoginHandler {
             if (!limiter.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60)) {
                 limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
             }
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
             return;
         } catch (final RuntimeException e) {
             // Anything else (DI binding failure, transient lookup error, etc.) is a system
@@ -233,7 +233,7 @@ public class LoginHandler {
             // server would lock real users out. We surface INTERNAL_ERROR with a generic
             // message; the exception detail goes to the log only.
             logger.warn("login failed unexpectedly", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
 
@@ -276,7 +276,7 @@ public class LoginHandler {
             payload.put("csrf_token", token);
             addReturnTo(payload, returnTo);
         }
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
     }
 
     /**
@@ -284,9 +284,9 @@ public class LoginHandler {
      * Uses {@link UserPayloads#toJson(FessUserBean)} to guarantee shape parity
      * with MeHandler (MJ-28).
      */
-    private static Map<String, Object> buildUserPayload(final FessUserBean u, final String token, final String returnTo) {
+    private Map<String, Object> buildUserPayload(final FessUserBean u, final String token, final String returnTo) {
         final Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("user", UserPayloads.toJson(u));
+        payload.put("user", ComponentUtil.getV2UserPayloads().toJson(u));
         payload.put("csrf_token", token);
         addReturnTo(payload, returnTo);
         return payload;
@@ -298,7 +298,7 @@ public class LoginHandler {
      * any ASCII control character. The pattern requires a leading '/' so relative
      * paths below the app root are always safe.
      */
-    private static void addReturnTo(final Map<String, Object> payload, final String returnTo) {
+    private void addReturnTo(final Map<String, Object> payload, final String returnTo) {
         if (returnTo == null) {
             return;
         }
@@ -324,7 +324,7 @@ public class LoginHandler {
      * username and let the auth flow proceed with a stringified non-string, which
      * is not what the wire contract intends.
      */
-    private static String stringOrNull(final Object v) {
+    private String stringOrNull(final Object v) {
         return v instanceof String s ? s : null;
     }
 
@@ -342,7 +342,7 @@ public class LoginHandler {
      * @param username submitted username
      * @return composite key {@code clientIp + NUL + username}
      */
-    static String userScopeKey(final String clientIp, final String username) {
+    String userScopeKey(final String clientIp, final String username) {
         return clientIp + USER_SCOPE_KEY_SEP + username;
     }
 
@@ -351,7 +351,7 @@ public class LoginHandler {
      * falling back to {@link HttpServletRequest#getRemoteAddr()} when the helper
      * is not available — e.g. in slim test DI graphs.
      */
-    private static String resolveClientIp(final HttpServletRequest req) {
+    private String resolveClientIp(final HttpServletRequest req) {
         try {
             return ComponentUtil.getRateLimitHelper().getClientIp(req);
         } catch (final RuntimeException e) {

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.util.ComponentUtil;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
@@ -70,7 +70,7 @@ public class LogoutHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"POST".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "POST");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         try {
@@ -88,6 +88,6 @@ public class LogoutHandler {
                 // FessLoginAssist.logout() may have already invalidated the session.
             }
         }
-        V2EnvelopeWriter.writeSuccess(res, Map.of("ok", true));
+        ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, Map.of("ok", true));
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/MeHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/MeHandler.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.mylasta.action.FessUserBean;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/MeHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/MeHandler.java
@@ -77,7 +77,7 @@ public class MeHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"GET".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         OptionalThing<FessUserBean> userBean;
@@ -93,14 +93,14 @@ public class MeHandler {
         final Map<String, Object> payload = new LinkedHashMap<>();
         if (userBean.isPresent()) {
             final FessUserBean u = userBean.get();
-            // MJ-28: use shared UserPayloads.toJson() to guarantee the same wire shape as
+            // MJ-28: use shared ComponentUtil.getV2UserPayloads().toJson() to guarantee the same wire shape as
             // LoginHandler — roles/groups/permissions are always arrays, never null.
             payload.put("authenticated", true);
-            payload.put("user", UserPayloads.toJson(u));
+            payload.put("user", ComponentUtil.getV2UserPayloads().toJson(u));
         } else {
             payload.put("authenticated", false);
         }
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
@@ -147,7 +147,7 @@ public class PasswordChangeHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"POST".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "POST");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         // M-17: split DI-binding/lookup failure from "no user bean present". A genuine
@@ -159,7 +159,7 @@ public class PasswordChangeHandler {
             assist = ComponentUtil.getComponent(FessLoginAssist.class);
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/auth/password: could not acquire FessLoginAssist", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
         final OptionalThing<FessUserBean> userBean;
@@ -167,42 +167,45 @@ public class PasswordChangeHandler {
             userBean = assist.getSavedUserBean();
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/auth/password: getSavedUserBean failed", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
         if (!userBean.isPresent()) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "login required");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "login required");
             return;
         }
         final Map<String, Object> body;
         try {
-            body = V2JsonBody.read(req, MAX_BODY_BYTES);
+            body = ComponentUtil.getV2JsonBody().read(req, MAX_BODY_BYTES);
         } catch (final V2JsonBody.PayloadTooLargeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.PAYLOAD_TOO_LARGE, e.getMessage());
             return;
         } catch (final V2JsonBody.UnsupportedMediaTypeException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
             return;
         } catch (final V2JsonBody.MalformedJsonException e) {
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;
         }
         final String currentPw = stringOrNull(body.get("current_password"));
         final String newPw = stringOrNull(body.get("new_password"));
         final String confirm = stringOrNull(body.get("confirm_password"));
         if (StringUtil.isBlank(currentPw)) {
-            V2EnvelopeWriter.writeErrorWithDetails(res, V2ErrorCode.INVALID_REQUEST, "current_password is required",
-                    Map.of("reason", "current_password_required"));
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeErrorWithDetails(res, V2ErrorCode.INVALID_REQUEST, "current_password is required",
+                            Map.of("reason", "current_password_required"));
             return;
         }
         if (newPw == null || newPw.isBlank()) {
-            V2EnvelopeWriter.writeErrorWithDetails(res, V2ErrorCode.INVALID_REQUEST, "new_password is required",
-                    Map.of("reason", "new_password_required"));
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeErrorWithDetails(res, V2ErrorCode.INVALID_REQUEST, "new_password is required",
+                            Map.of("reason", "new_password_required"));
             return;
         }
         if (!newPw.equals(confirm)) {
-            V2EnvelopeWriter.writeErrorWithDetails(res, V2ErrorCode.INVALID_REQUEST, "passwords do not match",
-                    Map.of("reason", "password_mismatch"));
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeErrorWithDetails(res, V2ErrorCode.INVALID_REQUEST, "passwords do not match",
+                            Map.of("reason", "password_mismatch"));
             return;
         }
         final String userId = userBean.get().getUserId();
@@ -229,7 +232,7 @@ public class PasswordChangeHandler {
         if (rate != null && userLimit > 0 && !rate.peek(LoginRateLimiter.Scope.USER, userId, userLimit, 60)) {
             rate.lockOut(LoginRateLimiter.Scope.USER, userId, lockoutSec);
             res.setHeader("Retry-After", Integer.toString(Math.max(lockoutSec, 1)));
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.RATE_LIMITED, "too many password-change attempts");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many password-change attempts");
             return;
         }
 
@@ -242,7 +245,7 @@ public class PasswordChangeHandler {
             verified = assist.findLoginUser(new LocalUserCredential(userId, currentPw));
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/auth/password: findLoginUser failed", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "failed to change password");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "failed to change password");
             return;
         }
         if (verified == null || !verified.isPresent()) {
@@ -251,11 +254,12 @@ public class PasswordChangeHandler {
             if (rate != null && userLimit > 0 && !rate.allow(LoginRateLimiter.Scope.USER, userId, userLimit, 60)) {
                 rate.lockOut(LoginRateLimiter.Scope.USER, userId, lockoutSec);
                 res.setHeader("Retry-After", Integer.toString(Math.max(lockoutSec, 1)));
-                V2EnvelopeWriter.writeError(res, V2ErrorCode.RATE_LIMITED, "too many password-change attempts");
+                ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many password-change attempts");
                 return;
             }
-            V2EnvelopeWriter.writeErrorWithDetails(res, V2ErrorCode.AUTH_REQUIRED, "invalid current password",
-                    Map.of("reason", "invalid_current_password"));
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeErrorWithDetails(res, V2ErrorCode.AUTH_REQUIRED, "invalid current password",
+                            Map.of("reason", "invalid_current_password"));
             return;
         }
         final String validationError = ComponentUtil.getSystemHelper().validatePassword(newPw);
@@ -268,14 +272,15 @@ public class PasswordChangeHandler {
                     details.put("min_length", minLength);
                 }
             }
-            V2EnvelopeWriter.writeErrorWithDetails(res, V2ErrorCode.INVALID_REQUEST, "weak password: " + validationError, details);
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeErrorWithDetails(res, V2ErrorCode.INVALID_REQUEST, "weak password: " + validationError, details);
             return;
         }
         try {
             ComponentUtil.getComponent(UserService.class).changePassword(userId, newPw);
         } catch (final Exception e) {
             logger.warn("/api/v2/auth/password: changePassword failed", e);
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "failed to change password");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "failed to change password");
             return;
         }
         // C-3: successful change resets the per-user bucket so any earlier failed attempts
@@ -320,7 +325,7 @@ public class PasswordChangeHandler {
         final Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("ok", true);
         payload.put("re_login_required", true);
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
     }
 
     /**
@@ -329,7 +334,7 @@ public class PasswordChangeHandler {
      * stringified by {@code v.toString()} and could mask bugs in callers; treat any
      * non-string value as missing instead.
      */
-    private static String stringOrNull(final Object v) {
+    private String stringOrNull(final Object v) {
         return v instanceof final String s ? s : null;
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.service.UserService;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/PopularWordsHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/PopularWordsHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.api.v2.V2ErrorCode;
+import org.codelibs.fess.entity.SearchRequestParams;
+import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
+import org.codelibs.fess.helper.PopularWordHelper;
+import org.codelibs.fess.util.ComponentUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Handles the {@code /api/v2/popular-words} endpoint.
+ */
+public class PopularWordsHandler {
+
+    private static final Logger logger = LogManager.getLogger(PopularWordsHandler.class);
+
+    /**
+     * Default constructor used by the DI container.
+     */
+    public PopularWordsHandler() {
+        // default constructor
+    }
+
+    /**
+     * Processes one popular words request.
+     *
+     * @param request the incoming HTTP request
+     * @param response the HTTP response to write to
+     * @throws IOException if writing the envelope fails
+     */
+    public void handle(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        if (!"GET".equalsIgnoreCase(request.getMethod())) {
+            response.setHeader("Allow", "GET");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            return;
+        }
+        if (!ComponentUtil.getFessConfig().isWebApiPopularWord()) {
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, "unsupported operation");
+            return;
+        }
+        try {
+            final String seed = request.getParameter("seed");
+            String[] tags = SearchRequestParams.getParamValueArray(request, "label");
+            final String virtualHostKey = ComponentUtil.getVirtualHostHelper().getVirtualHostKey();
+            if (StringUtil.isNotBlank(virtualHostKey)) {
+                tags = ArrayUtils.addAll(tags, virtualHostKey);
+            }
+            final String[] fields = request.getParameterValues("field");
+            final PopularWordHelper popularWordHelper = ComponentUtil.getPopularWordHelper();
+            final List<String> words =
+                    popularWordHelper.getWordList(SearchRequestType.JSON, seed, tags, null, fields, StringUtil.EMPTY_STRINGS);
+            final Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("record_count", words.size());
+            payload.put("popular_words", words);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(response, payload);
+        } catch (final Exception e) {
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2/popular-words");
+        }
+    }
+}

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/RelatedContentHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/RelatedContentHandler.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.helper.RelatedContentHelper;
 import org.codelibs.fess.util.ComponentUtil;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/RelatedContentHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/RelatedContentHandler.java
@@ -74,7 +74,7 @@ public class RelatedContentHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"GET".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         try {
@@ -90,9 +90,9 @@ public class RelatedContentHandler {
             final Map<String, Object> payload = new LinkedHashMap<>();
             payload.put("content", content);
             payload.put("content_type", "html");
-            V2EnvelopeWriter.writeSuccess(res, payload);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/related-content");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/related-content");
         }
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/RelatedQueriesHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/RelatedQueriesHandler.java
@@ -73,7 +73,7 @@ public class RelatedQueriesHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"GET".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         try {
@@ -88,9 +88,9 @@ public class RelatedQueriesHandler {
             }
             final Map<String, Object> payload = new LinkedHashMap<>();
             payload.put("queries", queries);
-            V2EnvelopeWriter.writeSuccess(res, payload);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/related-queries");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/related-queries");
         }
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/RelatedQueriesHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/RelatedQueriesHandler.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.helper.RelatedQueryHelper;
 import org.codelibs.fess.util.ComponentUtil;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandler.java
@@ -113,12 +113,12 @@ public class ScrollSearchHandler {
     public void handle(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         if (!"GET".equalsIgnoreCase(request.getMethod())) {
             response.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         if (!fessConfig.isApiSearchScroll()) {
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.INVALID_REQUEST, "scroll search is not available");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, "scroll search is not available");
             return;
         }
         request.setAttribute(Constants.SEARCH_LOG_ACCESS_TYPE, Constants.SEARCH_LOG_ACCESS_TYPE_JSON);
@@ -153,12 +153,12 @@ public class ScrollSearchHandler {
                 logger.debug("Loaded {} documents", count);
             }
         } catch (final V2JsonRequestParams.InvalidPageSizeException e) {
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
         } catch (final InvalidQueryException | ResultOffsetExceededException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("invalid /api/v2/documents/all request", e);
             }
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
         } catch (final UncheckedIOException e) {
             // Surface the underlying IOException so the servlet container can log/respond.
             throw e.getCause();
@@ -183,7 +183,7 @@ public class ScrollSearchHandler {
                     logger.warn("/api/v2/documents/all: could not write error terminator", flushEx);
                 }
             } else {
-                V2EnvelopeWriter.writeInternalError(response, e, logger, "/api/v2/documents/all");
+                ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2/documents/all");
             }
         }
     }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/SearchHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/SearchHandler.java
@@ -91,7 +91,7 @@ public class SearchHandler {
     public void handle(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         if (!"GET".equalsIgnoreCase(request.getMethod())) {
             response.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         request.setAttribute(Constants.SEARCH_LOG_ACCESS_TYPE, Constants.SEARCH_LOG_ACCESS_TYPE_JSON);
@@ -103,16 +103,16 @@ public class SearchHandler {
             final SearchRenderData data = new SearchRenderData();
             final V2JsonRequestParams params = new V2JsonRequestParams(request, fessConfig);
             searchHelper.search(params, data, OptionalThing.empty());
-            V2EnvelopeWriter.writeSuccess(response, buildPayload(params.getQuery(), data));
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(response, buildPayload(params.getQuery(), data));
         } catch (final V2JsonRequestParams.InvalidPageSizeException e) {
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
         } catch (final InvalidQueryException | ResultOffsetExceededException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("invalid /api/v2/search request", e);
             }
-            V2EnvelopeWriter.writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(response, e, logger, "/api/v2/search");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2/search");
         }
     }
 

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/SuggestWordsHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/SuggestWordsHandler.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.api.v2.V2ErrorCode;
+import org.codelibs.fess.entity.SearchRequestParams;
+import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
+import org.codelibs.fess.helper.SuggestHelper;
+import org.codelibs.fess.helper.VirtualHostHelper;
+import org.codelibs.fess.suggest.entity.SuggestItem;
+import org.codelibs.fess.suggest.request.suggest.SuggestRequestBuilder;
+import org.codelibs.fess.suggest.request.suggest.SuggestResponse;
+import org.codelibs.fess.util.ComponentUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Handles the {@code /api/v2/suggest-words} endpoint.
+ */
+public class SuggestWordsHandler {
+
+    private static final Logger logger = LogManager.getLogger(SuggestWordsHandler.class);
+
+    /**
+     * Default constructor used by the DI container.
+     */
+    public SuggestWordsHandler() {
+        // default constructor
+    }
+
+    /**
+     * Processes one suggest words request.
+     *
+     * @param request the incoming HTTP request
+     * @param response the HTTP response to write to
+     * @throws IOException if writing the envelope fails
+     */
+    public void handle(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        if (!"GET".equalsIgnoreCase(request.getMethod())) {
+            response.setHeader("Allow", "GET");
+            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            return;
+        }
+        try {
+            final String q = request.getParameter("q");
+            final String numStr = request.getParameter("num");
+            final int num;
+            if (StringUtil.isNotBlank(numStr) && StringUtils.isNumeric(numStr)) {
+                num = Integer.parseInt(numStr);
+            } else {
+                num = 10;
+            }
+            final String[] fields = SearchRequestParams.getParamValueArray(request, "fn");
+            final String[] langs = SearchRequestParams.getParamValueArray(request, "lang");
+            final String[] tags = SearchRequestParams.getParamValueArray(request, "label");
+
+            final SuggestHelper suggestHelper = ComponentUtil.getSuggestHelper();
+            final SuggestRequestBuilder builder = suggestHelper.suggester().suggest();
+            if (q != null) {
+                builder.setQuery(q);
+            }
+            for (final String field : fields) {
+                builder.addField(field);
+            }
+            ComponentUtil.getRoleQueryHelper().build(SearchRequestType.SUGGEST).forEach(builder::addRole);
+            builder.setSize(num);
+            for (final String lang : langs) {
+                builder.addLang(lang);
+            }
+            for (final String tag : tags) {
+                builder.addTag(tag);
+            }
+            final VirtualHostHelper virtualHostHelper = ComponentUtil.getVirtualHostHelper();
+            final String virtualHostKey = virtualHostHelper.getVirtualHostKey();
+            if (StringUtil.isNotBlank(virtualHostKey)) {
+                builder.addTag(virtualHostKey);
+            }
+            builder.addKind(SuggestItem.Kind.USER.toString());
+            if (ComponentUtil.getFessConfig().isSuggestSearchLog()) {
+                builder.addKind(SuggestItem.Kind.QUERY.toString());
+            }
+            if (ComponentUtil.getFessConfig().isSuggestDocuments()) {
+                builder.addKind(SuggestItem.Kind.DOCUMENT.toString());
+            }
+
+            final SuggestResponse suggestResponse = builder.execute().getResponse();
+
+            final List<Map<String, Object>> items = new ArrayList<>(suggestResponse.getItems().size());
+            for (final SuggestItem item : suggestResponse.getItems()) {
+                final Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("text", item.getText());
+                final String[] itemTags = item.getTags();
+                entry.put("types", itemTags == null ? new ArrayList<String>() : List.of(itemTags));
+                items.add(entry);
+            }
+
+            final Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("q", q == null ? "" : q);
+            payload.put("page_size", suggestResponse.getNum());
+            payload.put("record_count", suggestResponse.getTotal());
+            payload.put("query_time", suggestResponse.getTookMs());
+            payload.put("suggest_words", items);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(response, payload);
+        } catch (final Exception e) {
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2/suggest-words");
+        }
+    }
+}

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/UiConfigHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/UiConfigHandler.java
@@ -123,7 +123,7 @@ public class UiConfigHandler {
         return list;
     }
 
-    private static void addSortOption(final List<Map<String, Object>> list, final String value, final String labelKey) {
+    private void addSortOption(final List<Map<String, Object>> list, final String value, final String labelKey) {
         final Map<String, Object> entry = new LinkedHashMap<>();
         entry.put("value", value);
         entry.put("label_key", labelKey);
@@ -148,7 +148,7 @@ public class UiConfigHandler {
     public void handle(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
         if (!"GET".equalsIgnoreCase(req.getMethod())) {
             res.setHeader("Allow", "GET");
-            V2EnvelopeWriter.writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.METHOD_NOT_ALLOWED, "method not allowed");
             return;
         }
         try {
@@ -389,9 +389,9 @@ public class UiConfigHandler {
             payload.put("filetype_options", buildFiletypeOptions());
             payload.put("csrf_required", csrfRequired);
             payload.put("csrf_token", csrfToken);
-            V2EnvelopeWriter.writeSuccess(res, payload);
+            ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
         } catch (final Exception e) {
-            V2EnvelopeWriter.writeInternalError(res, e, logger, "/api/v2/ui/config");
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/ui/config");
         }
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/UiConfigHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/UiConfigHandler.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.api.v2.SessionCsrfTokenManager;
-import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.chat.ChatClient;
 import org.codelibs.fess.entity.FacetQueryView;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/UserPayloads.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/UserPayloads.java
@@ -39,10 +39,10 @@ import org.codelibs.fess.util.ComponentUtil;
  * developer-facing English. Clients MUST use error.code (the V2ErrorCode token)
  * for user-facing i18n.</p>
  */
-public final class UserPayloads {
+public class UserPayloads {
 
-    private UserPayloads() {
-        // utility class — no instances
+    public UserPayloads() {
+        // default constructor
     }
 
     /**
@@ -54,7 +54,7 @@ public final class UserPayloads {
      * @param u the authenticated user bean (must not be null)
      * @return a LinkedHashMap suitable for inclusion in a v2 response payload
      */
-    public static Map<String, Object> toJson(final FessUserBean u) {
+    public Map<String, Object> toJson(final FessUserBean u) {
         final Map<String, Object> userMap = new LinkedHashMap<>();
         final String userId = u.getUserId();
         userMap.put("user_id", userId);
@@ -76,7 +76,7 @@ public final class UserPayloads {
         return userMap;
     }
 
-    private static List<String> arrayOrEmpty(final String[] arr) {
+    private List<String> arrayOrEmpty(final String[] arr) {
         return arr == null ? List.of() : List.of(arr);
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/UserPayloads.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/UserPayloads.java
@@ -41,6 +41,11 @@ import org.codelibs.fess.util.ComponentUtil;
  */
 public class UserPayloads {
 
+    /**
+     * Creates the user-payload helper. Registered as the DI component
+     * {@code v2UserPayloads} and obtained via
+     * {@link org.codelibs.fess.util.ComponentUtil#getV2UserPayloads()}.
+     */
     public UserPayloads() {
         // default constructor
     }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/V2JsonBody.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/V2JsonBody.java
@@ -61,6 +61,11 @@ public class V2JsonBody {
     /** UTF-8 BOM byte sequence (EF BB BF). Present in some editor-generated JSON files. */
     private static final byte[] UTF8_BOM = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
 
+    /**
+     * Creates the v2 JSON body reader. Registered as the DI component
+     * {@code v2JsonBody} and obtained via
+     * {@link org.codelibs.fess.util.ComponentUtil#getV2JsonBody()}.
+     */
     public V2JsonBody() {
         // default constructor
     }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/V2JsonBody.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/V2JsonBody.java
@@ -38,7 +38,7 @@ import jakarta.servlet.http.HttpServletRequest;
  * {@code application/json}, and malformed JSON. The empty body is treated as
  * an empty map so callers do not need to null-check before lookups.</p>
  */
-public final class V2JsonBody {
+public class V2JsonBody {
 
     /**
      * Shared Jackson mapper with tight {@link StreamReadConstraints} to defend against
@@ -50,7 +50,7 @@ public final class V2JsonBody {
      *   <li>{@code maxStringLength(1 MiB)} — rejects individual string values exceeding 1 MiB.</li>
      * </ul>
      */
-    private static final JsonMapper MAPPER = JsonMapper.builder(JsonFactory.builder()
+    private final JsonMapper mapper = JsonMapper.builder(JsonFactory.builder()
             .streamReadConstraints(
                     StreamReadConstraints.builder().maxNestingDepth(32).maxNumberLength(1000).maxStringLength(1 << 20).build())
             .build()).build();
@@ -61,7 +61,8 @@ public final class V2JsonBody {
     /** UTF-8 BOM byte sequence (EF BB BF). Present in some editor-generated JSON files. */
     private static final byte[] UTF8_BOM = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
 
-    private V2JsonBody() {
+    public V2JsonBody() {
+        // default constructor
     }
 
     /**
@@ -91,7 +92,7 @@ public final class V2JsonBody {
      * @throws MalformedJsonException if the body is not valid JSON
      * @throws IOException if reading the request stream fails
      */
-    public static Map<String, Object> read(final HttpServletRequest req, final int maxBytes) throws IOException {
+    public Map<String, Object> read(final HttpServletRequest req, final int maxBytes) throws IOException {
         final String ct = req.getContentType();
         if (ct == null) {
             throw new UnsupportedMediaTypeException("content-type is required");
@@ -132,7 +133,7 @@ public final class V2JsonBody {
         }
         final byte[] jsonBytes = offset == 0 ? buf : java.util.Arrays.copyOfRange(buf, offset, buf.length);
         try {
-            return MAPPER.readValue(new String(jsonBytes, StandardCharsets.UTF_8), TYPE);
+            return mapper.readValue(new String(jsonBytes, StandardCharsets.UTF_8), TYPE);
         } catch (final JsonProcessingException e) {
             throw new MalformedJsonException(e.getMessage());
         }

--- a/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
@@ -15,10 +15,12 @@
  */
 package org.codelibs.fess.helper;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -26,7 +28,9 @@ import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.fess.api.v2.handlers.ChatRequestBody;
 import org.codelibs.fess.Constants;
+import org.codelibs.fess.entity.ChatMessage.ChatSource;
 import org.codelibs.fess.entity.FacetQueryView;
 import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -156,6 +160,49 @@ public class ChatApiHelper {
     }
 
     /**
+     * Parses a raw v2 chat JSON body into a validated {@link ChatRequestBody}.
+     *
+     * @param raw the parsed JSON request body
+     * @param maxMessageLength upper bound on the {@code message} length, in characters
+     * @return a validated request body
+     * @throws ChatRequestBody.MessageTooLongException if {@code message} exceeds {@code maxMessageLength}
+     * @throws IOException if validation reports an unrecoverable error
+     */
+    public ChatRequestBody parseRequestBody(final Map<String, Object> raw, final int maxMessageLength) throws IOException {
+        final String message = trimmedOrNull(raw.get("message"));
+        final String sessionId = trimmedOrNull(raw.get("session_id"));
+        if (message != null && message.length() > maxMessageLength) {
+            throw new ChatRequestBody.MessageTooLongException("message exceeds max length: " + message.length() + " > " + maxMessageLength);
+        }
+        final Map<String, List<String>> warnings = new HashMap<>();
+        final Map<String, String[]> fields = parseFieldFilters(raw, warnings);
+        final String[] extraQueries = parseExtraQueries(raw, warnings);
+        return new ChatRequestBody(message, sessionId, fields, extraQueries, warnings);
+    }
+
+    /**
+     * Converts chat sources to the v2 API response shape.
+     *
+     * @param sources list of chat sources to convert
+     * @return list of snake_case maps, one per source
+     */
+    public List<Map<String, Object>> toSourceMaps(final List<ChatSource> sources) {
+        final List<Map<String, Object>> result = new ArrayList<>(sources.size());
+        for (final ChatSource src : sources) {
+            final Map<String, Object> m = new LinkedHashMap<>();
+            m.put("rank", src.getIndex());
+            putIfNotNull(m, "title", src.getTitle());
+            putIfNotNull(m, "url", src.getUrl());
+            putIfNotNull(m, "doc_id", src.getDocId());
+            putIfNotNull(m, "snippet", src.getSnippet());
+            putIfNotNull(m, "url_link", src.getUrlLink());
+            putIfNotNull(m, "go_url", src.getGoUrl());
+            result.add(m);
+        }
+        return result;
+    }
+
+    /**
      * Coerces a raw request value into a list of strings: each element of a {@link List} is
      * converted via {@code toString()} (skipping nulls); any other non-null value yields a
      * single-element list. A {@code null} input yields an empty list.
@@ -163,7 +210,7 @@ public class ChatApiHelper {
      * @param raw the raw value (a {@code List}, a scalar, or {@code null})
      * @return the coerced string values (never {@code null})
      */
-    private static List<String> toStringList(final Object raw) {
+    private List<String> toStringList(final Object raw) {
         final List<String> values = new ArrayList<>();
         if (raw instanceof List<?> l) {
             for (final Object o : l) {
@@ -177,6 +224,20 @@ public class ChatApiHelper {
         return values;
     }
 
+    private String trimmedOrNull(final Object v) {
+        if (v == null) {
+            return null;
+        }
+        final String s = v.toString().trim();
+        return s.isEmpty() ? null : s;
+    }
+
+    private void putIfNotNull(final Map<String, Object> map, final String key, final Object value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+
     /**
      * Partitions {@code values} against an allowlist, returning the accepted values and recording
      * rejected ones under {@code warningKey} in {@code warnings} (only when non-empty).
@@ -187,7 +248,7 @@ public class ChatApiHelper {
      * @param warnings mutable map collecting rejected values
      * @return the values present in {@code allowed} (never {@code null})
      */
-    private static List<String> partitionAllowed(final List<String> values, final Set<String> allowed, final String warningKey,
+    private List<String> partitionAllowed(final List<String> values, final Set<String> allowed, final String warningKey,
             final Map<String, List<String>> warnings) {
         final List<String> valid = new ArrayList<>();
         final List<String> rejected = new ArrayList<>();

--- a/src/main/java/org/codelibs/fess/helper/SseResponseHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SseResponseHelper.java
@@ -36,6 +36,11 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class SseResponseHelper {
 
+    /**
+     * Creates the SSE response helper. Registered as the DI component
+     * {@code sseResponseHelper} and obtained via
+     * {@link org.codelibs.fess.util.ComponentUtil#getSseResponseHelper()}.
+     */
     public SseResponseHelper() {
         // default constructor
     }

--- a/src/main/java/org/codelibs/fess/helper/SseResponseHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SseResponseHelper.java
@@ -31,13 +31,13 @@ import jakarta.servlet.http.HttpServletResponse;
  * stream is buffered until the connection closes, which defeats the purpose of SSE
  * and breaks the chat UX.</p>
  *
- * <p>This is a stateless utility — {@code final} class with a private constructor.
- * No DI registration is required; callers invoke the static method directly.</p>
+ * <p>This is a DI-managed singleton helper; obtain it through
+ * {@link org.codelibs.fess.util.ComponentUtil#getSseResponseHelper()}.</p>
  */
-public final class SseResponseHelper {
+public class SseResponseHelper {
 
-    private SseResponseHelper() {
-        // Utility class — no instances.
+    public SseResponseHelper() {
+        // default constructor
     }
 
     /**
@@ -56,7 +56,7 @@ public final class SseResponseHelper {
      *
      * @param response the HTTP response to configure; must not be {@code null}
      */
-    public static void applySseHeaders(final HttpServletResponse response) {
+    public void applySseHeaders(final HttpServletResponse response) {
         response.setCharacterEncoding("UTF-8");
         response.setContentType("text/event-stream; charset=UTF-8");
         response.setHeader("Cache-Control", "no-cache");

--- a/src/main/java/org/codelibs/fess/util/ComponentUtil.java
+++ b/src/main/java/org/codelibs/fess/util/ComponentUtil.java
@@ -27,7 +27,12 @@ import org.codelibs.core.crypto.CachedCipher;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.api.WebApiManagerFactory;
 import org.codelibs.fess.api.v2.SessionCsrfTokenManager;
+import org.codelibs.fess.api.v2.V2EnvelopeWriter;
+import org.codelibs.fess.api.v2.handlers.CsrfRequirement;
+import org.codelibs.fess.api.v2.handlers.DocIdValidator;
 import org.codelibs.fess.api.v2.handlers.LoginRateLimiter;
+import org.codelibs.fess.api.v2.handlers.UserPayloads;
+import org.codelibs.fess.api.v2.handlers.V2JsonBody;
 import org.codelibs.fess.auth.AuthenticationManager;
 import org.codelibs.fess.chat.ChatClient;
 import org.codelibs.fess.chat.ChatContentFetcher;
@@ -76,6 +81,7 @@ import org.codelibs.fess.helper.RoleQueryHelper;
 import org.codelibs.fess.helper.SambaHelper;
 import org.codelibs.fess.helper.SearchHelper;
 import org.codelibs.fess.helper.SearchLogHelper;
+import org.codelibs.fess.helper.SseResponseHelper;
 import org.codelibs.fess.helper.SuggestHelper;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.helper.ThemeHelper;
@@ -151,6 +157,18 @@ public final class ComponentUtil {
     private static final String LOGIN_RATE_LIMITER = "loginRateLimiter";
 
     private static final String SESSION_CSRF_TOKEN_MANAGER = "sessionCsrfTokenManager";
+
+    private static final String V2_ENVELOPE_WRITER = "v2EnvelopeWriter";
+
+    private static final String V2_JSON_BODY = "v2JsonBody";
+
+    private static final String V2_USER_PAYLOADS = "v2UserPayloads";
+
+    private static final String V2_CSRF_REQUIREMENT = "v2CsrfRequirement";
+
+    private static final String V2_DOC_ID_VALIDATOR = "v2DocIdValidator";
+
+    private static final String SSE_RESPONSE_HELPER = "sseResponseHelper";
 
     private static final String THEME_REGISTRY = "themeRegistry";
 
@@ -779,6 +797,54 @@ public final class ComponentUtil {
      */
     public static SessionCsrfTokenManager getSessionCsrfTokenManager() {
         return getComponent(SESSION_CSRF_TOKEN_MANAGER);
+    }
+
+    /**
+     * Gets the v2 envelope writer component.
+     * @return The v2 envelope writer.
+     */
+    public static V2EnvelopeWriter getV2EnvelopeWriter() {
+        return getComponent(V2_ENVELOPE_WRITER);
+    }
+
+    /**
+     * Gets the v2 JSON body reader component.
+     * @return The v2 JSON body reader.
+     */
+    public static V2JsonBody getV2JsonBody() {
+        return getComponent(V2_JSON_BODY);
+    }
+
+    /**
+     * Gets the v2 user payload builder component.
+     * @return The v2 user payload builder.
+     */
+    public static UserPayloads getV2UserPayloads() {
+        return getComponent(V2_USER_PAYLOADS);
+    }
+
+    /**
+     * Gets the v2 CSRF requirement component.
+     * @return The v2 CSRF requirement component.
+     */
+    public static CsrfRequirement getV2CsrfRequirement() {
+        return getComponent(V2_CSRF_REQUIREMENT);
+    }
+
+    /**
+     * Gets the v2 document id validator component.
+     * @return The v2 document id validator.
+     */
+    public static DocIdValidator getV2DocIdValidator() {
+        return getComponent(V2_DOC_ID_VALIDATOR);
+    }
+
+    /**
+     * Gets the SSE response helper component.
+     * @return The SSE response helper.
+     */
+    public static SseResponseHelper getSseResponseHelper() {
+        return getComponent(SSE_RESPONSE_HELPER);
     }
 
     /**

--- a/src/main/resources/fess_api.xml
+++ b/src/main/resources/fess_api.xml
@@ -9,6 +9,14 @@
 
 	<component name="searchEngineApiManager" class="org.codelibs.fess.api.engine.SearchEngineApiManager"/>
 
+	<!-- v2 shared components. -->
+	<component name="v2EnvelopeWriter" class="org.codelibs.fess.api.v2.V2EnvelopeWriter"/>
+	<component name="v2JsonBody" class="org.codelibs.fess.api.v2.handlers.V2JsonBody"/>
+	<component name="v2UserPayloads" class="org.codelibs.fess.api.v2.handlers.UserPayloads"/>
+	<component name="v2CsrfRequirement" class="org.codelibs.fess.api.v2.handlers.CsrfRequirement"/>
+	<component name="v2DocIdValidator" class="org.codelibs.fess.api.v2.handlers.DocIdValidator"/>
+	<component name="sseResponseHelper" class="org.codelibs.fess.helper.SseResponseHelper"/>
+
 	<!-- v2 request handlers, injected into searchApiV2Manager by field name. -->
 	<component name="searchHandler" class="org.codelibs.fess.api.v2.handlers.SearchHandler"/>
 	<component name="scrollSearchHandler" class="org.codelibs.fess.api.v2.handlers.ScrollSearchHandler"/>
@@ -24,6 +32,10 @@
 	<component name="chatStreamHandler" class="org.codelibs.fess.api.v2.handlers.ChatStreamHandler"/>
 	<component name="chatSessionClearHandler" class="org.codelibs.fess.api.v2.handlers.ChatSessionClearHandler"/>
 	<component name="cacheHandler" class="org.codelibs.fess.api.v2.handlers.CacheHandler"/>
+	<component name="healthHandler" class="org.codelibs.fess.api.v2.handlers.HealthHandler"/>
+	<component name="suggestWordsHandler" class="org.codelibs.fess.api.v2.handlers.SuggestWordsHandler"/>
+	<component name="labelsHandler" class="org.codelibs.fess.api.v2.handlers.LabelsHandler"/>
+	<component name="popularWordsHandler" class="org.codelibs.fess.api.v2.handlers.PopularWordsHandler"/>
 	<component name="loginHandler" class="org.codelibs.fess.api.v2.handlers.LoginHandler"/>
 	<component name="relatedQueriesHandler" class="org.codelibs.fess.api.v2.handlers.RelatedQueriesHandler"/>
 	<component name="relatedContentHandler" class="org.codelibs.fess.api.v2.handlers.RelatedContentHandler"/>

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerCsrfTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerCsrfTest.java
@@ -180,8 +180,8 @@ public class SearchApiV2ManagerCsrfTest extends UnitFessTestCase {
     @Test
     public void searchApiV2Manager_handlerThrows_doesNotLeakMessage() throws Exception {
         // Verify the outer catch's sanitization by directly inspecting the source. The
-        // fix replaced `V2EnvelopeWriter.writeError(response, V2ErrorCode.INTERNAL_ERROR, e.getMessage())`
-        // with `V2EnvelopeWriter.writeError(response, V2ErrorCode.INTERNAL_ERROR, "internal error")`.
+        // fix replaced `ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INTERNAL_ERROR, e.getMessage())`
+        // with `ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INTERNAL_ERROR, "internal error")`.
         // The simplest verifiable invariant from a unit test: read the source file (under
         // src/main) and confirm the broad catch no longer passes `e.getMessage()`. This is
         // a static-assertion-style test that protects against future regressions where a
@@ -194,10 +194,10 @@ public class SearchApiV2ManagerCsrfTest extends UnitFessTestCase {
         assertTrue(catchIdx >= 0, "broad-catch log statement not found — has the file been restructured?");
         // Inspect the small window of source immediately after the log call.
         final String window = source.substring(catchIdx, Math.min(source.length(), catchIdx + 2000));
-        // Find the actual V2EnvelopeWriter.writeError call inside the broad catch and assert
+        // Find the actual ComponentUtil.getV2EnvelopeWriter().writeError call inside the broad catch and assert
         // its arguments — the window also contains a "do not leak e.getMessage()" comment we
         // intentionally keep, so scope the leak check to the function-call expression.
-        final int writeErrorCall = window.indexOf("V2EnvelopeWriter.writeError(response, V2ErrorCode.INTERNAL_ERROR");
+        final int writeErrorCall = window.indexOf("ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INTERNAL_ERROR");
         assertTrue(writeErrorCall >= 0, "broad-catch writeError call missing: " + window);
         final int callEnd = window.indexOf(");", writeErrorCall);
         final String call = window.substring(writeErrorCall, callEnd >= 0 ? callEnd : window.length());
@@ -229,7 +229,7 @@ public class SearchApiV2ManagerCsrfTest extends UnitFessTestCase {
         // broad-catch declaration.
         final String window = source.substring(catchIdx, Math.min(source.length(), catchIdx + 2000));
         final int committedIdx = window.indexOf("isCommitted()");
-        final int writeErrorIdx = window.indexOf("V2EnvelopeWriter.writeError");
+        final int writeErrorIdx = window.indexOf("ComponentUtil.getV2EnvelopeWriter().writeError");
         assertTrue(committedIdx > 0, "isCommitted() guard missing: " + window);
         assertTrue(writeErrorIdx > 0, "writeError call missing: " + window);
         assertTrue(committedIdx < writeErrorIdx, "isCommitted() guard must precede writeError() in the broad catch: " + window);

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
@@ -246,19 +246,18 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
 
     @Test
     public void test_handleHealth_does_not_leak_exception_message() throws Exception {
-        // Source-level assertion: the handleHealth catch block must not pass e.getMessage()
+        // Source-level assertion: the HealthHandler catch block must not pass e.getMessage()
         // to writeError. Uses writeInternalError which logs and emits a generic message.
-        final java.nio.file.Path src = java.nio.file.Paths.get("src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java");
+        final java.nio.file.Path src = java.nio.file.Paths.get("src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java");
         org.junit.jupiter.api.Assumptions.assumeTrue(java.nio.file.Files.exists(src),
                 "skipping: source file not present at runtime cwd=" + java.nio.file.Paths.get(".").toAbsolutePath());
         final String source = java.nio.file.Files.readString(src);
-        // Find handleHealth and look for the catch block
-        final int healthIdx = source.indexOf("private void handleHealth");
-        assertTrue(healthIdx >= 0, "handleHealth not found in source");
+        final int healthIdx = source.indexOf("public void handle");
+        assertTrue(healthIdx >= 0, "HealthHandler.handle not found in source");
         final String healthSection = source.substring(healthIdx, Math.min(source.length(), healthIdx + 2000));
         // The catch must use writeInternalError, not writeError with e.getMessage()
-        assertTrue(healthSection.contains("writeInternalError"), "handleHealth catch must use writeInternalError: " + healthSection);
-        assertFalse(healthSection.contains("e.getMessage()"), "handleHealth must not leak e.getMessage(): " + healthSection);
+        assertTrue(healthSection.contains("writeInternalError"), "HealthHandler catch must use writeInternalError: " + healthSection);
+        assertFalse(healthSection.contains("e.getMessage()"), "HealthHandler must not leak e.getMessage(): " + healthSection);
     }
 
     @Test
@@ -266,7 +265,7 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
         final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
         final CapturingResponse res = new CapturingResponse();
         m.process(new StubRequest("/api/v2/health"), res, new NopChain());
-        // The /health route writes its envelope through handleHealth(). The engine may or
+        // The /health route writes its envelope through HealthHandler. The engine may or
         // may not be reachable from the unit harness; success / service_unavailable (red) /
         // internal_error are all accepted as long as the v2 envelope shape is preserved.
         // C-9 invariant: envelope.status >= 1 iff HTTP >= 400 — red clusters now emit a
@@ -291,21 +290,21 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
 
     @Test
     public void test_handleHealth_clusterRedMapsTo503_sourceLevel() throws Exception {
-        // Source-level assertion: the handleHealth method must check for "red" cluster status
+        // Source-level assertion: the HealthHandler must check for "red" cluster status
         // and set response.setStatus(503). This test reads the source to confirm the pattern.
-        final java.nio.file.Path src = java.nio.file.Paths.get("src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java");
+        final java.nio.file.Path src = java.nio.file.Paths.get("src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java");
         org.junit.jupiter.api.Assumptions.assumeTrue(java.nio.file.Files.exists(src),
                 "skipping: source not available at cwd=" + java.nio.file.Paths.get(".").toAbsolutePath());
         final String source = java.nio.file.Files.readString(src);
-        final int healthIdx = source.indexOf("private void handleHealth");
-        assertTrue(healthIdx >= 0, "handleHealth not found in source");
+        final int healthIdx = source.indexOf("public void handle");
+        assertTrue(healthIdx >= 0, "HealthHandler.handle not found in source");
         final String healthSection = source.substring(healthIdx, Math.min(source.length(), healthIdx + 2500));
         // Must reference SERVICE_UNAVAILABLE (the 503 code added by MJ-26 fix).
         assertTrue(healthSection.contains("SERVICE_UNAVAILABLE"),
-                "handleHealth must map red cluster to SERVICE_UNAVAILABLE: " + healthSection);
+                "HealthHandler must map red cluster to SERVICE_UNAVAILABLE: " + healthSection);
         // Must check for "red" cluster status.
         assertTrue(healthSection.contains("\"red\"") || healthSection.contains("red"),
-                "handleHealth must check for red cluster status: " + healthSection);
+                "HealthHandler must check for red cluster status: " + healthSection);
     }
 
     @Test
@@ -495,7 +494,7 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
         // user identity on /auth/me and /auth/login, and role-filtered hits on /search.
         // process() must therefore default every v2 response to Cache-Control: no-store
         // before dispatch so shared proxies never store them. The error path already gets
-        // the header from V2EnvelopeWriter.writeErrorWithDetails, so this asserts the
+        // the header from new V2EnvelopeWriter().writeErrorWithDetails, so this asserts the
         // success path via a stub handler that does NOT set the header itself.
         final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
         final org.codelibs.fess.api.v2.handlers.LoginHandler stub =

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTestSupport.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTestSupport.java
@@ -23,11 +23,16 @@ import org.codelibs.fess.api.v2.handlers.ClickHandler;
 import org.codelibs.fess.api.v2.handlers.FavoriteGetHandler;
 import org.codelibs.fess.api.v2.handlers.FavoritePostHandler;
 import org.codelibs.fess.api.v2.handlers.LoginHandler;
+import org.codelibs.fess.api.v2.handlers.FavoritesListHandler;
+import org.codelibs.fess.api.v2.handlers.HealthHandler;
+import org.codelibs.fess.api.v2.handlers.LabelsHandler;
 import org.codelibs.fess.api.v2.handlers.LogoutHandler;
 import org.codelibs.fess.api.v2.handlers.MeHandler;
 import org.codelibs.fess.api.v2.handlers.PasswordChangeHandler;
+import org.codelibs.fess.api.v2.handlers.PopularWordsHandler;
 import org.codelibs.fess.api.v2.handlers.ScrollSearchHandler;
 import org.codelibs.fess.api.v2.handlers.SearchHandler;
+import org.codelibs.fess.api.v2.handlers.SuggestWordsHandler;
 import org.codelibs.fess.api.v2.handlers.UiConfigHandler;
 
 /**
@@ -63,6 +68,7 @@ final class SearchApiV2ManagerTestSupport {
         m.scrollSearchHandler = new ScrollSearchHandler();
         m.favoriteGetHandler = new FavoriteGetHandler();
         m.favoritePostHandler = new FavoritePostHandler();
+        m.favoritesListHandler = new FavoritesListHandler();
         m.meHandler = new MeHandler();
         m.logoutHandler = new LogoutHandler();
         m.passwordChangeHandler = new PasswordChangeHandler();
@@ -72,6 +78,10 @@ final class SearchApiV2ManagerTestSupport {
         m.chatStreamHandler = new ChatStreamHandler();
         m.chatSessionClearHandler = new ChatSessionClearHandler();
         m.cacheHandler = new CacheHandler();
+        m.healthHandler = new HealthHandler();
+        m.suggestWordsHandler = new SuggestWordsHandler();
+        m.labelsHandler = new LabelsHandler();
+        m.popularWordsHandler = new PopularWordsHandler();
         m.loginHandler = new LoginHandler();
         return m;
     }

--- a/src/test/java/org/codelibs/fess/api/v2/V2EnvelopeWriterTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/V2EnvelopeWriterTest.java
@@ -35,7 +35,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         final CapturingResponse res = new CapturingResponse();
         final Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("k", "v");
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        new V2EnvelopeWriter().writeSuccess(res, payload);
         final String body = res.body();
         assertTrue(body.contains("\"status\":0"), body);
         assertFalse(body.contains("\"version\""), body);
@@ -46,7 +46,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
     @Test
     public void test_writeError_setsStatusAndCode() throws Exception {
         final CapturingResponse res = new CapturingResponse();
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.AUTH_REQUIRED, "login required");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "login required");
         final String body = res.body();
         assertEquals(401, res.status);
         assertTrue(body.contains("\"status\":1"), body);
@@ -57,7 +57,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
     @Test
     public void test_writeError_notFoundSetsHttpStatus404() throws Exception {
         final CapturingResponse res = new CapturingResponse();
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "no");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "no");
         assertEquals(404, res.status);
         assertTrue(res.body().contains("\"code\":\"not_found\""));
     }
@@ -65,7 +65,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
     @Test
     public void test_writeError_forbiddenSetsHttpStatus403() throws Exception {
         final CapturingResponse res = new CapturingResponse();
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.FORBIDDEN, "no permission");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.FORBIDDEN, "no permission");
         assertEquals(403, res.status);
         assertTrue(res.body().contains("\"code\":\"forbidden\""));
     }
@@ -73,7 +73,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
     @Test
     public void test_writeError_sets_characterEncoding_to_UTF_8() throws Exception {
         final CapturingResponse res = new CapturingResponse();
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.INVALID_REQUEST, "bad");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "bad");
         assertEquals("UTF-8", res.characterEncoding);
     }
 
@@ -85,7 +85,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
                 return true;
             }
         };
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "should not appear");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "should not appear");
         // If response is committed, nothing should be written to the body
         assertEquals("", res.body());
         // Status should not be changed from initial 200
@@ -95,18 +95,18 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
     @Test
     public void test_writeError_mapsStatusSystemError_for_5xx_codes() throws Exception {
         final CapturingResponse res = new CapturingResponse();
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "err");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "err");
         assertTrue(res.body().contains("\"status\":9"), res.body());
     }
 
     @Test
     public void test_writeError_mapsStatusUserError_for_4xx_codes() throws Exception {
         final CapturingResponse res = new CapturingResponse();
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.NOT_FOUND, "not found");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "not found");
         assertTrue(res.body().contains("\"status\":1"), res.body());
 
         final CapturingResponse res2 = new CapturingResponse();
-        V2EnvelopeWriter.writeError(res2, V2ErrorCode.INVALID_REQUEST, "bad request");
+        new V2EnvelopeWriter().writeError(res2, V2ErrorCode.INVALID_REQUEST, "bad request");
         assertTrue(res2.body().contains("\"status\":1"), res2.body());
     }
 
@@ -115,7 +115,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         final CapturingResponse res = new CapturingResponse();
         final Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("status", 99); // reserved — must be rejected
-        assertThrows(IllegalStateException.class, () -> V2EnvelopeWriter.writeSuccess(res, payload),
+        assertThrows(IllegalStateException.class, () -> new V2EnvelopeWriter().writeSuccess(res, payload),
                 "payload containing 'status' should throw IllegalStateException");
     }
 
@@ -125,7 +125,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         final CapturingResponse res = new CapturingResponse();
         final Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("version", "custom");
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        new V2EnvelopeWriter().writeSuccess(res, payload);
         assertTrue(res.body().contains("\"version\":\"custom\""), res.body());
     }
 
@@ -133,7 +133,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
     public void test_writeSuccess_nullPayloadIsAllowed() throws Exception {
         // null payload is documented as "treated as empty"; must not throw.
         final CapturingResponse res = new CapturingResponse();
-        V2EnvelopeWriter.writeSuccess(res, null);
+        new V2EnvelopeWriter().writeSuccess(res, null);
         final String body = res.body();
         assertTrue(body.contains("\"status\":0"), body);
         assertFalse(body.contains("\"version\""), body);
@@ -151,7 +151,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         res.getWriter().write("{\"partial\":1}\n");
         res.getWriter().write("{\"partial\":2}\n");
         // Failure pre-flush → writeError takes over.
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "boom");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "boom");
         // resetBuffer must have been invoked.
         assertTrue(res.resetBufferCalled, "writeError must call resetBuffer() to clear streaming partial body");
         // Content-Type must end up as application/json (not the NDJSON one set earlier).
@@ -170,7 +170,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         final Map<String, Object> engine = new LinkedHashMap<>();
         engine.put("cluster_name", "fess");
         engine.put("status", "red");
-        V2EnvelopeWriter.writeErrorWithDetails(res, V2ErrorCode.SERVICE_UNAVAILABLE, "cluster red", Map.of("engine", engine));
+        new V2EnvelopeWriter().writeErrorWithDetails(res, V2ErrorCode.SERVICE_UNAVAILABLE, "cluster red", Map.of("engine", engine));
         final String body = res.body();
         assertEquals(503, res.status);
         assertTrue(body.contains("\"code\":\"service_unavailable\""), body);
@@ -195,7 +195,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         };
         final java.util.Map<String, Object> payload = new java.util.LinkedHashMap<>();
         payload.put("k", "v");
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        new V2EnvelopeWriter().writeSuccess(res, payload);
         // Nothing must be written to the body — the response is committed.
         assertEquals("", res.body());
         // HTTP status must remain at the default 200 (not changed).
@@ -213,7 +213,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         res.getWriter().write("{\"partial\":\"stale\"}");
         final java.util.Map<String, Object> payload = new java.util.LinkedHashMap<>();
         payload.put("result", "ok");
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        new V2EnvelopeWriter().writeSuccess(res, payload);
         // resetBuffer() must have been called, discarding the stale partial body.
         assertTrue(res.resetBufferCalled, "writeSuccess must call resetBuffer() before writing");
         final String body = res.body();
@@ -232,7 +232,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         final CapturingResponse res = new CapturingResponse();
         // Simulate the SSE prelude header that was set before the handler errored.
         res.setHeader("Cache-Control", "no-cache");
-        V2EnvelopeWriter.writeError(res, V2ErrorCode.INTERNAL_ERROR, "boom");
+        new V2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "boom");
         assertEquals("writeError must override Cache-Control to no-store so SSE prelude no-cache does not leak", "no-store",
                 res.headers.get("Cache-Control"));
     }
@@ -242,7 +242,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         // F4: the details-bearing path must apply the same Cache-Control override.
         final CapturingResponse res = new CapturingResponse();
         res.setHeader("Cache-Control", "no-cache");
-        V2EnvelopeWriter.writeErrorWithDetails(res, V2ErrorCode.SERVICE_UNAVAILABLE, "red", java.util.Map.of("engine", "red"));
+        new V2EnvelopeWriter().writeErrorWithDetails(res, V2ErrorCode.SERVICE_UNAVAILABLE, "red", java.util.Map.of("engine", "red"));
         assertEquals("writeErrorWithDetails must also override Cache-Control to no-store", "no-store", res.headers.get("Cache-Control"));
     }
 
@@ -257,7 +257,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         // assertion here is that writeSuccess itself does not set Cache-Control.
         final java.util.Map<String, Object> payload = new java.util.LinkedHashMap<>();
         payload.put("k", "v");
-        V2EnvelopeWriter.writeSuccess(res, payload);
+        new V2EnvelopeWriter().writeSuccess(res, payload);
         assertFalse(res.headers.containsKey("Cache-Control"),
                 "writeSuccess must not set Cache-Control on its own; caching is endpoint-specific");
     }
@@ -268,7 +268,7 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         // Create a logger that does nothing (we just need to not throw)
         final org.apache.logging.log4j.Logger noopLogger = org.apache.logging.log4j.LogManager.getLogger("test-noop");
         final Exception secret = new RuntimeException("secret connection string: jdbc:postgresql://10.0.0.1:5432/prod");
-        V2EnvelopeWriter.writeInternalError(res, secret, noopLogger, "/test");
+        new V2EnvelopeWriter().writeInternalError(res, secret, noopLogger, "/test");
         final String body = res.body();
         // Must contain the safe message, not the secret
         assertTrue(body.contains("internal error"), "expected 'internal error' in body: " + body);

--- a/src/test/java/org/codelibs/fess/api/v2/V2ErrorCodeTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/V2ErrorCodeTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
  *
  * <p>The enum is part of the {@code /api/v2} wire contract — its string codes
  * are emitted into the {@code error.code} field of every error envelope, and
- * its HTTP statuses drive {@code V2EnvelopeWriter.writeError}'s
+ * its HTTP statuses drive {@code new V2EnvelopeWriter().writeError}'s
  * {@code res.setStatus} call. Locking down both surfaces here prevents an
  * accidental rename or status flip from silently breaking SPA clients.</p>
  */

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatHandlerTest.java
@@ -121,7 +121,8 @@ public class ChatHandlerTest extends UnitFessTestCase {
         src.setSnippet("some snippet");
         src.setUrlLink("https://example.com/link");
         src.setGoUrl("https://go.example.com");
-        final java.util.List<java.util.Map<String, Object>> maps = ChatHandler.toSourceMaps(java.util.List.of(src));
+        final java.util.List<java.util.Map<String, Object>> maps =
+                new org.codelibs.fess.helper.ChatApiHelper().toSourceMaps(java.util.List.of(src));
         assertEquals(1, maps.size());
         final java.util.Map<String, Object> m = maps.get(0);
         assertEquals("rank must be getIndex() value", 1, m.get("rank"));
@@ -144,7 +145,8 @@ public class ChatHandlerTest extends UnitFessTestCase {
         final org.codelibs.fess.entity.ChatMessage.ChatSource src = new org.codelibs.fess.entity.ChatMessage.ChatSource();
         src.setIndex(2);
         // All optional fields left null
-        final java.util.List<java.util.Map<String, Object>> maps = ChatHandler.toSourceMaps(java.util.List.of(src));
+        final java.util.List<java.util.Map<String, Object>> maps =
+                new org.codelibs.fess.helper.ChatApiHelper().toSourceMaps(java.util.List.of(src));
         final java.util.Map<String, Object> m = maps.get(0);
         assertEquals(2, m.get("rank"));
         assertFalse(m.containsKey("title"), "null title must be omitted");

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatRequestBodyTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatRequestBodyTest.java
@@ -20,15 +20,18 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.List;
 import java.util.Map;
 
+import org.codelibs.fess.helper.ChatApiHelper;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
 
 public class ChatRequestBodyTest extends UnitFessTestCase {
 
+    private final ChatApiHelper chatApiHelper = new ChatApiHelper();
+
     @Test
     public void test_parsesMessageAndSessionId() throws Exception {
         final Map<String, Object> raw = Map.of("message", "hello", "session_id", "s1");
-        final ChatRequestBody body = ChatRequestBody.from(raw, 4000);
+        final ChatRequestBody body = chatApiHelper.parseRequestBody(raw, 4000);
         assertEquals("hello", body.message());
         assertEquals("s1", body.sessionId());
         // clear flag removed — session clearing uses DELETE /api/v2/chat/sessions/{id}
@@ -36,27 +39,27 @@ public class ChatRequestBodyTest extends UnitFessTestCase {
 
     @Test
     public void test_blankMessageReturnsNull() throws Exception {
-        assertNull(ChatRequestBody.from(Map.of("message", "  "), 4000).message());
-        assertNull(ChatRequestBody.from(Map.of(), 4000).message());
+        assertNull(chatApiHelper.parseRequestBody(Map.of("message", "  "), 4000).message());
+        assertNull(chatApiHelper.parseRequestBody(Map.of(), 4000).message());
     }
 
     @Test
     public void test_oversizedMessageThrows() {
         final String big = "x".repeat(101);
-        assertThrows(ChatRequestBody.MessageTooLongException.class, () -> ChatRequestBody.from(Map.of("message", big), 100));
+        assertThrows(ChatRequestBody.MessageTooLongException.class, () -> chatApiHelper.parseRequestBody(Map.of("message", big), 100));
     }
 
     @Test
     public void test_filtersOnlyAcceptKnownLabels_nestedFields() throws Exception {
         // v2 nested fields object: {"fields": {"label": ["nope"]}}
-        final ChatRequestBody body = ChatRequestBody.from(Map.of("fields", Map.of("label", java.util.List.of("nope"))), 4000);
+        final ChatRequestBody body = chatApiHelper.parseRequestBody(Map.of("fields", Map.of("label", java.util.List.of("nope"))), 4000);
         assertNotNull(body.fields());
     }
 
     @Test
     public void test_filtersOnlyAcceptKnownLabels_dottedFallback() throws Exception {
         // Legacy dotted-key fallback: still accepted during transition.
-        final ChatRequestBody body = ChatRequestBody.from(Map.of("fields.label", java.util.List.of("nope")), 4000);
+        final ChatRequestBody body = chatApiHelper.parseRequestBody(Map.of("fields.label", java.util.List.of("nope")), 4000);
         assertNotNull(body.fields());
     }
 
@@ -65,7 +68,7 @@ public class ChatRequestBodyTest extends UnitFessTestCase {
     @Test
     public void test_warnings_emptyWhenNothingDropped() throws Exception {
         // When no fields.label or extra_queries are supplied, getWarnings() must return an empty map.
-        final ChatRequestBody body = ChatRequestBody.from(Map.of("message", "hi"), 4000);
+        final ChatRequestBody body = chatApiHelper.parseRequestBody(Map.of("message", "hi"), 4000);
         assertNotNull(body.getWarnings(), "warnings must not be null");
         assertTrue(body.getWarnings().isEmpty(), "warnings must be empty when nothing was dropped: " + body.getWarnings());
     }
@@ -74,7 +77,7 @@ public class ChatRequestBodyTest extends UnitFessTestCase {
     public void test_warnings_containsRejectedLabelValues() throws Exception {
         // When the allowlist is empty (helper unavailable in unit tests), every supplied
         // fields.label value is rejected and must appear in getWarnings()["fields.label"].
-        final ChatRequestBody body = ChatRequestBody.from(Map.of("fields", Map.of("label", List.of("label-a", "label-b"))), 4000);
+        final ChatRequestBody body = chatApiHelper.parseRequestBody(Map.of("fields", Map.of("label", List.of("label-a", "label-b"))), 4000);
         assertNotNull(body.getWarnings(), "warnings must not be null");
         final List<String> warnedLabels = body.getWarnings().get("fields.label");
         assertNotNull(warnedLabels, "rejected labels must be tracked in warnings");
@@ -84,7 +87,7 @@ public class ChatRequestBodyTest extends UnitFessTestCase {
     @Test
     public void test_warnings_containsRejectedExtraQueryValues() throws Exception {
         // extra_queries replaces the old ex_q key.
-        final ChatRequestBody body = ChatRequestBody.from(Map.of("extra_queries", List.of("q=foo", "q=bar")), 4000);
+        final ChatRequestBody body = chatApiHelper.parseRequestBody(Map.of("extra_queries", List.of("q=foo", "q=bar")), 4000);
         assertNotNull(body.getWarnings(), "warnings must not be null");
         final List<String> warnedExQ = body.getWarnings().get("extra_queries");
         assertNotNull(warnedExQ, "rejected extra_queries must be tracked in warnings");
@@ -94,7 +97,7 @@ public class ChatRequestBodyTest extends UnitFessTestCase {
     @Test
     public void test_warnings_isUnmodifiable() throws Exception {
         // getWarnings() must return an unmodifiable view.
-        final ChatRequestBody body = ChatRequestBody.from(Map.of("fields", Map.of("label", List.of("x"))), 4000);
+        final ChatRequestBody body = chatApiHelper.parseRequestBody(Map.of("fields", Map.of("label", List.of("x"))), 4000);
         final Map<String, List<String>> warnings = body.getWarnings();
         assertThrows(UnsupportedOperationException.class, () -> warnings.put("new", List.of()), "warnings map must be unmodifiable");
     }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ClickHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ClickHandlerTest.java
@@ -126,13 +126,14 @@ public class ClickHandlerTest extends UnitFessTestCase {
     @Test
     public void test_epochMsToUtcLocalDateTime_isTimezoneInvariant() {
         final java.util.TimeZone original = java.util.TimeZone.getDefault();
+        final ClickHandler handler = new ClickHandler();
         try {
             // 2024-06-15T12:34:56.789Z — picked so PST and JST land on different calendar days.
             final long epochMs = 1718454896789L;
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("America/Los_Angeles"));
-            final java.time.LocalDateTime pst = ClickHandler.epochMsToUtcLocalDateTime(epochMs);
+            final java.time.LocalDateTime pst = handler.epochMsToUtcLocalDateTime(epochMs);
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Tokyo"));
-            final java.time.LocalDateTime jst = ClickHandler.epochMsToUtcLocalDateTime(epochMs);
+            final java.time.LocalDateTime jst = handler.epochMsToUtcLocalDateTime(epochMs);
             // Same epoch must yield the same LocalDateTime irrespective of default zone.
             assertEquals(pst, jst);
             // And that LocalDateTime must be the UTC wall-clock for the epoch.
@@ -146,7 +147,7 @@ public class ClickHandlerTest extends UnitFessTestCase {
     public void test_epochMsToUtcLocalDateTime_handlesEpochZero() {
         // Defensive sanity: epoch 0 → 1970-01-01T00:00:00 UTC. Was prone to off-by-hours
         // drift under the old systemDefault() conversion in non-UTC test environments.
-        assertEquals(java.time.LocalDateTime.of(1970, 1, 1, 0, 0, 0), ClickHandler.epochMsToUtcLocalDateTime(0L));
+        assertEquals(java.time.LocalDateTime.of(1970, 1, 1, 0, 0, 0), new ClickHandler().epochMsToUtcLocalDateTime(0L));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/CsrfRequirementCompleteCoverageTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/CsrfRequirementCompleteCoverageTest.java
@@ -123,12 +123,12 @@ public class CsrfRequirementCompleteCoverageTest {
 
     @Test
     public void test_everyEndpointHasDeliberateCsrfDecision() {
-        // Enumerate every entry and assert the decision matches CsrfRequirement.requiresCsrf.
+        // Enumerate every entry and assert the decision matches new CsrfRequirement().requiresCsrf.
         final List<String> failures = new java.util.ArrayList<>();
         for (final Map.Entry<String, Boolean> entry : ENDPOINT_DECISIONS.entrySet()) {
             final String subPath = entry.getKey();
             final boolean expectedCsrf = entry.getValue();
-            final boolean actualCsrf = CsrfRequirement.requiresCsrf(subPath, "POST");
+            final boolean actualCsrf = new CsrfRequirement().requiresCsrf(subPath, "POST");
             if (actualCsrf != expectedCsrf) {
                 failures.add(String.format("  subPath=%-35s POST: expected csrf=%b, got=%b", subPath, expectedCsrf, actualCsrf));
             }
@@ -136,7 +136,7 @@ public class CsrfRequirementCompleteCoverageTest {
         if (!failures.isEmpty()) {
             fail("CsrfRequirement decision mismatch for the following endpoints:\n" + String.join("\n", failures)
                     + "\n\nFor each mismatch, either:\n"
-                    + "  (a) update CsrfRequirement.requiresCsrf() to reflect the intended decision, or\n"
+                    + "  (a) update new CsrfRequirement().requiresCsrf() to reflect the intended decision, or\n"
                     + "  (b) update this test's ENDPOINT_DECISIONS table if the intended decision changed.");
         }
     }
@@ -148,10 +148,10 @@ public class CsrfRequirementCompleteCoverageTest {
         final List<String> stateChangingPost =
                 Arrays.asList("/auth/logout", "/auth/password", "/click", "/documents/abc123/favorite", "/chat", "/chat/stream");
         for (final String path : stateChangingPost) {
-            assertTrue(CsrfRequirement.requiresCsrf(path, "POST"), "State-changing endpoint must require CSRF token: POST " + path);
+            assertTrue(new CsrfRequirement().requiresCsrf(path, "POST"), "State-changing endpoint must require CSRF token: POST " + path);
         }
         // DELETE /chat/sessions/{session_id} is state-changing — CSRF required
-        assertTrue(CsrfRequirement.requiresCsrf("/chat/sessions/abc", "DELETE"),
+        assertTrue(new CsrfRequirement().requiresCsrf("/chat/sessions/abc", "DELETE"),
                 "DELETE /chat/sessions/{session_id} must require CSRF token");
     }
 
@@ -159,28 +159,29 @@ public class CsrfRequirementCompleteCoverageTest {
     public void test_deleteChatSessions_requiresCsrf() {
         // DELETE /chat/sessions/{session_id} was added as a state-mutating endpoint.
         // Verify several representative session_id values all require CSRF.
-        assertTrue(CsrfRequirement.requiresCsrf("/chat/sessions/abc", "DELETE"), "DELETE /chat/sessions/abc must require CSRF");
-        assertTrue(CsrfRequirement.requiresCsrf("/chat/sessions/def", "DELETE"), "DELETE /chat/sessions/def must require CSRF");
-        assertTrue(CsrfRequirement.requiresCsrf("/chat/sessions/", "DELETE"), "DELETE /chat/sessions/ (trailing slash) must require CSRF");
+        assertTrue(new CsrfRequirement().requiresCsrf("/chat/sessions/abc", "DELETE"), "DELETE /chat/sessions/abc must require CSRF");
+        assertTrue(new CsrfRequirement().requiresCsrf("/chat/sessions/def", "DELETE"), "DELETE /chat/sessions/def must require CSRF");
+        assertTrue(new CsrfRequirement().requiresCsrf("/chat/sessions/", "DELETE"),
+                "DELETE /chat/sessions/ (trailing slash) must require CSRF");
     }
 
     @Test
     public void test_getChatSessions_isExemptByGetRule() {
         // GET on chat/sessions path must be exempt — GET is always idempotent
-        assertFalse(CsrfRequirement.requiresCsrf("/chat/sessions/abc", "GET"), "GET /chat/sessions/{session_id} must be CSRF-exempt");
+        assertFalse(new CsrfRequirement().requiresCsrf("/chat/sessions/abc", "GET"), "GET /chat/sessions/{session_id} must be CSRF-exempt");
     }
 
     @Test
     public void test_loginIsExplicitlyExempt() {
         // /auth/login must be CSRF-exempt because the client has no token yet.
-        assertFalse(CsrfRequirement.requiresCsrf("/auth/login", "POST"), "/auth/login POST must be CSRF-exempt");
+        assertFalse(new CsrfRequirement().requiresCsrf("/auth/login", "POST"), "/auth/login POST must be CSRF-exempt");
     }
 
     @Test
     public void test_getMethodIsAlwaysExemptForAllKnownPaths() {
         // All known endpoints: GET must never require CSRF regardless of path.
         for (final String subPath : ENDPOINT_DECISIONS.keySet()) {
-            assertFalse(CsrfRequirement.requiresCsrf(subPath, "GET"), "GET must always be CSRF-exempt, including: " + subPath);
+            assertFalse(new CsrfRequirement().requiresCsrf(subPath, "GET"), "GET must always be CSRF-exempt, including: " + subPath);
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/CsrfRequirementTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/CsrfRequirementTest.java
@@ -22,50 +22,50 @@ public class CsrfRequirementTest {
 
     @Test
     public void test_getNeverRequiresCsrf() {
-        assertFalse(CsrfRequirement.requiresCsrf("/search", "GET"));
-        assertFalse(CsrfRequirement.requiresCsrf("/auth/me", "GET"));
-        assertFalse(CsrfRequirement.requiresCsrf("/documents/abc/favorite", "GET"));
+        assertFalse(new CsrfRequirement().requiresCsrf("/search", "GET"));
+        assertFalse(new CsrfRequirement().requiresCsrf("/auth/me", "GET"));
+        assertFalse(new CsrfRequirement().requiresCsrf("/documents/abc/favorite", "GET"));
     }
 
     @Test
     public void test_loginIsExemptFromCsrf() {
-        assertFalse(CsrfRequirement.requiresCsrf("/auth/login", "POST"));
+        assertFalse(new CsrfRequirement().requiresCsrf("/auth/login", "POST"));
     }
 
     @Test
     public void test_logoutRequiresCsrf() {
-        assertTrue(CsrfRequirement.requiresCsrf("/auth/logout", "POST"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/auth/logout", "POST"));
     }
 
     @Test
     public void test_passwordRequiresCsrf() {
-        assertTrue(CsrfRequirement.requiresCsrf("/auth/password", "POST"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/auth/password", "POST"));
     }
 
     @Test
     public void test_favoritePostRequiresCsrf() {
-        assertTrue(CsrfRequirement.requiresCsrf("/documents/abc/favorite", "POST"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/documents/abc/favorite", "POST"));
     }
 
     @Test
     public void test_clickRequiresCsrf() {
-        assertTrue(CsrfRequirement.requiresCsrf("/click", "POST"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/click", "POST"));
     }
 
     @Test
     public void test_chatPostRequiresCsrf() {
-        assertTrue(CsrfRequirement.requiresCsrf("/chat", "POST"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/chat", "POST"));
     }
 
     @Test
     public void test_chatStreamPostRequiresCsrf() {
-        assertTrue(CsrfRequirement.requiresCsrf("/chat/stream", "POST"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/chat/stream", "POST"));
     }
 
     @Test
     public void test_chatGetIsExemptFromCsrf() {
-        assertFalse(CsrfRequirement.requiresCsrf("/chat", "GET"));
-        assertFalse(CsrfRequirement.requiresCsrf("/chat/stream", "GET"));
+        assertFalse(new CsrfRequirement().requiresCsrf("/chat", "GET"));
+        assertFalse(new CsrfRequirement().requiresCsrf("/chat/stream", "GET"));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class CsrfRequirementTest {
         // The manager normalizes paths before dispatch so /chat/ is normalized to /chat
         // before it reaches CsrfRequirement. The trailing-slash form is therefore not an
         // exempted path and falls through to the secure default: CSRF required.
-        assertTrue(CsrfRequirement.requiresCsrf("/chat/", "POST"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/chat/", "POST"));
     }
 
     @Test
@@ -82,8 +82,8 @@ public class CsrfRequirementTest {
         // state-changing method (POST/PUT/DELETE) must require CSRF so that a new endpoint
         // added to SearchApiV2Manager.process without a corresponding CsrfRequirement entry
         // is CSRF-gated rather than silently exempt.
-        assertTrue(CsrfRequirement.requiresCsrf("/some/future/path", "POST"));
-        assertTrue(CsrfRequirement.requiresCsrf("/unknown/endpoint", "PUT"));
-        assertTrue(CsrfRequirement.requiresCsrf("/another/new/path", "DELETE"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/some/future/path", "POST"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/unknown/endpoint", "PUT"));
+        assertTrue(new CsrfRequirement().requiresCsrf("/another/new/path", "DELETE"));
     }
 }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandlerTest.java
@@ -178,7 +178,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
                 res, "abc");
         if (res.status == 500) {
             final String body = res.body();
-            // V2EnvelopeWriter.writeInternalError always emits "internal error" — the
+            // new V2EnvelopeWriter().writeInternalError always emits "internal error" — the
             // exact literal used by all internal-error paths in the v2 API. The original
             // expectation of "favorite add failed" predated writeInternalError and is
             // corrected here to match the current fixed-string contract.

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/HealthHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/HealthHandlerTest.java
@@ -1,0 +1,655 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
+
+/**
+ * Unit tests for {@link HealthHandler}.
+ *
+ * <p>Verifies the wire contract for {@code GET /api/v2/health}: the method gate
+ * rejects non-GET requests with a structured 405 + {@code Allow: GET}, and the
+ * success envelope carries the engine status keys. The embedded search engine is
+ * not always wired in the unit JVM, so the envelope-shape test tolerates either a
+ * real 200 or the structured 503/500 error envelope the handler emits when
+ * {@code ping()} is unavailable — same tolerance pattern as the other v2 handler
+ * tests.</p>
+ */
+public class HealthHandlerTest extends UnitFessTestCase {
+
+    @Test
+    public void test_health_methodGate_rejectsPost() throws Exception {
+        final HealthHandler handler = new HealthHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/health").withMethod("POST"), res);
+        assertEquals(405, res.status);
+        final String body = res.body();
+        assertTrue(body.contains("\"status\":1"), body);
+        assertTrue(body.contains("\"code\":\"method_not_allowed\""), body);
+        assertTrue(body.contains("method not allowed"), body);
+        assertEquals("Allow header must be set on 405", "GET", res.getHeader("Allow"));
+    }
+
+    @Test
+    public void test_health_methodGate_rejectsDelete() throws Exception {
+        final HealthHandler handler = new HealthHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/health").withMethod("DELETE"), res);
+        assertEquals(405, res.status);
+        final String body = res.body();
+        assertTrue(body.contains("\"status\":1"), body);
+        assertTrue(body.contains("\"code\":\"method_not_allowed\""), body);
+        assertEquals("Allow header must be set on 405", "GET", res.getHeader("Allow"));
+    }
+
+    @Test
+    public void test_health_envelopeShape() throws Exception {
+        final HealthHandler handler = new HealthHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/health"), res);
+        final String body = res.body();
+        // The v2 envelope never carries a "version" key, on either the happy or failure path.
+        assertFalse(body.contains("\"version\""), body);
+        if (res.status == 200) {
+            assertTrue(body.contains("\"status\":0"), body);
+            assertTrue(body.contains("\"engine\""), body);
+            assertTrue(body.contains("\"cluster_name\""), body);
+            assertTrue(body.contains("\"ping_status\""), body);
+        } else {
+            // No engine in this JVM → handler emits a structured 503 (cluster red /
+            // unavailable) or 500 (ping threw). Accept both so the test stays stable.
+            assertTrue(res.status == 503 || res.status == 500, "unexpected status " + res.status + ": " + body);
+            assertTrue(body.contains("\"code\":\"service_unavailable\"") || body.contains("\"code\":\"internal_error\""), body);
+        }
+    }
+
+    /** Minimal HttpServletResponse stub — local copy of SearchApiV2ManagerTest.CapturingResponse. */
+    private static class CapturingResponse implements HttpServletResponse {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter writer = new PrintWriter(sw);
+        int status = 200;
+        String contentType;
+        final java.util.Map<String, String> headers = new java.util.HashMap<>();
+
+        String body() {
+            writer.flush();
+            return sw.toString();
+        }
+
+        @Override
+        public void setStatus(final int sc) {
+            this.status = sc;
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        @Override
+        public void setContentType(final String type) {
+            this.contentType = type;
+        }
+
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return writer;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public void setCharacterEncoding(final String s) {
+        }
+
+        @Override
+        public jakarta.servlet.ServletOutputStream getOutputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setContentLength(final int len) {
+        }
+
+        @Override
+        public void setContentLengthLong(final long len) {
+        }
+
+        @Override
+        public void setBufferSize(final int size) {
+        }
+
+        @Override
+        public int getBufferSize() {
+            return 0;
+        }
+
+        @Override
+        public void flushBuffer() {
+        }
+
+        @Override
+        public void resetBuffer() {
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void setLocale(final java.util.Locale loc) {
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public void addCookie(final jakarta.servlet.http.Cookie cookie) {
+        }
+
+        @Override
+        public boolean containsHeader(final String name) {
+            return false;
+        }
+
+        @Override
+        public String encodeURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeRedirectURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public void sendError(final int sc, final String msg) {
+        }
+
+        @Override
+        public void sendError(final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void setDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void addDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void setHeader(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public void addHeader(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public void setIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public void addIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return headers.get(name);
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaders(final String name) {
+            final String v = headers.get(name);
+            return v == null ? java.util.Collections.emptyList() : java.util.Collections.singletonList(v);
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaderNames() {
+            return headers.keySet();
+        }
+    }
+
+    /** Minimal HttpServletRequest stub — local copy of SearchApiV2ManagerTest.StubRequest. */
+    private static class StubRequest implements HttpServletRequest {
+        private final String uri;
+        private final Map<String, Object> attrs = new HashMap<>();
+        private final Map<String, String[]> params;
+        private String method = "GET";
+
+        StubRequest(final String uri) {
+            this(uri, Collections.emptyMap());
+        }
+
+        StubRequest(final String uri, final Map<String, String[]> params) {
+            this.uri = uri;
+            this.params = params == null ? Collections.emptyMap() : params;
+        }
+
+        StubRequest withMethod(final String m) {
+            this.method = m;
+            return this;
+        }
+
+        @Override
+        public String getServletPath() {
+            return uri;
+        }
+
+        @Override
+        public String getMethod() {
+            return method;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return uri;
+        }
+
+        @Override
+        public String getContextPath() {
+            return "";
+        }
+
+        @Override
+        public Object getAttribute(final String name) {
+            return attrs.get(name);
+        }
+
+        @Override
+        public void setAttribute(final String name, final Object value) {
+            if (value == null) {
+                attrs.remove(name);
+            } else {
+                attrs.put(name, value);
+            }
+        }
+
+        @Override
+        public void removeAttribute(final String name) {
+            attrs.remove(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attrs.keySet());
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(final String path) {
+            return null;
+        }
+
+        @Override
+        public String getAuthType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.servlet.http.Cookie[] getCookies() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getDateHeader(final String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(final String name) {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public int getIntHeader(final String name) {
+            return -1;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return null;
+        }
+
+        @Override
+        public String getQueryString() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isUserInRole(final String role) {
+            return false;
+        }
+
+        @Override
+        public java.security.Principal getUserPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return null;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return new StringBuffer(uri);
+        }
+
+        @Override
+        public HttpSession getSession(final boolean create) {
+            return null;
+        }
+
+        @Override
+        public HttpSession getSession() {
+            return null;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return null;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return false;
+        }
+
+        @Override
+        public boolean authenticate(final HttpServletResponse response) {
+            return false;
+        }
+
+        @Override
+        public void login(final String username, final String password) {
+        }
+
+        @Override
+        public void logout() {
+        }
+
+        @Override
+        public java.util.Collection<Part> getParts() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Part getPart(final String name) {
+            return null;
+        }
+
+        @Override
+        public <T extends HttpUpgradeHandler> T upgrade(final Class<T> handlerClass) {
+            return null;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterEncoding(final String env) {
+        }
+
+        @Override
+        public int getContentLength() {
+            return 0;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return 0;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getParameter(final String name) {
+            final String[] vals = params.get(name);
+            return vals == null || vals.length == 0 ? null : vals[0];
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return Collections.enumeration(params.keySet());
+        }
+
+        @Override
+        public String[] getParameterValues(final String name) {
+            return params.get(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return Collections.unmodifiableMap(params);
+        }
+
+        @Override
+        public String getProtocol() {
+            return "HTTP/1.1";
+        }
+
+        @Override
+        public String getScheme() {
+            return "http";
+        }
+
+        @Override
+        public String getServerName() {
+            return "localhost";
+        }
+
+        @Override
+        public int getServerPort() {
+            return 8080;
+        }
+
+        @Override
+        public java.io.BufferedReader getReader() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return "localhost";
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public Enumeration<java.util.Locale> getLocales() {
+            return Collections.enumeration(java.util.Collections.singleton(java.util.Locale.ROOT));
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public int getRemotePort() {
+            return 0;
+        }
+
+        @Override
+        public String getLocalName() {
+            return "localhost";
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public int getLocalPort() {
+            return 8080;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncContext startAsync() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncContext startAsync(final ServletRequest req, final ServletResponse resp) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return false;
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return false;
+        }
+
+        @Override
+        public AsyncContext getAsyncContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DispatcherType getDispatcherType() {
+            return DispatcherType.REQUEST;
+        }
+
+        @Override
+        public String getRequestId() {
+            return "";
+        }
+
+        @Override
+        public String getProtocolRequestId() {
+            return "";
+        }
+
+        @Override
+        public jakarta.servlet.ServletConnection getServletConnection() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LabelsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LabelsHandlerTest.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
+
+/**
+ * Unit tests for {@link LabelsHandler}.
+ *
+ * <p>Verifies the wire contract for {@code GET /api/v2/labels}: the method gate
+ * rejects non-GET with a structured 405 + {@code Allow: GET}, and the success
+ * envelope carries the label payload keys. {@code LabelTypeHelper} is wired in the
+ * unit harness and returns an empty label list when none is configured, so the 200
+ * path is normally deterministic; the envelope-shape test still tolerates a
+ * structured 500 for safety — same tolerance pattern as the other v2 handler
+ * tests.</p>
+ */
+public class LabelsHandlerTest extends UnitFessTestCase {
+
+    @Test
+    public void test_labels_methodGate_rejectsPost() throws Exception {
+        final LabelsHandler handler = new LabelsHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/labels").withMethod("POST"), res);
+        assertEquals(405, res.status);
+        final String body = res.body();
+        assertTrue(body.contains("\"status\":1"), body);
+        assertTrue(body.contains("\"code\":\"method_not_allowed\""), body);
+        assertTrue(body.contains("method not allowed"), body);
+        assertEquals("Allow header must be set on 405", "GET", res.getHeader("Allow"));
+    }
+
+    @Test
+    public void test_labels_envelopeShape() throws Exception {
+        final LabelsHandler handler = new LabelsHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/labels"), res);
+        final String body = res.body();
+        assertFalse(body.contains("\"version\""), body);
+        if (res.status == 200) {
+            assertTrue(body.contains("\"status\":0"), body);
+            assertTrue(body.contains("\"record_count\""), body);
+            assertTrue(body.contains("\"labels\""), body);
+        } else {
+            // Tolerate the structured 500 the handler emits if the helper is unavailable.
+            assertTrue(res.status == 500, "unexpected status " + res.status + ": " + body);
+            assertTrue(body.contains("\"code\":\"internal_error\""), body);
+        }
+    }
+
+    /** Minimal HttpServletResponse stub — local copy of SearchApiV2ManagerTest.CapturingResponse. */
+    private static class CapturingResponse implements HttpServletResponse {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter writer = new PrintWriter(sw);
+        int status = 200;
+        String contentType;
+        final java.util.Map<String, String> headers = new java.util.HashMap<>();
+
+        String body() {
+            writer.flush();
+            return sw.toString();
+        }
+
+        @Override
+        public void setStatus(final int sc) {
+            this.status = sc;
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        @Override
+        public void setContentType(final String type) {
+            this.contentType = type;
+        }
+
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return writer;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public void setCharacterEncoding(final String s) {
+        }
+
+        @Override
+        public jakarta.servlet.ServletOutputStream getOutputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setContentLength(final int len) {
+        }
+
+        @Override
+        public void setContentLengthLong(final long len) {
+        }
+
+        @Override
+        public void setBufferSize(final int size) {
+        }
+
+        @Override
+        public int getBufferSize() {
+            return 0;
+        }
+
+        @Override
+        public void flushBuffer() {
+        }
+
+        @Override
+        public void resetBuffer() {
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void setLocale(final java.util.Locale loc) {
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public void addCookie(final jakarta.servlet.http.Cookie cookie) {
+        }
+
+        @Override
+        public boolean containsHeader(final String name) {
+            return false;
+        }
+
+        @Override
+        public String encodeURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeRedirectURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public void sendError(final int sc, final String msg) {
+        }
+
+        @Override
+        public void sendError(final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void setDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void addDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void setHeader(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public void addHeader(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public void setIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public void addIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return headers.get(name);
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaders(final String name) {
+            final String v = headers.get(name);
+            return v == null ? java.util.Collections.emptyList() : java.util.Collections.singletonList(v);
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaderNames() {
+            return headers.keySet();
+        }
+    }
+
+    /** Minimal HttpServletRequest stub — local copy of SearchApiV2ManagerTest.StubRequest. */
+    private static class StubRequest implements HttpServletRequest {
+        private final String uri;
+        private final Map<String, Object> attrs = new HashMap<>();
+        private final Map<String, String[]> params;
+        private String method = "GET";
+
+        StubRequest(final String uri) {
+            this(uri, Collections.emptyMap());
+        }
+
+        StubRequest(final String uri, final Map<String, String[]> params) {
+            this.uri = uri;
+            this.params = params == null ? Collections.emptyMap() : params;
+        }
+
+        StubRequest withMethod(final String m) {
+            this.method = m;
+            return this;
+        }
+
+        @Override
+        public String getServletPath() {
+            return uri;
+        }
+
+        @Override
+        public String getMethod() {
+            return method;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return uri;
+        }
+
+        @Override
+        public String getContextPath() {
+            return "";
+        }
+
+        @Override
+        public Object getAttribute(final String name) {
+            return attrs.get(name);
+        }
+
+        @Override
+        public void setAttribute(final String name, final Object value) {
+            if (value == null) {
+                attrs.remove(name);
+            } else {
+                attrs.put(name, value);
+            }
+        }
+
+        @Override
+        public void removeAttribute(final String name) {
+            attrs.remove(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attrs.keySet());
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(final String path) {
+            return null;
+        }
+
+        @Override
+        public String getAuthType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.servlet.http.Cookie[] getCookies() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getDateHeader(final String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(final String name) {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public int getIntHeader(final String name) {
+            return -1;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return null;
+        }
+
+        @Override
+        public String getQueryString() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isUserInRole(final String role) {
+            return false;
+        }
+
+        @Override
+        public java.security.Principal getUserPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return null;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return new StringBuffer(uri);
+        }
+
+        @Override
+        public HttpSession getSession(final boolean create) {
+            return null;
+        }
+
+        @Override
+        public HttpSession getSession() {
+            return null;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return null;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return false;
+        }
+
+        @Override
+        public boolean authenticate(final HttpServletResponse response) {
+            return false;
+        }
+
+        @Override
+        public void login(final String username, final String password) {
+        }
+
+        @Override
+        public void logout() {
+        }
+
+        @Override
+        public java.util.Collection<Part> getParts() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Part getPart(final String name) {
+            return null;
+        }
+
+        @Override
+        public <T extends HttpUpgradeHandler> T upgrade(final Class<T> handlerClass) {
+            return null;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterEncoding(final String env) {
+        }
+
+        @Override
+        public int getContentLength() {
+            return 0;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return 0;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getParameter(final String name) {
+            final String[] vals = params.get(name);
+            return vals == null || vals.length == 0 ? null : vals[0];
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return Collections.enumeration(params.keySet());
+        }
+
+        @Override
+        public String[] getParameterValues(final String name) {
+            return params.get(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return Collections.unmodifiableMap(params);
+        }
+
+        @Override
+        public String getProtocol() {
+            return "HTTP/1.1";
+        }
+
+        @Override
+        public String getScheme() {
+            return "http";
+        }
+
+        @Override
+        public String getServerName() {
+            return "localhost";
+        }
+
+        @Override
+        public int getServerPort() {
+            return 8080;
+        }
+
+        @Override
+        public java.io.BufferedReader getReader() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return "localhost";
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public Enumeration<java.util.Locale> getLocales() {
+            return Collections.enumeration(java.util.Collections.singleton(java.util.Locale.ROOT));
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public int getRemotePort() {
+            return 0;
+        }
+
+        @Override
+        public String getLocalName() {
+            return "localhost";
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public int getLocalPort() {
+            return 8080;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncContext startAsync() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncContext startAsync(final ServletRequest req, final ServletResponse resp) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return false;
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return false;
+        }
+
+        @Override
+        public AsyncContext getAsyncContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DispatcherType getDispatcherType() {
+            return DispatcherType.REQUEST;
+        }
+
+        @Override
+        public String getRequestId() {
+            return "";
+        }
+
+        @Override
+        public String getProtocolRequestId() {
+            return "";
+        }
+
+        @Override
+        public jakarta.servlet.ServletConnection getServletConnection() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -95,12 +95,12 @@ public class LoginHandlerTest extends UnitFessTestCase {
         //  (b) the SAME username from a DIFFERENT IP is NOT gated (its composite bucket is empty),
         //      so the request flows past the gate into the (test-DI-unavailable) login subsystem.
         final LoginRateLimiter rl = new LoginRateLimiter();
+        final LoginHandler handler = new LoginHandler(rl);
         final String attackerIp = "10.0.0.99";
         final String victimIp = "10.0.0.50";
         for (int i = 0; i < 5; i++) {
-            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, LoginHandler.userScopeKey(attackerIp, "bob"), 5, 60));
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, handler.userScopeKey(attackerIp, "bob"), 5, 60));
         }
-        final LoginHandler handler = new LoginHandler(rl);
 
         final CapturingResponse attacker = new CapturingResponse();
         handler.handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"p\"}")
@@ -126,11 +126,12 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // the direct peer is a trusted proxy 127.0.0.1), not the proxy's own address. UnitFessTestCase
         // wires app.xml so RateLimitHelper honours XFF for the default trusted proxy.
         final LoginRateLimiter rl = new LoginRateLimiter();
+        final LoginHandler handler = new LoginHandler(rl);
         for (int i = 0; i < 5; i++) {
-            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, LoginHandler.userScopeKey("203.0.113.5", "bob"), 5, 60));
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, handler.userScopeKey("203.0.113.5", "bob"), 5, 60));
         }
         final CapturingResponse res = new CapturingResponse();
-        new LoginHandler(rl).handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"p\"}")
+        handler.handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"p\"}")
                 .withRemoteAddr("127.0.0.1")
                 .withHeader("X-Forwarded-For", "203.0.113.5"), res);
         // In this slim DI graph the RateLimitHelper does not resolve XFF to 203.0.113.5, so the
@@ -455,7 +456,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // can verify the clear() contract at the limiter layer directly. The on-success clear
         // targets the (clientIp, username) composite key, so we mirror that key here.
         final LoginRateLimiter rl = new LoginRateLimiter();
-        final String userKey = LoginHandler.userScopeKey("10.0.0.7", "dave");
+        final String userKey = new LoginHandler().userScopeKey("10.0.0.7", "dave");
         for (int i = 0; i < 5; i++) {
             assertTrue(rl.allow(LoginRateLimiter.Scope.USER, userKey, 5, 60));
         }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/MeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/MeHandlerTest.java
@@ -115,7 +115,7 @@ public class MeHandlerTest extends UnitFessTestCase {
 
         @Override
         public String[] getRoleNames() {
-            return null; // intentionally null — UserPayloads.toJson must handle this
+            return null; // intentionally null — ComponentUtil.getV2UserPayloads().toJson must handle this
         }
 
         @Override

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
@@ -735,7 +735,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
         assertFalse(rl.peek(LoginRateLimiter.Scope.USER, userId, 5, 60));
         // ...while the LoginHandler-style composite key for the same user is a DIFFERENT bucket
         // and remains available. This proves the two key shapes do not collide.
-        assertTrue(rl.peek(LoginRateLimiter.Scope.USER, LoginHandler.userScopeKey("10.0.0.7", userId), 5, 60));
+        assertTrue(rl.peek(LoginRateLimiter.Scope.USER, new LoginHandler().userScopeKey("10.0.0.7", userId), 5, 60));
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PopularWordsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PopularWordsHandlerTest.java
@@ -1,0 +1,658 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
+
+/**
+ * Unit tests for {@link PopularWordsHandler}.
+ *
+ * <p>Verifies the wire contract for {@code GET /api/v2/popular-words}: the method
+ * gate rejects non-GET with a structured 405 + {@code Allow: GET} (and runs before
+ * the feature-flag check), the feature-disabled path returns a deterministic 400,
+ * and the success envelope carries the popular-word payload keys. The popular-word
+ * engine is not always wired in the unit JVM, so the envelope-shape test tolerates
+ * either a real 200 or the structured 500 error envelope — same tolerance pattern as
+ * the other v2 handler tests.</p>
+ */
+public class PopularWordsHandlerTest extends UnitFessTestCase {
+
+    @Test
+    public void test_popularWords_methodGate_rejectsPost() throws Exception {
+        final PopularWordsHandler handler = new PopularWordsHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/popular-words").withMethod("POST"), res);
+        assertEquals(405, res.status);
+        final String body = res.body();
+        assertTrue(body.contains("\"status\":1"), body);
+        assertTrue(body.contains("\"code\":\"method_not_allowed\""), body);
+        assertTrue(body.contains("method not allowed"), body);
+        assertEquals("Allow header must be set on 405", "GET", res.getHeader("Allow"));
+    }
+
+    @Test
+    public void test_popularWords_featureDisabled_returnsUnsupported() throws Exception {
+        final PopularWordsHandler handler = new PopularWordsHandler();
+        final CapturingResponse res = new CapturingResponse();
+        try {
+            ComponentUtil.getFessConfig().setWebApiPopularWord(false);
+            handler.handle(new StubRequest("/api/v2/popular-words"), res);
+            assertEquals(400, res.status);
+            final String body = res.body();
+            assertTrue(body.contains("\"status\":1"), body);
+            assertTrue(body.contains("\"code\":\"invalid_request\""), body);
+            assertTrue(body.contains("unsupported operation"), body);
+        } finally {
+            ComponentUtil.getFessConfig().setWebApiPopularWord(true);
+        }
+    }
+
+    @Test
+    public void test_popularWords_envelopeShape() throws Exception {
+        final PopularWordsHandler handler = new PopularWordsHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/popular-words"), res);
+        final String body = res.body();
+        assertFalse(body.contains("\"version\""), body);
+        if (res.status == 200) {
+            assertTrue(body.contains("\"status\":0"), body);
+            assertTrue(body.contains("\"record_count\""), body);
+            assertTrue(body.contains("\"popular_words\""), body);
+        } else {
+            // No popular-word engine in this JVM → handler emits a structured 500.
+            assertTrue(res.status == 500, "unexpected status " + res.status + ": " + body);
+            assertTrue(body.contains("\"code\":\"internal_error\""), body);
+        }
+    }
+
+    /** Minimal HttpServletResponse stub — local copy of SearchApiV2ManagerTest.CapturingResponse. */
+    private static class CapturingResponse implements HttpServletResponse {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter writer = new PrintWriter(sw);
+        int status = 200;
+        String contentType;
+        final java.util.Map<String, String> headers = new java.util.HashMap<>();
+
+        String body() {
+            writer.flush();
+            return sw.toString();
+        }
+
+        @Override
+        public void setStatus(final int sc) {
+            this.status = sc;
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        @Override
+        public void setContentType(final String type) {
+            this.contentType = type;
+        }
+
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return writer;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public void setCharacterEncoding(final String s) {
+        }
+
+        @Override
+        public jakarta.servlet.ServletOutputStream getOutputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setContentLength(final int len) {
+        }
+
+        @Override
+        public void setContentLengthLong(final long len) {
+        }
+
+        @Override
+        public void setBufferSize(final int size) {
+        }
+
+        @Override
+        public int getBufferSize() {
+            return 0;
+        }
+
+        @Override
+        public void flushBuffer() {
+        }
+
+        @Override
+        public void resetBuffer() {
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void setLocale(final java.util.Locale loc) {
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public void addCookie(final jakarta.servlet.http.Cookie cookie) {
+        }
+
+        @Override
+        public boolean containsHeader(final String name) {
+            return false;
+        }
+
+        @Override
+        public String encodeURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeRedirectURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public void sendError(final int sc, final String msg) {
+        }
+
+        @Override
+        public void sendError(final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void setDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void addDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void setHeader(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public void addHeader(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public void setIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public void addIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return headers.get(name);
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaders(final String name) {
+            final String v = headers.get(name);
+            return v == null ? java.util.Collections.emptyList() : java.util.Collections.singletonList(v);
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaderNames() {
+            return headers.keySet();
+        }
+    }
+
+    /** Minimal HttpServletRequest stub — local copy of SearchApiV2ManagerTest.StubRequest. */
+    private static class StubRequest implements HttpServletRequest {
+        private final String uri;
+        private final Map<String, Object> attrs = new HashMap<>();
+        private final Map<String, String[]> params;
+        private String method = "GET";
+
+        StubRequest(final String uri) {
+            this(uri, Collections.emptyMap());
+        }
+
+        StubRequest(final String uri, final Map<String, String[]> params) {
+            this.uri = uri;
+            this.params = params == null ? Collections.emptyMap() : params;
+        }
+
+        StubRequest withMethod(final String m) {
+            this.method = m;
+            return this;
+        }
+
+        @Override
+        public String getServletPath() {
+            return uri;
+        }
+
+        @Override
+        public String getMethod() {
+            return method;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return uri;
+        }
+
+        @Override
+        public String getContextPath() {
+            return "";
+        }
+
+        @Override
+        public Object getAttribute(final String name) {
+            return attrs.get(name);
+        }
+
+        @Override
+        public void setAttribute(final String name, final Object value) {
+            if (value == null) {
+                attrs.remove(name);
+            } else {
+                attrs.put(name, value);
+            }
+        }
+
+        @Override
+        public void removeAttribute(final String name) {
+            attrs.remove(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attrs.keySet());
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(final String path) {
+            return null;
+        }
+
+        @Override
+        public String getAuthType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.servlet.http.Cookie[] getCookies() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getDateHeader(final String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(final String name) {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public int getIntHeader(final String name) {
+            return -1;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return null;
+        }
+
+        @Override
+        public String getQueryString() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isUserInRole(final String role) {
+            return false;
+        }
+
+        @Override
+        public java.security.Principal getUserPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return null;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return new StringBuffer(uri);
+        }
+
+        @Override
+        public HttpSession getSession(final boolean create) {
+            return null;
+        }
+
+        @Override
+        public HttpSession getSession() {
+            return null;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return null;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return false;
+        }
+
+        @Override
+        public boolean authenticate(final HttpServletResponse response) {
+            return false;
+        }
+
+        @Override
+        public void login(final String username, final String password) {
+        }
+
+        @Override
+        public void logout() {
+        }
+
+        @Override
+        public java.util.Collection<Part> getParts() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Part getPart(final String name) {
+            return null;
+        }
+
+        @Override
+        public <T extends HttpUpgradeHandler> T upgrade(final Class<T> handlerClass) {
+            return null;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterEncoding(final String env) {
+        }
+
+        @Override
+        public int getContentLength() {
+            return 0;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return 0;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getParameter(final String name) {
+            final String[] vals = params.get(name);
+            return vals == null || vals.length == 0 ? null : vals[0];
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return Collections.enumeration(params.keySet());
+        }
+
+        @Override
+        public String[] getParameterValues(final String name) {
+            return params.get(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return Collections.unmodifiableMap(params);
+        }
+
+        @Override
+        public String getProtocol() {
+            return "HTTP/1.1";
+        }
+
+        @Override
+        public String getScheme() {
+            return "http";
+        }
+
+        @Override
+        public String getServerName() {
+            return "localhost";
+        }
+
+        @Override
+        public int getServerPort() {
+            return 8080;
+        }
+
+        @Override
+        public java.io.BufferedReader getReader() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return "localhost";
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public Enumeration<java.util.Locale> getLocales() {
+            return Collections.enumeration(java.util.Collections.singleton(java.util.Locale.ROOT));
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public int getRemotePort() {
+            return 0;
+        }
+
+        @Override
+        public String getLocalName() {
+            return "localhost";
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public int getLocalPort() {
+            return 8080;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncContext startAsync() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncContext startAsync(final ServletRequest req, final ServletResponse resp) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return false;
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return false;
+        }
+
+        @Override
+        public AsyncContext getAsyncContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DispatcherType getDispatcherType() {
+            return DispatcherType.REQUEST;
+        }
+
+        @Override
+        public String getRequestId() {
+            return "";
+        }
+
+        @Override
+        public String getProtocolRequestId() {
+            return "";
+        }
+
+        @Override
+        public jakarta.servlet.ServletConnection getServletConnection() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/SuggestWordsHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/SuggestWordsHandlerTest.java
@@ -1,0 +1,656 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
+
+/**
+ * Unit tests for {@link SuggestWordsHandler}.
+ *
+ * <p>Verifies the wire contract for {@code GET /api/v2/suggest-words}: the method
+ * gate rejects non-GET with a structured 405 + {@code Allow: GET}, and the success
+ * envelope carries the suggest payload keys. The suggest engine is not always wired
+ * in the unit JVM, so the envelope-shape test tolerates either a real 200 or the
+ * structured 400/500 error envelope the handler emits otherwise — same tolerance
+ * pattern as the other v2 handler tests.</p>
+ */
+public class SuggestWordsHandlerTest extends UnitFessTestCase {
+
+    @Test
+    public void test_suggestWords_methodGate_rejectsPost() throws Exception {
+        final SuggestWordsHandler handler = new SuggestWordsHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/suggest-words").withMethod("POST"), res);
+        assertEquals(405, res.status);
+        final String body = res.body();
+        assertTrue(body.contains("\"status\":1"), body);
+        assertTrue(body.contains("\"code\":\"method_not_allowed\""), body);
+        assertTrue(body.contains("method not allowed"), body);
+        assertEquals("Allow header must be set on 405", "GET", res.getHeader("Allow"));
+    }
+
+    @Test
+    public void test_suggestWords_envelopeShape() throws Exception {
+        final SuggestWordsHandler handler = new SuggestWordsHandler();
+        final CapturingResponse res = new CapturingResponse();
+        final Map<String, String[]> params = new HashMap<>();
+        params.put("q", new String[] { "foo" });
+        handler.handle(new StubRequest("/api/v2/suggest-words", params), res);
+        final String body = res.body();
+        assertFalse(body.contains("\"version\""), body);
+        if (res.status == 200) {
+            assertTrue(body.contains("\"status\":0"), body);
+            for (final String key : new String[] { "\"q\"", "\"page_size\"", "\"record_count\"", "\"query_time\"", "\"suggest_words\"" }) {
+                assertTrue(body.contains(key), "missing key " + key + " in body: " + body);
+            }
+        } else {
+            // No suggest engine in this JVM → handler emits a structured 400/500. Accept both.
+            assertTrue(res.status == 400 || res.status == 500, "unexpected status " + res.status + ": " + body);
+            assertTrue(body.contains("\"code\":\"invalid_request\"") || body.contains("\"code\":\"internal_error\""), body);
+        }
+    }
+
+    @Test
+    public void test_suggestWords_defaultNumOnSuccess() throws Exception {
+        final SuggestWordsHandler handler = new SuggestWordsHandler();
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/suggest-words"), res);
+        // The handler defaults num=10, but page_size is only observable on a live engine.
+        // When the engine is not wired the call returns a structured error — inconclusive,
+        // so allow pass to keep the suite stable.
+        if (res.status == 200) {
+            final String body = res.body();
+            assertTrue(body.contains("\"page_size\""), "page_size must be present on success: " + body);
+        }
+    }
+
+    /** Minimal HttpServletResponse stub — local copy of SearchApiV2ManagerTest.CapturingResponse. */
+    private static class CapturingResponse implements HttpServletResponse {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter writer = new PrintWriter(sw);
+        int status = 200;
+        String contentType;
+        final java.util.Map<String, String> headers = new java.util.HashMap<>();
+
+        String body() {
+            writer.flush();
+            return sw.toString();
+        }
+
+        @Override
+        public void setStatus(final int sc) {
+            this.status = sc;
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        @Override
+        public void setContentType(final String type) {
+            this.contentType = type;
+        }
+
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return writer;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public void setCharacterEncoding(final String s) {
+        }
+
+        @Override
+        public jakarta.servlet.ServletOutputStream getOutputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setContentLength(final int len) {
+        }
+
+        @Override
+        public void setContentLengthLong(final long len) {
+        }
+
+        @Override
+        public void setBufferSize(final int size) {
+        }
+
+        @Override
+        public int getBufferSize() {
+            return 0;
+        }
+
+        @Override
+        public void flushBuffer() {
+        }
+
+        @Override
+        public void resetBuffer() {
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void setLocale(final java.util.Locale loc) {
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public void addCookie(final jakarta.servlet.http.Cookie cookie) {
+        }
+
+        @Override
+        public boolean containsHeader(final String name) {
+            return false;
+        }
+
+        @Override
+        public String encodeURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeRedirectURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public void sendError(final int sc, final String msg) {
+        }
+
+        @Override
+        public void sendError(final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc, final boolean clearBuffer) {
+        }
+
+        @Override
+        public void setDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void addDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void setHeader(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public void addHeader(final String name, final String value) {
+            headers.put(name, value);
+        }
+
+        @Override
+        public void setIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public void addIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return headers.get(name);
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaders(final String name) {
+            final String v = headers.get(name);
+            return v == null ? java.util.Collections.emptyList() : java.util.Collections.singletonList(v);
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaderNames() {
+            return headers.keySet();
+        }
+    }
+
+    /** Minimal HttpServletRequest stub — local copy of SearchApiV2ManagerTest.StubRequest. */
+    private static class StubRequest implements HttpServletRequest {
+        private final String uri;
+        private final Map<String, Object> attrs = new HashMap<>();
+        private final Map<String, String[]> params;
+        private String method = "GET";
+
+        StubRequest(final String uri) {
+            this(uri, Collections.emptyMap());
+        }
+
+        StubRequest(final String uri, final Map<String, String[]> params) {
+            this.uri = uri;
+            this.params = params == null ? Collections.emptyMap() : params;
+        }
+
+        StubRequest withMethod(final String m) {
+            this.method = m;
+            return this;
+        }
+
+        @Override
+        public String getServletPath() {
+            return uri;
+        }
+
+        @Override
+        public String getMethod() {
+            return method;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return uri;
+        }
+
+        @Override
+        public String getContextPath() {
+            return "";
+        }
+
+        @Override
+        public Object getAttribute(final String name) {
+            return attrs.get(name);
+        }
+
+        @Override
+        public void setAttribute(final String name, final Object value) {
+            if (value == null) {
+                attrs.remove(name);
+            } else {
+                attrs.put(name, value);
+            }
+        }
+
+        @Override
+        public void removeAttribute(final String name) {
+            attrs.remove(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attrs.keySet());
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(final String path) {
+            return null;
+        }
+
+        @Override
+        public String getAuthType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.servlet.http.Cookie[] getCookies() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getDateHeader(final String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(final String name) {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public int getIntHeader(final String name) {
+            return -1;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return null;
+        }
+
+        @Override
+        public String getQueryString() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isUserInRole(final String role) {
+            return false;
+        }
+
+        @Override
+        public java.security.Principal getUserPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return null;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return new StringBuffer(uri);
+        }
+
+        @Override
+        public HttpSession getSession(final boolean create) {
+            return null;
+        }
+
+        @Override
+        public HttpSession getSession() {
+            return null;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return null;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return false;
+        }
+
+        @Override
+        public boolean authenticate(final HttpServletResponse response) {
+            return false;
+        }
+
+        @Override
+        public void login(final String username, final String password) {
+        }
+
+        @Override
+        public void logout() {
+        }
+
+        @Override
+        public java.util.Collection<Part> getParts() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Part getPart(final String name) {
+            return null;
+        }
+
+        @Override
+        public <T extends HttpUpgradeHandler> T upgrade(final Class<T> handlerClass) {
+            return null;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterEncoding(final String env) {
+        }
+
+        @Override
+        public int getContentLength() {
+            return 0;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return 0;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getParameter(final String name) {
+            final String[] vals = params.get(name);
+            return vals == null || vals.length == 0 ? null : vals[0];
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return Collections.enumeration(params.keySet());
+        }
+
+        @Override
+        public String[] getParameterValues(final String name) {
+            return params.get(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return Collections.unmodifiableMap(params);
+        }
+
+        @Override
+        public String getProtocol() {
+            return "HTTP/1.1";
+        }
+
+        @Override
+        public String getScheme() {
+            return "http";
+        }
+
+        @Override
+        public String getServerName() {
+            return "localhost";
+        }
+
+        @Override
+        public int getServerPort() {
+            return 8080;
+        }
+
+        @Override
+        public java.io.BufferedReader getReader() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return "localhost";
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.ROOT;
+        }
+
+        @Override
+        public Enumeration<java.util.Locale> getLocales() {
+            return Collections.enumeration(java.util.Collections.singleton(java.util.Locale.ROOT));
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public int getRemotePort() {
+            return 0;
+        }
+
+        @Override
+        public String getLocalName() {
+            return "localhost";
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public int getLocalPort() {
+            return 8080;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncContext startAsync() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncContext startAsync(final ServletRequest req, final ServletResponse resp) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return false;
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return false;
+        }
+
+        @Override
+        public AsyncContext getAsyncContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DispatcherType getDispatcherType() {
+            return DispatcherType.REQUEST;
+        }
+
+        @Override
+        public String getRequestId() {
+            return "";
+        }
+
+        @Override
+        public String getProtocolRequestId() {
+            return "";
+        }
+
+        @Override
+        public jakarta.servlet.ServletConnection getServletConnection() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/V2JsonBodyTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/V2JsonBodyTest.java
@@ -59,54 +59,54 @@ public class V2JsonBodyTest {
     @Test
     public void test_parsesJsonObject() throws Exception {
         final HttpServletRequest req = stub("{\"username\":\"alice\",\"password\":\"x\"}", "application/json");
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals("alice", body.get("username"));
     }
 
     @Test
     public void test_emptyBodyReturnsEmptyMap() throws Exception {
         final HttpServletRequest req = stub("", "application/json");
-        assertTrue(V2JsonBody.read(req, 1024).isEmpty());
+        assertTrue(new V2JsonBody().read(req, 1024).isEmpty());
     }
 
     @Test
     public void test_rejectsOversizedBody() {
         final byte[] big = new byte[2048];
         final HttpServletRequest req = stub(new String(big), "application/json");
-        assertThrows(V2JsonBody.PayloadTooLargeException.class, () -> V2JsonBody.read(req, 1024));
+        assertThrows(V2JsonBody.PayloadTooLargeException.class, () -> new V2JsonBody().read(req, 1024));
     }
 
     @Test
     public void test_rejectsNonJsonContentType() {
         final HttpServletRequest req = stub("{\"k\":1}", "text/plain");
-        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> V2JsonBody.read(req, 1024));
+        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> new V2JsonBody().read(req, 1024));
     }
 
     @Test
     public void test_rejectsMalformedJson() {
         final HttpServletRequest req = stub("{not json", "application/json");
-        assertThrows(V2JsonBody.MalformedJsonException.class, () -> V2JsonBody.read(req, 1024));
+        assertThrows(V2JsonBody.MalformedJsonException.class, () -> new V2JsonBody().read(req, 1024));
     }
 
     @Test
     public void test_rejectsNullContentType() {
         // A null Content-Type (header absent) must be rejected — callers cannot assume JSON.
         final HttpServletRequest req = stub("{\"k\":1}", null);
-        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> V2JsonBody.read(req, 1024));
+        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> new V2JsonBody().read(req, 1024));
     }
 
     @Test
     public void test_rejectsNonUtf8Charset() {
         // application/json with an explicit non-UTF-8 charset must be rejected.
         final HttpServletRequest req = stub("{\"k\":1}", "application/json; charset=Shift_JIS");
-        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> V2JsonBody.read(req, 1024));
+        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> new V2JsonBody().read(req, 1024));
     }
 
     @Test
     public void test_acceptsExplicitUtf8Charset() throws Exception {
         // Explicit charset=utf-8 is acceptable (common from curl/Postman).
         final HttpServletRequest req = stub("{\"k\":\"v\"}", "application/json; charset=utf-8");
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals("v", body.get("k"));
     }
 
@@ -120,7 +120,7 @@ public class V2JsonBodyTest {
         withBom[2] = (byte) 0xBF;
         System.arraycopy(json, 0, withBom, 3, json.length);
         final HttpServletRequest req = stubBytes(withBom, "application/json");
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals(Boolean.TRUE, body.get("bom"));
     }
 
@@ -130,7 +130,7 @@ public class V2JsonBodyTest {
     public void test_acceptsJsonWithUtf8Charset() throws Exception {
         // application/json; charset=utf-8 → accepted (the standard case).
         final HttpServletRequest req = stub("{\"k\":\"v\"}", "application/json; charset=utf-8");
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals("v", body.get("k"));
     }
 
@@ -138,14 +138,14 @@ public class V2JsonBodyTest {
     public void test_rejectsUtf16Charset() {
         // application/json; charset=utf-16 → rejected (non-UTF-8 charset).
         final HttpServletRequest req = stub("{\"k\":1}", "application/json; charset=utf-16");
-        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> V2JsonBody.read(req, 1024));
+        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> new V2JsonBody().read(req, 1024));
     }
 
     @Test
     public void test_rejectsIso88591Charset() {
         // application/json; charset=iso-8859-1 → rejected.
         final HttpServletRequest req = stub("{\"k\":1}", "application/json; charset=iso-8859-1");
-        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> V2JsonBody.read(req, 1024));
+        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> new V2JsonBody().read(req, 1024));
     }
 
     @Test
@@ -155,7 +155,7 @@ public class V2JsonBodyTest {
         // should do so. The old indexOf("charset=") scan would falsely reject this.
         final HttpServletRequest req = stub("{\"k\":\"v\"}", "application/json; x-charset=utf-16");
         // Must NOT throw UnsupportedMediaTypeException — "x-charset" is a different param.
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals("v", body.get("k"));
     }
 
@@ -163,7 +163,7 @@ public class V2JsonBodyTest {
     public void test_acceptsQuotedUtf8Charset() throws Exception {
         // charset="utf-8" (quoted value) is acceptable; the parser strips quotes.
         final HttpServletRequest req = stub("{\"k\":\"v\"}", "application/json; charset=\"utf-8\"");
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals("v", body.get("k"));
     }
 
@@ -172,7 +172,7 @@ public class V2JsonBodyTest {
         // charset=UTF-8 (uppercase) must be accepted because the code lower-cases the
         // full Content-Type before splitting on ';'.
         final HttpServletRequest req = stub("{\"k\":\"v\"}", "application/json; charset=UTF-8");
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals("v", body.get("k"));
     }
 
@@ -181,7 +181,7 @@ public class V2JsonBodyTest {
         // A parameter with no '=' (e.g. "something") must be silently skipped —
         // no crash, no false rejection.
         final HttpServletRequest req = stub("{\"k\":\"v\"}", "application/json; something");
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals("v", body.get("k"));
     }
 
@@ -189,7 +189,7 @@ public class V2JsonBodyTest {
     public void test_multipleParamsIncludingCharset_accepted() throws Exception {
         // Multi-param ordering: charset appears after another param — must still be found.
         final HttpServletRequest req = stub("{\"k\":\"v\"}", "application/json; boundary=x; charset=utf-8");
-        final Map<String, Object> body = V2JsonBody.read(req, 1024);
+        final Map<String, Object> body = new V2JsonBody().read(req, 1024);
         assertEquals("v", body.get("k"));
     }
 
@@ -197,7 +197,7 @@ public class V2JsonBodyTest {
     public void test_multipleParamsIncludingCharset_rejected() {
         // Multi-param ordering: non-UTF-8 charset after another param — must be rejected.
         final HttpServletRequest req = stub("{\"k\":1}", "application/json; boundary=x; charset=utf-16");
-        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> V2JsonBody.read(req, 1024));
+        assertThrows(V2JsonBody.UnsupportedMediaTypeException.class, () -> new V2JsonBody().read(req, 1024));
     }
 
     @Test
@@ -212,7 +212,7 @@ public class V2JsonBodyTest {
             sb.append("}");
         }
         final HttpServletRequest req = stub(sb.toString(), "application/json");
-        assertThrows(V2JsonBody.MalformedJsonException.class, () -> V2JsonBody.read(req, 1 << 20));
+        assertThrows(V2JsonBody.MalformedJsonException.class, () -> new V2JsonBody().read(req, 1 << 20));
     }
 
     private static HttpServletRequest stubBytes(final byte[] body, final String contentType) {

--- a/src/test/java/org/codelibs/fess/helper/SseResponseHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SseResponseHelperTest.java
@@ -37,7 +37,7 @@ public class SseResponseHelperTest extends UnitFessTestCase {
         // F2: ensure the centralised SSE header set matches the previously inlined
         // 5-line block in v1 ChatApiManager and v2 ChatStreamHandler exactly.
         final CapturingResponse res = new CapturingResponse();
-        SseResponseHelper.applySseHeaders(res);
+        new SseResponseHelper().applySseHeaders(res);
         // Content-Type and charset
         assertEquals("text/event-stream; charset=UTF-8", res.contentType);
         assertEquals("UTF-8", res.characterEncoding);
@@ -53,8 +53,8 @@ public class SseResponseHelperTest extends UnitFessTestCase {
         // F2: calling twice (e.g. due to a re-dispatch retry) must yield the same final
         // header values; setHeader semantics mean each call overwrites the previous.
         final CapturingResponse res = new CapturingResponse();
-        SseResponseHelper.applySseHeaders(res);
-        SseResponseHelper.applySseHeaders(res);
+        new SseResponseHelper().applySseHeaders(res);
+        new SseResponseHelper().applySseHeaders(res);
         assertEquals("text/event-stream; charset=UTF-8", res.contentType);
         assertEquals("UTF-8", res.characterEncoding);
         assertEquals("no-cache", res.headers.get("Cache-Control"));

--- a/src/test/resources/test_app.xml
+++ b/src/test/resources/test_app.xml
@@ -11,4 +11,10 @@
 	<!-- Stateless helper used by v2 chat API handlers/tests (its getUserId DI path is exercised
 	     only in production; handler tests override the handler getUserId seam). -->
 	<component name="chatApiHelper" class="org.codelibs.fess.helper.ChatApiHelper" />
+	<component name="v2EnvelopeWriter" class="org.codelibs.fess.api.v2.V2EnvelopeWriter" />
+	<component name="v2JsonBody" class="org.codelibs.fess.api.v2.handlers.V2JsonBody" />
+	<component name="v2UserPayloads" class="org.codelibs.fess.api.v2.handlers.UserPayloads" />
+	<component name="v2CsrfRequirement" class="org.codelibs.fess.api.v2.handlers.CsrfRequirement" />
+	<component name="v2DocIdValidator" class="org.codelibs.fess.api.v2.handlers.DocIdValidator" />
+	<component name="sseResponseHelper" class="org.codelibs.fess.helper.SseResponseHelper" />
 </components>


### PR DESCRIPTION
Refactors v2 API response, JSON body, CSRF, user payload, document ID, chat, and SSE helpers into DI-managed components. Extracts the remaining SearchApiV2Manager endpoint logic into dedicated handlers.

## Refactoring
- Convert `V2EnvelopeWriter`, `V2JsonBody`, `CsrfRequirement`, `DocIdValidator`, `UserPayloads`, `ChatRequestBody` and `SseResponseHelper` from static utilities into DI-managed components, accessed via new `ComponentUtil` accessors and registered in `fess_api.xml` / `test_app.xml`.
- Extract the remaining inline endpoint logic in `SearchApiV2Manager` into dedicated handlers: `HealthHandler`, `SuggestWordsHandler`, `LabelsHandler` and `PopularWordsHandler`.
- Move chat request-body parsing from `ChatRequestBody.from(...)` to `ChatApiHelper.parseRequestBody(...)`.
- The unconditional two-layer CSRF/Origin protection (#3159) is preserved: the token remains always required and no disable flag is reintroduced.

## Tests
- Add dedicated handler-level unit tests for the four newly extracted endpoints (`HealthHandlerTest`, `SuggestWordsHandlerTest`, `LabelsHandlerTest`, `PopularWordsHandlerTest`), covering the GET-only method gate (405 with `Allow` header) and the v2 envelope shape, plus the deterministic disabled-feature path (`web.api.popular.word=false`) for popular-words.
- Existing v2 API tests are updated to use the new DI accessors with no change to their assertions.