### PR TITLE
fix(theme): drop raw-text elements instead of unwrapping in the bootstrap sanitizer

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/format.js
+++ b/src/main/webapp/themes/bootstrap/assets/format.js
@@ -97,6 +97,30 @@ const ALLOWED_TAGS = new Set([
 ]);
 
 /**
+ * Elements dropped whole, children included, rather than unwrapped like an
+ * ordinary disallowed tag. For the raw-text members — SCRIPT, STYLE,
+ * TEXTAREA, TITLE, XMP, PLAINTEXT, NOEMBED, NOFRAMES — and for IFRAME,
+ * OBJECT, EMBED, the child "text" is the element's own source or markup,
+ * not prose: unwrapping would surface that source as visible content (a
+ * <script> body becomes the literal string "alert(1)"). NOSCRIPT is
+ * dropped for a different reason: sanitizeHtml() parses with a <template>
+ * element, which runs with the scripting flag disabled, so a <noscript>'s
+ * children parse as ordinary elements, not raw text — but that content is
+ * a no-JS fallback, meaningless in this JS-required SPA, so it is dropped
+ * rather than unwrapped. TEMPLATE is kept mainly for foreign content:
+ * inside <svg>, a <template> has real childNodes and no `.content`
+ * fragment, so it would otherwise leak its text like the raw-text members
+ * above; in ordinary HTML content its children live in `.content`, a
+ * fragment this function never traverses, so dropping it here is usually
+ * a no-op.
+ */
+const DROP_WITH_CONTENT = new Set([
+  "SCRIPT", "STYLE", "TEXTAREA", "TITLE", "NOSCRIPT",
+  "IFRAME", "OBJECT", "EMBED", "TEMPLATE", "XMP",
+  "PLAINTEXT", "NOEMBED", "NOFRAMES"
+]);
+
+/**
  * Allowed attributes per tag (lowercase tag name → Set of lowercase attr names).
  * Attributes not listed here are stripped.
  */
