### PR TITLE
fix(api-v2): validate click query_id membership and bound rank

### DIFF
--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -1621,7 +1621,11 @@ components:
         rank:
           type: integer
           minimum: 1
-          description: 1-based position in the result list.
+          maximum: 10000
+          description: |-
+            1-based position in the result list. The upper bound aligns with
+            the OpenSearch default `index.max_result_window`; ranks above it
+            are rejected with `invalid_request` (400).
         rt:
           type: integer
           format: int64

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ClickHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ClickHandler.java
@@ -23,8 +23,10 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.helper.SearchHelper;
 import org.codelibs.fess.helper.SearchLogHelper;
@@ -82,6 +84,13 @@ public class ClickHandler {
 
     /** Maximum length of {@code query_id} as declared in the OpenAPI spec. */
     private static final int QUERY_ID_MAX_LENGTH = 100;
+
+    /**
+     * Upper bound for the 1-based click rank; aligns with OpenSearch default
+     * {@code index.max_result_window}; values above this (including ones that
+     * overflow int) are rejected to limit analytics forgery (L-5).
+     */
+    private static final int MAX_RANK = 10000;
 
     /**
      * Default constructor. The handler is stateless and intended to be
@@ -202,6 +211,25 @@ public class ClickHandler {
         if (rank instanceof Number && ((Number) rank).intValue() < 0) {
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "rank must not be negative");
             return;
+        }
+        // rank upper-bound guard (L-5): evaluate as long to also catch int-overflow values.
+        if (rank instanceof Number && ((Number) rank).longValue() > MAX_RANK) {
+            ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "rank exceeds the maximum");
+            return;
+        }
+        // query_id membership (L-5, best-effort): only reject a provable mismatch; skip when the
+        // per-session result set is unknown/empty so logging is never broken in default deployments.
+        if (StringUtil.isNotBlank(queryId)) {
+            String[] resultDocIds;
+            try {
+                resultDocIds = ComponentUtil.getUserInfoHelper().getResultDocIds(queryId);
+            } catch (final RuntimeException e) {
+                resultDocIds = null; // unverifiable; do not break logging
+            }
+            if (resultDocIds != null && resultDocIds.length > 0 && !ArrayUtils.contains(resultDocIds, docId)) {
+                ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.NOT_FOUND, "doc not in search result");
+                return;
+            }
         }
         try {
             final SearchHelper searchHelper = ComponentUtil.getSearchHelper();

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ClickHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ClickHandlerTest.java
@@ -25,9 +25,17 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.codelibs.fess.helper.SearchHelper;
+import org.codelibs.fess.helper.SearchLogHelper;
+import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.helper.UserInfoHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.opensearch.log.exentity.ClickLog;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalEntity;
+import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.AsyncContext;
@@ -395,6 +403,227 @@ public class ClickHandlerTest extends UnitFessTestCase {
                     "valid query_id must not yield 400 with query_id error: " + res.body());
         } finally {
             ComponentUtil.register(new UserInfoHelper(), "userInfoHelper");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // L-5: query_id membership (best-effort) and rank upper-bound enforcement
+    // -----------------------------------------------------------------------
+
+    /**
+     * Registers the full collaborator graph the click success path touches so a
+     * well-formed POST reaches {@code addClickLog} and returns {@code logged:true}.
+     * The {@code resultDocIds}/{@code throwResultDocIds} knobs drive the L-5
+     * membership branch; everything else is a happy-path no-op stub.
+     *
+     * @param userCode the user session code returned by the stub UserInfoHelper
+     * @param resultDocIds the per-session result docIds (ignored when {@code throwResultDocIds})
+     * @param throwResultDocIds when true, {@code getResultDocIds} throws to exercise the best-effort skip
+     */
+    private static void registerClickSuccessStubs(final String userCode, final String[] resultDocIds, final boolean throwResultDocIds) {
+        final FessConfig cfgStub = new SearchLogEnabledFessConfig();
+        ComponentUtil.setFessConfig(cfgStub);
+        ComponentUtil.register(cfgStub, "fessConfig");
+        ComponentUtil.register(cfgStub, FessConfig.class.getCanonicalName());
+
+        final UserInfoHelper userInfoStub = new UserInfoHelper() {
+            @Override
+            public String getUserCode() {
+                return userCode;
+            }
+
+            @Override
+            public String[] getResultDocIds(final String queryId) {
+                if (throwResultDocIds) {
+                    throw new RuntimeException("forced getResultDocIds failure");
+                }
+                return resultDocIds;
+            }
+        };
+        ComponentUtil.register(userInfoStub, "userInfoHelper");
+        ComponentUtil.register(userInfoStub, UserInfoHelper.class.getCanonicalName());
+
+        final SearchHelper searchHelperStub = new SearchHelper() {
+            @Override
+            public OptionalEntity<Map<String, Object>> getDocumentByDocId(final String docId, final String[] fields,
+                    final OptionalThing<FessUserBean> ub) {
+                final Map<String, Object> doc = new HashMap<>();
+                doc.put("url", "http://example.com/" + docId);
+                doc.put("_id", docId + "-id");
+                return OptionalEntity.of(doc);
+            }
+        };
+        ComponentUtil.register(searchHelperStub, "searchHelper");
+        ComponentUtil.register(searchHelperStub, SearchHelper.class.getCanonicalName());
+
+        final SearchLogHelper searchLogStub = new SearchLogHelper() {
+            @Override
+            public void addClickLog(final ClickLog clickLog) {
+                // no-op: skip the real log store in the unit harness
+            }
+        };
+        ComponentUtil.register(searchLogStub, "searchLogHelper");
+        ComponentUtil.register(searchLogStub, SearchLogHelper.class.getCanonicalName());
+
+        final SystemHelper systemHelperStub = new SystemHelper() {
+            @Override
+            public java.time.LocalDateTime getCurrentTimeAsLocalDateTime() {
+                return java.time.LocalDateTime.now();
+            }
+        };
+        ComponentUtil.register(systemHelperStub, "systemHelper");
+        ComponentUtil.register(systemHelperStub, SystemHelper.class.getCanonicalName());
+    }
+
+    /** Restores fresh default components so registrations do not leak across tests. */
+    private static void resetClickSuccessStubs() {
+        ComponentUtil.register(new UserInfoHelper(), "userInfoHelper");
+        ComponentUtil.register(new UserInfoHelper(), UserInfoHelper.class.getCanonicalName());
+    }
+
+    @Test
+    public void test_queryIdMembership_contains_logsClick() throws Exception {
+        // L-5: query_id present and the result set CONTAINS docId -> success, logged:true.
+        registerClickSuccessStubs("test-user-code", new String[] { "abc" }, false);
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new ClickHandler().handle(
+                    new StubRequest("POST", "/api/v2/click").withJsonBody("{\"doc_id\":\"abc\",\"query_id\":\"q\",\"rank\":3}"), res);
+            assertEquals(200, res.status, res.body());
+            assertTrue(res.body().contains("\"logged\":true"), res.body());
+        } finally {
+            resetClickSuccessStubs();
+        }
+    }
+
+    @Test
+    public void test_queryIdMembership_notContains_returnsNotFound() throws Exception {
+        // L-5: query_id present but the result set does NOT contain docId -> NOT_FOUND.
+        registerClickSuccessStubs("test-user-code", new String[] { "other" }, false);
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new ClickHandler().handle(
+                    new StubRequest("POST", "/api/v2/click").withJsonBody("{\"doc_id\":\"abc\",\"query_id\":\"q\",\"rank\":3}"), res);
+            assertEquals(404, res.status, res.body());
+            assertTrue(res.body().contains("\"code\":\"not_found\""), res.body());
+            assertTrue(res.body().contains("doc not in search result"), res.body());
+        } finally {
+            resetClickSuccessStubs();
+        }
+    }
+
+    @Test
+    public void test_queryIdMembership_emptyResultSet_skipsCheckAndLogs() throws Exception {
+        // L-5 best-effort: an EMPTY result set is unverifiable -> skip the check, still log.
+        registerClickSuccessStubs("test-user-code", new String[0], false);
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new ClickHandler().handle(
+                    new StubRequest("POST", "/api/v2/click").withJsonBody("{\"doc_id\":\"abc\",\"query_id\":\"q\",\"rank\":3}"), res);
+            assertEquals(200, res.status, res.body());
+            assertTrue(res.body().contains("\"logged\":true"), res.body());
+        } finally {
+            resetClickSuccessStubs();
+        }
+    }
+
+    @Test
+    public void test_queryIdMembership_lookupThrows_skipsCheckAndLogs() throws Exception {
+        // L-5 best-effort: getResultDocIds THROWS -> treat as unverifiable, do not break logging.
+        registerClickSuccessStubs("test-user-code", null, true);
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new ClickHandler().handle(
+                    new StubRequest("POST", "/api/v2/click").withJsonBody("{\"doc_id\":\"abc\",\"query_id\":\"q\",\"rank\":3}"), res);
+            assertEquals(200, res.status, res.body());
+            assertTrue(res.body().contains("\"logged\":true"), res.body());
+        } finally {
+            resetClickSuccessStubs();
+        }
+    }
+
+    @Test
+    public void test_noQueryId_skipsMembershipAndLogs() throws Exception {
+        // L-5 regression: no query_id -> membership check is skipped, click is logged.
+        registerClickSuccessStubs("test-user-code", new String[] { "other" }, false);
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new ClickHandler().handle(new StubRequest("POST", "/api/v2/click").withJsonBody("{\"doc_id\":\"abc\",\"rank\":3}"), res);
+            assertEquals(200, res.status, res.body());
+            assertTrue(res.body().contains("\"logged\":true"), res.body());
+        } finally {
+            resetClickSuccessStubs();
+        }
+    }
+
+    @Test
+    public void test_rankOverMax_returns400() throws Exception {
+        // L-5: rank above MAX_RANK (10000) must be rejected with 400 invalid_request.
+        registerClickSuccessStubs("test-user-code", new String[] { "abc" }, false);
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new ClickHandler().handle(
+                    new StubRequest("POST", "/api/v2/click").withJsonBody("{\"doc_id\":\"abc\",\"query_id\":\"q\",\"rank\":10001}"), res);
+            assertEquals(400, res.status, res.body());
+            assertTrue(res.body().contains("\"code\":\"invalid_request\""), res.body());
+            assertTrue(res.body().contains("rank exceeds the maximum"), res.body());
+        } finally {
+            resetClickSuccessStubs();
+        }
+    }
+
+    @Test
+    public void test_rankOverflowsInt_returns400() throws Exception {
+        // L-5: a rank that overflows int (2^32 = 4294967296) must still be caught via longValue().
+        registerClickSuccessStubs("test-user-code", new String[] { "abc" }, false);
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new ClickHandler().handle(
+                    new StubRequest("POST", "/api/v2/click").withJsonBody("{\"doc_id\":\"abc\",\"query_id\":\"q\",\"rank\":4294967296}"),
+                    res);
+            assertEquals(400, res.status, res.body());
+            assertTrue(res.body().contains("\"code\":\"invalid_request\""), res.body());
+            assertTrue(res.body().contains("rank exceeds the maximum"), res.body());
+        } finally {
+            resetClickSuccessStubs();
+        }
+    }
+
+    @Test
+    public void test_rankWithinRange_logsClick() throws Exception {
+        // L-5: a rank within range (5) with otherwise-valid setup -> success, logged:true.
+        registerClickSuccessStubs("test-user-code", new String[] { "abc" }, false);
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new ClickHandler().handle(
+                    new StubRequest("POST", "/api/v2/click").withJsonBody("{\"doc_id\":\"abc\",\"query_id\":\"q\",\"rank\":5}"), res);
+            assertEquals(200, res.status, res.body());
+            assertTrue(res.body().contains("\"logged\":true"), res.body());
+        } finally {
+            resetClickSuccessStubs();
+        }
+    }
+
+    /**
+     * Minimal {@link FessConfig} stub that enables the search-log feature and supplies the
+     * index-field names the click path accesses. Everything else delegates to {@code SimpleImpl}.
+     */
+    private static class SearchLogEnabledFessConfig extends FessConfig.SimpleImpl {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean isSearchLog() {
+            return true;
+        }
+
+        @Override
+        public String getIndexFieldId() {
+            return "_id";
+        }
+
+        @Override
+        public String getIndexFieldUrl() {
+            return "url";
         }
     }
 


