### PR TITLE
docs: refresh README and trim CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,205 +4,95 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Project Overview
 
-Fess is an Enterprise Search Server built on OpenSearch. It's a Java-based web application that crawls and indexes documents from various sources and provides full-text search capabilities. Licensed under Apache License 2.0.
+Fess is an enterprise search server built on OpenSearch. It is a Java web application that crawls and indexes documents from web sites, file systems, and data stores, and provides full-text search through a web UI and a REST API. Licensed under Apache License 2.0.
 
-**Key Capabilities:**
-- Full-text search with OpenSearch backend
-- Web, file system, and data store crawling
-- Multi-format document support (Office, PDF, etc.)
-- Admin GUI for configuration
-- REST API for programmatic access
-- SSO integration (OIDC, SAML, SPNEGO, Entra ID)
-- i18n support (20+ languages)
+Key capabilities: full-text search, multi-source crawling, multi-format document support (Office, PDF, etc.), an admin GUI, SSO (LDAP, OIDC, SAML, SPNEGO, Entra ID), and i18n (20+ languages).
 
 ## Tech Stack
 
 | Component | Technology |
 |-----------|------------|
-| Web Framework | LastaFlute (MVC framework) |
-| DI Container | Lasta Di |
-| Data Access | DBFlute (type-safe ORM for OpenSearch) |
-| Search Engine | OpenSearch |
-| App Server | Embedded Tomcat |
-| Crawler | fess-crawler library |
+| Web framework | LastaFlute (MVC) |
+| DI container | Lasta Di |
+| Data access | DBFlute (type-safe access to OpenSearch) |
+| Search engine | OpenSearch |
+| App server | Embedded Tomcat |
+| Crawler | fess-crawler |
 | Scheduler | Lasta Job |
-| Logging | Log4j2 |
 | Testing | JUnit 4/5, UTFlute, REST Assured |
 
 ## Development Commands
 
-### Setup
 ```bash
+# Setup
 mvn antrun:run          # Download OpenSearch plugins (required before first build)
-mvn dbflute:download    # One-time setup for DBFlute
-mvn dbflute:freegen     # Generate DBFlute source code
-mvn license:format      # Add license headers
-```
+mvn dbflute:download    # One-time DBFlute setup
+mvn dbflute:freegen     # Regenerate DBFlute source
 
-### Build
-```bash
-mvn package             # Standard build
-mvn clean package       # Clean build
+# Build
+mvn package             # Build (use `mvn clean package` for a clean build)
 mvn rpm:rpm             # Build .rpm package
 mvn jdeb:jdeb           # Build .deb package
-```
 
-### Testing
-```bash
-mvn test                                    # Run unit tests (*Test.java)
-mvn test -Dtest=ClassName                   # Run single unit test
-
-# To install fess jar for plugin dependency resolution:
-# Change pom.xml <packaging>war</packaging> to <packaging>jar</packaging> first
-mvn clean install -DskipTests               # Then revert packaging back to war
-
-# Integration tests (*Tests.java) - requires running Fess server
+# Test
+mvn test                            # Unit tests (*Test.java)
+mvn test -Dtest=ClassName           # Single unit test
 mvn test -P integrationTests -Dtest.fess.url="http://localhost:8080" -Dtest.search_engine.url="http://localhost:9201"
+
+# Format (run before committing)
+mvn formatter:format
+mvn license:format
+
+# Run
+./bin/fess              # From a built package, or run org.codelibs.fess.FessBoot from the IDE
+# Access http://localhost:8080/ (admin UI: admin/admin)
 ```
 
-### Running
-```bash
-./bin/fess              # From command line
-# Or run org.codelibs.fess.FessBoot from IDE
-# Access: http://localhost:8080/ (Admin: admin/admin)
-```
+Fess is packaged as a WAR. To install it as a jar so plugins can resolve it as a dependency, temporarily change `<packaging>war</packaging>` to `jar` in pom.xml, run `mvn clean install -DskipTests`, then revert.
 
-### Code Formatting
-```bash
-mvn formatter:format    # Format code
-mvn license:format      # Add license headers
-```
+## Architecture
 
