### PR TITLE
perf(crawler): parse HTML once per page in FessXpathTransformer

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/transformer/FessXpathTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/FessXpathTransformer.java
@@ -145,6 +145,13 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
     private final Map<String, Pattern> convertUrlPatternCache = new ConcurrentHashMap<>();
 
     /**
+     * Thread-local holder for the {@link Document} parsed by {@link #storeData(ResponseData, ResultData)}.
+     * Reusing it in {@link #storeChildUrls(ResponseData, ResultData)} avoids parsing the same HTML body twice.
+     * The bean is a shared singleton across crawler threads, so an instance field would not be thread-safe.
+     */
+    private final ThreadLocal<Document> currentDocument = new ThreadLocal<>();
+
+    /**
      * Default constructor.
      */
     public FessXpathTransformer() {
@@ -185,6 +192,28 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
     }
 
     /**
+     * Transforms the response data, ensuring the thread-local parsed document is cleared afterward.
+     * <p>
+     * Delegates the actual transformation to the base {@link org.codelibs.fess.crawler.transformer.impl.HtmlTransformer#transform(ResponseData)},
+     * which calls {@link #storeData(ResponseData, ResultData)} (stashing the parsed {@link Document} into
+     * {@link #currentDocument}) and then {@link #storeChildUrls(ResponseData, ResultData)} (reusing it). The
+     * stashed document is removed in a finally block so a pooled crawler thread never leaks a DOM reference
+     * between pages.
+     * </p>
+     *
+     * @param responseData the response data from crawling
+     * @return the transformed result data
+     */
+    @Override
+    public ResultData transform(final ResponseData responseData) {
+        try {
+            return super.transform(responseData);
+        } finally {
+            currentDocument.remove();
+        }
+    }
+
+    /**
      * Stores parsed data from response into result data.
      * Processes HTML content using XPath expressions and handles robots tags.
      *
@@ -211,6 +240,9 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
         }
 
         final Document document = parser.getDocument();
+        // Stash the parsed document so storeChildUrls (called later, possibly from
+        // applyRobotsDirective for the noindex case) can reuse it instead of re-parsing.
+        currentDocument.set(document);
 
         processMetaRobots(responseData, resultData, document);
         processXRobotsTag(responseData, resultData);
@@ -237,7 +269,10 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
                     final Boolean isPruned = fieldPrunedRuleMap.get(entry.getKey());
                     Node value = getXPathAPI().selectSingleNode(document, entry.getValue());
                     if (value != null && isPruned != null && isPruned.booleanValue()) {
-                        value = pruneNode(value, getCrawlingConfig(responseData));
+                        // Prune a deep clone, not the live node, since document is shared with
+                        // child-URL/anchor extraction (see currentDocument) - pruning in place would
+                        // silently drop <A> links nested under pruned nodes (e.g. //H1, //H2, //H3).
+                        value = pruneNode(value.cloneNode(true), getCrawlingConfig(responseData));
                     }
                     putResultDataBody(dataMap, entry.getKey(), value != null ? value.getTextContent() : null);
                     break;
@@ -974,6 +1009,36 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
             urlSet.add(requestData.getUrl());
         }
         return new ArrayList<>(urlSet);
+    }
+
+    /**
+     * Stores child URLs found in the HTML content, reusing the {@link Document} already parsed by
+     * {@link #storeData(ResponseData, ResultData)} instead of re-parsing the response body.
+     * <p>
+     * Falls back to the base (re-parsing) implementation if no document was stashed, which should not
+     * happen on the normal {@code transform()} path but guards against direct callers.
+     * </p>
+     *
+     * @param responseData the response data containing the HTML content
+     * @param resultData the result data to store child URLs in
+     */
+    @Override
+    protected void storeChildUrls(final ResponseData responseData, final ResultData resultData) {
+        final Document document = currentDocument.get();
+        if (document == null) {
+            super.storeChildUrls(responseData, resultData);
+            return;
+        }
+        // Mirror the exception handling of the base storeChildUrls(ResponseData, ResultData) so callers
+        // observe the same behavior: rethrow CrawlerSystemException as-is, wrap anything else (including
+        // the MalformedURLException the three-arg overload declares) in a CrawlerSystemException.
+        try {
+            storeChildUrls(responseData, resultData, document);
+        } catch (final CrawlerSystemException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new CrawlerSystemException("Could not store data.", e);
+        }
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/crawler/transformer/FessXpathTransformerTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/transformer/FessXpathTransformerTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.crawler.transformer;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -66,7 +67,6 @@ import org.codelibs.fess.util.MemoryUtil;
 import org.codelibs.nekohtml.parsers.DOMParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.lastaflute.di.core.exception.ComponentNotFoundException;
 import org.lastaflute.di.core.factory.SingletonLaContainerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -89,17 +89,7 @@ public class FessXpathTransformerTest extends UnitFessTestCase {
 
         final FessXpathTransformer fessXpathTransformer = new FessXpathTransformer();
         fessXpathTransformer.init();
-        SingletonLaContainerFactory.getContainer().register(CrawlingInfoHelper.class, "crawlingInfoHelper");
-        SingletonLaContainerFactory.getContainer().register(PathMappingHelper.class, "pathMappingHelper");
-        SingletonLaContainerFactory.getContainer().register(CrawlingConfigHelper.class, "crawlingConfigHelper");
-        SingletonLaContainerFactory.getContainer().register(SystemHelper.class, "systemHelper");
-        SingletonLaContainerFactory.getContainer().register(FileTypeHelper.class, "fileTypeHelper");
-        SingletonLaContainerFactory.getContainer().register(DocumentHelper.class, "documentHelper");
-        SingletonLaContainerFactory.getContainer().register(LabelTypeHelper.class, "labelTypeHelper");
-
-        WebConfig webConfig = new WebConfig();
-        ComponentUtil.getCrawlingConfigHelper().store("test", webConfig);
-        setValueToObject(ComponentUtil.getLabelTypeHelper(), "labelTypePatternList", new ArrayList<LabelTypePattern>());
+        final String sessionId = registerCrawlingHelpers();
 
         System.gc();
         long current = MemoryUtil.getUsedMemory();
@@ -117,7 +107,7 @@ public class FessXpathTransformerTest extends UnitFessTestCase {
             responseData.setMimeType("text/html");
             responseData.setParentUrl("http://fess.codelibs.org/");
             responseData.setResponseBody(data.getBytes());
-            responseData.setSessionId("test-1");
+            responseData.setSessionId(sessionId);
             responseData.setStatus(0);
             responseData.setUrl("http://fess.codelibs.org/test.html");
             /*ResultData resultData =*/fessXpathTransformer.transform(responseData);
@@ -141,6 +131,191 @@ public class FessXpathTransformerTest extends UnitFessTestCase {
         Field field = ClassUtil.getDeclaredField(obj.getClass(), name);
         field.setAccessible(true);
         FieldUtil.set(field, obj, value);
+    }
+
+    /** Guards the one-time container registration in {@link #registerCrawlingHelpers()}; the
+     *  LastaDi container is a JVM-wide singleton that is not reset between test methods, and
+     *  registering the same component name into it twice throws TooManyRegistrationComponentException. */
+    private static boolean crawlingHelpersRegistered = false;
+
+    /**
+     * Registers the helpers needed to run a full {@link FessXpathTransformer#transform(ResponseData)}
+     * call (mirrors the original setup in {@link #test_transform()}), and returns a fresh session id
+     * to use with {@link ResponseData#setSessionId(String)} so {@code getCrawlingConfig(responseData)}
+     * resolves a freshly-stored {@link WebConfig}. Safe to call from multiple test methods.
+     */
+    private String registerCrawlingHelpers() {
+        if (!crawlingHelpersRegistered) {
+            SingletonLaContainerFactory.getContainer().register(CrawlingInfoHelper.class, "crawlingInfoHelper");
+            SingletonLaContainerFactory.getContainer().register(PathMappingHelper.class, "pathMappingHelper");
+            SingletonLaContainerFactory.getContainer().register(CrawlingConfigHelper.class, "crawlingConfigHelper");
+            SingletonLaContainerFactory.getContainer().register(SystemHelper.class, "systemHelper");
+            SingletonLaContainerFactory.getContainer().register(FileTypeHelper.class, "fileTypeHelper");
+            SingletonLaContainerFactory.getContainer().register(DocumentHelper.class, "documentHelper");
+            SingletonLaContainerFactory.getContainer().register(LabelTypeHelper.class, "labelTypeHelper");
+            crawlingHelpersRegistered = true;
+        }
+
+        final WebConfig webConfig = new WebConfig();
+        // A real crawl always stores a WebConfig with a DB-assigned id; give it one here too, since
+        // CrawlingConfig#getConfigId() (used by FessXpathTransformer#pruneNode's cache key) returns
+        // null for an id-less WebConfig, and the field-rule loop's default branch only catches
+        // XPathExpressionException - not the NullPointerException that a null cache key triggers.
+        webConfig.setId("1");
+        final String sessionId = ComponentUtil.getCrawlingConfigHelper().store("test", webConfig);
+        setValueToObject(ComponentUtil.getLabelTypeHelper(), "labelTypePatternList", new ArrayList<LabelTypePattern>());
+        return sessionId;
+    }
+
+    private ResponseData createHtmlResponseData(final String sessionId, final String url, final String html) {
+        final ResponseData responseData = new ResponseData();
+        responseData.setCharSet("UTF-8");
+        responseData.setContentLength(html.length());
+        responseData.setExecutionTime(1000L);
+        responseData.setHttpStatusCode(200);
+        responseData.setLastModified(new Date());
+        responseData.setMethod("GET");
+        responseData.setMimeType("text/html");
+        responseData.setParentUrl("http://fess.codelibs.org/");
+        responseData.setResponseBody(html.getBytes());
+        responseData.setSessionId(sessionId);
+        responseData.setStatus(0);
+        responseData.setUrl(url);
+        return responseData;
+    }
+
+    @Test
+    public void test_transform_linkUnderPrunedHeading_isDiscovered() throws Exception {
+        final String sessionId = registerCrawlingHelpers();
+
+        // The page1 link sits inside a <NAV>, which is itself nested inside an <H1>. The <H1> is
+        // pruned (as "important_content") by the default Fess field-rule wiring (see
+        // crawler/transformer.xml), and <NAV> is one of the default crawler.document.html.pruned.tags
+        // (see fess_config.properties: "noscript,script,style,header,footer,aside,nav,a[rel=nofollow]").
+        // pruneNode/pruneNodeByTags (FessXpathTransformer) only remove descendants that match a
+        // configured pruned-tag pattern - a bare <A> matches none of them, so it is never actually
+        // removed by pruning. Nesting the link under a genuinely-pruned <NAV> is what makes this
+        // fixture exercise the clone-before-prune fix: reverting to pruning the live H1 node removes
+        // the <NAV> (and the page1 link inside it) from the shared document before child-URL
+        // extraction runs.
+        final String html = "<html><head><title>Test</title></head><body>"
+                + "<h1>Heading Text<nav><a href=\"http://example.com/page1.html\">Nav Link</a></nav></h1>" //
+                + "<p><a href=\"http://example.com/page2.html\">Body Link</a></p>" //
+                + "</body></html>";
+
+        final FessXpathTransformer transformer = new FessXpathTransformer();
+        transformer.init();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+        // Mirrors the production field rules registered in crawler/transformer.xml.
+        transformer.addFieldRule("title", "//TITLE", true);
+        transformer.addFieldRule("important_content", "//*[self::H1 or self::H2 or self::H3]", true);
+
+        final ResponseData responseData = createHtmlResponseData(sessionId, "http://example.com/", html);
+
+        final ResultData resultData = transformer.transform(responseData);
+
+        // Without the clone-before-prune fix, pruning the LIVE H1 node in storeData's field-rule
+        // loop would remove the nested <NAV> - and the page1 link inside it - from the shared
+        // document before child-URL extraction runs, silently dropping this link. This assertion
+        // fails without that fix.
+        final Set<String> childUrls = resultData.getChildUrlSet().stream().map(RequestData::getUrl).collect(Collectors.toSet());
+        assertEquals(2, childUrls.size(), "child URLs: " + childUrls);
+        assertTrue(childUrls.contains("http://example.com/page1.html"),
+                "child URL nested under a pruned <NAV> inside a pruned H1 was lost: " + childUrls);
+        assertTrue(childUrls.contains("http://example.com/page2.html"), "missing page2: " + childUrls);
+
+        // The pruned field value itself must have the <NAV> content removed, proving pruning
+        // actually occurred on the (cloned) H1 node.
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> dataMap = (Map<String, Object>) resultData.getRawData();
+        final String importantContent = (String) dataMap.get("important_content");
+        assertEquals("Heading Text", importantContent.trim());
+        assertFalse(importantContent.contains("Nav Link"), "important_content should not contain pruned nav text: " + importantContent);
+    }
+
+    @Test
+    public void test_transform_parsesBodyOnce() throws Exception {
+        final String sessionId = registerCrawlingHelpers();
+
+        final String html = "<html><head><title>Test</title></head><body>" //
+                + "<p>Welcome. <a href=\"http://example.com/page1.html\">Link1</a></p>" //
+                + "</body></html>";
+
+        final FessXpathTransformer transformer = new FessXpathTransformer();
+        transformer.init();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+        transformer.addFieldRule("title", "//TITLE", true);
+
+        final int[] bodyReadCount = { 0 };
+        final ResponseData responseData = new ResponseData() {
+            @Override
+            public InputStream getResponseBody() {
+                bodyReadCount[0]++;
+                return super.getResponseBody();
+            }
+        };
+        responseData.setCharSet("UTF-8");
+        responseData.setContentLength(html.length());
+        responseData.setExecutionTime(1000L);
+        responseData.setHttpStatusCode(200);
+        responseData.setLastModified(new Date());
+        responseData.setMethod("GET");
+        responseData.setMimeType("text/html");
+        responseData.setParentUrl("http://fess.codelibs.org/");
+        responseData.setResponseBody(html.getBytes());
+        responseData.setSessionId(sessionId);
+        responseData.setStatus(0);
+        responseData.setUrl("http://example.com/");
+
+        transformer.transform(responseData);
+
+        // The response body is read exactly 3 times per transform() call:
+        //   1) HtmlTransformer.updateCharset(...) sniffs the charset (base class, before storeData)
+        //   2) FessXpathTransformer.storeData(...) parses the DOM - this is the Document that gets
+        //      reused for child-URL/anchor extraction
+        //   3) processAdditionalData(...) reads the raw bytes again to populate the "cache" field
+        //      (crawler.document.cache.enabled=true by default for text/html)
+        // Crucially, there is NO 4th read: storeChildUrls(responseData, resultData) reuses the
+        // Document stashed by storeData instead of re-parsing the body via a fresh DOMParser -
+        // that removed 4th read is exactly what this test guards against regressing.
+        assertEquals(3, bodyReadCount[0]);
+    }
+
+    @Test
+    public void test_transform_normalPage_fieldsAndChildUrlsUnaffected() throws Exception {
+        final String sessionId = registerCrawlingHelpers();
+
+        final String html = "<html><head><title>Test Page</title></head><body>" //
+                + "<p>Welcome. <a href=\"http://example.com/page1.html\">Link1</a></p>" //
+                + "<p><a href=\"http://example.com/page2.html\">Link2</a></p>" //
+                + "</body></html>";
+
+        final FessXpathTransformer transformer = new FessXpathTransformer();
+        transformer.init();
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("//A", "href");
+        transformer.setChildUrlRuleMap(rules);
+        transformer.addFieldRule("title", "//TITLE", true);
+        transformer.addFieldRule("important_content", "//*[self::H1 or self::H2 or self::H3]", true);
+
+        final ResponseData responseData = createHtmlResponseData(sessionId, "http://example.com/", html);
+
+        final ResultData resultData = transformer.transform(responseData);
+
+        final Set<String> childUrls = resultData.getChildUrlSet().stream().map(RequestData::getUrl).collect(Collectors.toSet());
+        assertEquals(2, childUrls.size());
+        assertTrue(childUrls.contains("http://example.com/page1.html"), "missing page1: " + childUrls);
+        assertTrue(childUrls.contains("http://example.com/page2.html"), "missing page2: " + childUrls);
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> dataMap = (Map<String, Object>) resultData.getRawData();
+        assertEquals("Test Page", dataMap.get("title"));
+        // No H1/H2/H3 present on this page.
+        assertNull(dataMap.get("important_content"));
     }
 
     @Test
@@ -681,12 +856,20 @@ public class FessXpathTransformerTest extends UnitFessTestCase {
         final ResponseData responseData = new ResponseData();
         responseData.setUrl("http://example.com/");
 
+        // Absent or self-referential canonical URLs must never trigger a ChildUrlsException
+        // redirect. processAdditionalData() continues past the canonical check into code that
+        // needs other DI components not set up in this narrow unit test; whether that surfaces
+        // as ComponentNotFoundException or (if a sibling test has since registered those
+        // components into the shared, JVM-wide container) another exception like
+        // NullPointerException is incidental environment noise, not the behavior under test.
         String data = "<html><body>aaa</body></html>";
         Document document = getDocument(data);
         try {
             transformer.processAdditionalData(dataMap, responseData, document);
             fail();
-        } catch (final ComponentNotFoundException e) {
+        } catch (final ChildUrlsException e) {
+            fail("Unexpected canonical redirect: " + e.getChildUrlList());
+        } catch (final Exception e) {
             // ignore
         }
 
@@ -695,7 +878,9 @@ public class FessXpathTransformerTest extends UnitFessTestCase {
         try {
             transformer.processAdditionalData(dataMap, responseData, document);
             fail();
-        } catch (final ComponentNotFoundException e) {
+        } catch (final ChildUrlsException e) {
+            fail("Unexpected canonical redirect: " + e.getChildUrlList());
+        } catch (final Exception e) {
             // ignore
         }
 


### PR DESCRIPTION
## Summary

Parse each crawled HTML page's DOM once instead of twice. `FessXpathTransformer` previously parsed the response body into a DOM in `storeData` (field/anchor extraction) and then the inherited `HtmlTransformer.storeChildUrls` parsed the same body a second time for child-URL discovery.

## Dependency

Requires **codelibs/fess-crawler#177** (the `storeChildUrls(ResponseData, ResultData, Document)` overload). Merge that first; this PR builds against fess-crawler `15.8.0-SNAPSHOT` including it.

## Changes

- Stash the `Document` parsed in `storeData` into a `ThreadLocal` (the transformer is a shared singleton across crawler threads, so an instance field would not be thread-safe).
- Override the two-argument `storeChildUrls` to reuse that `Document` via the new base three-argument overload instead of re-parsing. Its exception handling mirrors the base method exactly — and since `ChildUrlsException extends CrawlerSystemException`, the canonical/noindex redirect mechanism is preserved with its original type.
- Wrap `transform()` in a `try/finally` that clears the `ThreadLocal`, so a pooled crawler thread never leaks or reuses a stale DOM. A defensive `null` check falls back to the base (re-parsing) method.
- Clone-before-prune fix: the field-rule loop's `default` branch prunes a deep clone instead of the live node.

## Behavior notes

Because the DOM is now shared between field extraction and child-URL/anchor discovery:
- **Clone-before-prune** prevents links nested under pruned subtrees (e.g. a `<nav>` inside a pruned `//H1`/`//H2`/`//H3`) from being silently dropped from child-URL discovery. The indexed field value (`getTextContent()` of the pruned clone) is byte-identical to before.
- Child-URL/anchor extraction now runs on the `storeData` parse (Fess-detected charset via `InputSource.setEncoding` + UTF-8 BOM strip) instead of a separate neko auto-detected parse — a consistency improvement, converging on the charset already used for content/anchor extraction.
- The indexed `anchor` field can now also retain links under pruned-tag subtrees nested in headings.

## Testing

- `test_transform_linkUnderPrunedHeading_isDiscovered` — a link nested under a pruned `<nav>` inside a pruned heading is still discovered. Verified to FAIL if the clone-before-prune fix is reverted to in-place pruning (the link is dropped), i.e. it genuinely guards the regression.
- `test_transform_parsesBodyOnce` — asserts the response body is read exactly 3 times per `transform()` (charset sniff + `storeData` parse + document-cache read); there is no 4th read, confirming child-URL discovery no longer re-parses.
- `test_transform_normalPage_fieldsAndChildUrlsUnaffected` — ordinary pages extract identical fields and child URLs.
- `FessXpathTransformerTest`: 65 tests pass; `mvn formatter:format` / `license:format` clean.
