### PR TITLE
fix(admin/theme): remove duplicate <la:errors> rendering on theme list page

### DIFF
--- a/src/main/webapp/WEB-INF/view/admin/theme/admin_theme.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/theme/admin_theme.jsp
@@ -50,8 +50,6 @@ ${fe:html(true)}
                                     <div class="alert alert-success">${msg}</div>
                                 </la:info>
                                 <la:errors/>
-                                <la:errors property="_global"/>
-                                <la:errors property="name"/>
                             </div>
                             <%-- Default theme selector --%>
                             <c:if test="${editable}">


### PR DESCRIPTION
## Problem

On the theme admin list page (`admin_theme.jsp`), the message block rendered a bare `<la:errors/>` **and** two property-specific tags:

```jsp
<la:errors/>
<la:errors property="_global"/>
<la:errors property="name"/>
```

A bare `<la:errors/>` already outputs the errors of every property, so any global action error (for example a failed theme reload or a theme-not-found error, which `AdminThemeAction` registers under the global property) was rendered **twice** on the screen.

In addition, `<la:errors property="name"/>` was dead code: the theme list flow never registers errors under the `name` property (`ThemeListForm` only has a `defaultTheme` field).

This is the only admin page that combined a bare `<la:errors/>` with property-specific `<la:errors>` tags in the same block; all sibling list pages use a single bare `<la:errors/>`.

## Fix

Keep only the bare `<la:errors/>`, removing the two redundant property-specific tags. Every error is now displayed exactly once, and no error is dropped (the bare tag still covers `_global` as well as field errors such as `defaultTheme`). This matches the other admin list pages (`dict`, `backup`, `maintenance`, `plugin`, `storage`, `log`).

## How to reproduce

Trigger any global error on the theme list page (e.g. a theme reload failure). Before the fix the message appears twice; after the fix it appears once.