@@ -155,6 +179,12 @@ function sanitizeNode(node) {
 
   if (node.nodeType === Node.ELEMENT_NODE) {
     const tag = node.tagName.toUpperCase();
+
+    if (DROP_WITH_CONTENT.has(tag)) {
+      // See the DROP_WITH_CONTENT comment above for why each member is
+      // dropped whole here instead of being unwrapped.
+      return null;
+    }
 
     if (!ALLOWED_TAGS.has(tag)) {
       // Disallowed tag: unwrap — keep its sanitized children in a fragment.

--- a/src/main/webapp/themes/bootstrap/assets/format.js
+++ b/src/main/webapp/themes/bootstrap/assets/format.js
@@ -98,26 +98,37 @@ const ALLOWED_TAGS = new Set([
 
 /**
  * Elements dropped whole, children included, rather than unwrapped like an
- * ordinary disallowed tag. For the raw-text members — SCRIPT, STYLE,
- * TEXTAREA, TITLE, XMP, PLAINTEXT, NOEMBED, NOFRAMES — and for IFRAME,
- * OBJECT, EMBED, the child "text" is the element's own source or markup,
- * not prose: unwrapping would surface that source as visible content (a
- * <script> body becomes the literal string "alert(1)"). NOSCRIPT is
- * dropped for a different reason: sanitizeHtml() parses with a <template>
- * element, which runs with the scripting flag disabled, so a <noscript>'s
- * children parse as ordinary elements, not raw text — but that content is
- * a no-JS fallback, meaningless in this JS-required SPA, so it is dropped
- * rather than unwrapped. TEMPLATE is kept mainly for foreign content:
- * inside <svg>, a <template> has real childNodes and no `.content`
- * fragment, so it would otherwise leak its text like the raw-text members
- * above; in ordinary HTML content its children live in `.content`, a
- * fragment this function never traverses, so dropping it here is usually
- * a no-op.
+ * ordinary disallowed tag. For the raw-text members — IFRAME, NOEMBED,
+ * NOFRAMES, PLAINTEXT, SCRIPT, STYLE, TEXTAREA, TITLE, XMP — the child
+ * "text" is the element's own source, not prose: unwrapping would surface
+ * that source as visible content (a <script> body becomes the literal
+ * string "alert(1)"). NOSCRIPT is dropped for a different reason:
+ * sanitizeHtml() parses with a <template> element, which runs with the
+ * scripting flag disabled, so a <noscript>'s children parse as ordinary
+ * elements, not raw text — but that content is a no-JS fallback,
+ * meaningless in this JS-required SPA, so it is dropped rather than
+ * unwrapped. TEMPLATE is kept mainly for foreign content: inside <svg>, a
+ * <template> has real childNodes and no `.content` fragment, so it would
+ * otherwise leak its text like the raw-text members above; in ordinary
+ * HTML content its children live in `.content`, a fragment this function
+ * never traverses, so dropping it here is usually a no-op.
+ *
+ * This is a denylist over unwrap-by-default, not an exhaustive one: the
+ * foreign-content text holders <svg desc>, <svg metadata>, <math
+ * annotation> and <math annotation-xml> leak the same way but are left
+ * out, their leak being cosmetic. <svg><title> and <svg><style> are
+ * covered only because those names case-fold onto the HTML members above —
+ * incidental, not foreign-content handling.
+ *
+ * OBJECT and EMBED are deliberately absent. An <object>'s children are its
+ * fallback prose, which the unwrap path already sanitizes recursively;
+ * dropping them would only discard content this theme should render.
+ * <embed> is a void element, so it never has children to drop.
  */
 const DROP_WITH_CONTENT = new Set([
   "SCRIPT", "STYLE", "TEXTAREA", "TITLE", "NOSCRIPT",
-  "IFRAME", "OBJECT", "EMBED", "TEMPLATE", "XMP",
-  "PLAINTEXT", "NOEMBED", "NOFRAMES"
+  "IFRAME", "TEMPLATE", "XMP", "PLAINTEXT",
+  "NOEMBED", "NOFRAMES"
 ]);
 
 /**

--- a/src/main/webapp/themes/bootstrap/theme.yml
+++ b/src/main/webapp/themes/bootstrap/theme.yml
@@ -2,7 +2,7 @@ apiVersion: fess.codelibs.org/v1
 kind: StaticTheme
 name: bootstrap
 displayName: "Bootstrap"
-version: "1.0.0"
+version: "1.0.1"
 author: "CodeLibs Project"
 description: "Reference static theme for Fess. Bootstrap 5-based vanilla-JS SPA exercising /api/v2/*."
 license: "Apache-2.0"

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1171,6 +1171,36 @@ public class BundledBootstrapThemeTest {
     }
 
     /**
+     * format.js must drop raw-text elements whole instead of unwrapping them:
+     * their child text is the element's own source, so unwrapping surfaces that
+     * source as visible prose. Guards the nine HTML raw-text elements plus
+     * NOSCRIPT and TEMPLATE, which are dropped for their own documented reasons.
+     */
+    @Test
+    public void test_formatJs_sanitizerDropsRawTextElementsWithContent() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("const DROP_WITH_CONTENT = new Set(["), "format.js must define the DROP_WITH_CONTENT set");
+        for (final String tag : new String[] { "IFRAME", "NOEMBED", "NOFRAMES", "PLAINTEXT", "SCRIPT", "STYLE", "TEXTAREA", "TITLE", "XMP",
+                "NOSCRIPT", "TEMPLATE" }) {
+            assertTrue(js.contains("\"" + tag + "\""), "format.js DROP_WITH_CONTENT must contain \"" + tag + "\"");
+        }
+    }
+
+    /**
+     * OBJECT and EMBED must stay out of DROP_WITH_CONTENT. An &lt;object&gt;'s
+     * children are fallback prose that the unwrap path already sanitizes
+     * recursively, so dropping them buys no safety and only discards content;
+     * &lt;embed&gt; is a void element, so it never has children and the entry
+     * would be inert. Re-adding either is a regression, not a hardening.
+     */
+    @Test
+    public void test_formatJs_sanitizerDoesNotDropObjectOrEmbedContent() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
+        assertFalse(js.contains("\"OBJECT\""), "format.js must not drop <object> fallback prose: the unwrap path already sanitizes it");
+        assertFalse(js.contains("\"EMBED\""), "format.js must not list \"EMBED\": it is a void element, so the entry can never fire");
+    }
+
+    /**
      * R4-9: advance.js per-page fallback list must match JSP parity ([10,20,30,40,50,100]).
      * The shorter legacy list ([10,20,50,100]) must not appear as the fallback.
      */


### PR DESCRIPTION
`sanitizeNode()` in the bundled `bootstrap` theme's `format.js` unwraps any disallowed element and keeps its sanitized children. That is right for prose elements — `<article>foo</article>` should keep `foo` — but wrong for raw-text elements, where the child text *is* the element's own source. `<script>alert(1)</script>` sanitized down to a bare text node `alert(1)`, which then rendered as visible literal text.

**This is a rendering defect, not XSS.** The resulting text is never re-parsed as HTML and never executed. It is still non-empty, though, so any "did sanitized content survive?" check upstream treats it as real content and renders a populated container showing script or stylesheet source to the user.

## Fix

Add a `DROP_WITH_CONTENT` set checked before the existing unwrap branch; its members are dropped whole, children included — the same drop-instead-of-unwrap approach DOMPurify takes with `FORBID_CONTENTS`.

```
SCRIPT, STYLE, TEXTAREA, TITLE, NOSCRIPT, IFRAME, OBJECT, EMBED,
TEMPLATE, XMP, PLAINTEXT, NOEMBED, NOFRAMES
```

It is deliberately **not** a verbatim copy of DOMPurify's list: `THEAD` is in this file's `ALLOWED_TAGS`, so importing that list wholesale would silently drop every table header row. `COLGROUP`/`HEAD`/`SVG`/`MATH`/`VIDEO`/`AUDIO` would likewise discard legitimate content.

Two members are in the set for reasons other than raw text, and the code comment says so rather than implying a uniform rationale:

- **`NOSCRIPT`** — `sanitizeHtml()` parses via a `<template>`, which runs with the scripting flag *disabled*, so a `<noscript>`'s children parse as ordinary elements, not raw text. It is dropped because a no-JS fallback is meaningless in a JS-required SPA, not because its text is source.
- **`TEMPLATE`** — in ordinary HTML its children live in `.content`, a fragment this function never traverses, so dropping it is usually a no-op. It earns its place via foreign content: inside `<svg>`, a `<template>` has real `childNodes` and no `.content`, and did leak its text.

`DROP_WITH_CONTENT ∩ ALLOWED_TAGS = ∅`, verified programmatically — no allowed tag changes behaviour.

## Why it matters beyond this repository

`bootstrap` is the reference theme the themes in `codelibs/fess-themes` derive from, and this file was byte-identical to the copy shipped in several of them. The same patch is applied to all of those in `codelibs/fess-themes` so the copies stay in step; after both land, every copy is byte-identical except line 2, a per-theme module comment.

## Reachability

`sanitizeHtml()`/`sanitizeNode()` is reachable from a wider set of content sources than admin input alone:

- admin-authored notification text — `app.js:143`, `auth.js:253`, `advance.js:285`
- admin-authored related-content rendering — `search.js:1760`
- `help.js:54` — renders a theme-shipped static JSON help bundle; a trigger only if that shipped bundle is edited
- `chat.js:570` `setHtmlContent()` — renders `html_content` from the RAG *done* event, which is server/LLM-derived, not admin-authored

`chat.js:563` `setBuffer()` is **not** a trigger: `markdown.js` escapes everything first, so no raw-text element reaches the sanitizer.

## Verification

The identical patch was live-verified in headless Chrome against a byte-identical copy of this file (16/16 payloads dropped whole: script/style/textarea/title/xmp/iframe/object/noscript/template). The three additions beyond the original ten were verified the same way in a differential old-vs-new harness — `plaintext`, `noembed` and `noframes` reproduce the defect identically before and after the ten-tag fix, and are dropped after this change. `<plaintext>` was the worst of them: the tokenizer switches to PLAINTEXT state, so the *entire remainder* of the input becomes one text node.

This is a single-file JavaScript change with no Java or build impact.

## Known gap, deliberately not addressed here

All four call sites gate container visibility on the **raw input string** (`html.trim() !== ""`) rather than on the sanitized output. So `<style>.a{}</style>`-only input now unhides an empty container where it previously showed the stylesheet source as text. This pre-dates the change — comment-only input already did it — and the patch trades visible garbage for an empty box, a net improvement. Fixing it properly means gating on sanitized output across all four call sites, which is a separate change.
