### PR TITLE
fix(related-content): encode the search query in related content placeholders to prevent reflected XSS

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/RelatedContentHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/RelatedContentHelper.java
@@ -15,13 +15,18 @@
  */
 package org.codelibs.fess.helper;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,7 +34,9 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.Pair;
 import org.codelibs.fess.opensearch.config.exbhv.RelatedContentBhv;
 import org.codelibs.fess.opensearch.config.exentity.RelatedContent;
+import org.codelibs.fess.taglib.FessFunctions;
 import org.codelibs.fess.util.ComponentUtil;
+import org.lastaflute.taglib.function.LaFunctions;
 
 import jakarta.annotation.PostConstruct;
 
@@ -74,6 +81,22 @@ public class RelatedContentHelper extends AbstractConfigHelper {
      * a regex pattern matches the query.
      */
     protected String queryPlaceHolder = "__QUERY__";
+
+    /**
+     * Placeholder string used in regex-based related content templates for URL contexts.
+     * This placeholder is replaced with the URL-encoded search query when
+     * a regex pattern matches the query, making it safe to embed in URL parameters
+     * (e.g. {@code href="...?q=..."}).
+     */
+    protected String urlQueryPlaceHolder = "__URL_QUERY__";
+
+    /**
+     * Placeholder string used in regex-based related content templates for JavaScript contexts.
+     * This placeholder is replaced with the JavaScript-escaped search query when
+     * a regex pattern matches the query, making it safe to embed inside a JavaScript
+     * string literal (e.g. inside a {@code <script>} block).
+     */
+    protected String jsQueryPlaceHolder = "__JS_QUERY__";
 
     /**
      * Initializes the RelatedContentHelper by loading related content configurations
@@ -148,7 +171,9 @@ public class RelatedContentHelper extends AbstractConfigHelper {
     /**
      * Retrieves related content for a given search query.
      * First checks for exact term matches, then evaluates regex patterns.
-     * For regex matches, the query placeholder is replaced with the actual query.
+     * For regex matches, the query placeholders are replaced with the actual query,
+     * each encoded for its target context (HTML / URL / JavaScript) to prevent
+     * reflected XSS.
      *
      * @param query the search query to find related content for
      * @return array of related content strings, or empty array if no matches found
@@ -164,12 +189,59 @@ public class RelatedContentHelper extends AbstractConfigHelper {
             }
             for (final Pair<Pattern, String> regexData : pair.getSecond()) {
                 if (regexData.getFirst().matcher(query).matches()) {
-                    contentList.add(regexData.getSecond().replace(queryPlaceHolder, query));
+                    // query is untrusted user input; encode it for each context (HTML/URL/JS) before
+                    // substituting into the admin template to prevent reflected XSS. The substitution is
+                    // performed in a single pass and substituted values are never re-scanned, so an
+                    // encoded value cannot be re-substituted through another placeholder.
+                    contentList.add(applyQueryPlaceHolders(regexData.getSecond(), query));
                 }
             }
             return contentList.toArray(new String[contentList.size()]);
         }
         return StringUtil.EMPTY_STRINGS;
+    }
+
+    /**
+     * Substitutes the query placeholders in the given template with the search query,
+     * encoding the query for each placeholder's target context (HTML / URL / JavaScript).
+     * <p>
+     * The three placeholders are replaced in a single regex pass: the template is scanned
+     * once and each matched placeholder is replaced with its context-encoded query value.
+     * Only the query value is encoded; the admin template itself is never modified or
+     * re-encoded. Because substituted values are never re-scanned, an encoded value cannot
+     * be re-substituted through another placeholder (which would otherwise allow escaping
+     * to be bypassed, e.g. attribute injection).
+     *
+     * @param template the admin-registered content template containing placeholders
+     * @param query the untrusted search query to substitute
+     * @return the template with placeholders replaced by context-encoded query values
+     */
+    protected String applyQueryPlaceHolders(final String template, final String query) {
+        final Map<String, String> replacements = new LinkedHashMap<>();
+        putPlaceHolder(replacements, urlQueryPlaceHolder, URLEncoder.encode(query, StandardCharsets.UTF_8));
+        putPlaceHolder(replacements, jsQueryPlaceHolder, FessFunctions.escapeJs(query));
+        putPlaceHolder(replacements, queryPlaceHolder, LaFunctions.h(query));
+        if (replacements.isEmpty()) {
+            return template;
+        }
+        final String regex = replacements.keySet()
+                .stream()
+                .sorted((a, b) -> b.length() - a.length())
+                .map(Pattern::quote)
+                .collect(Collectors.joining("|"));
+        final Matcher matcher = Pattern.compile(regex).matcher(template);
+        final StringBuilder buf = new StringBuilder();
+        while (matcher.find()) {
+            matcher.appendReplacement(buf, Matcher.quoteReplacement(replacements.get(matcher.group())));
+        }
+        matcher.appendTail(buf);
+        return buf.toString();
+    }
+
+    private void putPlaceHolder(final Map<String, String> replacements, final String placeHolder, final String value) {
+        if (StringUtil.isNotBlank(placeHolder)) {
+            replacements.putIfAbsent(placeHolder, value);
+        }
     }
 
     private String toLowerCase(final String term) {
@@ -196,6 +268,28 @@ public class RelatedContentHelper extends AbstractConfigHelper {
      */
     public void setQueryPlaceHolder(final String queryPlaceHolder) {
         this.queryPlaceHolder = queryPlaceHolder;
+    }
+
+    /**
+     * Sets the placeholder string used in regex-based related content templates for URL contexts.
+     * This placeholder is replaced with the URL-encoded search query when
+     * a regex pattern matches the query.
+     *
+     * @param urlQueryPlaceHolder the placeholder string to be replaced with the URL-encoded query (default: "__URL_QUERY__")
+     */
+    public void setUrlQueryPlaceHolder(final String urlQueryPlaceHolder) {
+        this.urlQueryPlaceHolder = urlQueryPlaceHolder;
+    }
+
+    /**
+     * Sets the placeholder string used in regex-based related content templates for JavaScript contexts.
+     * This placeholder is replaced with the JavaScript-escaped search query when
+     * a regex pattern matches the query.
+     *
+     * @param jsQueryPlaceHolder the placeholder string to be replaced with the JavaScript-escaped query (default: "__JS_QUERY__")
+     */
+    public void setJsQueryPlaceHolder(final String jsQueryPlaceHolder) {
+        this.jsQueryPlaceHolder = jsQueryPlaceHolder;
     }
 
 }

--- a/src/test/java/org/codelibs/fess/helper/RelatedContentHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RelatedContentHelperTest.java
@@ -347,6 +347,231 @@ public class RelatedContentHelperTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getRelatedContents_xssEscaped() {
+        // Security regression test for reflected XSS via __QUERY__ substitution.
+        // The query placeholder substitution feature must be preserved (no degradation from 15.6),
+        // but the substituted query value must be HTML-escaped to prevent reflected XSS.
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "Related: __QUERY__", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        // The script payload must be HTML-escaped (placeholder still substituted = no regression).
+        String[] results = relatedContentHelper.getRelatedContents("<script>alert(1)</script>");
+        assertEquals(1, results.length);
+        assertEquals("Related: &lt;script&gt;alert(1)&lt;/script&gt;", results[0]);
+        // Guard against the previous regression (placeholder removed) and escaping bypass.
+        assertFalse(results[0].contains("<script>"));
+        assertFalse(results[0].contains("</script>"));
+        assertTrue(results[0].contains("&lt;script&gt;"));
+
+        // Each special character is converted to the exact entity produced by LaFunctions.h.
+        assertEscapedQuery("\"", "&#034;");
+        assertEscapedQuery("'", "&#039;");
+        assertEscapedQuery("<", "&lt;");
+        assertEscapedQuery(">", "&gt;");
+        assertEscapedQuery("&", "&amp;");
+    }
+
+    @Test
+    public void test_getRelatedContents_normalQueryNotRegressed() {
+        // Normal queries (no special characters) must still be substituted exactly as in 15.6.
+        // HTML-escaping is an identity transform for such input, so there is no degradation.
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "Related: __QUERY__", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        String[] results = relatedContentHelper.getRelatedContents("laptop");
+        assertEquals(1, results.length);
+        assertEquals("Related: laptop", results[0]);
+    }
+
+    @Test
+    public void test_getRelatedContents_exactMatchNotAffected() {
+        // Exact-match entries return the admin-registered content verbatim (no user input reflected),
+        // so the admin HTML must not be escaped or altered.
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("test", "<a href=\"/foo\">Admin HTML</a>", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        String[] results = relatedContentHelper.getRelatedContents("test");
+        assertEquals(1, results.length);
+        assertEquals("<a href=\"/foo\">Admin HTML</a>", results[0]);
+    }
+
+    @Test
+    public void test_getRelatedContents_urlQueryEncoded() {
+        // __URL_QUERY__ must substitute the URL-encoded query so it is safe inside URL parameters.
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "<a href=\"/s?q=__URL_QUERY__\">link</a>", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        String[] results = relatedContentHelper.getRelatedContents("a b&c<d");
+        assertEquals(1, results.length);
+        assertEquals("<a href=\"/s?q=" + java.net.URLEncoder.encode("a b&c<d", java.nio.charset.StandardCharsets.UTF_8) + "\">link</a>",
+                results[0]);
+        // The raw (unencoded) special characters must not appear in the output.
+        assertFalse(results[0].contains(" b&c<d"));
+    }
+
+    @Test
+    public void test_getRelatedContents_jsQueryEscaped() {
+        // __JS_QUERY__ must substitute the JavaScript-escaped query so it is safe inside a JS string literal.
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "<script>var q='__JS_QUERY__';</script>", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        String[] results = relatedContentHelper.getRelatedContents("';alert(1)//</script>");
+        assertEquals(1, results.length);
+        assertEquals(
+                "<script>var q='" + org.apache.commons.text.StringEscapeUtils.escapeEcmaScript("';alert(1)//</script>") + "';</script>",
+                results[0]);
+        // The query-derived quote must be escaped and the closing tag must be neutralized (/ -> \/).
+        assertTrue(results[0].contains("\\'"));
+        assertTrue(results[0].contains("<\\/script>"));
+        // The raw, unescaped query-derived closing tag (which would break out of the script block)
+        // must not appear; it is neutralized to "<\/script>".
+        assertFalse(results[0].contains("//</script>"));
+    }
+
+    @Test
+    public void test_getRelatedContents_singlePassNoReSubstitution() {
+        // Regression guard for the sequential-replace vulnerability: substitution must be a single pass,
+        // so an encoded value (here a URL-encoded query) is never re-scanned and re-substituted through
+        // another placeholder. If sequential replace() were used, the literal __JS_QUERY__ left in the
+        // URL-encoded value would be replaced by escapeJs(query), turning \" into a raw " and breaking
+        // out of the attribute (attribute injection).
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "<a href=\"/s?q=__URL_QUERY__\">x</a>", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        final String payload = "__JS_QUERY__\" onmouseover=alert(1) x=\"";
+        String[] results = relatedContentHelper.getRelatedContents(payload);
+        assertEquals(1, results.length);
+        // The raw attribute-injection sequence must not appear (it is URL-encoded instead).
+        assertFalse(results[0].contains("\" onmouseover=alert(1) x=\""));
+        // The literal __JS_QUERY__ must survive (URL-encoded value was not re-scanned/re-substituted).
+        assertTrue(results[0].contains("__JS_QUERY__"));
+        // Exact expected output: only __URL_QUERY__ is replaced, with the whole payload URL-encoded.
+        assertEquals("<a href=\"/s?q=" + java.net.URLEncoder.encode(payload, java.nio.charset.StandardCharsets.UTF_8) + "\">x</a>",
+                results[0]);
+    }
+
+    @Test
+    public void test_getRelatedContents_multiplePlaceholders() {
+        // A template may use all three placeholders at once; for a normal query (no special characters)
+        // every context-encoding is an identity transform, so each is substituted with the query verbatim.
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*",
+                "<a href=\"/s?q=__URL_QUERY__\" title=\"__QUERY__\">__QUERY__</a><script>var q='__JS_QUERY__';</script>", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        String[] results = relatedContentHelper.getRelatedContents("hello");
+        assertEquals(1, results.length);
+        assertEquals("<a href=\"/s?q=hello\" title=\"hello\">hello</a><script>var q='hello';</script>", results[0]);
+    }
+
+    @Test
+    public void test_getRelatedContents_blankPlaceHoldersReturnTemplate() {
+        // When all placeholders are configured as blank, putPlaceHolder's isNotBlank guard skips
+        // every entry, so replacements.isEmpty() short-circuits and the template is returned verbatim.
+        // This also guards against compiling an empty-alternation regex (which would match at every
+        // position) when a placeholder is blank.
+        relatedContentHelper.setQueryPlaceHolder("");
+        relatedContentHelper.setUrlQueryPlaceHolder("");
+        relatedContentHelper.setJsQueryPlaceHolder("");
+
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "Related: __QUERY__", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        String[] results = relatedContentHelper.getRelatedContents("anything");
+        assertEquals(1, results.length);
+        // The template is returned unchanged: no substitution occurs for blank placeholders.
+        assertEquals("Related: __QUERY__", results[0]);
+    }
+
+    @Test
+    public void test_getRelatedContents_quoteReplacementLiteral() {
+        // Matcher.quoteReplacement must neutralize regex-replacement metacharacters (\ and $) in the
+        // substituted query value, so they are inserted literally rather than interpreted as escape
+        // sequences or capturing-group back-references.
+
+        // Case A (JS context, backslash): a single backslash query is escaped to two backslashes by
+        // escapeEcmaScript, and both must survive as literal backslashes (not consumed as an escape).
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "<script>var q='__JS_QUERY__';</script>", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        String[] results = relatedContentHelper.getRelatedContents("\\");
+        assertEquals(1, results.length);
+        assertEquals("<script>var q='" + org.apache.commons.text.StringEscapeUtils.escapeEcmaScript("\\") + "';</script>", results[0]);
+
+        // Case B (HTML context, dollar sign): a "$1" query must be inserted literally and must not be
+        // misinterpreted as a "$1" capturing-group back-reference during regex replacement.
+        testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "X__QUERY__X", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        results = relatedContentHelper.getRelatedContents("$1");
+        assertEquals(1, results.length);
+        assertEquals("X$1X", results[0]);
+    }
+
+    @Test
+    public void test_getRelatedContents_singlePassReverse() {
+        // Reverse-direction single-pass guard: a JS template substituted with a query that contains the
+        // literal __URL_QUERY__ placeholder must remain single-pass. Only __JS_QUERY__ is replaced, and
+        // the escaped value (which contains the literal __URL_QUERY__) is never re-scanned/re-substituted.
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "<script>var q='__JS_QUERY__';</script>", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        final String payload = "__URL_QUERY__';alert(1)//";
+        String[] results = relatedContentHelper.getRelatedContents(payload);
+        assertEquals(1, results.length);
+        // Only __JS_QUERY__ is replaced, with the whole payload JS-escaped.
+        assertEquals("<script>var q='" + org.apache.commons.text.StringEscapeUtils.escapeEcmaScript(payload) + "';</script>", results[0]);
+        // The literal __URL_QUERY__ embedded in the escaped value survives, proving it was not re-scanned.
+        assertTrue(results[0].contains("__URL_QUERY__"));
+    }
+
+    // Asserts that a single special-character query is substituted into the template
+    // with the query part HTML-escaped to the expected entity reference.
+    private void assertEscapedQuery(final String payload, final String expectedEntity) {
+        List<RelatedContent> testData = new ArrayList<>();
+        testData.add(createRelatedContent("regex:.*", "X__QUERY__X", ""));
+        mockBhv.setTestData(testData);
+
+        relatedContentHelper.load();
+
+        String[] results = relatedContentHelper.getRelatedContents(payload);
+        assertEquals(1, results.length);
+        assertEquals("X" + expectedEntity + "X", results[0]);
+    }
+
+    @Test
     public void test_inheritance_setReloadInterval() {
         assertEquals(1000L, relatedContentHelper.reloadInterval);
 


### PR DESCRIPTION
## Summary

The related content feature substitutes placeholders in regex-matched templates with the
user's search query. The substituted value was not encoded, so it was reflected as raw HTML
in the v1 search page (`search.jsp` renders related content without escaping) and in v2 API
responses. When an administrator registered a related content template containing a
placeholder, this allowed reflected XSS.

## Changes

`RelatedContentHelper` now encodes the query for the **context of each placeholder** before
substituting it into the admin template. Only the query is encoded; the admin-registered
template is left intact.

| Placeholder | Context | Encoding |
| --- | --- | --- |
| `__QUERY__` | HTML text / attribute (existing, backward compatible) | `LaFunctions.h()` (HTML escape) |
| `__URL_QUERY__` | URL parameter (e.g. `href="...?q=..."`) | `URLEncoder.encode(query, UTF-8)` |
| `__JS_QUERY__` | JavaScript string literal (inside `<script>`) | `FessFunctions.escapeJs()` |

- The existing `__QUERY__` behavior is preserved. For normal queries (no special characters)
  every encoding is an identity transform, so the output is identical to before.
- Substitution is performed in a **single pass** (one regex scan): an already-encoded value
  is never re-scanned and matched as another placeholder. This prevents an encoded value from
  being re-substituted through a different placeholder, which could otherwise bypass encoding
  (e.g. attribute injection).
- The exact-match path is unaffected (it never reflects user input).

## Why encode (not remove)

The `__QUERY__` substitution is a released feature used to embed the search query in related
content, so the query is encoded rather than dropped. `__URL_QUERY__` and `__JS_QUERY__` are
added so administrators can safely embed the query in URL and JavaScript contexts as well.

## Impact

`RelatedContentHelper` is the single source for all related content output paths (v1 search
page, v2 `/api/v2/related-content`, v2 `/api/v2/search`, and the API plugins), so this single
change covers every path. None of these paths apply a separate HTML escape, so no
double-encoding occurs. The v2 themes additionally sanitize related content on the client
side, which remains as defense-in-depth.

## Tests

- Existing `RelatedContentHelperTest` cases (regex substitution with normal queries) pass
  unchanged, confirming no regression.
- Added tests: HTML escaping, URL encoding, and JavaScript escaping of the query for the
  respective placeholders; a single-pass regression test proving an encoded value is not
  re-substituted; a normal-query no-regression test; a multi-placeholder template test; and
  an exact-match-unaffected test.
