### PR TITLE
Enumerate v2 search-hit fields in the OpenAPI spec and pin the response-field allowlist

### DIFF
--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -291,11 +291,25 @@ paths:
           schema: { type: string }
       responses:
         '200':
-          description: NDJSON stream.
+          description: |-
+            NDJSON stream. Each successful line is a `{"data": <SearchHit>}`
+            object whose document fields follow the same server-side allowlist
+            (`QueryFieldConfig#isApiResponseField`) as `GET /search`; see the
+            `SearchHit` schema for the exact fields and types. The collapse-only
+            fields `similar_docs_count` / `similar_docs_hash` are never present
+            on this scroll endpoint. If a failure occurs mid-stream the handler
+            emits a final
+            `{"error":{"code":"internal_error","message":"stream error"}}` line
+            and flushes; clients MUST inspect the last line's first key to
+            distinguish stream-complete from server-crashed.
           content:
             application/x-ndjson:
               schema:
                 type: string
+                description: |-
+                  Newline-delimited JSON. Each line is either
+                  `{"data": <SearchHit>}` (see the `SearchHit` schema) or, as the
+                  final line on mid-stream failure, `{"error":{...}}`.
                 example: |
                   {"data":{"url":"https://example.com/","title":"Example"}}
                   {"data":{"url":"https://example.org/","title":"Example Org"}}
@@ -1127,13 +1141,9 @@ components:
                   items: { type: string }
                 data:
                   type: array
-                  description: |-
-                    One entry per document. Only fields permitted by
-                    `QueryFieldConfig#isApiResponseField` are present; nulls
-                    and blank keys are dropped.
+                  description: One entry per matching document.
                   items:
-                    type: object
-                    additionalProperties: true
+                    $ref: '#/components/schemas/SearchHit'
                 facet_field:
                   type: array
                   description: Present only when facet fields were requested.
@@ -1159,6 +1169,64 @@ components:
                     properties:
                       value: { type: string }
                       count: { type: integer, format: int64 }
+
+    SearchHit:
+      type: object
+      description: |-
+        A single search hit derived from an indexed document. This object
+        describes the `data[]` entries only (the sibling `related_query` /
+        `related_contents` fields are a different, non-document channel).
+        The set of emitted fields is server-side allowlisted by
+        `QueryFieldConfig#isApiResponseField` (authoritative). ACL / role /
+        internal fields (for example `role`, `virtual_host`, the raw
+        `content` body) are never emitted. Null values and blank keys are
+        dropped, so any given field MAY be absent (fields are therefore
+        optional and never `null`). Operators can expose additional crawled
+        fields via `query.additional.api.response.fields` (and dynamic
+        language-template fields such as `*_ja` / `*_en` may pass through),
+        which is why `additionalProperties` is `true`.
+      properties:
+        url: { type: string }
+        title: { type: string }
+        digest: { type: string }
+        content_description: { type: string }
+        content_title: { type: string }
+        site: { type: string }
+        site_path: { type: string }
+        url_link: { type: string }
+        host: { type: string }
+        mimetype: { type: string }
+        filetype: { type: string }
+        filename: { type: string }
+        content_length: { type: integer, format: int64 }
+        last_modified: { type: string, format: date-time }
+        timestamp: { type: string, format: date-time }
+        created: { type: string, format: date-time }
+        score: { type: number, format: float }
+        boost: { type: number, format: float }
+        doc_id: { type: string }
+        _id:
+          type: string
+          description: OpenSearch document `_id` (the only metadata field exposed).
+        thumbnail: { type: string }
+        has_cache:
+          type: string
+          enum: ['true', 'false']
+          description: Stored as the string `"true"`/`"false"`, not a JSON boolean.
+        click_count: { type: integer, format: int64 }
+        favorite_count: { type: integer, format: int64 }
+        similar_docs_count:
+          type: integer
+          format: int64
+          description: |-
+            Present only when result collapsing is enabled and the group has
+            duplicates. Never present on `/documents/all`.
+        similar_docs_hash:
+          type: string
+          description: |-
+            Present only when result collapsing is enabled. Never present on
+            `/documents/all`.
+      additionalProperties: true
 
     # --- Suggest / labels / popular ---------------------------------
     SuggestWordsResponse:
@@ -1668,6 +1736,7 @@ components:
                   items:
                     type: object
                     required: [doc_id]
