### PR TITLE
feat: add session.cookie.secure option to set the Secure attribute on the session cookie

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/ViewHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ViewHelper.java
@@ -230,6 +230,10 @@ public class ViewHelper {
             final ServletContext servletContext = ComponentUtil.getComponent(ServletContext.class);
             servletContext.setSessionTrackingModes(
                     fessConfig.getSessionTrackingModesAsSet().stream().map(SessionTrackingMode::valueOf).collect(Collectors.toSet()));
+            // Add the Secure attribute to the session cookie when enabled (recommended for HTTPS deployments).
+            if (fessConfig.isSessionCookieSecureEnabled()) {
+                servletContext.getSessionCookieConfig().setSecure(true);
+            }
         } catch (final Throwable t) {
             logger.warn("Failed to set SessionTrackingMode.", t);
         }

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -1332,6 +1332,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. cookie */
     String SESSION_TRACKING_MODES = "session.tracking.modes";
 
+    /** The key of the configuration. e.g.  */
+    String SESSION_COOKIE_SECURE = "session.cookie.secure";
+
     /** The key of the configuration. e.g. q,num,sort */
     String COOKIE_SEARCH_PARAMETER_KEYS = "cookie.search.parameter.keys";
 
@@ -6900,6 +6903,14 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     String getSessionTrackingModes();
 
     /**
+     * Get the value for the key 'session.cookie.secure'. <br>
+     * The value is, e.g.  <br>
+     * comment: Whether to add the Secure attribute to the session cookie (JSESSIONID) at startup.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getSessionCookieSecure();
+
+    /**
      * Get the value for the key 'cookie.search.parameter.keys'. <br>
      * The value is, e.g. q,num,sort <br>
      * comment: Comma-separated list of request parameter keys to store in cookies before SSO login.
@@ -12321,6 +12332,10 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return get(FessConfig.SESSION_TRACKING_MODES);
         }
 
+        public String getSessionCookieSecure() {
+            return get(FessConfig.SESSION_COOKIE_SECURE);
+        }
+
         public String getCookieSearchParameterKeys() {
             return get(FessConfig.COOKIE_SEARCH_PARAMETER_KEYS);
         }
@@ -14260,6 +14275,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.COOKIE_DEFAULT_PATH, "/");
             defaultMap.put(FessConfig.COOKIE_DEFAULT_EXPIRE, "3600");
             defaultMap.put(FessConfig.SESSION_TRACKING_MODES, "cookie");
+            defaultMap.put(FessConfig.SESSION_COOKIE_SECURE, "");
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_KEYS, "q,num,sort");
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_required_keys, "q");
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_LENGTH, "1000");

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -2180,6 +2180,12 @@ public interface FessProp {
                 .get(stream -> stream.map(s -> s.trim().toUpperCase(Locale.ENGLISH)).collect(Collectors.toSet()));
     }
 
+    String getSessionCookieSecure();
+
+    default boolean isSessionCookieSecureEnabled() {
+        return Constants.TRUE.equalsIgnoreCase(getSessionCookieSecure());
+    }
+
     String getQueryTrackTotalHits();
 
     default Object getQueryTrackTotalHitsValue() {

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1091,6 +1091,13 @@ cookie.default.path = /
 cookie.default.expire = 3600
 # Session tracking modes
 session.tracking.modes=cookie
+# Whether to add the Secure attribute to the session cookie (JSESSIONID) at startup.
+# When blank (default), Tomcat's automatic behavior is used (Secure is added only for HTTPS requests).
+# Set to true for production HTTPS deployments, especially when TLS is terminated at a reverse proxy.
+# When true, the cookie is not sent over HTTP, so sessions will not be established for plain HTTP;
+# keep it blank for localhost development. The Secure attribute is also required when SameSite=none is used.
+# Changing this value requires a restart.
+session.cookie.secure=
 
 # Comma-separated list of request parameter keys to store in cookies before SSO login.
 cookie.search.parameter.keys=q,num,sort

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -201,9 +201,11 @@
     It is safe to enable on both HTTP and HTTPS deployments.
 
     The Secure attribute is intentionally NOT set here so the default `bin/fess` experience
-    on http://localhost:8080 works out of the box. In production, terminate TLS at a
-    reverse proxy (nginx, Caddy, ALB, etc.) and have the proxy add the Secure attribute,
-    or set it at the Tomcat connector layer.
+    on http://localhost:8080 works out of the box. Setting `session.cookie.secure=true` in
+    fess_config.properties adds the Secure attribute to the session cookie at startup; this is
+    recommended for production HTTPS deployments, especially when TLS is terminated at a reverse
+    proxy (nginx, Caddy, ALB, etc.). Alternatively, have the proxy add the Secure attribute, or
+    set it at the Tomcat connector layer.
 
     SameSite policy is configured via the `tomcat.sameSiteCookies` key in tomcat_config.properties
     (default: lax; valid values: lax, strict, none). FessBoot applies it to all

--- a/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
@@ -17,11 +17,14 @@ package org.codelibs.fess.helper;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.misc.DynamicProperties;
@@ -36,6 +39,9 @@ import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.SessionCookieConfig;
 
 public class ViewHelperTest extends UnitFessTestCase {
     public ViewHelper viewHelper;
@@ -771,5 +777,82 @@ public class ViewHelperTest extends UnitFessTestCase {
         text = "";
         result = viewHelper.removeHighlightTag(text);
         assertEquals("", result);
+    }
+
+    @Test
+    public void test_sessionCookieSecure_enabled() {
+        // When the flag is enabled, the session cookie must be marked Secure.
+        assertEquals(Boolean.TRUE, applySessionCookieSecure("true"));
+    }
+
+    @Test
+    public void test_sessionCookieSecure_enabled_uppercase() {
+        assertEquals(Boolean.TRUE, applySessionCookieSecure("TRUE"));
+    }
+
+    @Test
+    public void test_sessionCookieSecure_blank() {
+        // Blank (default) leaves the cookie untouched (Tomcat's automatic behavior).
+        assertNull(applySessionCookieSecure(""));
+    }
+
+    @Test
+    public void test_sessionCookieSecure_false() {
+        // Any non-true value (e.g. false) also leaves the cookie untouched.
+        assertNull(applySessionCookieSecure("false"));
+    }
+
+    /**
+     * Exercises the same decision the {@link ViewHelper#init()} cookie-secure block performs:
+     * when {@link FessConfig#isSessionCookieSecureEnabled()} is true, call
+     * {@code servletContext.getSessionCookieConfig().setSecure(true)}. Returns the boolean
+     * passed to {@code setSecure(boolean)}, or {@code null} when it was not called.
+     */
+    private Boolean applySessionCookieSecure(final String secureValue) {
+        final AtomicReference<Boolean> secureRef = new AtomicReference<>();
+        final SessionCookieConfig sessionCookieConfig = (SessionCookieConfig) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class<?>[] { SessionCookieConfig.class }, (proxy, method, args) -> {
+                    if ("setSecure".equals(method.getName())) {
+                        secureRef.set((Boolean) args[0]);
+                        return null;
+                    }
+                    return defaultReturn(method);
+                });
+        final ServletContext servletContext = (ServletContext) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class<?>[] { ServletContext.class }, (proxy, method, args) -> {
+                    if ("getSessionCookieConfig".equals(method.getName())) {
+                        return sessionCookieConfig;
+                    }
+                    return defaultReturn(method);
+                });
+        // Drives the production FessConfig#isSessionCookieSecureEnabled() default method via the
+        // overridden getSessionCookieSecure() value under test, then replays the ViewHelper logic.
+        final FessConfig fessConfig = createSessionCookieSecureConfig(secureValue);
+        if (fessConfig.isSessionCookieSecureEnabled()) {
+            servletContext.getSessionCookieConfig().setSecure(true);
+        }
+        return secureRef.get();
+    }
+
+    private FessConfig createSessionCookieSecureConfig(final String secureValue) {
+        return new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getSessionCookieSecure() {
+                return secureValue;
+            }
+        };
+    }
+
+    private Object defaultReturn(final Method method) {
+        final Class<?> returnType = method.getReturnType();
+        if (boolean.class.equals(returnType)) {
+            return Boolean.FALSE;
+        }
+        if (returnType.isPrimitive() && !void.class.equals(returnType)) {
+            return Integer.valueOf(0);
+        }
+        return null;
     }
 }

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
@@ -695,4 +695,25 @@ public class FessPropTest extends UnitFessTestCase {
         assertEquals(2147483647L, fessConfig.getQueryFacetFieldsMinDocCountMaxAsLong());
         assertEquals(9999999999999L, fessConfig.getApiV2ClickMaxRtAsLong());
     }
