### PR TITLE
fix(theme/bootstrap): run filter-only searches in the SPA theme

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1134,9 +1134,7 @@ export function applyHomeOptions(params) {
 export function runFromUrl() {
   const params = new URLSearchParams(location.search);
   const q = params.get("q");
-  // Only run a search when a query is present in the URL.
-  if (!q) return;
-  state.q = q;
+  state.q = q || "";
   state.start = Number(params.get("start")) || 0;
   const numVal = Number(params.get("num"));
   if (numVal > 0) state.num = numVal;
@@ -1163,6 +1161,17 @@ export function runFromUrl() {
     }
   }
   state.exQ = params.getAll("ex_q").filter(v => v !== "");
+  // Run a search when a keyword OR any active filter is present in the URL (label /
+  // other fields, geo, or ex_q). The classic JSP theme issues the request for
+  // filter-only URLs such as /search?fields.label=foo, so mirror that here instead
+  // of bailing on an empty keyword. sort/num/lang are query modifiers, not a search
+  // on their own. Hydrating state above before this check also sets state.q to "" for
+  // a filter-only URL, so a previous keyword can't leak into the next search:
+  // runSearch() reads state.q, and the option-drawer Search button omits an empty q.
+  const hasFields = Object.keys(state.fields).length > 0;
+  const hasGeo = !!(state.geo.lat && state.geo.lon && state.geo.distance);
+  const hasExQ = state.exQ.length > 0;
+  if (!state.q && !hasFields && !hasGeo && !hasExQ) return;
   runSearch();
 }
 


### PR DESCRIPTION
## Summary

The bundled Bootstrap SPA theme did not show results for keyword-less searches. This fixes `runFromUrl()` so a filter-only URL runs a search, matching the `/api/v2` search endpoint.

## Problem

The Bootstrap SPA theme drives search entirely from the URL, but `runFromUrl()` returned early whenever the `q` keyword parameter was empty:

```js
const q = params.get("q");
if (!q) return;
```

A filter-only URL such as `/search?fields.label=foo` (or a complete geo filter) therefore never issued an API request and left the results area blank, even though the same search returns results otherwise.

## Changes

- `runFromUrl()`: hydrate every URL parameter first, then run a search when a keyword **or** any active filter (`fields.*`, a complete geo filter, `ex_q`) is present.
- Always assign `state.q = q || ""` so a previously submitted keyword cannot leak into the next option-only search (`runSearch()` reads `state.q`, and the option-drawer Search button omits an empty `q` from the URL).

## Notes

- **Parity scope.** For keyword and field filters such as `fields.label`, this matches the classic JSP theme, whose `SearchAction` runs a search when `q` is blank but field filters are present. Geo and `ex_q` are SPA/API features that the classic JSP search form does not expose, so for those the behavior matches the `/api/v2` search endpoint rather than the JSP UI.
- `sort` / `num` / `lang` alone (no keyword, no filter) still do not trigger a search; an empty `/search` with no parameters still shows nothing, matching prior behavior.
- A geo filter requires latitude, longitude and distance together; distance alone is not a searchable query and correctly returns nothing.
- The home-view state reset is unchanged and remains handled by `clearSearchState()`.

## Testing

- `node --check` passes for the changed file.
- Reviewed against normal keyword search, an empty `/search`, back/forward navigation (popstate), and home navigation.