-## Directory Structure
+Source lives under `src/main/java/org/codelibs/fess/`. `FessBoot` is the entry point. Notable packages: `app/web` (Actions and Forms, with `admin/` and `api/` controllers), `app/service` (business logic), `opensearch/` (DBFlute integration for the `config`, `log`, and `user` indices), `helper/` (stateless utilities), and `crawler/`, `sso/`, `auth/`, `ldap/`. Configuration and i18n resources live under `src/main/resources/` (`fess_config.properties`, `*.xml` DI files, `fess_label_*`/`fess_message_*` properties, `fess_indices/` mappings). JSP views are under `src/main/webapp/WEB-INF/view/`.
 
-```
-src/main/java/org/codelibs/fess/
-├── FessBoot.java              # Application entry point
-├── Constants.java             # Central application constants
-├── app/
-│   ├── web/                   # Controllers (Actions)
-│   │   ├── base/              # Base action classes (FessBaseAction, FessAdminAction)
-│   │   ├── admin/             # Admin controllers ({feature}/ with Action, Forms)
-│   │   └── api/               # API controllers
-│   ├── service/               # Business logic services
-│   ├── pager/                 # Pagination handlers
-│   └── job/                   # Background jobs
-├── api/                       # REST API infrastructure
-├── opensearch/                # DBFlute integration for OpenSearch
-│   ├── config/                # Config index (crawl configs, schedules)
-│   ├── log/                   # Log index (search logs, click logs)
-│   └── user/                  # User index (users, groups, roles)
-├── helper/                    # Cross-cutting utilities (~40+ helpers)
-├── crawler/                   # Crawling engine (processor, transformer, service)
-├── sso/                       # SSO implementations (oic, saml, spnego, entraid)
-├── auth/                      # Authentication management
-├── ldap/                      # LDAP integration
-├── filter/                    # Servlet filters
-├── validation/                # Custom validators
-├── dict/                      # Dictionary management
-└── ds/                        # Data store connectors
-
-src/main/resources/
-├── fess_config.properties     # Main configuration
-├── app.xml, fess.xml          # DI configuration
-├── fess_*.xml                 # Feature-specific DI
-├── fess_label_*.properties    # UI labels (i18n)
-├── fess_message_*.properties  # Validation messages (i18n)
-└── fess_indices/              # OpenSearch index mappings
-
-src/main/webapp/WEB-INF/view/  # JSP templates
-src/test/java/.../it/          # Integration tests (*Tests.java)
-```
-
-## Architecture Patterns
-
-### Action (Controller)
-- Hierarchy: `TypicalAction` → `FessBaseAction` → `FessAdminAction`/`FessSearchAction`
-- `@Execute` marks web endpoints
-- `@Resource` for DI
-- `@Secured({ "role", "role-view" })` for authorization
+### Action (controller)
+- Hierarchy: `TypicalAction` → `FessBaseAction` → `FessAdminAction` / `FessSearchAction`
+- `@Execute` marks endpoints; `@Resource` for DI; `@Secured({ "role", "role-view" })` for authorization
 - Return `HtmlResponse` for JSP, `JsonResponse` for APIs
 
-### Service
-- Inject behaviors (Bhv) for data access
-- Use `OptionalEntity<T>` for nullable returns
-- Plain classes (no extends/implements)
+### Service and Helper
+- Services are plain classes; inject behaviors (Bhv) for data access; use `OptionalEntity<T>` for nullable returns
+- Helpers are stateless utilities named with a `Helper` suffix, accessed via `ComponentUtil.getXyzHelper()`
 
-### Helper
-- Stateless utility classes
-- Access via `ComponentUtil.getXyzHelper()`
-- Named with "Helper" suffix
+### DBFlute (OpenSearch access)
+- Under `opensearch/{index}/`: `bsentity`/`bsbhv` are generated base classes — do not edit; customize in `exentity`/`exbhv`; `cbean` holds condition beans (query builders)
+- Use Bhv classes for data access rather than the OpenSearch client directly
 
-### DBFlute Generated Code
-```
-opensearch/{index}/
-├── bsentity/, bsbhv/    # Base classes (DO NOT EDIT)
-├── exentity/, exbhv/    # Extended classes (customize here)
-└── cbean/               # Condition beans (query builders)
-```
-
-### Form Classes
+### Form classes
 - POJOs with public fields (no getters/setters)
