### PR TITLE
fix(api-v2): key chat throttle by client IP for anonymous callers

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatHandler.java
@@ -200,7 +200,9 @@ public class ChatHandler {
      * @return the rate-limit key (never null/blank)
      */
     protected String getRateLimitKey(final HttpServletRequest req) {
-        return ComponentUtil.getChatApiHelper().resolveChatRateLimitKey(req);
+        final String username = ComponentUtil.getSystemHelper().getUsername();
+        return ComponentUtil.getChatApiHelper()
+                .resolveChatRateLimitKey(username, () -> ComponentUtil.getRateLimitHelper().getClientIp(req));
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatHandler.java
@@ -137,11 +137,8 @@ public class ChatHandler {
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
-        // Rate-limit by a key that an anonymous attacker cannot rotate: the server-validated
-        // username for authenticated callers, otherwise the proxy-aware client IP. Keying on the
-        // forgeable guest userCode (as the old userId-based throttle did) let anonymous callers
-        // rotate the key per request and bypass the limit; the key is always non-blank so the
-        // throttle now always applies. userId above is still used for chat-session binding.
+        // Throttle by a key an anonymous caller cannot rotate (see ChatApiHelper#resolveChatRateLimitKey);
+        // the key is always non-blank so the throttle always applies. userId above stays for chat-session binding.
         final String rateLimitKey = getRateLimitKey(req);
         if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(rateLimitKey)
                 && !limiter.allow(LoginRateLimiter.Scope.CHAT, rateLimitKey, chatLimit, 60)) {

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatHandler.java
@@ -137,11 +137,14 @@ public class ChatHandler {
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
-        // Skip the per-user throttle for anonymous callers with no resolvable user id
-        // (e.g. a guest whose session is not yet established): a null/blank key would
-        // otherwise hit the limiter's null-key deny path and 429 the first request.
-        if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(userId)
-                && !limiter.allow(LoginRateLimiter.Scope.CHAT, userId, chatLimit, 60)) {
+        // Rate-limit by a key that an anonymous attacker cannot rotate: the server-validated
+        // username for authenticated callers, otherwise the proxy-aware client IP. Keying on the
+        // forgeable guest userCode (as the old userId-based throttle did) let anonymous callers
+        // rotate the key per request and bypass the limit; the key is always non-blank so the
+        // throttle now always applies. userId above is still used for chat-session binding.
+        final String rateLimitKey = getRateLimitKey(req);
+        if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(rateLimitKey)
+                && !limiter.allow(LoginRateLimiter.Scope.CHAT, rateLimitKey, chatLimit, 60)) {
             res.setHeader("Retry-After", "60");
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
             return;
@@ -184,6 +187,20 @@ public class ChatHandler {
      */
     protected String getUserId(final HttpServletRequest req) {
         return ComponentUtil.getChatApiHelper().getUserId();
+    }
+
+    /**
+     * Resolves the chat rate-limit key (server-validated username for authenticated callers, else the
+     * proxy-aware client IP). Exposed as a seam so unit tests can pin the throttle key deterministically;
+     * the underlying {@code SystemHelper}/{@code RateLimitHelper} are smart-deploy components that are
+     * unreliable to stub via {@code ComponentUtil.register} once the shared test container has resolved
+     * the real ones (same rationale as {@link #getUserId}).
+     *
+     * @param req the incoming HTTP request
+     * @return the rate-limit key (never null/blank)
+     */
+    protected String getRateLimitKey(final HttpServletRequest req) {
+        return ComponentUtil.getChatApiHelper().resolveChatRateLimitKey(req);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
@@ -170,6 +170,8 @@ public class ChatSessionClearHandler {
      * @return the rate-limit key (never null/blank)
      */
     protected String getRateLimitKey(final HttpServletRequest req) {
-        return ComponentUtil.getChatApiHelper().resolveChatRateLimitKey(req);
+        final String username = ComponentUtil.getSystemHelper().getUsername();
+        return ComponentUtil.getChatApiHelper()
+                .resolveChatRateLimitKey(username, () -> ComponentUtil.getRateLimitHelper().getClientIp(req));
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
@@ -117,11 +117,8 @@ public class ChatSessionClearHandler {
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
-        // Rate-limit by a key that an anonymous attacker cannot rotate: the server-validated
-        // username for authenticated callers, otherwise the proxy-aware client IP. Keying on the
-        // forgeable guest userCode (as the old userId-based throttle did) let anonymous callers
-        // rotate the key per request and bypass the limit; the key is always non-blank so the
-        // throttle now always applies. userId above is still used for chat-session binding.
+        // Throttle by a key an anonymous caller cannot rotate (see ChatApiHelper#resolveChatRateLimitKey);
+        // the key is always non-blank so the throttle always applies. userId above stays for chat-session binding.
         final String rateLimitKey = getRateLimitKey(req);
         if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(rateLimitKey)
                 && !limiter.allow(LoginRateLimiter.Scope.CHAT, rateLimitKey, chatLimit, 60)) {

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandler.java
@@ -117,11 +117,14 @@ public class ChatSessionClearHandler {
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
-        // Skip the per-user throttle for anonymous callers with no resolvable user id
-        // (e.g. a guest whose session is not yet established): a null/blank key would
-        // otherwise hit the limiter's null-key deny path and 429 the first request.
-        if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(userId)
-                && !limiter.allow(LoginRateLimiter.Scope.CHAT, userId, chatLimit, 60)) {
+        // Rate-limit by a key that an anonymous attacker cannot rotate: the server-validated
+        // username for authenticated callers, otherwise the proxy-aware client IP. Keying on the
+        // forgeable guest userCode (as the old userId-based throttle did) let anonymous callers
+        // rotate the key per request and bypass the limit; the key is always non-blank so the
+        // throttle now always applies. userId above is still used for chat-session binding.
+        final String rateLimitKey = getRateLimitKey(req);
+        if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(rateLimitKey)
+                && !limiter.allow(LoginRateLimiter.Scope.CHAT, rateLimitKey, chatLimit, 60)) {
             res.setHeader("Retry-After", "60");
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
             return;
@@ -154,5 +157,19 @@ public class ChatSessionClearHandler {
      */
     protected String getUserId(final HttpServletRequest req) {
         return ComponentUtil.getChatApiHelper().getUserId();
+    }
+
+    /**
+     * Resolves the chat rate-limit key (server-validated username for authenticated callers, else the
+     * proxy-aware client IP). Exposed as a seam so unit tests can pin the throttle key deterministically;
+     * the underlying {@code SystemHelper}/{@code RateLimitHelper} are smart-deploy components that are
+     * unreliable to stub via {@code ComponentUtil.register} once the shared test container has resolved
+     * the real ones (same rationale as {@link #getUserId}).
+     *
+     * @param req the incoming HTTP request
+     * @return the rate-limit key (never null/blank)
+     */
+    protected String getRateLimitKey(final HttpServletRequest req) {
+        return ComponentUtil.getChatApiHelper().resolveChatRateLimitKey(req);
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
@@ -365,7 +365,9 @@ public class ChatStreamHandler {
      * @return the rate-limit key (never null/blank)
      */
     protected String getRateLimitKey(final HttpServletRequest req) {
-        return ComponentUtil.getChatApiHelper().resolveChatRateLimitKey(req);
+        final String username = ComponentUtil.getSystemHelper().getUsername();
+        return ComponentUtil.getChatApiHelper()
+                .resolveChatRateLimitKey(username, () -> ComponentUtil.getRateLimitHelper().getClientIp(req));
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
@@ -250,11 +250,8 @@ public class ChatStreamHandler {
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
-        // Rate-limit by a key that an anonymous attacker cannot rotate: the server-validated
-        // username for authenticated callers, otherwise the proxy-aware client IP. Keying on the
-        // forgeable guest userCode (as the old userId-based throttle did) let anonymous callers
-        // rotate the key per request and bypass the limit; the key is always non-blank so the
-        // throttle now always applies. userId above is still used for chat-session binding.
+        // Throttle by a key an anonymous caller cannot rotate (see ChatApiHelper#resolveChatRateLimitKey);
+        // the key is always non-blank so the throttle always applies. userId above stays for chat-session binding.
         final String rateLimitKey = getRateLimitKey(req);
         if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(rateLimitKey)
                 && !limiter.allow(LoginRateLimiter.Scope.CHAT, rateLimitKey, chatLimit, 60)) {

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
@@ -250,11 +250,14 @@ public class ChatStreamHandler {
             return;
         }
         final int chatLimit = fessConfig.getChatRateLimitPerMinute();
-        // Skip the per-user throttle for anonymous callers with no resolvable user id
-        // (e.g. a guest whose session is not yet established): a null/blank key would
-        // otherwise hit the limiter's null-key deny path and 429 the first request.
-        if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(userId)
-                && !limiter.allow(LoginRateLimiter.Scope.CHAT, userId, chatLimit, 60)) {
+        // Rate-limit by a key that an anonymous attacker cannot rotate: the server-validated
+        // username for authenticated callers, otherwise the proxy-aware client IP. Keying on the
+        // forgeable guest userCode (as the old userId-based throttle did) let anonymous callers
+        // rotate the key per request and bypass the limit; the key is always non-blank so the
+        // throttle now always applies. userId above is still used for chat-session binding.
+        final String rateLimitKey = getRateLimitKey(req);
+        if (limiter != null && chatLimit > 0 && StringUtil.isNotBlank(rateLimitKey)
+                && !limiter.allow(LoginRateLimiter.Scope.CHAT, rateLimitKey, chatLimit, 60)) {
             res.setHeader("Retry-After", "60");
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many chat requests");
             return;
@@ -349,6 +352,20 @@ public class ChatStreamHandler {
      */
     protected String getUserId(final HttpServletRequest req) {
         return ComponentUtil.getChatApiHelper().getUserId();
+    }
+
+    /**
+     * Resolves the chat rate-limit key (server-validated username for authenticated callers, else the
+     * proxy-aware client IP). Exposed as a seam so unit tests can pin the throttle key deterministically;
+     * the underlying {@code SystemHelper}/{@code RateLimitHelper} are smart-deploy components that are
+     * unreliable to stub via {@code ComponentUtil.register} once the shared test container has resolved
+     * the real ones (same rationale as {@link #getUserId}).
+     *
+     * @param req the incoming HTTP request
+     * @return the rate-limit key (never null/blank)
+     */
+    protected String getRateLimitKey(final HttpServletRequest req) {
+        return ComponentUtil.getChatApiHelper().resolveChatRateLimitKey(req);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/InvalidRequestParameterException.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/InvalidRequestParameterException.java
@@ -22,6 +22,11 @@ package org.codelibs.fess.api.v2.handlers;
 public class InvalidRequestParameterException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs the exception with a message describing the violated constraint.
+     *
+     * @param message the detail message describing the invalid request parameter
+     */
     public InvalidRequestParameterException(final String message) {
         super(message);
     }

--- a/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
@@ -37,8 +37,6 @@ import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 /**
  * Shared utilities for v2 chat API handlers.
  *
@@ -343,64 +341,33 @@ public class ChatApiHelper {
      * back to the cookie-bound, client-supplied userCode for guests), this key must be robust
      * against abuse: the guest userCode is only validated by regex/length, so a malicious client
      * could forge and rotate it per request to obtain a fresh throttle bucket and bypass the limit.
-     * Instead, authenticated callers are keyed by their server-validated session username and all
-     * other callers (guest / anonymous / forged / rotated / blank userCode) are keyed by the
-     * proxy-aware client IP, which an anonymous attacker cannot freely rotate.</p>
+     * Authenticated (non-guest) callers are keyed by their server-validated username
+     * ({@code "u:"+username}); all other callers (guest / anonymous / forged / rotated / blank
+     * userCode) are keyed by the proxy-aware client IP ({@code "ip:"+clientIp}), which an anonymous
+     * attacker cannot freely rotate. The client-IP supplier is evaluated lazily so the IP is only
+     * resolved for guest visitors.</p>
      *
      * <p>The returned key is namespaced ({@code "u:"} for usernames, {@code "ip:"} for client IPs)
      * so the two key spaces never collide, and is always non-blank so the chat throttle always
      * applies.</p>
      *
-     * <p>Behind a reverse proxy the per-IP key is only as trustworthy as the proxy setup:
-     * {@link RateLimitHelper#getClientIp(jakarta.servlet.http.HttpServletRequest)} honors
-     * {@code X-Forwarded-For} / {@code X-Real-IP} only from proxies listed in
-     * {@code rate.limit.trusted.proxies}, so that fronting proxy must be trusted and must
-     * sanitize any inbound forwarded headers for the per-IP key to resist rotation.</p>
-     *
-     * @param req the incoming HTTP request (used to resolve the client IP for guests)
-     * @return the chat rate-limit key (never null/blank)
-     */
-    public String resolveChatRateLimitKey(final HttpServletRequest req) {
-        final String username = ComponentUtil.getSystemHelper().getUsername();
-        return resolveChatRateLimitKey(username, () -> resolveClientIp(req));
-    }
-
-    /**
-     * Pure resolution logic behind {@link #resolveChatRateLimitKey(HttpServletRequest)}, separated so
-     * the branching can be unit-tested without the DI container. Authenticated (non-guest) callers
-     * are keyed by their server-validated username ({@code "u:"+username}); all other callers
-     * (guest / anonymous / forged / rotated / blank userCode) are keyed by the proxy-aware client IP
-     * ({@code "ip:"+clientIp}), which an anonymous attacker cannot freely rotate. The client-IP
-     * supplier is evaluated lazily so the IP is only resolved for guest visitors.
+     * <p>The client IP is resolved by the caller (the v2 chat handlers, via
+     * {@code RateLimitHelper#getClientIp}) rather than here, so this helper carries no servlet-API
+     * dependency and stays loadable by non-web Fess processes (e.g. the crawler) whose DI container
+     * also instantiates it. Behind a reverse proxy the per-IP key is only as trustworthy as the
+     * proxy setup: {@code rate.limit.trusted.proxies} gates which proxies' {@code X-Forwarded-For} /
+     * {@code X-Real-IP} headers are honored, so the fronting proxy must be trusted and must sanitize
+     * any inbound forwarded headers for the per-IP key to resist rotation.</p>
      *
      * @param username the authenticated username (may be {@link Constants#GUEST_USER})
      * @param clientIpSupplier supplies the proxy-aware client IP for guest visitors
      * @return the namespaced chat rate-limit key (never null/blank)
      */
-    String resolveChatRateLimitKey(final String username, final java.util.function.Supplier<String> clientIpSupplier) {
+    public String resolveChatRateLimitKey(final String username, final java.util.function.Supplier<String> clientIpSupplier) {
         if (!Constants.GUEST_USER.equals(username)) {
             return "u:" + username;
         }
         return "ip:" + clientIpSupplier.get();
-    }
-
-    /**
-     * Resolves the proxy-aware client IP, mirroring {@code LoginHandler#resolveClientIp}: prefer
-     * {@link RateLimitHelper#getClientIp(HttpServletRequest)} and fall back to
-     * {@link HttpServletRequest#getRemoteAddr()} if the helper is unavailable.
-     *
-     * @param req the incoming HTTP request
-     * @return the client IP (never null when {@code getRemoteAddr()} is set)
-     */
-    private String resolveClientIp(final HttpServletRequest req) {
-        try {
-            return ComponentUtil.getRateLimitHelper().getClientIp(req);
-        } catch (final RuntimeException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("RateLimitHelper.getClientIp unavailable; falling back to getRemoteAddr", e);
-            }
-            return req.getRemoteAddr();
-        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
@@ -37,6 +37,8 @@ import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 /**
  * Shared utilities for v2 chat API handlers.
  *
@@ -330,6 +332,73 @@ public class ChatApiHelper {
             return username;
         }
         return guestUserCodeSupplier.get();
+    }
+
+    /**
+     * Resolves a rate-limit key for the chat endpoints that an anonymous caller cannot rotate.
+     *
+     * <p>Unlike {@link #getUserId()} (which keys chat-session continuity and intentionally falls
+     * back to the cookie-bound, client-supplied userCode for guests), this key must be robust
+     * against abuse: the guest userCode is only validated by regex/length, so a malicious client
+     * could forge and rotate it per request to obtain a fresh throttle bucket and bypass the limit.
+     * Instead, authenticated callers are keyed by their server-validated session username and all
+     * other callers (guest / anonymous / forged / rotated / blank userCode) are keyed by the
+     * proxy-aware client IP, which an anonymous attacker cannot freely rotate.</p>
+     *
+     * <p>The returned key is namespaced ({@code "u:"} for usernames, {@code "ip:"} for client IPs)
+     * so the two key spaces never collide, and is always non-blank so the chat throttle always
+     * applies.</p>
+     *
+     * <p>Behind a reverse proxy the per-IP key is only as trustworthy as the proxy setup:
+     * {@link RateLimitHelper#getClientIp(jakarta.servlet.http.HttpServletRequest)} honors
+     * {@code X-Forwarded-For} / {@code X-Real-IP} only from proxies listed in
+     * {@code rate.limit.trusted.proxies}, so that fronting proxy must be trusted and must
+     * sanitize any inbound forwarded headers for the per-IP key to resist rotation.</p>
+     *
+     * @param req the incoming HTTP request (used to resolve the client IP for guests)
+     * @return the chat rate-limit key (never null/blank)
+     */
+    public String resolveChatRateLimitKey(final HttpServletRequest req) {
+        final String username = ComponentUtil.getSystemHelper().getUsername();
+        return resolveChatRateLimitKey(username, () -> resolveClientIp(req));
+    }
+
+    /**
+     * Pure resolution logic behind {@link #resolveChatRateLimitKey(HttpServletRequest)}, separated so
+     * the branching can be unit-tested without the DI container. Authenticated (non-guest) callers
+     * are keyed by their server-validated username ({@code "u:"+username}); all other callers
+     * (guest / anonymous / forged / rotated / blank userCode) are keyed by the proxy-aware client IP
+     * ({@code "ip:"+clientIp}), which an anonymous attacker cannot freely rotate. The client-IP
+     * supplier is evaluated lazily so the IP is only resolved for guest visitors.
+     *
+     * @param username the authenticated username (may be {@link Constants#GUEST_USER})
+     * @param clientIpSupplier supplies the proxy-aware client IP for guest visitors
+     * @return the namespaced chat rate-limit key (never null/blank)
+     */
+    String resolveChatRateLimitKey(final String username, final java.util.function.Supplier<String> clientIpSupplier) {
+        if (!Constants.GUEST_USER.equals(username)) {
+            return "u:" + username;
+        }
+        return "ip:" + clientIpSupplier.get();
+    }
+
+    /**
+     * Resolves the proxy-aware client IP, mirroring {@code LoginHandler#resolveClientIp}: prefer
+     * {@link RateLimitHelper#getClientIp(HttpServletRequest)} and fall back to
+     * {@link HttpServletRequest#getRemoteAddr()} if the helper is unavailable.
+     *
+     * @param req the incoming HTTP request
+     * @return the client IP (never null when {@code getRemoteAddr()} is set)
+     */
+    private String resolveClientIp(final HttpServletRequest req) {
+        try {
+            return ComponentUtil.getRateLimitHelper().getClientIp(req);
+        } catch (final RuntimeException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("RateLimitHelper.getClientIp unavailable; falling back to getRemoteAddr", e);
+            }
+            return req.getRemoteAddr();
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
@@ -84,6 +84,7 @@ public class ChatApiHelper {
      * @param raw the raw request body map
      * @param warnings mutable map to collect rejected values (keyed by field name)
      * @return a map of validated field filters, or an empty map when none are present
+     * @throws IOException if {@code fields.label} exceeds the configured maximum array size or per-element length
      */
     public Map<String, String[]> parseFieldFilters(final Map<String, Object> raw, final Map<String, List<String>> warnings)
             throws IOException {
@@ -150,6 +151,7 @@ public class ChatApiHelper {
      * @param raw the raw request body map
      * @param warnings mutable map to collect rejected values (keyed by field name)
      * @return array of validated extra query strings; empty array when none present
+     * @throws IOException if {@code extra_queries} exceeds the configured maximum array size or per-element length
      */
     public String[] parseExtraQueries(final Map<String, Object> raw, final Map<String, List<String>> warnings) throws IOException {
         final Object exqRaw = raw.get("extra_queries");

--- a/src/main/java/org/codelibs/fess/helper/RoleQueryHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/RoleQueryHelper.java
@@ -34,6 +34,7 @@ import org.codelibs.fess.exception.InvalidAccessTokenException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
 import org.lastaflute.web.login.LoginManager;
 import org.lastaflute.web.servlet.request.RequestManager;
 import org.lastaflute.web.util.LaRequestUtil;
@@ -181,7 +182,7 @@ public class RoleQueryHelper {
 
             final RequestManager requestManager = ComponentUtil.getRequestManager();
             try {
-                requestManager.findUserBean(FessUserBean.class)
+                findUserBean(requestManager)
                         .ifPresent(fessUserBean -> stream(fessUserBean.getPermissions()).of(stream -> stream.forEach(roleSet::add)))
                         .orElse(() -> {
                             if (isApiRequest && ComponentUtil.getFessConfig().getApiAccessTokenRequiredAsBoolean()) {
@@ -230,6 +231,18 @@ public class RoleQueryHelper {
             }).orElse(false);
         }
         return false;
+    }
+
+    /**
+     * Resolves the logged-in user bean for the current request. Exposed as a protected seam so unit
+     * tests can substitute an empty result without driving the shared LastaFlute container to resolve
+     * {@code FessLoginAssist} (and its OpenSearch-backed {@code UserBhv}), which is unavailable in the
+     * unit test environment.
+     * @param requestManager The request manager.
+     * @return the optional user bean, empty when no user is logged in.
+     */
+    protected OptionalThing<FessUserBean> findUserBean(final RequestManager requestManager) {
+        return requestManager.findUserBean(FessUserBean.class);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -2441,9 +2441,14 @@ public interface FessProp {
     /**
      * Resolves {@code api.v2.chat.rate.limit.per.user.per.minute} from the system
      * properties, defaulting to {@code 30} on absence or parse failure. A return
-     * value &le; 0 disables the per-user chat rate limit entirely.
+     * value &le; 0 disables the chat rate limit entirely.
      *
-     * @return max chat requests per minute per user, or {@code <= 0} to disable
+     * <p>This single threshold governs both chat throttle buckets: authenticated callers
+     * are limited per server-validated username, while guest / anonymous callers are
+     * limited per client IP (see {@code ChatApiHelper#resolveChatRateLimitKey}). The
+     * property name keeps its {@code per.user} form for backward compatibility.</p>
+     *
+     * @return max chat requests per minute per throttle key, or {@code <= 0} to disable
      */
     default int getChatRateLimitPerMinute() {
         try {

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatHandlerTest.java
@@ -321,12 +321,11 @@ public class ChatHandlerTest extends UnitFessTestCase {
         ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
         try {
             final CapturingResponse res = new CapturingResponse();
-            final java.util.concurrent.atomic.AtomicInteger rotation = new java.util.concurrent.atomic.AtomicInteger();
             final ChatHandler handler = new ChatHandler() {
                 @Override
                 protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    // Simulate a forged/rotated guest userCode that changes per request.
-                    return "forged-" + rotation.incrementAndGet();
+                    // A forged guest userCode — irrelevant to the IP-based throttle key below.
+                    return "forged-guest";
                 }
 
                 @Override

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatHandlerTest.java
@@ -227,6 +227,13 @@ public class ChatHandlerTest extends UnitFessTestCase {
                 }
 
                 @Override
+                protected String getRateLimitKey(final HttpServletRequest req) {
+                    // Fresh limiter → any non-blank key is allowed; pin it so the handler does not
+                    // touch the real SystemHelper/RateLimitHelper DI path.
+                    return "u:happy-user";
+                }
+
+                @Override
                 protected ChatClient getChatClient() {
                     return stubClient;
                 }
@@ -251,19 +258,19 @@ public class ChatHandlerTest extends UnitFessTestCase {
     @Test
     public void chat_rateLimited_returns429() throws Exception {
         // Drive the chat handler past the chat-disabled gate by enabling RAG, then exhaust
-        // the per-user CHAT bucket via a fresh limiter registered into DI. The 31st call
-        // (default limit is 30/min) should be rejected with 429/rate_limited regardless
-        // of the eventual ChatClient state — the handler must short-circuit before any
-        // ChatClient dispatch.
+        // the CHAT bucket via a fresh limiter registered into DI. The 31st call (default limit
+        // is 30/min) should be rejected with 429/rate_limited regardless of the eventual
+        // ChatClient state — the handler must short-circuit before any ChatClient dispatch.
+        // An authenticated caller is keyed by "u:<username>"; fix the rate-limit key via the
+        // getRateLimitKey seam instead of stubbing SystemHelper/RateLimitHelper (smart-deploy
+        // components whose ComponentUtil.register stubs are not reliably honored once the shared
+        // test container has resolved the real ones across the full suite).
         enableRagChat();
-        // Fix the user id via the getUserId seam instead of stubbing SystemHelper/UserInfoHelper
-        // (smart-deploy components whose ComponentUtil.register stubs are not reliably honored once
-        // the shared test container has resolved the real ones across the full suite).
-        final String userId = "rate-limited-user";
+        final String key = "u:rate-limited-user";
         final LoginRateLimiter rl = new LoginRateLimiter();
-        // Saturate the CHAT bucket for the fixed user id the handler will resolve.
+        // Saturate the CHAT bucket for the fixed key the handler will resolve.
         for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, userId, 30, 60);
+            rl.allow(LoginRateLimiter.Scope.CHAT, key, 30, 60);
         }
         ComponentUtil.register(rl, "loginRateLimiter");
         ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
@@ -272,11 +279,18 @@ public class ChatHandlerTest extends UnitFessTestCase {
             final ChatHandler handler = new ChatHandler() {
                 @Override
                 protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return userId;
+                    // Keep the userId seam pinned so the handler does not touch the real
+                    // SystemHelper/UserInfoHelper DI path for chat-session binding.
+                    return "rate-limited-user";
+                }
+
+                @Override
+                protected String getRateLimitKey(final jakarta.servlet.http.HttpServletRequest req) {
+                    return key;
                 }
             };
             handler.handle(new StubRequest("POST", "/api/v2/chat").withJsonBody("{\"message\":\"hi\"}"), res);
-            // The bucket for userId is pre-saturated (30/30), so this request is the 31st and must
+            // The bucket for key is pre-saturated (30/30), so this request is the 31st and must
             // be rejected deterministically before any ChatClient dispatch.
             assertEquals(429, res.status);
             assertTrue(res.body().contains("\"code\":\"rate_limited\""), res.body());
@@ -289,88 +303,43 @@ public class ChatHandlerTest extends UnitFessTestCase {
     }
 
     @Test
-    public void chat_anonymousUser_nullUserId_notRateLimited() throws Exception {
-        // When getUserId returns null, StringUtil.isNotBlank(null) is false, so the per-user
-        // throttle is skipped entirely — even with a saturated limiter and a positive chat limit.
-        // The handler must NOT return 429/rate_limited; it proceeds past the rate-limit gate.
-        // Without a real ChatClient the subsequent chat() call fails with INTERNAL_ERROR (500),
-        // which proves the rate-limit branch was bypassed.
+    public void chat_anonymousUser_rateLimitedByClientIp() throws Exception {
+        // Regression for L-1: anonymous callers used to bypass the throttle entirely because the
+        // guard skipped a blank userId and keyed on the forgeable guest userCode. Now the handler
+        // keys anonymous traffic by the client IP ("ip:<clientIp>"), so an anonymous caller from the
+        // same IP that exceeds the limit IS rate-limited. Even if the attacker rotates/forges a
+        // userCode per request, the IP-based key is unchanged, so the throttle still applies.
         enableRagChat();
+        final String clientIp = "203.0.113.7";
+        final String key = "ip:" + clientIp;
         final LoginRateLimiter rl = new LoginRateLimiter();
-        // Saturate the null-key bucket — this would 429 if null reached the limiter.
+        // Saturate the CHAT bucket for the client IP the handler resolves for anonymous traffic.
         for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
+            rl.allow(LoginRateLimiter.Scope.CHAT, key, 30, 60);
         }
         ComponentUtil.register(rl, "loginRateLimiter");
         ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
         try {
             final CapturingResponse res = new CapturingResponse();
+            final java.util.concurrent.atomic.AtomicInteger rotation = new java.util.concurrent.atomic.AtomicInteger();
             final ChatHandler handler = new ChatHandler() {
                 @Override
                 protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return null;
+                    // Simulate a forged/rotated guest userCode that changes per request.
+                    return "forged-" + rotation.incrementAndGet();
                 }
-            };
-            handler.handle(new StubRequest("POST", "/api/v2/chat").withJsonBody("{\"message\":\"hi\"}"), res);
-            // Must NOT be a 429 rate_limited response — the anonymous bypass must apply.
-            assertFalse("anonymous null userId must not yield 429, got: " + res.body(), res.body().contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous null userId must not yield 429 status, was: " + res.status, res.status != 429);
-        } finally {
-            ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
-            ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());
-        }
-    }
 
-    @Test
-    public void chat_anonymousUser_blankUserId_notRateLimited() throws Exception {
-        // When getUserId returns a blank string ("" or whitespace), StringUtil.isNotBlank is false,
-        // so the per-user throttle is skipped — the handler must NOT return 429/rate_limited.
-        enableRagChat();
-        final LoginRateLimiter rl = new LoginRateLimiter();
-        for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
-        }
-        ComponentUtil.register(rl, "loginRateLimiter");
-        ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
-        try {
-            final CapturingResponse res = new CapturingResponse();
-            final ChatHandler handler = new ChatHandler() {
                 @Override
-                protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return "   ";
+                protected String getRateLimitKey(final jakarta.servlet.http.HttpServletRequest req) {
+                    // Anonymous traffic is keyed by client IP, NOT the rotated userCode.
+                    return key;
                 }
             };
             handler.handle(new StubRequest("POST", "/api/v2/chat").withJsonBody("{\"message\":\"hi\"}"), res);
-            assertFalse("anonymous blank userId must not yield 429, got: " + res.body(), res.body().contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous blank userId must not yield 429 status, was: " + res.status, res.status != 429);
-        } finally {
-            ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
-            ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());
-        }
-    }
-
-    @Test
-    public void chat_anonymousUser_emptyStringUserId_notRateLimited() throws Exception {
-        // When getUserId returns an empty string, StringUtil.isNotBlank("") is false,
-        // so the per-user throttle is skipped — the handler must NOT return 429/rate_limited.
-        enableRagChat();
-        final LoginRateLimiter rl = new LoginRateLimiter();
-        for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
-        }
-        ComponentUtil.register(rl, "loginRateLimiter");
-        ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
-        try {
-            final CapturingResponse res = new CapturingResponse();
-            final ChatHandler handler = new ChatHandler() {
-                @Override
-                protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return "";
-                }
-            };
-            handler.handle(new StubRequest("POST", "/api/v2/chat").withJsonBody("{\"message\":\"hi\"}"), res);
-            assertFalse("anonymous empty userId must not yield 429, got: " + res.body(), res.body().contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous empty userId must not yield 429 status, was: " + res.status, res.status != 429);
+            // The IP bucket is pre-saturated (30/30), so this anonymous request must be 429.
+            assertEquals(429, res.status);
+            assertTrue(res.body().contains("\"code\":\"rate_limited\""), res.body());
+            assertTrue(res.body().contains("too many chat requests"), res.body());
         } finally {
             ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
             ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandlerTest.java
@@ -205,11 +205,11 @@ public class ChatSessionClearHandlerTest extends UnitFessTestCase {
     public void test_rateLimited_returns429() throws Exception {
         enableRagChat();
         final LoginRateLimiter rl = new LoginRateLimiter();
-        // Pre-saturate the CHAT bucket for the "test-user" userId returned by handlerForUser(...).
+        // Pre-saturate the CHAT bucket for the "u:test-user" key returned by handlerForUser(...).
         // LoginRateLimiter.allow() denies empty/null keys (MJ-6), so the bucket key must match
-        // the non-empty user id the handler resolves.
+        // the non-empty key the handler resolves.
         for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "test-user", 30, 60);
+            rl.allow(LoginRateLimiter.Scope.CHAT, "u:test-user", 30, 60);
         }
         ComponentUtil.register(rl, "loginRateLimiter");
         ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
@@ -227,15 +227,18 @@ public class ChatSessionClearHandlerTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_anonymousUser_nullUserId_notRateLimited() throws Exception {
-        // When getUserId returns null, StringUtil.isNotBlank(null) is false, so the per-user
-        // throttle is skipped entirely — even with a saturated limiter and a positive chat limit.
-        // Register a ChatSessionManager that clears successfully so the handler reaches 200,
-        // proving the rate-limit gate was bypassed (not rejected with 429).
+    public void test_anonymousUser_rateLimitedByClientIp() throws Exception {
+        // Regression for L-1: anonymous DELETE callers used to bypass the throttle entirely because
+        // the guard skipped a blank userId and keyed on the forgeable guest userCode. Now the handler
+        // keys anonymous traffic by the client IP ("ip:<clientIp>"), so an anonymous caller from the
+        // same IP that exceeds the limit IS rate-limited (429). Rotating/forging a userCode per
+        // request does not change the IP-based key, so the throttle still applies.
         enableRagChat();
+        final String clientIp = "203.0.113.7";
+        final String key = "ip:" + clientIp;
         final LoginRateLimiter rl = new LoginRateLimiter();
         for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
+            rl.allow(LoginRateLimiter.Scope.CHAT, key, 30, 60);
         }
         ComponentUtil.register(rl, "loginRateLimiter");
         ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
@@ -249,87 +252,24 @@ public class ChatSessionClearHandlerTest extends UnitFessTestCase {
         ComponentUtil.register(okManager, org.codelibs.fess.chat.ChatSessionManager.class.getCanonicalName());
         try {
             final CapturingResponse res = new CapturingResponse();
+            final java.util.concurrent.atomic.AtomicInteger rotation = new java.util.concurrent.atomic.AtomicInteger();
             final ChatSessionClearHandler handler = new ChatSessionClearHandler() {
                 @Override
                 protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return null;
+                    return "forged-" + rotation.incrementAndGet();
                 }
-            };
-            handler.handle(new StubRequest("DELETE"), res, "valid-session-1");
-            assertFalse("anonymous null userId must not yield 429, got: " + res.body(), res.body().contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous null userId must not yield 429 status, was: " + res.status, res.status != 429);
-        } finally {
-            ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
-            ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());
-        }
-    }
 
-    @Test
-    public void test_anonymousUser_blankUserId_notRateLimited() throws Exception {
-        // When getUserId returns a blank string, StringUtil.isNotBlank is false,
-        // so the per-user throttle is skipped — the handler must NOT return 429/rate_limited.
-        enableRagChat();
-        final LoginRateLimiter rl = new LoginRateLimiter();
-        for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
-        }
-        ComponentUtil.register(rl, "loginRateLimiter");
-        ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
-        final org.codelibs.fess.chat.ChatSessionManager okManager = new org.codelibs.fess.chat.ChatSessionManager() {
-            @Override
-            public boolean clearSession(final String sessionId, final String userId) {
-                return true;
-            }
-        };
-        ComponentUtil.register(okManager, "chatSessionManager");
-        ComponentUtil.register(okManager, org.codelibs.fess.chat.ChatSessionManager.class.getCanonicalName());
-        try {
-            final CapturingResponse res = new CapturingResponse();
-            final ChatSessionClearHandler handler = new ChatSessionClearHandler() {
                 @Override
-                protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return "   ";
+                protected String getRateLimitKey(final jakarta.servlet.http.HttpServletRequest req) {
+                    return key;
                 }
             };
             handler.handle(new StubRequest("DELETE"), res, "valid-session-1");
-            assertFalse("anonymous blank userId must not yield 429, got: " + res.body(), res.body().contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous blank userId must not yield 429 status, was: " + res.status, res.status != 429);
-        } finally {
-            ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
-            ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());
-        }
-    }
-
-    @Test
-    public void test_anonymousUser_emptyStringUserId_notRateLimited() throws Exception {
-        // When getUserId returns an empty string, StringUtil.isNotBlank("") is false,
-        // so the per-user throttle is skipped — the handler must NOT return 429/rate_limited.
-        enableRagChat();
-        final LoginRateLimiter rl = new LoginRateLimiter();
-        for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
-        }
-        ComponentUtil.register(rl, "loginRateLimiter");
-        ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
-        final org.codelibs.fess.chat.ChatSessionManager okManager = new org.codelibs.fess.chat.ChatSessionManager() {
-            @Override
-            public boolean clearSession(final String sessionId, final String userId) {
-                return true;
-            }
-        };
-        ComponentUtil.register(okManager, "chatSessionManager");
-        ComponentUtil.register(okManager, org.codelibs.fess.chat.ChatSessionManager.class.getCanonicalName());
-        try {
-            final CapturingResponse res = new CapturingResponse();
-            final ChatSessionClearHandler handler = new ChatSessionClearHandler() {
-                @Override
-                protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return "";
-                }
-            };
-            handler.handle(new StubRequest("DELETE"), res, "valid-session-1");
-            assertFalse("anonymous empty userId must not yield 429, got: " + res.body(), res.body().contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous empty userId must not yield 429 status, was: " + res.status, res.status != 429);
+            // The IP bucket is pre-saturated (30/30), so this anonymous request must be 429.
+            assertEquals(429, res.status);
+            assertTrue(res.body().contains("\"code\":\"rate_limited\""), res.body());
+            assertTrue(res.body().contains("too many chat requests"), res.body());
+            assertEquals("Retry-After header must be set", "60", res.getHeader("Retry-After"));
         } finally {
             ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
             ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());
@@ -486,6 +426,14 @@ public class ChatSessionClearHandlerTest extends UnitFessTestCase {
             @Override
             protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
                 return userId;
+            }
+
+            @Override
+            protected String getRateLimitKey(final jakarta.servlet.http.HttpServletRequest req) {
+                // Treat the fixed user as authenticated for throttle purposes: key by "u:<userId>".
+                // Pinning the rate-limit key keeps these tests off the real
+                // SystemHelper/RateLimitHelper DI path (smart-deploy components unreliable to stub).
+                return "u:" + userId;
             }
         };
     }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatSessionClearHandlerTest.java
@@ -252,11 +252,11 @@ public class ChatSessionClearHandlerTest extends UnitFessTestCase {
         ComponentUtil.register(okManager, org.codelibs.fess.chat.ChatSessionManager.class.getCanonicalName());
         try {
             final CapturingResponse res = new CapturingResponse();
-            final java.util.concurrent.atomic.AtomicInteger rotation = new java.util.concurrent.atomic.AtomicInteger();
             final ChatSessionClearHandler handler = new ChatSessionClearHandler() {
                 @Override
                 protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return "forged-" + rotation.incrementAndGet();
+                    // A forged guest userCode — irrelevant to the IP-based throttle key below.
+                    return "forged-guest";
                 }
 
                 @Override

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandlerTest.java
@@ -183,13 +183,14 @@ public class ChatStreamHandlerTest extends UnitFessTestCase {
         // ChatStreamHandler under the test harness, then assert the next request returns
         // the 429 JSON envelope.
         enableRagChat();
-        // Fix the user id via the getUserId seam instead of stubbing SystemHelper/UserInfoHelper
-        // (smart-deploy components whose ComponentUtil.register stubs are not reliably honored once
-        // the shared test container has resolved the real ones across the full suite).
-        final String userId = "rate-limited-user";
+        // An authenticated caller is keyed by "u:<username>". Fix the rate-limit key via the
+        // getRateLimitKey seam instead of stubbing SystemHelper/RateLimitHelper (smart-deploy
+        // components whose ComponentUtil.register stubs are not reliably honored once the shared
+        // test container has resolved the real ones across the full suite).
+        final String key = "u:rate-limited-user";
         final LoginRateLimiter rl = new LoginRateLimiter();
         for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, userId, 30, 60);
+            rl.allow(LoginRateLimiter.Scope.CHAT, key, 30, 60);
         }
         ComponentUtil.register(rl, "loginRateLimiter");
         ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
@@ -198,12 +199,19 @@ public class ChatStreamHandlerTest extends UnitFessTestCase {
             final ChatStreamHandler handler = new ChatStreamHandler() {
                 @Override
                 protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return userId;
+                    // Keep the userId seam pinned so the handler does not touch the real
+                    // SystemHelper/UserInfoHelper DI path for chat-session binding.
+                    return "rate-limited-user";
+                }
+
+                @Override
+                protected String getRateLimitKey(final jakarta.servlet.http.HttpServletRequest req) {
+                    return key;
                 }
             };
             handler.handle(new StubRequest("POST", "/api/v2/chat/stream").withJsonBody("{\"message\":\"hi\"}"), res);
             final String body = res.body();
-            // The bucket for userId is pre-saturated (30/30), so this request is the 31st and must
+            // The bucket for key is pre-saturated (30/30), so this request is the 31st and must
             // be rejected with the 429 JSON envelope — NOT an SSE event.
             assertEquals(429, res.status);
             assertEquals("application/json", contentTypeMimeOnly(res));
@@ -218,89 +226,44 @@ public class ChatStreamHandlerTest extends UnitFessTestCase {
     }
 
     @Test
-    public void chatStream_anonymousUser_nullUserId_notRateLimited() throws Exception {
-        // When getUserId returns null, StringUtil.isNotBlank(null) is false, so the per-user
-        // throttle is skipped entirely — even with a saturated limiter and a positive chat limit.
-        // The handler must NOT return 429/rate_limited; it proceeds past the rate-limit gate.
-        // Without a real ChatClient the subsequent chat invocation fails, but the response must
-        // NOT be the 429 JSON envelope — proving the anonymous bypass applied.
+    public void chatStream_anonymousUser_rateLimitedByClientIp() throws Exception {
+        // Regression for L-1: anonymous SSE callers used to bypass the throttle entirely because the
+        // guard skipped a blank userId and keyed on the forgeable guest userCode. Now the handler
+        // keys anonymous traffic by the client IP ("ip:<clientIp>"), so an anonymous caller from the
+        // same IP that exceeds the limit IS rate-limited with the pre-stream 429 JSON envelope (NOT
+        // an SSE event). Rotating/forging a userCode per request does not change the IP-based key.
         enableRagChat();
+        final String clientIp = "203.0.113.7";
+        final String key = "ip:" + clientIp;
         final LoginRateLimiter rl = new LoginRateLimiter();
         for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
+            rl.allow(LoginRateLimiter.Scope.CHAT, key, 30, 60);
         }
         ComponentUtil.register(rl, "loginRateLimiter");
         ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
         try {
             final CapturingResponse res = new CapturingResponse();
+            final java.util.concurrent.atomic.AtomicInteger rotation = new java.util.concurrent.atomic.AtomicInteger();
             final ChatStreamHandler handler = new ChatStreamHandler() {
                 @Override
                 protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return null;
+                    return "forged-" + rotation.incrementAndGet();
                 }
-            };
-            handler.handle(new StubRequest("POST", "/api/v2/chat/stream").withJsonBody("{\"message\":\"hi\"}"), res);
-            final String body = res.body();
-            assertFalse("anonymous null userId must not yield 429, got: " + body, body.contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous null userId must not yield 429 status, was: " + res.status, res.status != 429);
-        } finally {
-            ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
-            ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());
-        }
-    }
 
-    @Test
-    public void chatStream_anonymousUser_blankUserId_notRateLimited() throws Exception {
-        // When getUserId returns a blank string, StringUtil.isNotBlank is false,
-        // so the per-user throttle is skipped — the handler must NOT return 429/rate_limited.
-        enableRagChat();
-        final LoginRateLimiter rl = new LoginRateLimiter();
-        for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
-        }
-        ComponentUtil.register(rl, "loginRateLimiter");
-        ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
-        try {
-            final CapturingResponse res = new CapturingResponse();
-            final ChatStreamHandler handler = new ChatStreamHandler() {
                 @Override
-                protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return "   ";
+                protected String getRateLimitKey(final jakarta.servlet.http.HttpServletRequest req) {
+                    return key;
                 }
             };
             handler.handle(new StubRequest("POST", "/api/v2/chat/stream").withJsonBody("{\"message\":\"hi\"}"), res);
             final String body = res.body();
-            assertFalse("anonymous blank userId must not yield 429, got: " + body, body.contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous blank userId must not yield 429 status, was: " + res.status, res.status != 429);
-        } finally {
-            ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
-            ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());
-        }
-    }
-
-    @Test
-    public void chatStream_anonymousUser_emptyStringUserId_notRateLimited() throws Exception {
-        // When getUserId returns an empty string, StringUtil.isNotBlank("") is false,
-        // so the per-user throttle is skipped — the handler must NOT return 429/rate_limited.
-        enableRagChat();
-        final LoginRateLimiter rl = new LoginRateLimiter();
-        for (int i = 0; i < 30; i++) {
-            rl.allow(LoginRateLimiter.Scope.CHAT, "some-user", 30, 60);
-        }
-        ComponentUtil.register(rl, "loginRateLimiter");
-        ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
-        try {
-            final CapturingResponse res = new CapturingResponse();
-            final ChatStreamHandler handler = new ChatStreamHandler() {
-                @Override
-                protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return "";
-                }
-            };
-            handler.handle(new StubRequest("POST", "/api/v2/chat/stream").withJsonBody("{\"message\":\"hi\"}"), res);
-            final String body = res.body();
-            assertFalse("anonymous empty userId must not yield 429, got: " + body, body.contains("\"code\":\"rate_limited\""));
-            assertTrue("anonymous empty userId must not yield 429 status, was: " + res.status, res.status != 429);
+            // The IP bucket is pre-saturated (30/30), so this anonymous request must be the 429 JSON
+            // envelope — NOT an SSE event.
+            assertEquals(429, res.status);
+            assertEquals("application/json", contentTypeMimeOnly(res));
+            assertTrue(body.contains("\"code\":\"rate_limited\""), body);
+            assertTrue(body.contains("too many chat requests"), body);
+            assertFalse(body.contains("event: error"), body);
         } finally {
             ComponentUtil.register(new LoginRateLimiter(), "loginRateLimiter");
             ComponentUtil.register(new LoginRateLimiter(), LoginRateLimiter.class.getCanonicalName());

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandlerTest.java
@@ -243,11 +243,11 @@ public class ChatStreamHandlerTest extends UnitFessTestCase {
         ComponentUtil.register(rl, LoginRateLimiter.class.getCanonicalName());
         try {
             final CapturingResponse res = new CapturingResponse();
-            final java.util.concurrent.atomic.AtomicInteger rotation = new java.util.concurrent.atomic.AtomicInteger();
             final ChatStreamHandler handler = new ChatStreamHandler() {
                 @Override
                 protected String getUserId(final jakarta.servlet.http.HttpServletRequest req) {
-                    return "forged-" + rotation.incrementAndGet();
+                    // A forged guest userCode — irrelevant to the IP-based throttle key below.
+                    return "forged-guest";
                 }
 
                 @Override

--- a/src/test/java/org/codelibs/fess/helper/ChatApiHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ChatApiHelperTest.java
@@ -240,6 +240,40 @@ public class ChatApiHelperTest extends UnitFessTestCase {
         assertEquals("cookie-code-xyz", userId);
     }
 
+    // ── resolveChatRateLimitKey ───────────────────────────────────────────────
+
+    @Test
+    public void test_resolveChatRateLimitKey_authenticatedUser_keysByUsername() {
+        // A non-guest username is keyed as "u:<username>"; the client-IP supplier must NOT be
+        // consulted (the username is server-validated and cannot be rotated by the caller).
+        final String key = chatApiHelper.resolveChatRateLimitKey("alice", () -> {
+            throw new AssertionError("client IP must not be resolved for an authenticated user");
+        });
+        assertEquals("u:alice", key);
+    }
+
+    @Test
+    public void test_resolveChatRateLimitKey_guestUser_keysByClientIp() {
+        // GUEST_USER (anonymous) is keyed by the proxy-aware client IP as "ip:<clientIp>",
+        // never by the forgeable guest userCode.
+        final String key = chatApiHelper.resolveChatRateLimitKey(Constants.GUEST_USER, () -> "203.0.113.7");
+        assertEquals("ip:203.0.113.7", key);
+    }
+
+    @Test
+    public void test_resolveChatRateLimitKey_forgedUserCode_doesNotChangeKey() {
+        // L-1 regression: for a guest, the key must depend only on the client IP, not on any
+        // caller-supplied userCode. Even if a malicious client rotates/forges its userCode per
+        // request, the resolved key stays IP-based and unchanged, so a fresh throttle bucket
+        // cannot be obtained by rotating the userCode.
+        final String clientIp = "198.51.100.9";
+        final String first = chatApiHelper.resolveChatRateLimitKey(Constants.GUEST_USER, () -> clientIp);
+        final String second = chatApiHelper.resolveChatRateLimitKey(Constants.GUEST_USER, () -> clientIp);
+        assertEquals("ip:" + clientIp, first);
+        // Message-first overload: assertEquals(message, expected, actual).
+        assertEquals("key must be IP-based and stable across requests regardless of userCode", first, second);
+    }
+
     // ── getMaxMessageLength ───────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
@@ -459,6 +459,17 @@ public class RoleQueryHelperTest extends UnitFessTestCase {
                 // Anonymous request: no access token presented.
                 return false;
             }
+
+            @Override
+            protected org.dbflute.optional.OptionalThing<org.codelibs.fess.mylasta.action.FessUserBean> findUserBean(
+                    final org.lastaflute.web.servlet.request.RequestManager requestManager) {
+                // Anonymous request: no logged-in user. Returning empty keeps this test off the shared
+                // container's FessLoginAssist/UserBhv resolution path, which intermittently throws
+                // AutoBindingFailureException when a concurrent test clears ComponentUtil.componentMap
+                // under surefire parallel-class execution. The orElse branch (guest-role backfill) is
+                // exactly what this test asserts.
+                return org.dbflute.optional.OptionalThing.empty();
+            }
         };
         roleQueryHelper.init();
 


### PR DESCRIPTION
## Summary

The v2 chat endpoints (`/api/v2/chat`, `/api/v2/chat/stream`,
`DELETE /api/v2/chat/sessions/{id}`) throttled requests with a per-user key
from `ChatApiHelper#getUserId()`. For guests that key is a client-supplied
userCode (the `fsid` cookie or `userCode` request parameter) validated only by
regex/length. An anonymous client could forge or rotate the value on every
request — or omit it, since the throttle was skipped when the id was blank — to
get a fresh rate-limit bucket each time and bypass the limit on the
(potentially billable) LLM-backed chat endpoints.

## Change

- Add `ChatApiHelper#resolveChatRateLimitKey(req)`:
  - authenticated callers → keyed by their server-validated session username
  - everyone else (guest / anonymous / forged / rotated / blank) → keyed by the
    proxy-aware client IP (`RateLimitHelper#getClientIp`)
- The three chat handlers use this key and no longer skip the throttle for blank
  ids (the key is always non-blank). Keys are namespaced (`u:` / `ip:`).
- `getUserId()` is unchanged and still used for chat-session binding.
- Reuses the existing `LoginRateLimiter` (`Scope.CHAT`) and the existing
  `api.v2.chat.rate.limit.per.user.per.minute` threshold (default 30). No new
  rate-limiting mechanism and no new configuration property.

## Deployment note

Behind a reverse proxy / load balancer, set `rate.limit.trusted.proxies` to the
fronting proxy and ensure that proxy strips/overwrites any inbound
`X-Forwarded-For`; otherwise the per-IP key could be rotated. The default
(`127.0.0.1,::1`) is safe for non-proxied deployments.

## Tests

- New unit tests for `resolveChatRateLimitKey` (authenticated / guest /
  forged-rotated userCode).
- Each chat handler: anonymous callers exceeding the limit from the same client
  IP now receive `429 RATE_LIMITED`; rotated/forged userCode no longer escapes
  the limit; authenticated over-limit still returns 429. Stale "anonymous
  bypass" assertions replaced.
- `mvn test` over the v2 handler suite + `ChatApiHelperTest` +
  `LoginRateLimiterTest`: 333 tests, all green. `formatter:format` /
  `license:format` clean.