+                    additionalProperties: false
                     properties:
                       doc_id: { type: string }
 
@@ -1739,7 +1808,15 @@ components:
                 mimetype:
                   type: string
                   enum: [text/html]
-                content: { type: string }
+                content:
+                  type: string
+                  description: |-
+                    Cached document body for the requested document. The
+                    document is fetched role-filtered via
+                    `getDocumentByDocId(userBean)`, so a caller only receives
+                    content they are authorized to see. The fetch field set
+                    (`getCacheResponseFields()`) contains no ACL or internal
+                    fields.
                 url:
                   type: string
                   description: |-

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -786,6 +786,9 @@ query.additional.default.fields=
 # Additional response fields for queries.
 query.additional.response.fields=
 # Additional API response fields for queries.
+# This key only appends fields to the v2 API response allow-list (add-only).
+# Do not add ACL or internal fields (for example role, virtual_host); adding
+# them would expose access-control information in the search API response.
 query.additional.api.response.fields=
 # Additional scroll response fields for queries.
 query.additional.scroll.response.fields=
@@ -1057,6 +1060,10 @@ authentication.admin.roles=admin
 role.search.default.permissions=
 # Default display permissions for search roles.
 role.search.default.display.permissions={role}guest
+# Keep role.search.guest.permissions non-empty. It seeds the guest role that
+# keeps the anonymous search role set non-empty; if the resolved role set is
+# empty the role filter is skipped (fail-open), which can disable role-based
+# access control and expose documents to anonymous users.
 # Guest permissions for search roles.
 role.search.guest.permissions={role}guest
 

--- a/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
@@ -427,6 +427,60 @@ public class RoleQueryHelperTest extends UnitFessTestCase {
         }
     }
 