-- Validation: `@Required`, `@Size`, `@ValidateTypeFailure`, `@Pattern`
-- Include `crudMode` field for CRUD operations
+- Validate with `@Required`, `@Size`, `@ValidateTypeFailure`, `@Pattern`; include a `crudMode` field for CRUD operations
 
 ## Security and Authentication
 
-- `@Secured` annotation with role array (`"admin-user"`, `"admin-user-view"`)
-- Role-based query filtering via `RoleQueryHelper`
-- Authentication: Local (UserService), LDAP, OIDC, SAML, SPNEGO, Entra ID
-- Security features: AES encryption, LDAP injection prevention, password policy, rate limiting
-- Password hashing: BCrypt (`{bcrypt}$2a$10$...`, Spring Security v5.8 compatible) via `PasswordHashHelper` helper. Configure with `app.password.algorithm` / `app.password.bcrypt.cost`. Legacy SHA-256/512/MD5 hashes without prefix are verified via `app.digest.algorithm` for backward compatibility and re-hashed on next successful login when `app.password.upgrade.enabled=true` (default). **Downgrading to a pre-BCrypt Fess release will invalidate `{bcrypt}`-encoded passwords** — document this in release notes and plan for admin password reset.
-- Password write paths (`UserService.changePassword`, `AdminUserAction`, `SearchEngineClient` initial admin) must call `ComponentUtil.getPasswordHashHelper().encode(plain)` — do not call `FessLoginAssist.encryptPassword` from new code.
+- `@Secured` with a role array; role-based result filtering via `RoleQueryHelper`
+- Authentication: local (UserService), LDAP, OIDC, SAML, SPNEGO, Entra ID
+- Password hashing: BCrypt (`{bcrypt}$2a$10$...`, Spring Security 5.8 compatible) via `PasswordHashHelper`, configured with `app.password.algorithm` / `app.password.bcrypt.cost`. Legacy unprefixed SHA-256/512/MD5 hashes are verified via `app.digest.algorithm` and re-hashed on next login when `app.password.upgrade.enabled=true` (default). Downgrading to a pre-BCrypt release invalidates `{bcrypt}` passwords — note this in release notes. New password-write paths must call `ComponentUtil.getPasswordHashHelper().encode(plain)`, not `FessLoginAssist.encryptPassword`.
 
-## Naming Conventions
+## i18n
 
-| Element | Convention | Example |
-|---------|------------|---------|
-| Classes | PascalCase | `UserService`, `FessBaseAction` |
-| Methods | camelCase + verb | `getUserList()`, `setupHtmlData()` |
-| Constants | UPPER_SNAKE_CASE | `DEFAULT_PAGE_SIZE` |
-| Fields | camelCase | `userPager`, `fessConfig` |
+The project supports 20+ languages. When changing user-facing strings, labels, or error codes, propagate the change to all `fess_label_*.properties` and `fess_message_*.properties` files (and frontend i18n files).
 
-## Log Message Guidelines
+## Conventions
 
-- Logger: `LogManager.getLogger(ClassName.class)`
-- Format: `key=value` (e.g., `userId={}`, `url={}`)
-- Prefix with `[name]` when context identification is needed
-- Mask sensitive values (passwords, tokens)
-
-## i18n / Localization
-- This project supports up to 21 languages. When modifying user-facing strings, error codes, or labels, always propagate changes to ALL language files (fess_label_*.properties and frontend i18n files).
-
-## Important Patterns for AI Assistants
-
-### Do's
-1. Use `@Resource` for field injection (not constructor injection)
-2. Access helpers via `ComponentUtil.getXyzHelper()`
-3. Use `OptionalEntity<T>` for nullable entity returns
-4. Use DBFlute behavior classes (Bhv) for data access
-5. Put user-facing strings in `fess_label_*.properties`
-6. Run `mvn formatter:format` and `mvn license:format` before committing
-
-### Don'ts
-1. Don't edit files in `bsentity/` or `bsbhv/` (generated code)
-2. Don't use direct OpenSearch client in business code (use Bhv classes)
-3. Don't hardcode strings that should be internationalized
-4. Don't skip validation in form processing
-5. Don't log sensitive data (passwords, tokens, credentials)
-
-### Common Files to Check
-| Task | Files to Review |
-|------|-----------------|
-| Add admin feature | `app/web/admin/*/`, `app/service/`, `webapp/WEB-INF/view/admin/` |
-| Add API endpoint | `api/`, `app/web/api/` |
-| Modify search | `helper/SearchHelper.java`, `helper/QueryHelper.java` |
-| Add crawl config | `opensearch/config/`, `crawler/` |
-| Add SSO | `sso/`, `fess_sso.xml` |
-| Add i18n | `fess_label_*.properties`, `fess_message_*.properties` |
+- Use `@Resource` field injection (not constructor injection); access helpers via `ComponentUtil.getXyzHelper()`
+- Use Bhv classes for data access; use `OptionalEntity<T>` for nullable entities
+- Put user-facing strings in `fess_label_*.properties`; do not hardcode strings that should be internationalized
+- Do not edit generated code (`bsentity`/`bsbhv`); do not use the OpenSearch client directly in business code
+- Do not skip form validation; do not log secrets (passwords, tokens, credentials)
+- Loggers: `LogManager.getLogger(ClassName.class)`; log as `key=value`, masking sensitive values
+- Run `mvn formatter:format` and `mvn license:format` before committing
 
 ## External Resources
 