### PR DESCRIPTION
## Summary

`POST /api/v2/click` recorded `query_id` and `rank` from the request body without validation, allowing an authenticated caller to forge click logs and pollute search analytics (click-through rates, popular-document rankings, rank distribution). This builds on the v2 input-bounds hardening from #3162.

## Changes

- **query_id membership (best-effort):** when the caller's per-session search result set for the given `query_id` is known, the clicked `doc_id` must belong to it; otherwise the request is rejected with `not_found` (`"doc not in search result"`, matching `FavoritePostHandler`). When the mapping is unavailable — favorite feature off (default), cross-node/non-sticky session, LRU eviction, blank/unknown `query_id`, or a lookup failure — the check is **skipped and the click is still logged**, so click logging is never broken in default deployments.
- **rank upper bound:** ranks above `MAX_RANK` (`10000`, aligned with the default `index.max_result_window`) are rejected with `invalid_request` (`"rank exceeds the maximum"`). The comparison is performed as `long` so values that would overflow when narrowed to `int` are also caught. The pre-existing negative-rank check is unchanged.

## Scope / non-goals

- Scoped to the v2 `/click` endpoint. `rt` validation and the legacy `GoAction` path are intentionally out of scope (the same `rt` semantics apply to both and are tracked separately).
- `query_id` length/format and the rank negative bound are already enforced by #3162 and are **not** duplicated here. Combined, the two changes cover length/format/negative (#3162) plus membership/upper-bound (this PR).

## Residual behavior

When the per-session result-set mapping is unavailable, a real `query_id` paired with a doc that was not in that result set is still accepted; the existing drain-time `query_id`-existence drop in `SearchLogHelper` remains as defense-in-depth. This is an intentional trade-off to preserve logging in default configurations (priority: data-integrity, Low).

## Testing

- 8 new `ClickHandlerTest` cases: membership contains / not-contains / empty-set / lookup-throws / absent `query_id`, and rank over-max / int-overflow / in-range.
- `ClickHandlerTest`: 24 tests pass.
- Full `org.codelibs.fess.api.v2` package: 468 tests pass.
- `mvn formatter:validate` and `license:check` clean.