### PR TITLE
fix(rank-fusion): show previous page on multi-page semantic-only results

### DIFF
--- a/src/main/java/org/codelibs/fess/util/QueryResponseList.java
+++ b/src/main/java/org/codelibs/fess/util/QueryResponseList.java
@@ -137,9 +137,17 @@ public class QueryResponseList implements List<Map<String, Object>> {
             startWithOffset = 0;
         }
         allPageCount = (int) ((allRecordCount - 1) / pageSize) + 1;
-        existPrevPage = startWithOffset > 0;
-        existNextPage = startWithOffset < (long) (allPageCount - 1) * (long) pageSize;
         currentPageNumber = start / pageSize + 1;
+        // A previous page exists when the offset-adjusted start is positive, or simply
+        // when we are past the first page. The second term guards the rank-fusion case
+        // where the main searcher returns few/zero hits: offset inflates to ~the full
+        // result count and would otherwise clamp startWithOffset to 0 on pages 2..N.
+        existPrevPage = startWithOffset > 0 || currentPageNumber > 1;
+        // Next-page detection uses the raw start so it stays consistent with
+        // allPageCount (derived from allRecordCount). Using the offset-deflated
+        // startWithOffset here produced a spurious next page one page past the end,
+        // which the collapse logic below then turned into an inflated allPageCount.
+        existNextPage = start < (long) (allPageCount - 1) * (long) pageSize;
         if (existNextPage && size() < pageSize) {
             // collapsing
             existNextPage = false;

--- a/src/test/java/org/codelibs/fess/util/QueryResponseListTest.java
+++ b/src/test/java/org/codelibs/fess/util/QueryResponseListTest.java
@@ -763,6 +763,60 @@ public class QueryResponseListTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_calculatePageInfo_rankFusionZeroMainMultiPage() {
+        // Rank-fusion scenario: the main (BM25/default) searcher returns ~0 hits while a
+        // secondary searcher returns many, inflating offset to ~the full result count
+        // (37 total results, pageSize 10, offset 37).
+
+        // Page 2 (start=10): startWithOffset clamps to 0, but a previous page still exists.
+        QueryResponseList qrList = new QueryResponseList(null, 10, 10, 37) {
+            @Override
+            public int size() {
+                return 10;
+            }
+        };
+        qrList.allRecordCount = 37;
+        qrList.calculatePageInfo();
+        assertTrue(qrList.isExistPrevPage());
+
+        // Page 4 (start=30, last page with 7 remaining records): prev page exists, no next page,
+        // and allPageCount must be 4 (not inflated).
+        qrList = new QueryResponseList(null, 30, 10, 37) {
+            @Override
+            public int size() {
+                return 7;
+            }
+        };
+        qrList.allRecordCount = 37;
+        qrList.calculatePageInfo();
+        assertTrue(qrList.isExistPrevPage());
+        assertFalse(qrList.isExistNextPage());
+        assertEquals(4, qrList.getAllPageCount());
+
+        // Page 5 (start=40, past the end, no records): allPageCount must stay 4, not balloon to 5.
+        qrList = new QueryResponseList(null, 40, 10, 37) {
+            @Override
+            public int size() {
+                return 0;
+            }
+        };
+        qrList.allRecordCount = 37;
+        qrList.calculatePageInfo();
+        assertEquals(4, qrList.getAllPageCount());
+
+        // Page 1 guard (start=0): no previous page should exist.
+        qrList = new QueryResponseList(null, 0, 10, 37) {
+            @Override
+            public int size() {
+                return 10;
+            }
+        };
+        qrList.allRecordCount = 37;
+        qrList.calculatePageInfo();
+        assertFalse(qrList.isExistPrevPage());
+    }
+
+    @Test
     public void test_calculatePageInfo_pageNumberList_edgeCases() {
         // Test when current page is at the beginning
         QueryResponseList qrList = new QueryResponseList(null, 0, 10, 0) {


### PR DESCRIPTION
## Problem

When rank fusion runs and the primary (BM25 / `default`) searcher returns few or zero hits while a secondary searcher (e.g. a semantic/multimodal searcher) returns many, pagination breaks on multi-page result sets:

- `prev_page` is `false` on **every** page past the first, so themes that key their pager on `prev_page`/`next_page` hide the whole control and the user cannot navigate back.
- `page_count` inflates by one, one page past the actual end.

Example: a query that matches 37 documents only via the secondary searcher (4 pages of 10) reports `prev_page=false` on pages 2–4 and `page_count=5` past the end. A normal keyword query paginates correctly, because BM25 contributes to the main searcher's hit set.

## Root cause

`QueryResponseList`'s `offset` field does double duty:

- The rank-fusion merge inflates the effective record count by `offset` when the primary searcher contributes few/zero hits (`allRecordCount = mainCount + offset`).
- `calculatePageInfo()` also reused that same offset-adjusted value (`startWithOffset = start - offset`) as a **navigation origin-shift** for the pagination flags.

When the primary searcher returns ~0 hits, `offset` inflates to roughly the full result count, so `startWithOffset` clamps to `0` on every page. That makes `existPrevPage = startWithOffset > 0` false on all pages, and a spurious next page one page past the end is then collapsed into an inflated `allPageCount`.

## Fix

Decouple the navigation flags from the count-inflation role inside `calculatePageInfo()`:

- `existPrevPage` now also considers `currentPageNumber` — a previous page exists whenever we are past page 1.
- `existNextPage` is computed from the raw `start`, keeping it consistent with `allPageCount` (which is derived from `allRecordCount`), instead of the offset-deflated `startWithOffset`.

No other pagination logic changes. For `offset == 0` (all non-fusion / single-searcher paths) the behavior is provably identical to before, and normal deep-pagination behavior is preserved.

## Tests

Added `QueryResponseListTest#test_calculatePageInfo_rankFusionZeroMainMultiPage` covering the zero-primary multi-page case: previous page present on pages 2–4, no spurious next page, `page_count` stays 4, and no previous page on page 1.

`QueryResponseListTest` (38 tests) and `RankFusionProcessorTest` (11 tests) pass with no regressions.
