### PR TITLE
fix(api): stream all documents from /api/v2/documents/all

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandler.java
@@ -137,10 +137,14 @@ public class ScrollSearchHandler {
                 final Map<String, Object> line = new LinkedHashMap<>();
                 line.put("data", filtered);
                 try {
-                    // writeValue(writer, …) leaves the writer open between calls when the
-                    // target is a Writer (not OutputStream) — required so we can keep
-                    // streaming subsequent NDJSON lines.
-                    MAPPER.writeValue(writer, line);
+                    // Serialize to a String first, then write. Passing the servlet writer to
+                    // MAPPER.writeValue(Writer, …) closes it after the first line — Jackson's
+                    // JsonGenerator.Feature.AUTO_CLOSE_TARGET defaults to true, so the generator's
+                    // close() closes the underlying writer. Once closed, PrintWriter silently
+                    // swallows every subsequent write (it never throws, only sets an error flag),
+                    // so only the first document would reach the client while the scroll still
+                    // iterates all N matching documents.
+                    writer.write(MAPPER.writeValueAsString(line));
                     writer.write('\n');
                     wroteAnyLine[0] = true;
                 } catch (final IOException e) {
@@ -176,7 +180,9 @@ public class ScrollSearchHandler {
                     errBody.put("code", "internal_error");
                     errBody.put("message", "stream error");
                     errLine.put("error", errBody);
-                    MAPPER.writeValue(w, errLine);
+                    // Serialize first (see the success-path comment above): writeValue(Writer,…)
+                    // would close the writer before the trailing newline could be written.
+                    w.write(MAPPER.writeValueAsString(errLine));
                     w.write('\n');
                     response.flushBuffer();
                 } catch (final Exception flushEx) {

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandlerTest.java
@@ -23,7 +23,15 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.codelibs.fess.entity.SearchRequestParams;
+import org.codelibs.fess.helper.SearchHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.query.QueryFieldConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.BooleanFunction;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.AsyncContext;
@@ -141,6 +149,82 @@ public class ScrollSearchHandlerTest extends UnitFessTestCase {
         } else {
             assertTrue(res.contentType == null || res.contentType.startsWith("application/json"),
                     "unexpected content-type " + res.contentType);
+        }
+    }
+
+    /**
+     * Regression: {@code /api/v2/documents/all} must stream <em>every</em> matched
+     * document, not just the first.
+     *
+     * <p>The scroll helper faithfully iterates all N hits and invokes the cursor once per
+     * hit (mirroring {@code SearchEngineClient.scrollSearch}). If the NDJSON writer is
+     * closed after the first line — e.g. by {@code ObjectMapper.writeValue(Writer, …)},
+     * whose {@code AUTO_CLOSE_TARGET} default closes the servlet writer — the remaining
+     * documents are silently dropped ({@code PrintWriter} swallows post-close writes),
+     * so only one line reaches the client while the log still reports all N loaded.</p>
+     *
+     * <p>This test stubs the scroll helper to emit three documents and asserts all three
+     * NDJSON lines are present.</p>
+     */
+    @Test
+    public void test_scroll_writesEveryDocumentNotJustFirst() throws Exception {
+        final FessConfig originalConfig = ComponentUtil.getFessConfig();
+        // The unit container (test_app.xml) defines neither searchHelper nor queryFieldConfig,
+        // so both are supplied as stubs below; UTFlute rebuilds the container per test method,
+        // so the stub registrations do not leak into sibling tests.
+        final int docCount = 3;
+        try {
+            // Reach the streaming branch (api.search.scroll defaults to false).
+            ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public boolean isApiSearchScroll() {
+                    return true;
+                }
+            });
+            // Keep every field so filterDoc does not strip the payload.
+            ComponentUtil.register(new QueryFieldConfig() {
+                @Override
+                public boolean isApiResponseField(final String field) {
+                    return true;
+                }
+            }, "queryFieldConfig");
+            // Emit three documents through the cursor, one per hit.
+            ComponentUtil.register(new SearchHelper() {
+                @Override
+                public long scrollSearch(final SearchRequestParams params, final BooleanFunction<Map<String, Object>> cursor,
+                        final OptionalThing<FessUserBean> userBean) {
+                    long count = 0;
+                    for (int i = 0; i < docCount; i++) {
+                        final Map<String, Object> doc = new HashMap<>();
+                        doc.put("doc_id", "id-" + i);
+                        doc.put("title", "title-" + i);
+                        count++;
+                        if (!cursor.apply(doc)) {
+                            break;
+                        }
+                    }
+                    return count;
+                }
+            }, "searchHelper");
+
+            final ScrollSearchHandler handler = new ScrollSearchHandler();
+            final CapturingResponse res = new CapturingResponse();
+            final Map<String, String[]> params = new HashMap<>();
+            params.put("q", new String[] { "*" });
+            handler.handle(new StubRequest("/api/v2/documents/all", params), res);
+
+            final String body = res.body();
+            // UnitFessTestCase.assertEquals(String,Object,Object) is message-first.
+            assertEquals(body, "application/x-ndjson; charset=UTF-8", res.contentType);
+            final String[] lines = body.split("\n");
+            assertEquals(docCount, lines.length, "expected " + docCount + " NDJSON lines, got: " + body);
+            assertTrue(body.contains("id-0"), body);
+            assertTrue(body.contains("id-1"), body);
+            assertTrue(body.contains("id-2"), body);
+        } finally {
+            ComponentUtil.setFessConfig(originalConfig);
         }
     }
 


### PR DESCRIPTION
## Summary

`GET /api/v2/documents/all` (the NDJSON scroll export) returned only the **first** document even though the scroll iterated every matching hit and the debug log reported the full count (e.g. `Loaded 29 documents`). The stream stopped after one line with no error surfaced.

Requires `api.search.scroll=true` (the endpoint is otherwise disabled).

## Root cause

`ScrollSearchHandler` serialized each line with `ObjectMapper.writeValue(writer, line)` on the servlet `response.getWriter()`. Jackson's `JsonGenerator.Feature.AUTO_CLOSE_TARGET` defaults to `true`, so the generator's `close()` closes the underlying `PrintWriter` **after the first document**. A closed `PrintWriter` silently swallows all subsequent writes (it never throws — it only sets an internal error flag), so documents #2..N and their newlines were discarded while the scroll loop still ran to completion. Because nothing threw, the handler logged the full count while the client received a single line.

## Fix

Serialize each line to a `String` first, then write it, so the response writer stays open for the whole stream:

```java
writer.write(MAPPER.writeValueAsString(line));
writer.write('\n');
```

The mid-stream error terminator gets the same treatment so its trailing newline is emitted.

## Tests

Adds `ScrollSearchHandlerTest#test_scroll_writesEveryDocumentNotJustFirst`, which stubs the scroll helper to emit three documents and asserts all three NDJSON lines are present — it fails before the fix (1 line) and passes after (3 lines). Full `ScrollSearchHandlerTest` (5 tests) and `SearchApiV2ManagerTest` (27 tests) pass.