### PR TITLE
Improve bootstrap static theme: visible search feedback, loading state, data-i18n-alt

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/i18n.js
+++ b/src/main/webapp/themes/bootstrap/assets/i18n.js
@@ -124,4 +124,5 @@ export function applyDom(root) {
   root.querySelectorAll("[data-i18n]").forEach(el => { el.textContent = t(el.dataset.i18n); });
   root.querySelectorAll("[data-i18n-placeholder]").forEach(el => { el.setAttribute("placeholder", t(el.dataset.i18nPlaceholder)); });
   root.querySelectorAll("[data-i18n-aria-label]").forEach(el => { el.setAttribute("aria-label", t(el.dataset.i18nAriaLabel)); });
+  root.querySelectorAll("[data-i18n-alt]").forEach(el => { el.setAttribute("alt", t(el.dataset.i18nAlt)); });
 }

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -580,6 +580,16 @@ function renderResults(env) {
   if (favEnabled && env.query_id) syncFavorites(env.query_id);
 }
 
+/**
+ * Toggle the in-flight search loading indicator (#search-loading).
+ * Gives sighted users visible feedback during a /search request; cache and chat
+ * already have loading states, search did not.
+ */
+function showSearchLoading(show) {
+  const el = document.getElementById("search-loading");
+  if (el) el.classList.toggle("d-none", !show);
+}
+
 async function runSearch() {
   // Cancel any in-flight request before issuing a new one.
   if (currentSearchAbort) currentSearchAbort.abort();
@@ -592,6 +602,10 @@ async function runSearch() {
   // cards carry the correct rt parameter (mirrors JSP #rt hidden field).
   state.requestedTime = Date.now();
   document.title = state.q ? t("page.search_title").replace("{0}", state.q) : "Fess";
+  // Clear any stale error banner from a previous attempt and show the loading indicator.
+  const prevErr = document.getElementById("search-error");
+  if (prevErr) prevErr.classList.add("d-none");
+  showSearchLoading(true);
   try {
     const params = { q: state.q, start: state.start, num: state.num };
     if (state.sort) params.sort = state.sort;
@@ -673,20 +687,26 @@ async function runSearch() {
     loadRelated(state.q, currentRelatedAbort.signal);
     document.dispatchEvent(new CustomEvent("fess:search:after", { detail: env }));
   } catch (e) {
-    if (e && e.name === "AbortError") return; // request superseded — silently ignore
+    if (e && e.name === "AbortError") return; // request superseded — newer request owns the UI
     const errBox = document.getElementById("search-error");
     if (e && (e.code === "invalid_request" || e.code === "INVALID_REQUEST" || e.httpStatus === 400)) {
       if (errBox) { errBox.textContent = e.message || t("error.invalid_request"); errBox.classList.remove("d-none"); }
       else { document.getElementById("results-meta").textContent = e.message || t("error.invalid_request"); }
       return;
     }
-    if (errBox) errBox.classList.add("d-none");
-    const meta = document.getElementById("results-meta");
-    if (e && e.name === "NetworkError") {
-      meta.textContent = t("error.network");
-    } else {
-      meta.textContent = e.code === "AUTH_REQUIRED" ? t("error.auth_required") : t("error.server");
-    }
+    // Network/server/auth failures: surface in the VISIBLE banner too. Previously these wrote
+    // only to the screen-reader-only #results-meta sink, so a sighted user saw nothing when a
+    // search failed with a 500 or a dropped connection. Fall back to #results-meta when a
+    // theme has no visible banner.
+    const msg = (e && e.name === "NetworkError") ? t("error.network")
+              : (e && e.code === "AUTH_REQUIRED") ? t("error.auth_required")
+              : t("error.server");
+    if (errBox) { errBox.textContent = msg; errBox.classList.remove("d-none"); }
+    else { const meta = document.getElementById("results-meta"); if (meta) meta.textContent = msg; }
+  } finally {
+    // Only the latest request clears the spinner. If this request was superseded,
+    // currentSearchAbort already points at a newer controller, so leave it running.
+    if (currentSearchAbort && currentSearchAbort.signal === signal) showSearchLoading(false);
   }
 }
 

--- a/src/main/webapp/themes/bootstrap/i18n/messages.de.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.de.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Zurück zu den Ergebnissen",
   "labels.cache_not_found": "Der zwischengespeicherte Inhalt ist nicht verfügbar.",
   "labels.cache_loading": "Lade zwischengespeicherten Inhalt…",
+  "labels.search_loading": "Suche läuft…",
   "labels.search_result_cache": "Cache",
   "labels.search_cache_msg": "Dies ist ein Cache von {0}. Es ist ein Schnappschuss der Seite, wie sie am {1} erschien.",
   "labels.search_unknown": "Unbekannt",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.en.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.en.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Back to results",
   "labels.cache_not_found": "The cached content is not available.",
   "labels.cache_loading": "Loading cached content…",
+  "labels.search_loading": "Searching…",
   "labels.search_result_cache": "Cache",
   "labels.search_cache_msg": "This is a cache of {0}. It is a snapshot of the page as it appeared on {1}.",
   "labels.search_unknown": "Unknown",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.es.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.es.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Volver a los resultados",
   "labels.cache_not_found": "El contenido en caché no está disponible.",
   "labels.cache_loading": "Cargando contenido en caché…",
+  "labels.search_loading": "Buscando…",
   "labels.search_result_cache": "Caché",
   "labels.search_cache_msg": "Esta es una caché de {0}. Es una instantánea de la página tal como apareció en {1}.",
   "labels.search_unknown": "Desconocido",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.fr.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.fr.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Retour aux résultats",
   "labels.cache_not_found": "Le contenu en cache n'est pas disponible.",
   "labels.cache_loading": "Chargement du contenu en cache…",
+  "labels.search_loading": "Recherche en cours…",
   "labels.search_result_cache": "Cache",
   "labels.search_cache_msg": "Ceci est un cache de {0}. C'est un instantané de la page telle qu'elle est apparue le {1}.",
   "labels.search_unknown": "Inconnu",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.hi.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.hi.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "परिणामों पर वापस जाएं",
   "labels.cache_not_found": "कैश्ड सामग्री उपलब्ध नहीं है।",
   "labels.cache_loading": "कैश्ड सामग्री लोड हो रही है…",
+  "labels.search_loading": "खोज रहे हैं…",
   "labels.search_result_cache": "कैश",
   "labels.search_cache_msg": "यह {0} का कैश है। यह पृष्ठ का एक स्नैपशॉट है जैसा कि यह {1} पर दिखाई दिया था।",
   "labels.search_unknown": "अज्ञात",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.id.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.id.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Kembali ke hasil",
   "labels.cache_not_found": "Konten tembolok tidak tersedia.",
   "labels.cache_loading": "Memuat konten tembolok…",
+  "labels.search_loading": "Mencari…",
   "labels.search_result_cache": "Tembolok",
   "labels.search_cache_msg": "Ini adalah cache dari {0}. Ini adalah snapshot halaman seperti yang muncul pada {1}.",
   "labels.search_unknown": "Tidak Diketahui",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.it.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.it.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Torna ai risultati",
   "labels.cache_not_found": "Il contenuto in cache non è disponibile.",
   "labels.cache_loading": "Caricamento contenuto in cache…",
+  "labels.search_loading": "Ricerca in corso…",
   "labels.search_result_cache": "Cache",
   "labels.search_cache_msg": "Questa è una cache di {0}. È un'istantanea della pagina come appariva il {1}.",
   "labels.search_unknown": "Sconosciuto",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.ja.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.ja.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "検索結果に戻る",
   "labels.cache_not_found": "キャッシュされたコンテンツはありません。",
   "labels.cache_loading": "キャッシュされたコンテンツを読み込み中…",
+  "labels.search_loading": "検索中…",
   "labels.search_result_cache": "キャッシュ",
   "labels.search_cache_msg": "このページは {0} のキャッシュです。{1} に存在していたページのスナップショットです。",
   "labels.search_unknown": "不明",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.ko.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.ko.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "검색 결과로 돌아가기",
   "labels.cache_not_found": "캐시된 콘텐츠를 사용할 수 없습니다.",
   "labels.cache_loading": "캐시된 콘텐츠를 불러오는 중…",
+  "labels.search_loading": "검색 중…",
   "labels.search_result_cache": "캐시",
   "labels.search_cache_msg": "이 페이지는 {0}의 캐시입니다. {1}에 존재했던 페이지의 스냅샷입니다.",
   "labels.search_unknown": "알 수 없음",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.nl.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.nl.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Terug naar resultaten",
   "labels.cache_not_found": "De gecachete inhoud is niet beschikbaar.",
   "labels.cache_loading": "Gecachete inhoud laden…",
+  "labels.search_loading": "Zoeken…",
   "labels.search_result_cache": "Cache",
   "labels.search_cache_msg": "Dit is een cache van {0}. Het is een momentopname van de pagina zoals deze verscheen op {1}.",
   "labels.search_unknown": "Onbekend",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.pl.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.pl.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Powrót do wyników",
   "labels.cache_not_found": "Zawartość pamięci podręcznej nie jest dostępna.",
   "labels.cache_loading": "Ładowanie zawartości z pamięci podręcznej…",
+  "labels.search_loading": "Wyszukiwanie…",
   "labels.search_result_cache": "Pamięć podręczna",
   "labels.search_cache_msg": "To jest pamięć podręczna {0}. Jest to migawka strony, która pojawiła się {1}.",
   "labels.search_unknown": "Nieznany",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.pt-BR.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.pt-BR.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Voltar aos resultados",
   "labels.cache_not_found": "O conteúdo em cache não está disponível.",
   "labels.cache_loading": "Carregando conteúdo em cache…",
+  "labels.search_loading": "Pesquisando…",
   "labels.search_result_cache": "Cache",
   "labels.search_cache_msg": "Este é um cache de {0}. É um instantâneo da página como ela apareceu em {1}.",
   "labels.search_unknown": "Desconhecido",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.ru.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.ru.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Вернуться к результатам",
   "labels.cache_not_found": "Кэшированное содержимое недоступно.",
   "labels.cache_loading": "Загрузка кэшированного содержимого…",
+  "labels.search_loading": "Поиск…",
   "labels.search_result_cache": "Кэш",
   "labels.search_cache_msg": "Это кэш {0}. Это снимок страницы, как она выглядела {1}.",
   "labels.search_unknown": "Неизвестно",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.tr.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.tr.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "Sonuçlara dön",
   "labels.cache_not_found": "Önbelleğe alınmış içerik mevcut değil.",
   "labels.cache_loading": "Önbelleğe alınmış içerik yükleniyor…",
+  "labels.search_loading": "Aranıyor…",
   "labels.search_result_cache": "Önbellek",
   "labels.search_cache_msg": "Bu, {0} adresinin önbelleğidir. {1} tarihinde göründüğü şekliyle sayfanın bir anlık görüntüsüdür.",
   "labels.search_unknown": "Bilinmeyen",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.zh-CN.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.zh-CN.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "返回搜索结果",
   "labels.cache_not_found": "缓存内容不可用。",
   "labels.cache_loading": "正在加载缓存内容…",
+  "labels.search_loading": "正在搜索…",
   "labels.search_result_cache": "缓存",
   "labels.search_cache_msg": "此页面是 {0} 的缓存。它是 {1} 时页面的快照。",
   "labels.search_unknown": "未知",

--- a/src/main/webapp/themes/bootstrap/i18n/messages.zh-TW.json
+++ b/src/main/webapp/themes/bootstrap/i18n/messages.zh-TW.json
@@ -253,6 +253,7 @@
   "labels.cache_back_to_results": "返回搜尋結果",
   "labels.cache_not_found": "快取內容無法使用。",
   "labels.cache_loading": "正在載入快取內容…",
+  "labels.search_loading": "正在搜尋…",
   "labels.search_result_cache": "快取",
   "labels.search_cache_msg": "此頁面是 {0} 的快取。它是 {1} 時頁面的快照。",
   "labels.search_unknown": "未知",

--- a/src/main/webapp/themes/bootstrap/index.html
+++ b/src/main/webapp/themes/bootstrap/index.html
@@ -131,7 +131,7 @@
         <div class="row">
           <div class="col text-center searchFormBox">
             <h1 class="mainLogo">
-              <img src="/themes/bootstrap/assets/logo.png" alt="" data-i18n-alt="labels.index_title" class="home-logo">
+              <img src="/themes/bootstrap/assets/logo.png" alt="" data-i18n-alt="page.heading" class="home-logo">
             </h1>
             <!-- Notification banner (parity index.jsp .notification) — rendered by
                  app.js renderNotifications() from config.notifications.search_top. -->
@@ -182,6 +182,13 @@
         <!-- Notification + error banners (theme runtime extras). -->
         <div id="results-notification" class="d-none mb-2" role="status" aria-live="polite"></div>
         <div id="search-error" class="alert alert-danger d-none mb-2" role="alert" aria-live="assertive"></div>
+
+        <!-- Loading indicator shown while a /search request is in flight, so sighted
+             users get visible feedback on slow queries (parity with cache/chat loading). -->
+        <div id="search-loading" class="d-none text-center text-muted my-4" role="status" aria-live="polite">
+          <span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
+          <span data-i18n="labels.search_loading">Searching…</span>
+        </div>
 
         <!-- Options bar (parity searchResults.jsp ul.list-inline). -->
         <ul class="list-inline" id="options-bar"></ul>

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1345,4 +1345,88 @@ public class BundledBootstrapThemeTest {
         assertTrue(body.contains("renderSearchOptions()"),
                 "runFromUrl() must call renderSearchOptions() so the drawer selects reflect the URL after navigation");
     }
+
+    // ── Functional review fixes: visible failure feedback, loading indicator, data-i18n-alt ──
+
+    /**
+     * Fix 1: search.js must surface network/server/auth failures in the VISIBLE
+     * #search-error banner — previously these wrote only to the screen-reader-only
+     * #results-meta sink, leaving a sighted user with no feedback when a search failed
+     * with a 500 or a dropped connection.
+     */
+    @Test
+    public void test_searchJs_surfacesNetworkAndServerErrorsInVisibleBanner() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("t(\"error.network\")"), "search.js must map NetworkError to error.network");
+        assertTrue(js.contains("t(\"error.server\")"), "search.js must map server failures to error.server");
+        // The resolved message must be written to the visible banner (errBox), not only #results-meta.
+        assertTrue(js.contains("errBox.textContent = msg"),
+                "search.js must write network/server/auth failures to the visible #search-error banner (not only #results-meta)");
+    }
+
+    /**
+     * Fix 2: the results view must show a visible loading indicator while a /search
+     * request is in flight (cache and chat already had one; search did not).
+     */
+    @Test
+    public void test_indexHtml_hasSearchLoadingIndicator() throws Exception {
+        final String html = Files.readString(THEME_DIR.resolve("index.html"), StandardCharsets.UTF_8);
+        assertTrue(html.contains("id=\"search-loading\""), "index.html must contain the #search-loading indicator");
+        assertTrue(html.contains("data-i18n=\"labels.search_loading\""),
+                "the loading indicator must use the labels.search_loading i18n key");
+    }
+
+    /** Fix 2: search.js must toggle the loading indicator at the start and end of a search. */
+    @Test
+    public void test_searchJs_togglesLoadingIndicator() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("function showSearchLoading("), "search.js must define showSearchLoading()");
+        assertTrue(js.contains("showSearchLoading(true)"), "search.js must show the loading indicator when a search starts");
+        assertTrue(js.contains("showSearchLoading(false)"), "search.js must hide the loading indicator when a search settles");
+    }
+
+    /** Fix 2: every i18n bundle must contain the labels.search_loading key. */
+    @Test
+    public void test_i18n_hasSearchLoadingKey() throws Exception {
+        try (Stream<Path> files = Files.list(THEME_DIR.resolve("i18n"))) {
+            files.filter(p -> p.getFileName().toString().startsWith("messages.") && p.getFileName().toString().endsWith(".json"))
+                    .forEach(p -> {
+                        try {
+                            assertTrue(Files.readString(p, StandardCharsets.UTF_8).contains("\"labels.search_loading\""),
+                                    "i18n bundle " + p.getFileName() + " must contain labels.search_loading");
+                        } catch (final Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+    }
+
+    /**
+     * Fix 3: i18n.js applyDom must localize the alt attribute via data-i18n-alt
+     * (previously the attribute was present on the logos but never processed).
+     */
+    @Test
+    public void test_i18nJs_appliesDataI18nAlt() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/i18n.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("data-i18n-alt"), "i18n.js applyDom must process data-i18n-alt attributes");
+        assertTrue(js.contains("setAttribute(\"alt\""), "i18n.js must set the alt attribute from the data-i18n-alt key");
+    }
+
+    /**
+     * Fix 3: both theme logos must reference real i18n keys for their localized alt text,
+     * so the rendered alt is never the raw key string. The previously-referenced but
+     * never-defined labels.index_title key must be gone.
+     */
+    @Test
+    public void test_indexHtml_logoAltKeysResolve() throws Exception {
+        final String html = Files.readString(THEME_DIR.resolve("index.html"), StandardCharsets.UTF_8);
+        final String en = Files.readString(THEME_DIR.resolve("i18n/messages.en.json"), StandardCharsets.UTF_8);
+        assertTrue(html.contains("data-i18n-alt=\"labels.header_brand_name\""),
+                "header brand logo must localize alt via labels.header_brand_name");
+        assertTrue(html.contains("data-i18n-alt=\"page.heading\""), "home logo must localize alt via page.heading");
+        assertTrue(en.contains("\"labels.header_brand_name\""), "labels.header_brand_name must exist in en bundle");
+        assertTrue(en.contains("\"page.heading\""), "page.heading must exist in en bundle");
+        assertFalse(html.contains("data-i18n-alt=\"labels.index_title\""),
+                "home logo must not reference the undefined labels.index_title key");
+    }
 }


### PR DESCRIPTION
## Summary

Functional review fixes for the bundled `bootstrap` reference static theme. Three gaps were found where the theme consumes the `/api/v2/*` API correctly but the front-end did not give the user complete feedback:

1. **Visible search-failure feedback.** Network, server (5xx) and auth failures during a search were written only to the screen-reader-only `#results-meta` sink, so a sighted user saw stale/blank results with no indication the search had failed. These errors are now surfaced in the visible `#search-error` banner (which is already `role="alert"`), falling back to `#results-meta` only when a theme has no visible banner. The `invalid_request`/400 path is unchanged.

2. **Search loading indicator.** The cache and chat views had a loading state; the main search did not, so a slow query left the previous results on screen with no progress hint. A `#search-loading` spinner is now shown while a `/search` request is in flight and hidden when it settles. The hide is guarded so a superseded request never clears the spinner belonging to a newer one. A new `labels.search_loading` key was added to all 16 message bundles.

3. **`data-i18n-alt` support.** Both logos carried a `data-i18n-alt` attribute, but `i18n.js applyDom()` only processed `data-i18n` / `-placeholder` / `-aria-label`, so the intended localized `alt` text was never applied. `applyDom()` now handles `data-i18n-alt`. The home logo referenced a key (`labels.index_title`) that did not exist in any bundle; it has been repointed to the existing `page.heading` key (the header brand already uses the existing `labels.header_brand_name`).

## Changes

- `assets/i18n.js` — `applyDom()` now localizes `alt` via `data-i18n-alt`.
- `assets/search.js` — visible error feedback for network/server/auth failures; `showSearchLoading()` helper + supersede-safe loading toggle in `runSearch()`.
- `index.html` — `#search-loading` indicator in the results view; home logo `data-i18n-alt` repointed to `page.heading`.
- `i18n/messages.*.json` (16) — new `labels.search_loading` key.
- `BundledBootstrapThemeTest` — 7 regression tests covering the three fixes.

## Testing

`mvn test -Dtest='org.codelibs.fess.theme.*Test,org.codelibs.fess.i18n.LabelMessageThemeParityTest'` — all green (BundledBootstrapThemeTest 120, LabelMessageThemeParityTest 5+2, ThemeManifestTest 11, StaticThemeResponderTest 34, StaticThemeInstallerTest 23, ThemeRegistryTest 7). i18n key parity preserved across all 16 bundles.