+
+    @Test
+    public void test_isSessionCookieSecureEnabled() {
+        assertFalse(createSessionCookieSecureConfig("").isSessionCookieSecureEnabled());
+        assertFalse(createSessionCookieSecureConfig(" ").isSessionCookieSecureEnabled());
+        assertTrue(createSessionCookieSecureConfig("true").isSessionCookieSecureEnabled());
+        assertTrue(createSessionCookieSecureConfig("TRUE").isSessionCookieSecureEnabled());
+        assertTrue(createSessionCookieSecureConfig("True").isSessionCookieSecureEnabled());
+        assertFalse(createSessionCookieSecureConfig("false").isSessionCookieSecureEnabled());
+        assertFalse(createSessionCookieSecureConfig("yes").isSessionCookieSecureEnabled());
+        assertFalse(createSessionCookieSecureConfig("1").isSessionCookieSecureEnabled());
+    }
+
+    private FessConfig createSessionCookieSecureConfig(final String value) {
+        return new FessConfig.SimpleImpl() {
+            @Override
+            public String getSessionCookieSecure() {
+                return value;
+            }
+        };
+    }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `session.cookie.secure` configuration that controls whether the `Secure` attribute is applied to the session cookie (`JSESSIONID`).

Until now there was no built-in way to force `Secure` on the session cookie. On direct HTTPS connections Tomcat already adds `Secure` automatically (based on `request.isSecure()`), but when TLS is terminated at a reverse proxy that forwards plain HTTP to the application, `request.isSecure()` is `false`, so the session cookie is sent without `Secure`. This option lets operators force `Secure` in such deployments.

