### PR TITLE
fix: quote the replacement when highlighting cached content

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/ViewHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ViewHelper.java
@@ -802,7 +802,9 @@ public class ViewHelper {
             m.appendReplacement(segBuf, StringUtil.EMPTY);
             String segment = segBuf.toString();
             for (int i = 0; i < queries.length; i++) {
-                segment = Pattern.compile(regexQueries[i], Pattern.CASE_INSENSITIVE).matcher(segment).replaceAll(hlQueries[i]);
+                segment = Pattern.compile(regexQueries[i], Pattern.CASE_INSENSITIVE)
+                        .matcher(segment)
+                        .replaceAll(Matcher.quoteReplacement(hlQueries[i]));
             }
             buf.append(segment);
             buf.append(m.group(0));
@@ -811,7 +813,9 @@ public class ViewHelper {
         m.appendTail(segBuf);
         String segment = segBuf.toString();
         for (int i = 0; i < queries.length; i++) {
-            segment = Pattern.compile(regexQueries[i], Pattern.CASE_INSENSITIVE).matcher(segment).replaceAll(hlQueries[i]);
+            segment = Pattern.compile(regexQueries[i], Pattern.CASE_INSENSITIVE)
+                    .matcher(segment)
+                    .replaceAll(Matcher.quoteReplacement(hlQueries[i]));
         }
         buf.append(segment);
         return buf.toString();

--- a/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ViewHelperTest.java
@@ -605,6 +605,45 @@ public class ViewHelperTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_replaceHighlightQueries_highlightQueryWithDollar() {
+        // ViewHelper:805/814 called replaceAll() without Matcher.quoteReplacement, so
+        // a query containing '$' was parsed as a group reference and threw
+        // IndexOutOfBoundsException -> CacheHandler mapped it to HTTP 500.
+        // Search and cache-highlighting use different matching: search is
+        // token-based (the analyzer turns "$12" into token "12"), while
+        // replaceHighlightQueries matches the raw substring via Pattern.quote.
+        // So a query like "$12" against a page containing the literal "$12"
+        // both hits search (token "12") and reaches this method, whose own
+        // "$1" prefix is then read by replaceAll() as a group reference into
+        // the (group-less) quoted pattern. Verified against a released Fess
+        // image, not just this unit test. (createCacheContent is not used
+        // here because it resolves a real WEB-INF/view path via the servlet
+        // context before reaching the highlight code, which is not available
+        // in this unit test harness; replaceHighlightQueries is the protected
+        // method that actually contains the bug and is directly reachable
+        // from this test.)
+        String text = "Price is $1 per unit.";
+        String[] queries = { "$1" };
+        assertEquals("Price is <strong>$1</strong> per unit.", viewHelper.replaceHighlightQueries(text, queries));
+
+        // The real-world trigger: "$12" on a pricing FAQ hits search (token
+        // "12") and its raw substring is matched by the highlighter, whose
+        // "$1" prefix used to be read as a group reference.
+        String priceText = "Plans start at $12 per month.";
+        String[] priceQueries = { "$12" };
+        assertEquals("Plans start at <strong>$12</strong> per month.", viewHelper.replaceHighlightQueries(priceText, priceQueries));
+
+        // A '$' NOT followed by a digit takes a different path through
+        // Matcher.appendReplacement (IllegalArgumentException: "Illegal group
+        // reference", instead of IndexOutOfBoundsException) but is fixed the
+        // same way by Matcher.quoteReplacement(); verified with a scratch
+        // regex repro before asserting this.
+        String noDigitText = "Contact us at $support for help.";
+        String[] noDigitQueries = { "$support" };
+        assertEquals("Contact us at <strong>$support</strong> for help.", viewHelper.replaceHighlightQueries(noDigitText, noDigitQueries));
+    }
+
+    @Test
     public void test_getClientIp() {
         ViewHelper viewHelper = new ViewHelper();
         viewHelper.init();


### PR DESCRIPTION
`ViewHelper.replaceHighlightQueries()` passed the highlight replacement to
`Matcher.replaceAll()` unquoted, so a `$` in the query was parsed as a group
reference against a pattern that has none, throwing `IndexOutOfBoundsException`
(or `IllegalArgumentException` when the `$` is not followed by a digit).
`CacheHandler` maps that to **HTTP 500**.

`ViewHelper:318` already used `Matcher.quoteReplacement()`; this brings the other
two call sites (`:805`, `:814`) in line. The pattern side is `Pattern.quote()`d,
so it has no capturing groups and `$n` never had a legitimate meaning here —
quoting changes nothing for inputs that already worked.

### How it is reached

Search and cache highlighting match differently:

* **Search** is token-based — the analyzer turns a price like `$12` into the token `12`.
* **`replaceHighlightQueries`** matches the **raw substring** via `Pattern.quote`.

So a user searching for a price shown on the page gets hits, and opening the
cached view forwards that term as `hq`. The replacement `<strong>$12</strong>` is
then evaluated, and its own `$1` prefix is read as a group reference.

Every bundled UI is affected: the `bootstrap` static theme forwards
`highlight_params` as `hq` to `/cache/`.

### Reproduced against a released image (15.7.0)

A crawled page containing the literal `$12`:

| request | result |
|---|---|
| `q=plan` → `/api/v2/cache/{id}?hq=plan` | 200 |
| `q=$12` (2 hits) → `/api/v2/cache/{id}?hq=%2412` | **500** |
| `q=$49` (2 hits) → `/api/v2/cache/{id}?hq=%2449` | **500** |
| `/api/v2/cache/{id}?hq=%249` (page has no `$9`) | 200 — no substring match, replacement never evaluated |

After the fix the term is highlighted literally and the request returns 200.

### Tests

`ViewHelperTest#test_replaceHighlightQueries_highlightQueryWithDollar` covers
`$1`, `$12` (the real-world trigger) and `$support` (`$` not followed by a digit).
It fails on the current code with `IndexOutOfBoundsException: No group 1`.
`ViewHelperTest` passes 30/30 with the fix.
