### PR TITLE
fix(theme/bootstrap): redirect empty search to the home view

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1095,7 +1095,17 @@ export function runFromUrl() {
   const hasFields = Object.keys(state.fields).length > 0;
   const hasGeo = !!(state.geo.lat && state.geo.lon && state.geo.distance);
   const hasExQ = state.exQ.length > 0;
-  if (!state.q && !hasFields && !hasGeo && !hasExQ) return;
+  if (!state.q && !hasFields && !hasGeo && !hasExQ) {
+    // A blank query with no conditions (e.g. a sort/num/lang-only URL such as
+    // /search?num=10) is not a search. JSP parity: SearchAction.doSearch() redirects
+    // such requests to the top page via redirectToRoot(), so mirror that here. Without
+    // this, the results view keeps showing the PREVIOUS query's results, because the
+    // results DOM is re-rendered only when runSearch() runs and neither showView() nor
+    // clearSearchState() clears it. Use replace: true so the empty /search entry does
+    // not linger in history (matching the server-side redirect).
+    navigate("/", { replace: true });
+    return;
+  }
   runSearch();
 }
 


### PR DESCRIPTION
## Summary
Submitting the SPA search form with a blank query and no conditions (e.g. a sort/num/lang-only URL such as `/search?num=10`) left the previous query's results rendered on screen. `runFromUrl()` returned early without re-running a search, and because the results view is re-rendered only by `runSearch()` while neither `showView()` nor `clearSearchState()` clears the results DOM, the stale results stayed visible even though the URL carried no query or filter.

This mirrors the classic server-side behavior, where `SearchAction.doSearch()` redirects a blank query with no conditions to the top page via `redirectToRoot()`. `runFromUrl()` now navigates to `/` (using history replace, so the empty `/search` entry is not left in the back/forward stack) instead of leaving the stale results rendered. Searches that carry a keyword, a `fields.*` filter, a full geo point, or an `ex_q` are unaffected.

## Testing
- `node --check` on the modified asset
- `BundledBootstrapThemeTest` (120 tests) passes