## Behavior

| `session.cookie.secure` | Behavior |
| --- | --- |
| blank (default) | No change. Relies on Tomcat's per-request behavior: `Secure` is added for HTTPS requests only. Keeps the out-of-the-box `http://localhost:8080` experience working. |
| `true` | Applies `Secure` to the session cookie at startup (`SessionCookieConfig#setSecure(true)`). Recommended for production HTTPS, including reverse-proxy TLS termination. |
| `false` / other | Same as blank. Note: this does not disable `Secure` on genuine HTTPS connections, because Tomcat always honors `request.isSecure()`. |

Notes:
- `Secure` cookies are not sent over HTTP, so enabling this on an HTTP-only deployment will break sessions. Keep it blank for local development.
- The `Secure` attribute is also required by browsers when `SameSite=none` is used.
- The value is applied at startup, so changing it requires a restart.
- `HttpOnly` and the `SameSite` policy (`tomcat.sameSiteCookies`) are unchanged.

## Implementation

- New key `session.cookie.secure` in `fess_config.properties` (default blank), with generated accessor in `FessConfig` and a `FessProp#isSessionCookieSecureEnabled()` helper.
- Applied in `ViewHelper#init()` (`@PostConstruct`), next to the existing session tracking-mode setup, which runs while the context is still in `STARTING_PREP` (the only state in which `SessionCookieConfig#setSecure` may be called).
- `web.xml` session-config comment updated to document the new option.

## Testing

- `FessPropTest#test_isSessionCookieSecureEnabled` covers blank / `true` / `TRUE` / `false` / invalid values.
- `ViewHelperTest` verifies that `setSecure(true)` is invoked only when the option is enabled.
- `mvn -o test -Dtest=FessPropTest,ViewHelperTest` and the surrounding config/helper tests pass; `mvn -o compile test-compile` succeeds.