### PR TITLE
fix: reset in-memory facet state on navigation in the bootstrap theme

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1155,6 +1155,14 @@ export function runFromUrl() {
   } else { state.geo = { lat: "", lon: "", distance: "" }; }
   // ADV-2: hydrate lang / fields.* / ex_q from URL (forwarded by advance search submit)
   state.lang = params.getAll("lang").filter(v => v !== "");
+  // Facet selections (sidebar label facets and facet query views) live only
+  // in memory and are never written to the URL. Every navigation re-derives filter
+  // state from the URL, so these in-memory stores must be cleared too; otherwise a
+  // previously clicked facet survives a search-options submit (which navigates with
+  // only fields.* in the URL) and gets merged back into the request, applying both
+  // the old facet label and the new one.
+  state.facets = {};
+  state.facetQueries = [];
   state.fields = {};
   for (const [key, value] of params.entries()) {
     if (key.startsWith("fields.") && value !== "") {

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1163,6 +1163,9 @@ export function runFromUrl() {
   // the old facet label and the new one.
   state.facets = {};
   state.facetQueries = [];
+  // The similar-docs hash (sdh) is likewise memory-only and merged into the
+  // request, so it must be cleared on navigation too.
+  state.sdh = "";
   state.fields = {};
   for (const [key, value] of params.entries()) {
     if (key.startsWith("fields.") && value !== "") {


### PR DESCRIPTION
## Problem

In the bootstrap search theme, selecting a label via the sidebar facet and then
refining the search through the search-options panel keeps the previously
selected facet applied, even though it is no longer part of the new selection.

Steps to reproduce:
1. Search for a term that has more than one label facet.
2. Click a label in the sidebar facet (label A) → results filtered to A.
3. Open the search-options panel and select only a different label (label B).
4. Submit.

- Expected: only label B is applied.
- Actual: both label A and label B are applied. The active-filter chips show
  both and the result count reflects both labels, even though the URL only
  contains `fields.label=B`.

## Root cause

Filter state is kept client-side in two stores:

- `state.facets` — written only by sidebar facet clicks. Facet clicks call
  `runSearch()` directly, so the selection is never serialized to the URL.
- `state.fields` — written by the search-options label dropdown.

`runFromUrl()` re-derives state from the URL on every navigation, but it only
reset `state.fields` / `lang` / `geo` / `exQ`, leaving `state.facets` and
`state.facetQueries` intact. The search-options submit navigates with only
`fields.*` in the URL, so the stale `state.facets` survived and `runSearch()`
merged both stores together.

## Fix

Reset `state.facets` and `state.facetQueries` in `runFromUrl()` so the URL is
the single source of truth on every navigation (search-options submit, header
search, browser back/forward). Paging and facet clicks call `runSearch()`
directly without navigating, so an active facet still persists within the same
result view as before.

## Testing

Traced the control flow in `search.js` (facet click handler, search-options
submit handler, `runFromUrl`, the `runSearch` field merge, and pagination).
Confirmed the stale store is cleared on navigation and that paging/facet
interactions are unaffected because they do not navigate.