### PR TITLE
fix(api): omit cluster_name from anonymous /api/v2/health response

### DIFF
--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -1102,9 +1102,8 @@ components:
               properties:
                 engine:
                   type: object
-                  required: [cluster_name, status, ping_status]
+                  required: [status, ping_status]
                   properties:
-                    cluster_name: { type: string }
                     status:
                       type: string
                       enum: [green, yellow, red]

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java
@@ -59,7 +59,9 @@ public class HealthHandler {
             final PingResponse ping = ComponentUtil.getSearchEngineClient().ping();
             final String clusterStatus = ping.getClusterStatus();
             final Map<String, Object> engine = new LinkedHashMap<>();
-            engine.put("cluster_name", ping.getClusterName());
+            // The OpenSearch cluster name is intentionally omitted from this anonymous endpoint
+            // to avoid leaking deployment metadata; only the coarse status and ping_status are
+            // surfaced. Operators that need cluster details use the authenticated admin API.
             engine.put("status", clusterStatus);
             engine.put("ping_status", ping.getStatus());
             if ("red".equalsIgnoreCase(clusterStatus)) {

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
@@ -272,11 +272,13 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
         // service_unavailable error envelope (status:9) instead of a success envelope.
         final String body = res.body();
         assertFalse(body.contains("\"version\""), body);
+        // cluster_name is intentionally not exposed by the anonymous health endpoint to avoid
+        // leaking the OpenSearch cluster name; verify on every path (success / 503 / 500).
+        assertFalse(body.contains("\"cluster_name\""), body);
         if (res.status == 200) {
             // green or yellow — success envelope with engine details.
             assertTrue(body.contains("\"status\":0"), body);
             assertTrue(body.contains("\"engine\""), body);
-            assertTrue(body.contains("\"cluster_name\""), body);
         } else if (res.status == 503) {
             // red cluster — error envelope; engine details embedded under error.details.
             assertTrue(body.contains("\"status\":9"), body);

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/HealthHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/HealthHandlerTest.java
@@ -85,10 +85,12 @@ public class HealthHandlerTest extends UnitFessTestCase {
         final String body = res.body();
         // The v2 envelope never carries a "version" key, on either the happy or failure path.
         assertFalse(body.contains("\"version\""), body);
+        // cluster_name is intentionally not exposed by the anonymous health endpoint to avoid
+        // leaking the OpenSearch cluster name; verify on every path (success / 503 / 500).
+        assertFalse(body.contains("\"cluster_name\""), body);
         if (res.status == 200) {
             assertTrue(body.contains("\"status\":0"), body);
             assertTrue(body.contains("\"engine\""), body);
-            assertTrue(body.contains("\"cluster_name\""), body);
             assertTrue(body.contains("\"ping_status\""), body);
         } else {
             // No engine in this JVM → handler emits a structured 503 (cluster red /


### PR DESCRIPTION
## Summary

The anonymous `GET /api/v2/health` endpoint returned the OpenSearch cluster name (`engine.cluster_name`) to unauthenticated callers. The cluster name is deployment metadata with reconnaissance value and no benefit for health monitoring, so it is removed from the public health response.

`engine.status` (green/yellow/red) and `engine.ping_status` are retained, since they reflect whether the search service is usable. Operators that need detailed cluster information continue to use the authenticated admin API.

## Changes

- `HealthHandler`: stop emitting `cluster_name`. The success (200) and red-cluster (503 `error.details.engine`) paths share one engine map, so both are covered.
- OpenAPI `HealthResponse` schema: drop `cluster_name` from `required` and remove the property; `status` and `ping_status` remain.
- Unit tests (`HealthHandlerTest`, `SearchApiV2ManagerTest`): assert `cluster_name` is absent on every response path.

## Testing

- `mvn formatter:format license:format`
- `mvn test -Dtest=HealthHandlerTest,SearchApiV2ManagerTest,V2EnvelopeWriterTest` → 49 tests pass.

## Notes

- `PingResponse`, the admin APIs, and `/api/v1/health` are intentionally unchanged.
- Behavior change: external monitoring clients that read `engine.cluster_name` from `/api/v2/health` will no longer receive it.