+    /**
+     * Role-filter fail-open invariant (Excessive Data Exposure / OWASP API3:2023 Broken Object
+     * Property Level Authorization). The role filter in {@code QueryHelper#buildRoleQuery} and
+     * {@code SearchHelper} is applied only when {@code !roleSet.isEmpty()} (the
+     * {@code if (!roleSet.isEmpty())} guard at QueryHelper.java:170-177 / SearchHelper.java:409-413).
+     * If {@code RoleQueryHelper#build} ever returned an empty set in an anonymous context, that
+     * guard would skip the ACL filter entirely and the v2 search API would expose every document
+     * (ACL fully open). This test pins the invariant that an anonymous (no userBean) v2/JSON
+     * request always yields a non-empty role set seeded with the configured guest role(s), so the
+     * guard always engages.
+     *
+     * <p>The anonymous context here is a request with no cached {@code userRoles} attribute, no
+     * presented access token, and no logged-in {@code FessUserBean}; with
+     * {@code api.access.token.required=false} (see MockFessConfig#getApiAccessTokenRequiredAsBoolean)
+     * the helper falls into the guest-role backfill branch (RoleQueryHelper.java:186-193).
+     * {@code processAccessToken} is overridden to return {@code false} (no token) so the test does
+     * not require the OpenSearch-backed {@code AccessTokenService} / {@code AccessTokenBhv}, while
+     * still exercising the real guest-backfill logic.
+     */
+    @Test
+    public void test_build_anonymousJson_isNonEmptyWithGuestRole() {
+        final RoleQueryHelper roleQueryHelper = new RoleQueryHelper() {
+            @Override
+            protected long getCurrentTime() {
+                return System.currentTimeMillis();
+            }
+
+            @Override
+            protected boolean processAccessToken(final HttpServletRequest request, final Set<String> roleSet, final boolean isApiRequest) {
+                // Anonymous request: no access token presented.
+                return false;
+            }
+        };
+        roleQueryHelper.init();
+
+        // Anonymous v2/JSON request: a request exists but no userRoles attribute and no userBean.
+        getMockRequest();
+
+        final Set<String> roleSet = roleQueryHelper.build(SearchRequestType.JSON);
+
+        // The core invariant: never empty, otherwise the role filter guard fails open.
+        assertFalse(roleSet.isEmpty(), "anonymous JSON role set must never be empty (role filter would fail open): " + roleSet);
+
+        // Every configured guest role backfilled by build() (RoleQueryHelper.java:191) must be
+        // present. We compare against the live getSearchGuestRoleList() that build() itself reads,
+        // so the assertion is independent of how guest roles are encoded/prefixed in this harness.
+        final List<String> guestRoleList = ComponentUtil.getFessConfig().getSearchGuestRoleList();
+        // Defense-in-depth: the underlying invariant the backfill depends on must itself be non-empty.
+        assertFalse(guestRoleList.isEmpty(), "search.guest.role must be non-empty; emptying it fails the role filter open");
+        for (final String guestRole : guestRoleList) {
+            assertTrue(roleSet.contains(guestRole), "anonymous JSON role set must contain guest role '" + guestRole + "': " + roleSet);
+        }
+    }
+
     @Test
     public void test_build_withRequest() {
         final RoleQueryHelper roleQueryHelper = new RoleQueryHelper() {

--- a/src/test/java/org/codelibs/fess/query/QueryFieldConfigTest.java
+++ b/src/test/java/org/codelibs/fess/query/QueryFieldConfigTest.java
@@ -998,4 +998,94 @@ public class QueryFieldConfigTest extends UnitFessTestCase {
         assertTrue(queryFieldConfig.apiResponseFieldSet.contains("favorite_count"),
                 "apiResponseFieldSet must contain favorite_count; actual set: " + queryFieldConfig.apiResponseFieldSet);
     }
+
+    /**
+     * Regression guard for the v2 API response field allowlist (Excessive Data Exposure /
+     * OWASP API3:2023). This pins the
+     * default, DI-booted v2 API response field allowlist that
+     * {@link QueryFieldConfig#isApiResponseField(String)} enforces as an exact-match
+     * allowlist (no wildcard / prefix matching). It is the substantive security
+     * guarantee that ACL / role / internal fields are never serialized into
+     * SearchResponse.data[] or /documents/all.
+     *
+     * <p>Unlike {@code test_isApiResponseField}, which exercises synthetic fields via
+     * {@code setApiResponseFields(...)}, this test verifies the real allowlist built by
+     * {@code init()} during the DI boot (via {@link ComponentUtil#getQueryFieldConfig()}),
+     * so it catches regressions in the default field set itself.
+     *
+     * <p>The expected field names are resolved from the same {@link FessConfig} the
+     * {@code QueryFieldConfig} was booted with, rather than hard-coded, so the test pins the
+     * <em>logical</em> allowlist (which fields are emitted) independently of deployment-specific
+     * index field naming (for example {@code _id} vs {@code id}). The 26 logical fields match
+     * the v2 search hit contract enumerated in openapi-user.yaml's {@code SearchHit} schema.
+     * {@code _id} / {@code similar_docs_count} / {@code similar_docs_hash} are allowlist members
+     * deterministically (independent of runtime hit content), so they are asserted unconditionally.
+     */
+    @Test
+    public void test_isApiResponseField_defaultAllowlist_allowsSafeFields() {
+        final QueryFieldConfig config = ComponentUtil.getQueryFieldConfig();
+        assertNotNull(config, "queryFieldConfig must be available from the DI container");
+        assertNotNull(config.apiResponseFieldSet, "apiResponseFieldSet must not be null after init");
+
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        // The 26 logical fields the v2 SearchHit contract enumerates, resolved from FessConfig.
+        final String collapseName = fessConfig.getQueryCollapseInnerHitsName();
+        final String[] allowedFields = { fessConfig.getIndexFieldUrl(), fessConfig.getIndexFieldTitle(), fessConfig.getIndexFieldDigest(),
+                fessConfig.getResponseFieldContentDescription(), fessConfig.getResponseFieldContentTitle(), fessConfig.getIndexFieldSite(),
+                fessConfig.getResponseFieldSitePath(), fessConfig.getResponseFieldUrlLink(), fessConfig.getIndexFieldHost(),
+                fessConfig.getIndexFieldMimetype(), fessConfig.getIndexFieldFiletype(), fessConfig.getIndexFieldFilename(),
+                fessConfig.getIndexFieldContentLength(), fessConfig.getIndexFieldLastModified(), fessConfig.getIndexFieldTimestamp(),
+                fessConfig.getIndexFieldCreated(), QueryFieldConfig.SCORE_FIELD, fessConfig.getIndexFieldBoost(),
+                fessConfig.getIndexFieldDocId(), fessConfig.getIndexFieldId(), fessConfig.getIndexFieldThumbnail(),
+                fessConfig.getIndexFieldHasCache(), fessConfig.getIndexFieldClickCount(), fessConfig.getIndexFieldFavoriteCount(),
+                collapseName + "_count", collapseName + "_hash" };
+        for (final String field : allowedFields) {
+            assertTrue(config.isApiResponseField(field),
+                    "expected allowlisted API response field '" + field + "'; actual set: " + config.apiResponseFieldSet);
+        }
+        // Pin the cardinality so a silently widened allowlist (e.g. an accidental extra entry)
+        // is caught even if it happens to be a benign field name.
+        assertEquals(allowedFields.length, config.apiResponseFieldSet.size(),
+                "default API response allowlist size changed; actual set: " + config.apiResponseFieldSet);
+    }
+
+    /**
+     * Regression guard (Excessive Data Exposure / OWASP API3:2023): ACL / role / internal index
+     * fields must NOT be exposed by the v2 API.
+     * {@code isApiResponseField} is an exact-match allowlist, so any field not enumerated in
+     * the allowlist is automatically excluded (fail-safe). The fields below are explicitly
+     * asserted as the regression net: if any of them is ever (mistakenly) added to the
+     * allowlist, this test fails. Most critically {@code role} and {@code virtual_host}
+     * (search ACL / virtual-host isolation) must always return false.
+     *
+     * <p>Note {@code lang} is asymmetric: it is present in {@code responseFields} (fetched from
+     * the index) but intentionally absent from {@code apiResponseFieldSet} (not emitted to the
+     * API), which is easy to regress, so it is pinned here. Field names are resolved from the
+     * same {@link FessConfig} the {@code QueryFieldConfig} was booted with where typed accessors
+     * exist; the literals {@code virtual_host} / {@code important_content} / {@code content_minhash*}
+     * / {@code location} have no typed accessor here and are asserted by their canonical index names.
+     */
+    @Test
+    public void test_isApiResponseField_defaultAllowlist_excludesAclAndInternalFields() {
+        final QueryFieldConfig config = ComponentUtil.getQueryFieldConfig();
+        assertNotNull(config, "queryFieldConfig must be available from the DI container");
+        assertNotNull(config.apiResponseFieldSet, "apiResponseFieldSet must not be null after init");
+
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        // P1 (ACL / sensitive), P2 (internal), P3 (asymmetric / metadata) per design 3.2.1.
+        final String[] excludedFields = {
+                // P1: ACL / sensitive
+                fessConfig.getIndexFieldRole(), "virtual_host", fessConfig.getIndexFieldContent(), "important_content",
+                fessConfig.getIndexFieldCache(),
+                // P2: internal
+                fessConfig.getIndexFieldParentId(), fessConfig.getIndexFieldConfigId(), fessConfig.getIndexFieldExpires(),
+                fessConfig.getIndexFieldAnchor(), fessConfig.getIndexFieldSegment(), fessConfig.getIndexFieldLabel(),
+                // P3: asymmetric / metadata
+                fessConfig.getIndexFieldLang(), "content_minhash", "content_minhash_bits", "location", fessConfig.getIndexFieldVersion(),
+                fessConfig.getIndexFieldSeqNo(), fessConfig.getIndexFieldPrimaryTerm() };
+        for (final String field : excludedFields) {
+            assertFalse(config.isApiResponseField(field),
+                    "ACL/internal field '" + field + "' must never be an API response field; actual set: " + config.apiResponseFieldSet);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Makes the v2 API response contract machine-readable and adds regression tests
that pin the server-side response-field allowlist.

- Add a `SearchHit` schema enumerating the fields returned for v2 search hits
  with correct types (dates as date-time strings, `has_cache` as a string enum,
  counts as int64, score/boost as float); `SearchResponse.data[]` now `$ref`s it.
- Keep `additionalProperties: true` so deployments that expose extra fields via
  `query.additional.api.response.fields` stay contract-valid.
- Clarify `/documents/all` (NDJSON) and `CacheResponse.content` descriptions;
  close `/favorites` data items with `additionalProperties: false`.
- Regression tests: the default allowlist permits the documented fields and
  excludes ACL/role/internal index fields; the anonymous role set includes the
  guest role.
- Add config documentation for the related properties.

## Test
- `mvn -o test -Dtest='QueryFieldConfigTest,RoleQueryHelperTest'` -> 68 passed.
- OpenAPI YAML validated; no new lint findings vs. the base file.