-- **Documentation**: https://fess.codelibs.org/
-- **GitHub**: https://github.com/codelibs/fess
-- **Issues**: https://github.com/codelibs/fess/issues
+- Documentation: https://fess.codelibs.org/
+- Repository: https://github.com/codelibs/fess
+- Issues: https://github.com/codelibs/fess/issues

--- a/README.md
+++ b/README.md
@@ -1,45 +1,53 @@
 # Fess: Enterprise Search Server
 [![Java CI with Maven](https://github.com/codelibs/fess/actions/workflows/maven.yml/badge.svg)](https://github.com/codelibs/fess/actions/workflows/maven.yml)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/gitbucket/gitbucket/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/codelibs/fess/blob/master/LICENSE)
 ![GitHub Release](https://img.shields.io/github/v/release/codelibs/fess)
-
 
 ## Overview
 
-Fess is a very powerful and easily deployable Enterprise Search Server. You can quickly install and run Fess on any platform where you can run the Java Runtime Environment. Fess is provided under the [Apache License 2.0](LICENSE).
+Fess is an enterprise search server that you can install and run on any platform with a Java runtime. It is built on [OpenSearch](https://github.com/opensearch-project/OpenSearch), but prior OpenSearch knowledge is not required: Fess is configured through a browser-based administration UI.
 
-Fess is based on [OpenSearch](https://github.com/opensearch-project/OpenSearch), but knowledge/experience about OpenSearch is _not_ required. Fess provides an easy to use Administration GUI to configure the system via your browser.
-Fess also contains a Crawler, which can crawl documents on a [web server](https://fess.codelibs.org/15.6/admin/webconfig-guide.html), [file system](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html), or [Data Store](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html) (such as a CSV or database). Many file formats are supported including (but not limited to): Microsoft Office, PDF, and zip.
+A built-in crawler collects documents from [web sites](https://fess.codelibs.org/15.7/admin/webconfig-guide.html), [file systems](https://fess.codelibs.org/15.7/admin/fileconfig-guide.html), and [data stores](https://fess.codelibs.org/15.7/admin/dataconfig-guide.html) such as databases and CSV files. Many file formats are supported, including Microsoft Office, PDF, and ZIP archives.
 
-*[Fess Site Search](https://github.com/codelibs/fess-site-search)* is a free alternative to [Google Site Search](https://enterprise.google.com/search/products/gss.html). For more details, see the [FSS JS Generator documentation](https://fss-generator.codelibs.org/docs/manual).
+[Fess Site Search](https://github.com/codelibs/fess-site-search) is a free alternative to Google Site Search that you can embed in your own website. For details, see the [FSS JS Generator documentation](https://fss-generator.codelibs.org/docs/manual).
 
-## Website
+## Features
 
-[fess.codelibs.org](https://fess.codelibs.org/)
+- Full-text search with faceting, sorting, and search suggestions
+- Crawlers for web sites, file systems, and data stores (databases, cloud storage, and SaaS)
+- Support for many document formats, including Microsoft Office, PDF, and archives
+- Browser-based administration UI and a REST API
+- Role- and permission-based filtering of search results
+- Single sign-on with LDAP, OpenID Connect, SAML, SPNEGO, and Microsoft Entra ID
+- Multilingual user interface and text analysis (20+ languages)
+- Extensible through data store, ingest, script, and theme plugins
 
-## Issues/Questions
+## Requirements
 
-[discuss.codelibs.org](https://discuss.codelibs.org/c/FessEN/)
+- Java 21 or later, for the TAR.GZ, ZIP, RPM, and DEB packages
+- OpenSearch as the search engine backend. The Docker images bundle it; for other installations you set it up separately.
+
+See the [Installation Guide](https://fess.codelibs.org/15.7/install/index.html) for supported versions and setup details.
 
 ## Getting Started
 
-There are 2 ways to try Fess. The first is to download and install yourself. The second is to use [Docker](https://www.docker.com/products/docker-engine).
+There are two ways to try Fess: download and install it yourself, or run it with [Docker](https://www.docker.com/products/docker-engine).
 
 ### Download and Install/Run
 
-Fess 15.6 is now available and can be downloaded on the [Releases page](https://github.com/codelibs/fess/releases "download"). Downloads come in 3 flavors: deb, rpm, zip.
+Fess 15.7 can be downloaded from the [Releases page](https://github.com/codelibs/fess/releases). Downloads are available in three formats: DEB, RPM, and ZIP.
 
-The following commands show how to use the zip download:
+The following commands show how to use the ZIP download:
 
-    $ unzip fess-15.6.x.zip
-    $ cd fess-15.6.x
+    $ unzip fess-15.7.x.zip
+    $ cd fess-15.7.x
     $ ./bin/fess
 
-For more details, see the [Installation Guide](https://fess.codelibs.org/15.6/install/index.html).
+For more details, see the [Installation Guide](https://fess.codelibs.org/15.7/install/index.html).
 
 ### Docker
 
-We provide Docker images on [ghcr.io](https://github.com/orgs/codelibs/packages). We also provide a Docker Compose (YAML) file in [this repository](https://github.com/codelibs/docker-fess/tree/master/compose). 
+Docker images are published on [ghcr.io](https://github.com/orgs/codelibs/packages). A Docker Compose file is available in the [docker-fess repository](https://github.com/codelibs/docker-fess/tree/master/compose).
 
 ### Browser UI
 
@@ -51,15 +59,15 @@ We provide Docker images on [ghcr.io](https://github.com/orgs/codelibs/packages)
 
 ![Admin UI](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-You can register crawling targets in the Admin UI on the (Web, File, Data Store) crawler configuration pages, and then start the Crawler manually on the [Scheduler page](https://fess.codelibs.org/15.6/admin/scheduler-guide.html).
+Register crawling targets on the Web, File, or Data Store configuration pages in the Admin UI, then start the crawler from the [Scheduler page](https://fess.codelibs.org/15.7/admin/scheduler-guide.html).
 
-## Migration from another search provider
+## Migration from Another Search Provider
 
-Please see [MIGRATION.md](MIGRATION.md).
+See [MIGRATION.md](MIGRATION.md).
 
 ## Data Store
 
-Currently, Fess supports crawling the following [storage locations and APIs](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html):
+Fess can crawl the following [storage locations and APIs](https://fess.codelibs.org/15.7/admin/dataconfig-guide.html):
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)
@@ -77,46 +85,51 @@ Currently, Fess supports crawling the following [storage locations and APIs](htt
  - [SharePoint](https://github.com/codelibs/fess-ds-sharepoint)
  - [Slack](https://github.com/codelibs/fess-ds-slack)
 
-## Theme
+## Plugins
+
+Fess can be extended with plugins. In addition to the data store connectors above, the following are available.
+
+### Theme
 
  - [Simple](https://github.com/codelibs/fess-theme-simple)
  - [Classic](https://github.com/codelibs/fess-theme-classic)
 
-## Ingest
+### Ingest
 
  - [Logger](https://github.com/codelibs/fess-ingest-logger)
  - [NDJSON](https://github.com/codelibs/fess-ingest-ndjson)
 
-## Script
+### Script
 
  - [Groovy](https://github.com/codelibs/fess-script-groovy)
  - [OGNL](https://github.com/codelibs/fess-script-ognl)
 
-## Development Information
+## Development
 
-### Get Source Code
+### Get the Source Code
 
-1. Clone Fess's repository:
+1. Clone the repository:
     ```
-    $ cd ~/workspace
     $ git clone https://github.com/codelibs/fess.git
     ```
-    
-2. Import the cloned repository as a [Maven](https://maven.apache.org/) project on [Eclipse](https://www.eclipse.org/eclipseide/) or another IDE.
 
-### Setup for OpenSearch Plugins
+2. Import it as a [Maven](https://maven.apache.org/) project in your IDE.
 
-Run antrun:run to download plugins into the plugins directory:
+Building Fess requires Java 21 or later and Maven.
+
+### Set Up OpenSearch Plugins
+
+Run `antrun:run` to download plugins into the plugins directory:
 
     $ mvn antrun:run
 
 ### Run Fess
 
-Run or debug org.codelibs.fess.FessBoot on your IDE, and then access http://localhost:8080/
+Run or debug `org.codelibs.fess.FessBoot` in your IDE, then open http://localhost:8080/.
 
-### Build Package
+### Build a Package
 
-Run the `package` goal and then the release file will be created in target/releases.
+Run the `package` goal to create the release file in `target/releases`:
 
     $ mvn package
     $ mvn rpm:rpm   # .rpm package
@@ -124,58 +137,67 @@ Run the `package` goal and then the release file will be created in target/relea
 
 ### Generate Source Code
 
-    $ mvn dbflute:download # (one time command)
+    $ mvn dbflute:download # one-time setup
     $ mvn dbflute:freegen
     $ mvn license:format
 
 ### Integration Tests
 
-Integration tests require a running Fess server with OpenSearch. Follow these steps:
+Integration tests require a running Fess server with OpenSearch.
 
-#### 1. Build Fess
+1. Build Fess:
 
-    $ mvn antrun:run  # Download OpenSearch plugins (if not done)
-    $ mvn package     # Build the package
+        $ mvn antrun:run  # download OpenSearch plugins, if not done already
+        $ mvn package
 
-#### 2. Start Fess Server
+2. Start the Fess server:
 
-    $ unzip target/releases/fess-*.zip
-    $ ./fess-*/bin/fess &
+        $ unzip target/releases/fess-*.zip
+        $ ./fess-*/bin/fess &
 
-Wait for Fess to be ready (this may take up to 60 seconds):
+    Wait for Fess to become ready (this may take up to 60 seconds). It returns a JSON response when ready:
 
-    $ curl -s "http://localhost:8080/api/v1/health"
+        $ curl -s "http://localhost:8080/api/v1/health"
 
-You should see a JSON response when Fess is ready.
+3. Clone the test data (required for `SearchApiTests`):
 
-#### 3. Clone Test Data
+        $ git clone https://github.com/codelibs/fess-testdata.git /tmp/fess-testdata
 
-Required for SearchApiTests:
+4. Run the tests:
 
-    $ git clone https://github.com/codelibs/fess-testdata.git /tmp/fess-testdata
+        $ mvn test -P integrationTests -Dtest.fess.url="http://localhost:8080" -Dtest.search_engine.url="http://localhost:9201"
 
-#### 4. Run Integration Tests
+    To run a single test case:
 
-    $ mvn test -P integrationTests -Dtest.fess.url="http://localhost:8080" -Dtest.search_engine.url="http://localhost:9201"
+        $ mvn test -P integrationTests -Dtest.fess.url="http://localhost:8080" -Dtest.search_engine.url="http://localhost:9201" -Dtest=SearchApiTests
 
-To run a single test case:
+## Contributing
 
-    $ mvn test -P integrationTests -Dtest.fess.url="http://localhost:8080" -Dtest.search_engine.url="http://localhost:9201" -Dtest=SearchApiTests
+Contributions are welcome. If you find a bug or have a feature request, please open an [issue](https://github.com/codelibs/fess/issues). For questions and discussion, use the [forum](https://discuss.codelibs.org/c/FessEN/). Pull requests for fixes and improvements are appreciated; for larger changes, discussing the approach first is recommended.
 
-### Translate In Your Language
+Before committing, format the code and license headers:
 
-Fess is internationalized software.
+    $ mvn formatter:format
+    $ mvn license:format
 
-If you want to add labels/messages for your language, please translate properties file and then rename to fess\_\*\_[lang].properties.
+### Adding a Language
 
-* [fess_label_en.properties](https://github.com/codelibs/fess/blob/master/src/main/resources/fess_label_en.properties)
-* [fess_message_en.properties](https://github.com/codelibs/fess/blob/master/src/main/resources/fess_message_en.properties)
+Fess is internationalized. To add labels and messages for a language, translate the property files below and rename them with your language code (`fess_*_[lang].properties`):
 
-For search/index analyzer, if [doc.json](https://github.com/codelibs/fess/blob/master/src/main/resources/fess_indices/fess/doc.json) contains lang\_[lang] for your language, please modify the analyzer for your language. For more details about Analyzers, see the [OpenSearch documentation](https://opensearch.org/docs/latest/analyzers/search-analyzers/).
+- [fess_label_en.properties](https://github.com/codelibs/fess/blob/master/src/main/resources/fess_label_en.properties)
+- [fess_message_en.properties](https://github.com/codelibs/fess/blob/master/src/main/resources/fess_message_en.properties)
 
-We welcome pull requests for your language.
+For search and index analysis, if [doc.json](https://github.com/codelibs/fess/blob/master/src/main/resources/fess_indices/fess/doc.json) contains `lang_[lang]` for your language, adjust the analyzer accordingly. See the [OpenSearch documentation](https://opensearch.org/docs/latest/analyzers/search-analyzers/) on analyzers for details. Pull requests for new languages are welcome.
 
-### Translations
+## Community and Support
+
+- Website and documentation: [fess.codelibs.org](https://fess.codelibs.org/)
+- Questions and discussion: [discuss.codelibs.org](https://discuss.codelibs.org/c/FessEN/)
+- Bug reports and feature requests: [GitHub Issues](https://github.com/codelibs/fess/issues)
+
+## Translations
+
+This README is available in other languages:
 
 - [日本語 (Japanese)](docs/ja/README.md)
 - [简体中文 (Simplified Chinese)](docs/zh-CN/README.md)
@@ -187,8 +209,12 @@ We welcome pull requests for your language.
 
 ## Powered By
 
-* [Lasta Di](https://github.com/lastaflute/lasta-di "Lasta Di"): DI Container
-* [LastaFlute](https://github.com/lastaflute/lastaflute "LastaFlute"): Web Framework
-* [Lasta Job](https://github.com/lastaflute/lasta-job "Lasta Job"): Job Scheduler
-* [Fess Crawler](https://github.com/codelibs/fess-crawler "Fess Crawler"): Web Crawler
-* [OpenSearch](https://opensearch.org/ "OpenSearch"): Search Engine
+- [Lasta Di](https://github.com/lastaflute/lasta-di): DI container
+- [LastaFlute](https://github.com/lastaflute/lastaflute): web framework
+- [Lasta Job](https://github.com/lastaflute/lasta-job): job scheduler
+- [Fess Crawler](https://github.com/codelibs/fess-crawler): web crawler
+- [OpenSearch](https://opensearch.org/): search engine
+
+## License
+
+Fess is distributed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ Fess can be extended with plugins. In addition to the data store connectors abov
 
 ### Theme
 
- - [Simple](https://github.com/codelibs/fess-theme-simple)
- - [Classic](https://github.com/codelibs/fess-theme-classic)
+ - [fess-themes](https://github.com/codelibs/fess-themes): a collection of static themes, each a self-contained single-page app installed by uploading a ZIP in the admin UI
 
 ### Ingest
 


### PR DESCRIPTION
## Summary

Refresh `README.md` for an open-source audience and trim `CLAUDE.md` to essential guidance.

### README.md
- Add **Features**, **Requirements** (Java 21+, OpenSearch backend), **Contributing**, and **License** sections
- Fix the License badge, which linked to another project's `LICENSE`, to point at this repository's `LICENSE`
- Bump version references from 15.6 to 15.7
- Group Theme / Ingest / Script under a single **Plugins** section and add a **Community and Support** section
- Naturalize the Overview prose and keep the existing structure, screenshots, and links

### CLAUDE.md
- Trim to essential, non-obvious guidance (~208 → ~98 lines)
- Remove the large directory tree, the generic naming-convention table, and derivable navigation tables
- Keep the LastaFlute/DBFlute patterns, the password-hashing note, i18n propagation rules, and the WAR→jar install tip

No source or configuration files are changed.
