### PR TITLE
refactor: extract session-cookie configuration into a ViewHelper method

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/ViewHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ViewHelper.java
@@ -91,6 +91,7 @@ import com.ibm.icu.text.SimpleDateFormat;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.ServletContext;
+import jakarta.servlet.SessionCookieConfig;
 import jakarta.servlet.SessionTrackingMode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -228,14 +229,9 @@ public class ViewHelper {
         }
         try {
             final ServletContext servletContext = ComponentUtil.getComponent(ServletContext.class);
-            servletContext.setSessionTrackingModes(
-                    fessConfig.getSessionTrackingModesAsSet().stream().map(SessionTrackingMode::valueOf).collect(Collectors.toSet()));
-            // Add the Secure attribute to the session cookie when enabled (recommended for HTTPS deployments).
-            if (fessConfig.isSessionCookieSecureEnabled()) {
-                servletContext.getSessionCookieConfig().setSecure(true);
-            }
+            configureSessionCookie(servletContext, fessConfig);
         } catch (final Throwable t) {
-            logger.warn("Failed to set SessionTrackingMode.", t);
+            logger.warn("Failed to configure the session cookie.", t);
         }
 
         split(fessConfig.getQueryFacetQueries(), "\n").of(stream -> stream.map(String::trim).filter(StringUtil::isNotEmpty).forEach(s -> {
@@ -266,6 +262,24 @@ public class ViewHelper {
 
         split(fessConfig.getResponseInlineMimetypes(), ",")
                 .of(stream -> stream.map(String::trim).filter(StringUtil::isNotEmpty).forEach(inlineMimeTypeSet::add));
+    }
+
+    /**
+     * Configures the session cookie ({@code JSESSIONID}) on the given servlet context.
+     * Applies the configured session tracking modes and, when {@code session.cookie.secure}
+     * is enabled, adds the {@code Secure} attribute (recommended for HTTPS deployments).
+     * Must be called while the servlet context is still starting (i.e. before it becomes
+     * available), which is the only state in which {@link SessionCookieConfig} may be mutated.
+     *
+     * @param servletContext the servlet context to configure
+     * @param fessConfig the configuration holding the session cookie settings
+     */
+    protected void configureSessionCookie(final ServletContext servletContext, final FessConfig fessConfig) {
+        servletContext.setSessionTrackingModes(
+                fessConfig.getSessionTrackingModesAsSet().stream().map(SessionTrackingMode::valueOf).collect(Collectors.toSet()));
+        if (fessConfig.isSessionCookieSecureEnabled()) {
+            servletContext.getSessionCookieConfig().setSecure(true);
+        }
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
@@ -803,10 +803,11 @@ public class ViewHelperTest extends UnitFessTestCase {
     }
 
     /**
-     * Exercises the same decision the {@link ViewHelper#init()} cookie-secure block performs:
-     * when {@link FessConfig#isSessionCookieSecureEnabled()} is true, call
-     * {@code servletContext.getSessionCookieConfig().setSecure(true)}. Returns the boolean
-     * passed to {@code setSecure(boolean)}, or {@code null} when it was not called.
+     * Drives the real {@link ViewHelper#configureSessionCookie(ServletContext, FessConfig)} with the
+     * given {@code session.cookie.secure} value and captures whether {@code Secure} was applied to the
+     * session cookie. Returns the boolean passed to {@link SessionCookieConfig#setSecure(boolean)}, or
+     * {@code null} when it was not called. Because it invokes the production method (not a copy of its
+     * logic), a regression that removes or alters the cookie-secure block is caught here.
      */
     private Boolean applySessionCookieSecure(final String secureValue) {
         final AtomicReference<Boolean> secureRef = new AtomicReference<>();
@@ -825,12 +826,7 @@ public class ViewHelperTest extends UnitFessTestCase {
                     }
                     return defaultReturn(method);
                 });
-        // Drives the production FessConfig#isSessionCookieSecureEnabled() default method via the
-        // overridden getSessionCookieSecure() value under test, then replays the ViewHelper logic.
-        final FessConfig fessConfig = createSessionCookieSecureConfig(secureValue);
-        if (fessConfig.isSessionCookieSecureEnabled()) {
-            servletContext.getSessionCookieConfig().setSecure(true);
-        }
+        viewHelper.configureSessionCookie(servletContext, createSessionCookieSecureConfig(secureValue));
         return secureRef.get();
     }
 
@@ -841,6 +837,11 @@ public class ViewHelperTest extends UnitFessTestCase {
             @Override
             public String getSessionCookieSecure() {
                 return secureValue;
+            }
+
+            @Override
+            public String getSessionTrackingModes() {
+                return "cookie";
             }
         };
     }


### PR DESCRIPTION
## Summary

Follow-up cleanup on top of the merged `session.cookie.secure` option (#3166).

- Extract the session-cookie setup (tracking modes + `Secure` attribute) from `ViewHelper#init` into a dedicated `configureSessionCookie(ServletContext, FessConfig)` method.
- Fix the catch-block log message (`"Failed to set SessionTrackingMode."` → `"Failed to configure the session cookie."`) to reflect what the block now covers.
- Rework `ViewHelperTest#applySessionCookieSecure` to call the real `configureSessionCookie` method instead of re-implementing its logic, so a regression that removes or alters the cookie-secure block is now actually caught.

## Test

- `mvn test -Dtest=ViewHelperTest` → 29 passed, 0 failures