### PR TITLE
fix(theme/bootstrap): apply sort/num/lang options on search, not on change

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/app.js
+++ b/src/main/webapp/themes/bootstrap/assets/app.js
@@ -196,6 +196,15 @@ function attachHomeView() {
       if (q) {
         const params = new URLSearchParams();
         params.set("q", q);
+        // JSP parity: carry the shared drawer's sort / num / lang selections into
+        // the first search so options set on the home view before searching are applied
+        // (these selects no longer auto-run a search on change).
+        const sortSel = document.getElementById("sortSearchOption");
+        if (sortSel && sortSel.value) params.set("sort", sortSel.value);
+        const numSel = document.getElementById("numSearchOption");
+        if (numSel && numSel.value) params.set("num", numSel.value);
+        const langSel = document.getElementById("langSearchOption");
+        if (langSel) Array.from(langSel.selectedOptions).map(o => o.value).filter(Boolean).forEach(v => params.append("lang", v));
         router.navigate("/search?" + params.toString());
         // JSP parity: disable the submit button for 3s after navigation has been
         // triggered, to prevent rapid double-submits.

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1116,6 +1116,22 @@ export function attach() {
       for (const key of [...params.keys()]) {
         if (key.startsWith("fields.") || key === "ex_q") params.delete(key);
       }
+      // JSP parity: apply the current sort / num / lang drawer selections rather
+      // than only carrying over the previous URL values, so a manual change to these
+      // selects takes effect when the header Search button is pressed (the selects no
+      // longer auto-run a search on change). Guarded on config so the selects are
+      // populated before we read them.
+      if (api.getConfig()) {
+        const sortSel = document.getElementById("sortSearchOption");
+        if (sortSel) { if (sortSel.value) params.set("sort", sortSel.value); else params.delete("sort"); }
+        const numSel = document.getElementById("numSearchOption");
+        if (numSel && numSel.value) params.set("num", numSel.value);
+        const langSel = document.getElementById("langSearchOption");
+        if (langSel) {
+          params.delete("lang");
+          Array.from(langSel.selectedOptions).map(o => o.value).filter(Boolean).forEach(v => params.append("lang", v));
+        }
+      }
       navigate("/search?" + params.toString());
       // JSP parity: disable the submit button for 3s after the search has been
       // triggered, to prevent rapid double-submits.
@@ -1123,22 +1139,16 @@ export function attach() {
     });
   }
   // Search-options "Clear" button (searchOptions.jsp #searchOptionsClearButton):
-  // reset the drawer option controls (num/sort/lang/label + geo) to their defaults,
-  // then dispatch change events so the existing select handlers re-run the search.
+  // reset the drawer option controls (num/sort/lang/label + geo) to their defaults.
+  // JSP parity: this is a purely visual reset — it does NOT re-run the search.
+  // The reset values are applied on the next Search-button press, matching searchOptions.jsp
+  // whose Clear button only resets the select indices and never submits the form. (The geo
+  // inputs are cleared visually here too; the in-memory geo filter is dropped on the next
+  // search when the now-empty geo inputs are read.)
   const optClearBtn = document.getElementById("searchOptionsClearButton");
   if (optClearBtn) {
     optClearBtn.addEventListener("click", () => {
-      // Silent DOM reset (no change dispatch, no re-search).
       resetOptionsDOM();
-      // geo has no change handler that syncs state, so reset state.geo explicitly here
-      // before the change dispatches below trigger a re-search (parity: facet-clear handler).
-      state.geo = { lat: "", lon: "", distance: "" };
-      // Dispatch change on each drawer select so the existing handlers (sort/num/lang)
-      // pick up the reset value and re-run the search — preserving original behaviour.
-      ["numSearchOption", "sortSearchOption", "langSearchOption", "labelSearchOption"].forEach(id => {
-        const sel = document.getElementById(id);
-        if (sel) sel.dispatchEvent(new Event("change", { bubbles: true }));
-      });
     });
   }
   // Search-options drawer "Search" button. It is form="search-form" (the header form),
@@ -1251,31 +1261,13 @@ export function attach() {
   // Geo filter apply/clear is handled by the drawer's main Search / Clear buttons
   // (geo inputs were migrated into #searchOptions); no separate geo buttons.
 
-  // Sort select — options are populated by renderSortOptions() after config loads
-  const sortSelect = document.getElementById("sortSearchOption");
-  if (sortSelect) sortSelect.addEventListener("change", () => {
-    state.sort = sortSelect.value || "";
-    state.start = 0;
-    runSearch();
-  });
-
-  // Num select
-  const numSelect = document.getElementById("numSearchOption");
-  if (numSelect) numSelect.addEventListener("change", () => {
-    state.num = Number(numSelect.value) || 10;
-    state.start = 0;
-    runSearch();
-  });
-
-  // Lang multi-select: collect all selected option values; when "All" (value="")
-  // is selected or nothing is selected, reset to empty array.
-  const langSelect = document.getElementById("langSearchOption");
-  if (langSelect) langSelect.addEventListener("change", () => {
-    const selected = Array.from(langSelect.selectedOptions).map(o => o.value).filter(v => v !== "");
-    state.lang = selected;
-    state.start = 0;
-    runSearch();
-  });
+  // JSP parity: the sort / num / lang drawer selects do NOT auto-run a search on
+  // change. The default JSP search screen only applies these options when a Search button
+  // is pressed, so changing a select here is a no-op until the user submits — either via
+  // the header form (#search-form, which reads these selects in its submit handler above)
+  // or the drawer's own Search button (#searchOptions button[type="submit"], wired above).
+  // Re-introducing a `change -> runSearch()` handler here would resurrect the reported bug
+  // where results changed before the Search button was pressed.
 
   // Populate search option selects once config is available.
   // api.init() is awaited by app.js before attach() is called, so getConfig()

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1055,6 +1055,16 @@ export function runFromUrl() {
     }
   }
   state.exQ = params.getAll("ex_q").filter(v => v !== "");
+  // Re-sync the search-options drawer selects (sort / num / lang / label) to the
+  // freshly hydrated state. attach() renders them only once, so without this a
+  // navigation (link click, back/forward, facet submit) would leave the selects
+  // showing stale values. That matters now that the selects are applied on the
+  // Search button: a stale displayed value would otherwise be written back into the
+  // URL on the next submit, silently reverting the user's actual sort/num/lang.
+  // Guarded on config so the option lists exist before we re-render them.
+  if (api.getConfig()) {
+    renderSearchOptions();
+  }
   // Run a search when a keyword OR any active filter is present in the URL (label /
   // other fields, geo, or ex_q). The classic JSP theme issues the request for
   // filter-only URLs such as /search?fields.label=foo, so mirror that here instead
@@ -1125,6 +1135,8 @@ export function attach() {
         const sortSel = document.getElementById("sortSearchOption");
         if (sortSel) { if (sortSel.value) params.set("sort", sortSel.value); else params.delete("sort"); }
         const numSel = document.getElementById("numSearchOption");
+        // Unlike sort, the num select has no empty placeholder option, so its value is always
+        // present; there is no empty case to delete here.
         if (numSel && numSel.value) params.set("num", numSel.value);
         const langSel = document.getElementById("langSearchOption");
         if (langSel) {
@@ -1143,8 +1155,10 @@ export function attach() {
   // JSP parity: this is a purely visual reset — it does NOT re-run the search.
   // The reset values are applied on the next Search-button press, matching searchOptions.jsp
   // whose Clear button only resets the select indices and never submits the form. (The geo
-  // inputs are cleared visually here too; the in-memory geo filter is dropped on the next
-  // search when the now-empty geo inputs are read.)
+  // inputs are cleared visually here too; the geo filter is dropped only when the drawer's own
+  // Search button is pressed and reads the now-empty inputs. A header-form submit instead
+  // preserves the geo params already in the URL, matching the JSP theme whose header form
+  // carries geo forward via hidden inputs.)
   const optClearBtn = document.getElementById("searchOptionsClearButton");
   if (optClearBtn) {
     optClearBtn.addEventListener("click", () => {

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1277,4 +1277,52 @@ public class BundledBootstrapThemeTest {
         assertFalse(js.contains("submitOnSelect"),
                 "advance.js must NOT pass submitOnSelect — advanced search suggestion clicks must remain fill-only");
     }
+
+    // ── sort/num/lang apply on Search-button press, not on select change ──────────
+
+    /**
+     * The sort / num / lang drawer selects must NOT auto-run a search on change.
+     * The default JSP search screen only applies these options when a Search button is
+     * pressed, so the SPA must do the same: no {@code change -> runSearch()} wiring on the
+     * selects, and the Clear button must not dispatch synthetic change events to re-search.
+     */
+    @Test
+    public void test_searchJs_optionSelectsDoNotAutoSearchOnChange() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        assertFalse(js.contains("sortSelect.addEventListener(\"change\""),
+                "search.js must not auto-run a search when the sort select changes");
+        assertFalse(js.contains("numSelect.addEventListener(\"change\""),
+                "search.js must not auto-run a search when the num select changes");
+        assertFalse(js.contains("langSelect.addEventListener(\"change\""),
+                "search.js must not auto-run a search when the lang select changes");
+        // The Clear button must not dispatch synthetic change events to trigger a re-search.
+        assertFalse(js.contains("new Event(\"change\""), "search.js Clear button must not dispatch change events to re-run the search");
+    }
+
+    /**
+     * The header form (#search-form) submit must apply the current sort / num / lang
+     * drawer selections so a manual change to a select is honoured when the Search button is
+     * pressed (since the selects no longer auto-run a search on change).
+     */
+    @Test
+    public void test_searchJs_headerSubmitAppliesOptionSelects() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        // Sort is set when chosen and cleared when the placeholder is selected.
+        assertTrue(js.contains("params.delete(\"sort\")"),
+                "search.js header submit must clear the sort param when the sort select is unset");
+        // Lang params are rebuilt from the current multi-select selection.
+        assertTrue(js.contains("params.delete(\"lang\")"), "search.js header submit must rebuild lang params from the lang select");
+    }
+
+    /**
+     * The home form (home-search-form) submit must carry the shared drawer's
+     * sort / num / lang selections into the first search.
+     */
+    @Test
+    public void test_appJs_homeSubmitCarriesOptionSelects() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/app.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("getElementById(\"sortSearchOption\")"), "app.js home submit must read the sort select");
+        assertTrue(js.contains("getElementById(\"numSearchOption\")"), "app.js home submit must read the num select");
+        assertTrue(js.contains("getElementById(\"langSearchOption\")"), "app.js home submit must read the lang select");
+    }
 }

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1325,4 +1325,24 @@ public class BundledBootstrapThemeTest {
         assertTrue(js.contains("getElementById(\"numSearchOption\")"), "app.js home submit must read the num select");
         assertTrue(js.contains("getElementById(\"langSearchOption\")"), "app.js home submit must read the lang select");
     }
+
+    /**
+     * runFromUrl() must re-sync the drawer option selects to the URL-derived state on
+     * every navigation. attach() renders the selects only once, so without a re-render
+     * inside runFromUrl() a navigation (link / back-forward / facet submit) leaves the
+     * selects showing stale values. Now that the selects are applied on the Search
+     * button, a stale displayed value would be written back into the URL on the next
+     * submit, silently reverting the user's actual sort / num / lang.
+     */
+    @Test
+    public void test_searchJs_runFromUrlResyncsOptionSelects() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        final int start = js.indexOf("export function runFromUrl()");
+        assertTrue(start >= 0, "search.js must define runFromUrl()");
+        // Bound the search to the runFromUrl body (up to the next top-level function).
+        final int end = js.indexOf("\nfunction ", start);
+        final String body = end > start ? js.substring(start, end) : js.substring(start);
+        assertTrue(body.contains("renderSearchOptions()"),
+                "runFromUrl() must call renderSearchOptions() so the drawer selects reflect the URL after navigation");
+    }
 }


### PR DESCRIPTION
## Problem
In the bootstrap (Static/SPA) theme, changing the **sort**, **number of
results**, or **language** select in the search-options drawer immediately
re-ran the search, so results changed *before* the user pressed the Search
button. The default (JSP) search screen only applies these options when a
Search button is pressed.

## Fix (match the JSP behavior)
- Remove the `change -> runSearch()` handlers on the sort/num/lang drawer
  selects, so changing a select no longer auto-runs a search.
- When the header search form is submitted, read the current sort/num/lang
  selects so a manual change is applied on the Search button.
- The search-options **Clear** button now performs a visual-only reset and
  no longer re-runs the search, matching the JSP Clear button; the reset is
  applied on the next search.
- The home search form carries the drawer's sort/num/lang selections into
  the first search.

## Tests
- Added regression tests in `BundledBootstrapThemeTest`.
- `BundledBootstrapThemeTest`: 113 tests pass.
- `node --check` passes on the edited JS.
