### PR TITLE
fix(sso/spnego): harden Windows SSO defaults and fix login failure handling

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
@@ -284,7 +284,6 @@ public class AdminGeneralAction extends FessAdminAction {
         fessConfig.setSystemProperty("spnego.prompt.ntlm", String.valueOf(isCheckboxEnabled(form.spnegoPromptNtlm)));
         fessConfig.setSystemProperty("spnego.allow.localhost", String.valueOf(isCheckboxEnabled(form.spnegoAllowLocalhost)));
         fessConfig.setSystemProperty("spnego.allow.delegation", String.valueOf(isCheckboxEnabled(form.spnegoAllowDelegation)));
-        fessConfig.setSystemProperty("spnego.exclude.dirs", form.spnegoExcludeDirs);
         fessConfig.setSystemProperty("spnego.logger.level", form.spnegoLoggerLevel);
 
         // Entra ID
@@ -424,19 +423,18 @@ public class AdminGeneralAction extends FessAdminAction {
                 Constants.TRUE.equalsIgnoreCase(fessConfig.getSystemProperty("spnego.allow.basic", Constants.TRUE)) ? Constants.TRUE
                         : Constants.FALSE;
         form.spnegoAllowUnsecureBasic =
-                Constants.TRUE.equalsIgnoreCase(fessConfig.getSystemProperty("spnego.allow.unsecure.basic", Constants.TRUE))
+                Constants.TRUE.equalsIgnoreCase(fessConfig.getSystemProperty("spnego.allow.unsecure.basic", Constants.FALSE))
                         ? Constants.TRUE
                         : Constants.FALSE;
         form.spnegoPromptNtlm =
                 Constants.TRUE.equalsIgnoreCase(fessConfig.getSystemProperty("spnego.prompt.ntlm", Constants.TRUE)) ? Constants.TRUE
                         : Constants.FALSE;
         form.spnegoAllowLocalhost =
-                Constants.TRUE.equalsIgnoreCase(fessConfig.getSystemProperty("spnego.allow.localhost", Constants.TRUE)) ? Constants.TRUE
+                Constants.TRUE.equalsIgnoreCase(fessConfig.getSystemProperty("spnego.allow.localhost", Constants.FALSE)) ? Constants.TRUE
                         : Constants.FALSE;
         form.spnegoAllowDelegation =
                 Constants.TRUE.equalsIgnoreCase(fessConfig.getSystemProperty("spnego.allow.delegation", Constants.FALSE)) ? Constants.TRUE
                         : Constants.FALSE;
-        form.spnegoExcludeDirs = fessConfig.getSystemProperty("spnego.exclude.dirs", StringUtil.EMPTY);
         form.spnegoLoggerLevel = fessConfig.getSystemProperty("spnego.logger.level", StringUtil.EMPTY);
 
         // Entra ID

--- a/src/main/java/org/codelibs/fess/app/web/admin/general/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/EditForm.java
@@ -574,10 +574,6 @@ public class EditForm {
     @Size(max = 10)
     public String spnegoAllowDelegation;
 
-    /** SPNEGO directories to exclude from authentication. */
-    @Size(max = 1000)
-    public String spnegoExcludeDirs;
-
     /** SPNEGO logger level (0-7, auto-detected if empty). */
     @Size(max = 10)
     public String spnegoLoggerLevel;

--- a/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
@@ -28,6 +28,7 @@ import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.app.web.login.LoginAction;
 import org.codelibs.fess.app.web.search.SearchAction;
 import org.codelibs.fess.entity.RequestParameter;
+import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.exception.SsoMessageException;
 import org.codelibs.fess.sso.SsoManager;
 import org.codelibs.fess.sso.SsoResponseType;
@@ -85,7 +86,18 @@ public class SsoAction extends FessLoginAction {
             });
         }
         final SsoManager ssoManager = ComponentUtil.getSsoManager();
-        final LoginCredential loginCredential = ssoManager.getLoginCredential();
+        final LoginCredential loginCredential;
+        try {
+            loginCredential = ssoManager.getLoginCredential();
+        } catch (final SsoLoginException e) {
+            if (ssoManager.available()) {
+                logger.warn("Failed to process SSO login.", e);
+                saveError(messages -> messages.addErrorsSsoLoginError(GLOBAL));
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("Failed to process SSO login.", e);
+            }
+            return redirect(LoginAction.class);
+        }
         if (loginCredential == null) {
             if (ssoManager.available()) {
                 if (logger.isDebugEnabled()) {

--- a/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
@@ -3750,9 +3750,6 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Allow Delegation */
     public static final String LABELS_spnego_allow_delegation = "{labels.spnego_allow_delegation}";
 
-    /** The key of the message: Exclude Directories */
-    public static final String LABELS_spnego_exclude_dirs = "{labels.spnego_exclude_dirs}";
-
     /** The key of the message: Logger Level */
     public static final String LABELS_spnego_logger_level = "{labels.spnego_logger_level}";
 

--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -18,6 +18,8 @@ package org.codelibs.fess.sso.spnego;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,7 +30,6 @@ import org.codelibs.fess.app.web.base.login.FessLoginAssist.LoginCredentialResol
 import org.codelibs.fess.app.web.base.login.SpnegoCredential;
 import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
-import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.sso.SsoAuthenticator;
 import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.util.ComponentUtil;
@@ -45,6 +46,7 @@ import org.lastaflute.web.util.LaRequestUtil;
 import org.lastaflute.web.util.LaResponseUtil;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletResponse;
@@ -65,14 +67,14 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
     /** Logger for this class. */
     private static final Logger logger = LogManager.getLogger(SpnegoAuthenticator.class);
 
-    /** Configuration key for SPNEGO initialization status. */
-    protected static final String SPNEGO_INITIALIZED = "spnego.initialized";
-
     /** Configuration key for directories to exclude from SPNEGO authentication. */
     protected static final String SPNEGO_EXCLUDE_DIRS = "spnego.exclude.dirs";
 
     /** Configuration key for enabling delegation in SPNEGO authentication. */
     protected static final String SPNEGO_ALLOW_DELEGATION = "spnego.allow.delegation";
+
+    /** Configuration key for the comma-separated list of additionally allowed Kerberos realms. */
+    protected static final String SPNEGO_ALLOWED_REALMS = "spnego.allowed.realms";
 
     /** Configuration key for allowing localhost authentication bypass. */
     protected static final String SPNEGO_ALLOW_LOCALHOST = "spnego.allow.localhost";
@@ -130,29 +132,42 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Releases the SPNEGO server credentials and login context on shutdown.
+     */
+    @PreDestroy
+    public void destroy() {
+        if (authenticator != null) {
+            try {
+                authenticator.dispose();
+            } catch (final Exception e) {
+                logger.warn("Failed to dispose SPNEGO authenticator.", e);
+            } finally {
+                authenticator = null;
+            }
+        }
+    }
+
+    /**
      * Gets or creates the SPNEGO authenticator instance.
      *
      * This method implements lazy initialization with synchronization to ensure
-     * the authenticator is only created once. It configures the authenticator
-     * with the appropriate SPNEGO settings and marks initialization as complete.
+     * the authenticator is only created once per JVM. Because the underlying
+     * SpnegoFilterConfig is a JVM-wide singleton, the configuration is cached for
+     * the lifetime of the process and a Fess restart is required to apply changes.
      *
      * @return The configured SPNEGO authenticator instance
      * @throws SsoLoginException if SPNEGO initialization fails
      */
     protected synchronized org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
-        final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        if (authenticator != null && fessConfig.getSystemPropertyAsBoolean(SPNEGO_INITIALIZED, false)) {
+        if (authenticator != null) {
             return authenticator;
         }
         try {
-            // set some System properties
+            // NOTE: The underlying SpnegoFilterConfig is a JVM-wide singleton, so the SPNEGO
+            // configuration is effectively cached for the lifetime of the process. Changes to the
+            // spnego.* settings therefore require a Fess restart to take effect.
             final SpnegoFilterConfig config = SpnegoFilterConfig.getInstance(new SpnegoConfig());
-
-            // pre-authenticate
             authenticator = new org.codelibs.spnego.SpnegoAuthenticator(config);
-
-            fessConfig.setSystemPropertyAsBoolean(SPNEGO_INITIALIZED, true);
-            fessConfig.storeSystemProperties();
             return authenticator;
         } catch (final Exception e) {
             throw new SsoLoginException("Failed to initialize SPNEGO.", e);
@@ -225,13 +240,12 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 throw new SsoLoginException(msg);
             }
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("principal={}", principal);
-            }
-
             final String[] username = principal.getName().split("@", 2);
             if (logger.isDebugEnabled()) {
                 logger.debug("username={}", Arrays.toString(username));
+            }
+            if (username.length == 2 && StringUtil.isNotBlank(username[1]) && !isAllowedRealm(username[1])) {
+                throw new SsoLoginException("Kerberos realm is not allowed: realm=" + username[1]);
             }
             return new SpnegoCredential(username[0]);
         }).orElse(null);
@@ -291,7 +305,10 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             if (SpnegoHttpFilter.Constants.LOGGER_LEVEL.equals(name)) {
                 final String logLevel = getProperty(SPNEGO_LOGGER_LEVEL, StringUtil.EMPTY);
                 if (StringUtil.isNotBlank(logLevel)) {
-                    return logLevel;
+                    if (logLevel.chars().allMatch(Character::isDigit)) {
+                        return logLevel;
+                    }
+                    logger.warn("Invalid spnego.logger.level (must be numeric): {}. Falling back to auto-detection.", logLevel);
                 }
                 if (logger.isDebugEnabled()) {
                     return "3";
@@ -320,10 +337,13 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 return getProperty(SPNEGO_LOGIN_SERVER_MODULE, "spnego-server");
             }
             if (SpnegoHttpFilter.Constants.PREAUTH_USERNAME.equals(name)) {
-                return getProperty(SPNEGO_PREAUTH_USERNAME, "username");
+                // Empty by default so that keytab-based server login is used when the server login
+                // module is configured for it (the library only uses a keytab when both preauth
+                // username and password are empty).
+                return getProperty(SPNEGO_PREAUTH_USERNAME, StringUtil.EMPTY);
             }
             if (SpnegoHttpFilter.Constants.PREAUTH_PASSWORD.equals(name)) {
-                return getProperty(SPNEGO_PREAUTH_PASSWORD, "password");
+                return getProperty(SPNEGO_PREAUTH_PASSWORD, StringUtil.EMPTY);
             }
             if (SpnegoHttpFilter.Constants.ALLOW_BASIC.equals(name)) {
                 // SECURITY NOTE: Basic authentication is enabled by default for compatibility.
@@ -331,17 +351,19 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 return getProperty(SPNEGO_ALLOW_BASIC, "true");
             }
             if (SpnegoHttpFilter.Constants.ALLOW_UNSEC_BASIC.equals(name)) {
-                // SECURITY WARNING: Unsecure basic authentication is enabled by default.
-                // This sends credentials in Base64 encoding over potentially unencrypted connections.
-                // For production, it is STRONGLY RECOMMENDED to set spnego.allow.unsecure.basic to false
-                // and use HTTPS or more secure authentication methods.
-                return getProperty(SPNEGO_ALLOW_UNSECURE_BASIC, "true");
+                // SECURITY: unsecure basic authentication is disabled by default so that basic
+                // credentials are never offered over plain HTTP. When false, basic auth is only
+                // offered over HTTPS. Enable only if you fully understand the risk.
+                return getProperty(SPNEGO_ALLOW_UNSECURE_BASIC, "false");
             }
             if (SpnegoHttpFilter.Constants.PROMPT_NTLM.equals(name)) {
                 return getProperty(SPNEGO_PROMPT_NTLM, "true");
             }
             if (SpnegoHttpFilter.Constants.ALLOW_LOCALHOST.equals(name)) {
-                return getProperty(SPNEGO_ALLOW_LOCALHOST, "true");
+                // SECURITY: localhost bypass is disabled by default. When enabled, the spnego library
+                // authenticates same-host requests as the server OS user without Kerberos verification,
+                // which is unsafe behind a same-host reverse proxy. Opt in explicitly if required.
+                return getProperty(SPNEGO_ALLOW_LOCALHOST, "false");
             }
             if (SpnegoHttpFilter.Constants.ALLOW_DELEGATION.equals(name)) {
                 return getProperty(SPNEGO_ALLOW_DELEGATION, "false");
@@ -367,14 +389,15 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
          * Resolves a resource path to an absolute file path.
          *
          * @param path The resource path to resolve
-         * @return The absolute file path of the resource, or null if not found
+         * @return The resolved absolute file path of the resource
+         * @throws SsoLoginException if the file cannot be found
          */
         protected String getResourcePath(final String path) {
             final File file = ResourceUtil.getResourceAsFileNoException(path);
             if (file != null) {
                 return file.getAbsolutePath();
             }
-            return null;
+            throw new SsoLoginException("SPNEGO configuration file not found: " + path);
         }
 
         /**
@@ -388,6 +411,47 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             throw new UnsupportedOperationException("getInitParameterNames() is not supported in SpnegoFilterConfig");
         }
 
+    }
+
+    /**
+     * Determines whether the given Kerberos realm is permitted to log in.
+     * The server's own realm is always allowed.
+     *
+     * @param realm the Kerberos realm extracted from the client principal
+     * @return true if the realm is allowed
+     */
+    protected boolean isAllowedRealm(final String realm) {
+        return isAllowedRealm(realm, getAuthenticator().getServerRealm());
+    }
+
+    /**
+     * Determines whether the given Kerberos realm is permitted, considering the server realm and
+     * the comma-separated {@code spnego.allowed.realms} system property (for intentional cross-realm
+     * trust setups). When neither the server realm nor an allow list can be determined, the realm is
+     * accepted to preserve backward compatibility (a warning is logged).
+     *
+     * @param realm the Kerberos realm extracted from the client principal
+     * @param serverRealm the Kerberos realm of the SPNEGO server principal (may be blank)
+     * @return true if the realm is allowed
+     */
+    protected boolean isAllowedRealm(final String realm, final String serverRealm) {
+        final Set<String> allowedRealms = new HashSet<>();
+        if (StringUtil.isNotBlank(serverRealm)) {
+            allowedRealms.add(serverRealm);
+        }
+        final String configured = ComponentUtil.getSystemProperties().getProperty(SPNEGO_ALLOWED_REALMS, StringUtil.EMPTY);
+        if (StringUtil.isNotBlank(configured)) {
+            for (final String r : configured.split(",")) {
+                if (StringUtil.isNotBlank(r)) {
+                    allowedRealms.add(r.trim());
+                }
+            }
+        }
+        if (allowedRealms.isEmpty()) {
+            logger.warn("No allowed Kerberos realm could be determined; accepting realm={} without validation.", realm);
+            return true;
+        }
+        return allowedRealms.stream().anyMatch(r -> r.equalsIgnoreCase(realm));
     }
 
     /**

--- a/src/main/resources/fess_label.properties
+++ b/src/main/resources/fess_label.properties
@@ -1242,7 +1242,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_de.properties
+++ b/src/main/resources/fess_label_de.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_en.properties
+++ b/src/main/resources/fess_label_en.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_es.properties
+++ b/src/main/resources/fess_label_es.properties
@@ -1242,7 +1242,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_fr.properties
+++ b/src/main/resources/fess_label_fr.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_hi.properties
+++ b/src/main/resources/fess_label_hi.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_id.properties
+++ b/src/main/resources/fess_label_id.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_it.properties
+++ b/src/main/resources/fess_label_it.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_ja.properties
+++ b/src/main/resources/fess_label_ja.properties
@@ -1242,7 +1242,6 @@ labels.spnego_allow_unsecure_basic=\u975e\u30bb\u30ad\u30e5\u30a2Basic\u8a8d\u8a
 labels.spnego_prompt_ntlm=NTLM\u30d7\u30ed\u30f3\u30d7\u30c8
 labels.spnego_allow_localhost=\u30ed\u30fc\u30ab\u30eb\u30db\u30b9\u30c8\u8a31\u53ef
 labels.spnego_allow_delegation=\u59d4\u4efb\u8a31\u53ef
-labels.spnego_exclude_dirs=\u9664\u5916\u30c7\u30a3\u30ec\u30af\u30c8\u30ea
 labels.spnego_logger_level=ロガーレベル
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=\u30af\u30e9\u30a4\u30a2\u30f3\u30c8ID

--- a/src/main/resources/fess_label_ko.properties
+++ b/src/main/resources/fess_label_ko.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_nl.properties
+++ b/src/main/resources/fess_label_nl.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_pl.properties
+++ b/src/main/resources/fess_label_pl.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_pt_BR.properties
+++ b/src/main/resources/fess_label_pt_BR.properties
@@ -1242,7 +1242,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_ru.properties
+++ b/src/main/resources/fess_label_ru.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_tr.properties
+++ b/src/main/resources/fess_label_tr.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_zh_CN.properties
+++ b/src/main/resources/fess_label_zh_CN.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/resources/fess_label_zh_TW.properties
+++ b/src/main/resources/fess_label_zh_TW.properties
@@ -1243,7 +1243,6 @@ labels.spnego_allow_unsecure_basic=Allow Unsecure Basic Auth
 labels.spnego_prompt_ntlm=Prompt NTLM
 labels.spnego_allow_localhost=Allow Localhost
 labels.spnego_allow_delegation=Allow Delegation
-labels.spnego_exclude_dirs=Exclude Directories
 labels.spnego_logger_level=Logger Level
 labels.general_menu_entraid=Entra ID
 labels.entraid_client_id=Client ID

--- a/src/main/webapp/WEB-INF/view/admin/general/admin_general.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/general/admin_general.jsp
@@ -885,16 +885,6 @@ ${fe:html(true)}
                                     </div>
                                 </div>
                                 <div class="form-group row">
-                                    <label for="spnegoExcludeDirs"
-                                           class="col-sm-3 text-sm-right col-form-label"><la:message
-                                            key="labels.spnego_exclude_dirs"/></label>
-                                    <div class="col-sm-9">
-                                        <la:errors property="spnegoExcludeDirs"/>
-                                        <la:text styleId="spnegoExcludeDirs" property="spnegoExcludeDirs"
-                                                 styleClass="form-control"/>
-                                    </div>
-                                </div>
-                                <div class="form-group row">
                                     <label for="spnegoLoggerLevel"
                                            class="col-sm-3 text-sm-right col-form-label"><la:message
                                             key="labels.spnego_logger_level"/></label>

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
@@ -15,7 +15,13 @@
  */
 package org.codelibs.fess.sso.spnego;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.codelibs.core.misc.DynamicProperties;
+import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.spnego.SpnegoHttpFilter.Constants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -28,6 +34,10 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
 
     @Override
     protected void tearDown(TestInfo testInfo) throws Exception {
+        // Ensure spnego.* system properties possibly set by a test do not leak.
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        systemProperties.remove("spnego.logger.level");
+        systemProperties.remove("spnego.allowed.realms");
         super.tearDown(testInfo);
     }
 
@@ -40,38 +50,111 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
 
     @Test
     public void test_spnegoConfigClass() {
-        // Verify the inner class is named correctly: SpnegoConfig (not SpengoConfig)
-        // This test verifies the typo fix by ensuring the class compiles
-        SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
-        assertNotNull(authenticator);
+        // Verify the inner SpnegoConfig class can be instantiated directly.
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        assertNotNull(config);
 
-        // The typo fix (SpengoConfig -> SpnegoConfig) is verified at compile time
-        // If the class name was wrong, this test file wouldn't compile
-        assertTrue(true);
+        // The filter name should be the fully qualified name of the outer class.
+        assertEquals(SpnegoAuthenticator.class.getName(), config.getFilterName());
     }
 
     @Test
     public void test_securitySettings_allowBasic() throws Exception {
-        // Test that ALLOW_BASIC security setting can be accessed
-        // This verifies the security warnings are properly documented in code
-        SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
-        assertNotNull(authenticator);
-
-        // The constant should be accessible and properly named
-        // We can't easily test the actual configuration without full DI setup,
-        // but we verify the class structure is correct
-        assertTrue(true);
+        // Basic authentication remains enabled by default for compatibility.
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        assertEquals("true", config.getInitParameter(Constants.ALLOW_BASIC));
     }
 
     @Test
     public void test_securitySettings_allowUnsecureBasic() throws Exception {
-        // Verify the ALLOW_UNSEC_BASIC setting is documented with security warnings
-        SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
-        assertNotNull(authenticator);
+        // Unsecure basic authentication (basic over plain HTTP) is disabled by default.
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        assertEquals("false", config.getInitParameter(Constants.ALLOW_UNSEC_BASIC));
+    }
 
-        // The security warning comments should guide users to disable this in production
-        // This is a compile-time check that the code structure is correct
-        assertTrue(true);
+    @Test
+    public void test_getInitParameter_secureDefaults() {
+        // Verify the security-hardened defaults returned by SpnegoConfig#getInitParameter.
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+
+        // Localhost bypass must be off by default.
+        assertEquals("false", config.getInitParameter(Constants.ALLOW_LOCALHOST));
+        // Unsecure basic auth over plain HTTP must be off by default.
+        assertEquals("false", config.getInitParameter(Constants.ALLOW_UNSEC_BASIC));
+        // No pre-authentication credentials by default (keytab-based server login).
+        assertEquals("", config.getInitParameter(Constants.PREAUTH_USERNAME));
+        assertEquals("", config.getInitParameter(Constants.PREAUTH_PASSWORD));
+        // Basic auth stays enabled for compatibility.
+        assertEquals("true", config.getInitParameter(Constants.ALLOW_BASIC));
+        // Delegation must be off by default.
+        assertEquals("false", config.getInitParameter(Constants.ALLOW_DELEGATION));
+    }
+
+    @Test
+    public void test_getInitParameter_loggerLevel_nonNumericFallsBack() {
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            // A non-numeric level must be ignored and auto-detection used instead.
+            systemProperties.setProperty("spnego.logger.level", "abc");
+            String level = config.getInitParameter(Constants.LOGGER_LEVEL);
+            assertNotNull(level);
+            assertFalse("abc".equals(level));
+            // Auto-detection always yields a numeric level string.
+            assertTrue(level.chars().allMatch(Character::isDigit));
+
+            // A numeric level must be passed through unchanged.
+            systemProperties.setProperty("spnego.logger.level", "5");
+            assertEquals("5", config.getInitParameter(Constants.LOGGER_LEVEL));
+        } finally {
+            systemProperties.remove("spnego.logger.level");
+        }
+    }
+
+    @Test
+    public void test_getResourcePath_throwsWhenMissing() {
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        // A missing resource must raise SsoLoginException rather than returning null.
+        assertThrows(SsoLoginException.class, () -> config.getResourcePath("this-file-does-not-exist-xyz.conf"));
+    }
+
+    @Test
+    public void test_isAllowedRealm_serverRealmMatches() {
+        SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
+        // The server's own realm is always allowed.
+        assertTrue(authenticator.isAllowedRealm("CORP.EXAMPLE", "CORP.EXAMPLE"));
+        // Realm comparison is case-insensitive.
+        assertTrue(authenticator.isAllowedRealm("corp.example", "CORP.EXAMPLE"));
+    }
+
+    @Test
+    public void test_isAllowedRealm_rejectsForeignRealm() {
+        SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
+        // A realm other than the server realm is rejected when no allow list is configured.
+        assertFalse(authenticator.isAllowedRealm("EVIL.EXAMPLE", "CORP.EXAMPLE"));
+    }
+
+    @Test
+    public void test_isAllowedRealm_allowlistPermitsForeignRealm() {
+        SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
+        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            systemProperties.setProperty("spnego.allowed.realms", "TRUSTED.EXAMPLE");
+            // A realm explicitly listed in spnego.allowed.realms is permitted.
+            assertTrue(authenticator.isAllowedRealm("TRUSTED.EXAMPLE", "CORP.EXAMPLE"));
+            // A realm neither on the allow list nor the server realm is still rejected.
+            assertFalse(authenticator.isAllowedRealm("OTHER.EXAMPLE", "CORP.EXAMPLE"));
+        } finally {
+            systemProperties.remove("spnego.allowed.realms");
+        }
+    }
+
+    @Test
+    public void test_isAllowedRealm_backwardCompatWhenUndeterminable() {
+        SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
+        // When neither the server realm nor an allow list can be determined, any realm is
+        // accepted for backward compatibility (a warning is logged by the implementation).
+        assertTrue(authenticator.isAllowedRealm("ANY.EXAMPLE", ""));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Review and hardening of the SPNEGO (Windows SSO) implementation. Each finding was verified against the code before fixing.

### Security hardening (insecure-by-default changes)
- **`spnego.allow.localhost` now defaults to `false`.** When enabled, the underlying library authenticates same-host requests as the server OS user without Kerberos verification — unsafe behind a same-host reverse proxy.
- **`spnego.allow.unsecure.basic` now defaults to `false`**, so Basic credentials are never offered over plain HTTP (Basic is still offered over HTTPS).
- **Kerberos realm validation.** Only the server realm and realms listed in the new `spnego.allowed.realms` property are accepted, preventing cross-realm principals from collapsing onto the same local user. Single-realm setups are unaffected.

### Bug fixes / correctness
- `SsoAction.index()` now catches `SsoLoginException`, so SSO auth failures (SPNEGO/EntraID) redirect to the login page with an error instead of returning HTTP 500.
- Removed the non-functional `spnego.initialized` re-init flag (dead logic that also polluted `system.properties`); documented that SPNEGO settings require a restart because the library config is a JVM-wide singleton.
- Release server credentials/login context on shutdown via `@PreDestroy`.
- Fixed keytab authentication: `spnego.preauth.username`/`password` now default to empty so keytab-based server login is used when configured (previously placeholder values forced username/password mode).
- Removed the no-op `spnego.exclude.dirs` setting from the admin UI (only the unused servlet filter consumed it).
- Clearer "configuration file not found" error when `krb5.conf`/`login.conf` cannot be resolved.
- Non-numeric `spnego.logger.level` is ignored (warn + auto-detect) instead of failing SPNEGO initialization.
- Removed a duplicate debug log line.

### Tests
Replaced the placeholder `SpnegoAuthenticatorTest` assertions with real coverage (15 tests): secure defaults, realm validation, logger-level fallback, and the config-file-not-found path. `mvn test -Dtest=SpnegoAuthenticatorTest` passes (15/15).

### Upgrade notes
Deployments that relied on localhost bypass or plain-HTTP Basic will now require authentication / HTTPS. Intentional cross-realm trust setups must list the additional realms in `spnego.allowed.realms`.
