### PR TITLE
fix(error): route genuine 400s to the request error page and keep 401s intact for API clients

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/error/ErrorBadrequestAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/error/ErrorBadrequestAction.java
@@ -24,12 +24,12 @@ import org.lastaflute.web.response.HtmlResponse;
  * This action displays error pages when a client request contains
  * invalid syntax or cannot be fulfilled due to malformed request parameters.
  */
-public class ErrorBadrequrestAction extends FessSearchAction {
+public class ErrorBadrequestAction extends FessSearchAction {
 
     /**
-     * Default constructor for ErrorBadrequrestAction.
+     * Default constructor for ErrorBadrequestAction.
      */
-    public ErrorBadrequrestAction() {
+    public ErrorBadrequestAction() {
         super();
     }
 

--- a/src/main/java/org/codelibs/fess/util/WebApiUtil.java
+++ b/src/main/java/org/codelibs/fess/util/WebApiUtil.java
@@ -64,7 +64,7 @@ public final class WebApiUtil {
      * prefix reads as a browser request. Both are tolerable because the only caller decides
      * whether to replace an error status with an HTML page: every manager that can reach a
      * container error page issues {@code sendError} under {@code /admin/server_}, and a miss
-     * merely falls back to the redirect that preceded this check.
+     * merely takes the browser arm, as this branch did unconditionally before.
      *
      * <p>Deliberately dependency-free: it performs no component lookup and reads no
      * configuration, so it stays safe to call while rendering an error response.

--- a/src/main/java/org/codelibs/fess/util/WebApiUtil.java
+++ b/src/main/java/org/codelibs/fess/util/WebApiUtil.java
@@ -49,13 +49,22 @@ public final class WebApiUtil {
     /**
      * Determines whether a request URI addresses one of the web API endpoints.
      *
-     * <p>This mirrors the {@code WebApiManager#matches(HttpServletRequest)} implementations,
+     * <p>This approximates the {@code WebApiManager#matches(HttpServletRequest)} implementations,
      * which are the established way Fess tells an API request from a browser request: each
      * manager claims a path prefix and matches on the servlet path. This method exists for
      * callers that cannot consult the managers directly because the servlet path no longer
      * describes the original request -- notably the container error page, where the path
      * elements describe the error page itself and only the
      * {@code jakarta.servlet.error.request_uri} attribute still carries the original URI.
+     *
+     * <p>An approximation, not a faithful copy, in two ways. It knows only the prefixes claimed
+     * by the managers bundled here; plugins register further ones ({@code /api/v1},
+     * {@code /json}, {@code /suggest}, {@code /mcp}) that it cannot see. And it matches the raw,
+     * undecoded URI, whereas the managers compare the decoded servlet path, so a percent-encoded
+     * prefix reads as a browser request. Both are tolerable because the only caller decides
+     * whether to replace an error status with an HTML page: every manager that can reach a
+     * container error page issues {@code sendError} under {@code /admin/server_}, and a miss
+     * merely falls back to the redirect that preceded this check.
      *
      * <p>Deliberately dependency-free: it performs no component lookup and reads no
      * configuration, so it stays safe to call while rendering an error response.

--- a/src/main/java/org/codelibs/fess/util/WebApiUtil.java
+++ b/src/main/java/org/codelibs/fess/util/WebApiUtil.java
@@ -31,9 +31,54 @@ public final class WebApiUtil {
     private static final String WEB_API_EXCEPTION = "webApiException";
 
     /**
+     * Path prefix claimed by {@code SearchApiV2Manager}.
+     */
+    private static final String API_V2_PATH_PREFIX = "/api/v2";
+
+    /**
+     * Path prefix claimed by {@code SearchEngineApiManager}.
+     */
+    private static final String SEARCH_ENGINE_API_PATH_PREFIX = "/admin/server_";
+
+    /**
      * Private constructor to prevent instantiation.
      */
     private WebApiUtil() {
+    }
+
+    /**
+     * Determines whether a request URI addresses one of the web API endpoints.
+     *
+     * <p>This mirrors the {@code WebApiManager#matches(HttpServletRequest)} implementations,
+     * which are the established way Fess tells an API request from a browser request: each
+     * manager claims a path prefix and matches on the servlet path. This method exists for
+     * callers that cannot consult the managers directly because the servlet path no longer
+     * describes the original request -- notably the container error page, where the path
+     * elements describe the error page itself and only the
+     * {@code jakarta.servlet.error.request_uri} attribute still carries the original URI.
+     *
+     * <p>Deliberately dependency-free: it performs no component lookup and reads no
+     * configuration, so it stays safe to call while rendering an error response.
+     *
+     * @param requestUri The original request URI, including the context path (may be null)
+     * @param contextPath The context path to strip, as returned by {@code getContextPath()} (may be null)
+     * @return true if the URI addresses a web API endpoint
+     */
+    public static boolean isApiRequestUri(final String requestUri, final String contextPath) {
+        if (requestUri == null) {
+            return false;
+        }
+        String path = requestUri;
+        if (contextPath != null && !contextPath.isEmpty() && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
+        // SearchApiV2Manager#matches accepts the prefix itself or any sub-path of it.
+        if (path.equals(API_V2_PATH_PREFIX) || path.startsWith(API_V2_PATH_PREFIX + "/")) {
+            return true;
+        }
+        // SearchEngineApiManager#matches accepts a plain prefix match: the access token is
+        // appended directly to the prefix, so there is no separator to anchor on.
+        return path.startsWith(SEARCH_ENGINE_API_PATH_PREFIX);
     }
 
     /**

--- a/src/main/webapp/WEB-INF/view/error/redirect.jsp
+++ b/src/main/webapp/WEB-INF/view/error/redirect.jsp
@@ -22,11 +22,19 @@ if("systemError".equals(type)) {
 	redirectPage.append("/error/busy/");
 	response.sendRedirect(redirectPage.toString());
 } else if("badAuth".equals(type)) {
-	// F.11: Redirect badAuth to the SPA error view so static-theme mode renders a proper
-	// error page instead of leaking this JSP's plain-text "Bad Authentication." output.
-	// The message_key parameter lets the SPA surface a localised error detail.
-	redirectPage.append("/error/system?message_key=errors.bad_authentication");
-	response.sendRedirect(redirectPage.toString());
+	// This branch is reached only from the 401 error-page mapping, so the status the
+	// container is rendering this page for is always 401.
+	if(org.codelibs.fess.util.WebApiUtil.isApiRequestUri(requestUri, ((jakarta.servlet.http.HttpServletRequest)request).getContextPath())) {
+		// An API client needs the status, not a page: issuing no redirect leaves the 401
+		// the container already set intact, and the body below is returned as-is.
+%>Bad Authentication.<%
+	} else {
+		// A browser gets the themed error page instead of the plain-text output above.
+		// message_key lets a static theme surface a localised error detail; the JSP-mode
+		// action simply ignores the unknown parameter.
+		redirectPage.append("/error/systemerror/?message_key=errors.bad_authentication");
+		response.sendRedirect(redirectPage.toString());
+	}
 } else {
 	redirectPage.append("/error/notfound/?url=");
 	redirectPage.append(java.net.URLEncoder.encode(requestUri , "UTF-8"));

--- a/src/test/java/org/codelibs/fess/util/WebApiUtilTest.java
+++ b/src/test/java/org/codelibs/fess/util/WebApiUtilTest.java
@@ -425,4 +425,61 @@ public class WebApiUtilTest extends UnitFessTestCase {
         // In test environment, some operations might not work due to missing request context
         // but the methods should not throw unexpected exceptions
     }
+
+    @Test
+    public void test_isApiRequestUri_apiV2() {
+        assertTrue("the v2 prefix itself is an API path", WebApiUtil.isApiRequestUri("/api/v2", ""));
+        assertTrue("a v2 sub-path is an API path", WebApiUtil.isApiRequestUri("/api/v2/", ""));
+        assertTrue("a v2 endpoint is an API path", WebApiUtil.isApiRequestUri("/api/v2/documents/all", ""));
+    }
+
+    @Test
+    public void test_isApiRequestUri_searchEngineApi() {
+        // The access token is appended straight onto the prefix, hence a plain prefix match.
+        assertTrue("the search engine API prefix is an API path", WebApiUtil.isApiRequestUri("/admin/server_", ""));
+        assertTrue("a tokenised search engine API path is an API path", WebApiUtil.isApiRequestUri("/admin/server_sometoken/_search", ""));
+    }
+
+    @Test
+    public void test_isApiRequestUri_browserPaths() {
+        assertFalse("the root path is not an API path", WebApiUtil.isApiRequestUri("/", ""));
+        assertFalse("the search UI is not an API path", WebApiUtil.isApiRequestUri("/search/", ""));
+        assertFalse("the login page is not an API path", WebApiUtil.isApiRequestUri("/login/", ""));
+        assertFalse("an admin UI page is not an API path", WebApiUtil.isApiRequestUri("/admin/dashboard/", ""));
+        // Guard the prefix boundaries: neither manager would claim these.
+        assertFalse("a path merely starting with the v2 prefix text is not an API path", WebApiUtil.isApiRequestUri("/api/v2foo", ""));
+        assertFalse("the bare api path is not claimed by any manager", WebApiUtil.isApiRequestUri("/api/", ""));
+    }
+
+    @Test
+    public void test_isApiRequestUri_stripsContextPath() {
+        assertTrue("the context path should be stripped before matching", WebApiUtil.isApiRequestUri("/fess/api/v2/search", "/fess"));
+        assertTrue("the context path should be stripped for the engine API",
+                WebApiUtil.isApiRequestUri("/fess/admin/server_token/_search", "/fess"));
+        assertFalse("a browser path under a context path is not an API path", WebApiUtil.isApiRequestUri("/fess/search/", "/fess"));
+        // Without stripping, "/fess/api/v2" would not match any prefix.
+        assertFalse("an unstripped context path should not match", WebApiUtil.isApiRequestUri("/fess/api/v2/search", null));
+    }
+
+    @Test
+    public void test_isApiRequestUri_nullSafe() {
+        assertFalse("a null request URI is not an API path", WebApiUtil.isApiRequestUri(null, "/fess"));
+        assertFalse("a null request URI is not an API path", WebApiUtil.isApiRequestUri(null, null));
+        assertTrue("a null context path should be tolerated", WebApiUtil.isApiRequestUri("/api/v2/search", null));
+    }
+
+    /**
+     * The prefixes are duplicated from the API managers so that the check stays
+     * dependency-free on the error path. Pin them to the managers' real values so the copies
+     * cannot drift apart silently.
+     */
+    @Test
+    public void test_isApiRequestUri_prefixesMatchTheApiManagers() {
+        final String v2Prefix = new org.codelibs.fess.api.v2.SearchApiV2Manager().getPathPrefix();
+        final String enginePrefix = new org.codelibs.fess.api.engine.SearchEngineApiManager().getPathPrefix();
+        assertEquals("SearchApiV2Manager's path prefix changed; update WebApiUtil.isApiRequestUri", "/api/v2", v2Prefix);
+        assertEquals("SearchEngineApiManager's path prefix changed; update WebApiUtil.isApiRequestUri", "/admin/server_", enginePrefix);
+        assertTrue("the manager's own prefix must be recognised as an API path", WebApiUtil.isApiRequestUri(v2Prefix, ""));
+        assertTrue("the manager's own prefix must be recognised as an API path", WebApiUtil.isApiRequestUri(enginePrefix, ""));
+    }
 }

--- a/src/test/java/org/codelibs/fess/webapp/ErrorRedirectJspTest.java
+++ b/src/test/java/org/codelibs/fess/webapp/ErrorRedirectJspTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.webapp;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Locale;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the {@code /error/...} targets the container error page redirects to
+ * actually resolve to existing action classes.
+ *
+ * <p>{@code redirect.jsp} is the {@code <error-page>} target for every mapped status code
+ * (see {@code web.xml}). It hands control to LastaFlute by issuing a redirect to a URL such
+ * as {@code /error/notfound/}. LastaFlute resolves that URL back to an action class by
+ * convention, so a URL literal in the JSP that does not match an action class name is a
+ * silent breakage: the redirect lands on nothing and falls through to the 404 page. No
+ * compiler or existing test catches that mismatch, because one side is a string in a JSP
+ * and the other is a Java class name.
+ */
+public class ErrorRedirectJspTest extends UnitFessTestCase {
+
+    /** Package holding the error action classes that {@code /error/*} URLs resolve to. */
+    private static final String ERROR_ACTION_PACKAGE = "org.codelibs.fess.app.web.error";
+
+    private static final String REDIRECT_JSP_PATH = "src/main/webapp/WEB-INF/view/error/redirect.jsp";
+
+    private String readJsp(final String path) throws Exception {
+        final File file = new File(path);
+        assertTrue(path + " should exist", file.exists());
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Derives the action class name LastaFlute resolves an {@code /error/<kind>/} URL to.
+     *
+     * <p>Mirrors {@code ActionPathResolver#buildActionName}, which composes the component
+     * name as {@code pkg + classPrefix + "Action"} where {@code classPrefix} accumulates
+     * {@code initCap} of each path segment. So {@code /error/notfound/} resolves to
+     * {@code error_errorNotfoundAction}, i.e. the class
+     * {@code org.codelibs.fess.app.web.error.ErrorNotfoundAction}.
+     */
+    private String toActionClassName(final String kind) {
+        final String initCap = kind.substring(0, 1).toUpperCase(Locale.ROOT) + kind.substring(1);
+        return ERROR_ACTION_PACKAGE + ".Error" + initCap + "Action";
+    }
+
+    private void assertActionExists(final String kind, final String source) {
+        final String className = toActionClassName(kind);
+        try {
+            Class.forName(className);
+        } catch (final ClassNotFoundException e) {
+            fail(source + " redirects to /error/" + kind + "/ but no action class " + className
+                    + " exists, so the redirect resolves to nothing and falls through to the 404 page");
+        }
+    }
+
+    /**
+     * Pins the specific mismatch that shipped: the bad-request branch must point at the
+     * URL its action class is named for. The action was {@code ErrorBadrequrestAction}
+     * (note the transposed "requrest"), so LastaFlute served it at {@code /error/badrequrest/}
+     * while the JSP redirected genuine HTTP 400s to {@code /error/badrequest/} -- which
+     * resolved to nothing, and every 400 rendered the 404 page instead.
+     */
+    @Test
+    public void test_badRequestBranchTargetsTheBadRequestAction() throws Exception {
+        final String jsp = readJsp(REDIRECT_JSP_PATH);
+        assertTrue("the badRequest branch should redirect to /error/badrequest/", jsp.contains("/error/badrequest/"));
+        assertActionExists("badrequest", REDIRECT_JSP_PATH);
+    }
+}

--- a/src/test/java/org/codelibs/fess/webapp/ErrorRedirectJspTest.java
+++ b/src/test/java/org/codelibs/fess/webapp/ErrorRedirectJspTest.java
@@ -16,6 +16,8 @@
 package org.codelibs.fess.webapp;
 
 import java.io.File;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.LinkedHashSet;
@@ -56,6 +58,16 @@ public class ErrorRedirectJspTest extends UnitFessTestCase {
      * scanned anyway because it is a second copy of the same redirect table and can drift.
      */
     private static final String ORIG_REDIRECT_JSP_PATH = "src/main/webapp/WEB-INF/orig/view/error/redirect.jsp";
+
+    /** The class the badAuth branch calls, spelled out because a JSP has no imports. */
+    private static final String API_CHECK_CLASS = "org.codelibs.fess.util.WebApiUtil";
+
+    /** The method the badAuth branch calls on {@link #API_CHECK_CLASS}. */
+    private static final String API_CHECK_METHOD = "isApiRequestUri";
+
+    /** Matches the JSP's fully-qualified call, up to and including its opening parenthesis. */
+    private static final Pattern API_CHECK_CALL_PATTERN =
+            Pattern.compile(Pattern.quote(API_CHECK_CLASS + "." + API_CHECK_METHOD) + "\\s*\\(");
 
     private String readJsp(final String path) throws Exception {
         final File file = new File(path);
@@ -128,13 +140,40 @@ public class ErrorRedirectJspTest extends UnitFessTestCase {
 
     /**
      * The badAuth branch is the 401 error page. Redirecting an API client's 401 turns it into
-     * a 302 to an HTML page and destroys the status the client needs, so the branch must
-     * decide per client rather than redirecting unconditionally.
+     * a 302 to an HTML page and destroys the status the client needs, so the branch decides per
+     * client, by calling {@code WebApiUtil.isApiRequestUri} as an {@code if} condition.
+     *
+     * <p>That call is the only reference to a Fess class from any JSP in this webapp, and nothing
+     * in the build compiles the JSPs. So renaming the method, changing its parameters or return
+     * type, or dropping its {@code static} leaves the build and the rest of this suite green while
+     * the branch fails at runtime -- and it fails for every status code, since {@code web.xml} maps
+     * all seven of them to this one page.
+     *
+     * <p>Pins both ends of that link: the call literal in the JSP, and the exact method shape the
+     * JSP's {@code if} needs. The shape takes more than {@code getMethod}, which ignores the return
+     * type and matches instance methods too. Only the {@code view} copy is scanned -- the
+     * {@code orig} copy predates the check and has no such call.
+     *
+     * <p>Where the call sits is deliberately not asserted; that would pin the JSP's formatting.
      */
     @Test
-    public void test_badAuthBranchDoesNotRedirectApiClients() throws Exception {
+    public void test_apiClientCheckInJspResolvesToTheJavaMethod() throws Exception {
         final String jsp = readJsp(REDIRECT_JSP_PATH);
-        assertTrue("the badAuth branch should tell an API client from a browser before redirecting", jsp.contains("isApiRequestUri"));
+        assertTrue(REDIRECT_JSP_PATH + " should call " + API_CHECK_CLASS + "." + API_CHECK_METHOD
+                + " to tell an API client from a browser before redirecting", API_CHECK_CALL_PATTERN.matcher(jsp).find());
         assertTrue("an API client should still receive the plain-text body that preserves its 401", jsp.contains("Bad Authentication."));
+
+        try {
+            final Method method = Class.forName(API_CHECK_CLASS).getMethod(API_CHECK_METHOD, String.class, String.class);
+            assertEquals(API_CHECK_METHOD + " should return boolean, because the JSP calls it as an if condition", boolean.class,
+                    method.getReturnType());
+            assertTrue(API_CHECK_METHOD + " should be public, because the JSP calls it from outside its package",
+                    Modifier.isPublic(method.getModifiers()));
+            assertTrue(API_CHECK_METHOD + " should be static, because the JSP calls it on the class rather than an instance",
+                    Modifier.isStatic(method.getModifiers()));
+        } catch (final ClassNotFoundException | NoSuchMethodException e) {
+            fail(REDIRECT_JSP_PATH + " calls " + API_CHECK_CLASS + "." + API_CHECK_METHOD
+                    + "(String, String), but that method does not exist: " + e);
+        }
     }
 }

--- a/src/test/java/org/codelibs/fess/webapp/ErrorRedirectJspTest.java
+++ b/src/test/java/org/codelibs/fess/webapp/ErrorRedirectJspTest.java
@@ -18,7 +18,11 @@ package org.codelibs.fess.webapp;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.LinkedHashSet;
 import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
@@ -40,7 +44,17 @@ public class ErrorRedirectJspTest extends UnitFessTestCase {
     /** Package holding the error action classes that {@code /error/*} URLs resolve to. */
     private static final String ERROR_ACTION_PACKAGE = "org.codelibs.fess.app.web.error";
 
+    /** Matches the first path segment of an {@code /error/<kind>} URL literal in the JSP. */
+    private static final Pattern ERROR_URL_PATTERN = Pattern.compile("/error/([A-Za-z0-9]+)");
+
     private static final String REDIRECT_JSP_PATH = "src/main/webapp/WEB-INF/view/error/redirect.jsp";
+
+    /**
+     * The design-editor "Use Default" copy. Not dispatched to -- {@code web.xml} names the
+     * {@code view} copy above at a fixed path -- but kept in step so a broken target cannot
+     * be restored from it.
+     */
+    private static final String ORIG_REDIRECT_JSP_PATH = "src/main/webapp/WEB-INF/orig/view/error/redirect.jsp";
 
     private String readJsp(final String path) throws Exception {
         final File file = new File(path);
@@ -84,5 +98,42 @@ public class ErrorRedirectJspTest extends UnitFessTestCase {
         final String jsp = readJsp(REDIRECT_JSP_PATH);
         assertTrue("the badRequest branch should redirect to /error/badrequest/", jsp.contains("/error/badrequest/"));
         assertActionExists("badrequest", REDIRECT_JSP_PATH);
+    }
+
+    private Set<String> extractErrorKinds(final String jsp) {
+        final Set<String> kinds = new LinkedHashSet<>();
+        final Matcher matcher = ERROR_URL_PATTERN.matcher(jsp);
+        while (matcher.find()) {
+            kinds.add(matcher.group(1));
+        }
+        return kinds;
+    }
+
+    /**
+     * Every {@code /error/*} URL literal in the error redirect JSPs must resolve to an
+     * existing action class.
+     */
+    @Test
+    public void test_everyErrorRedirectTargetResolvesToAnAction() throws Exception {
+        for (final String path : new String[] { REDIRECT_JSP_PATH, ORIG_REDIRECT_JSP_PATH }) {
+            final String jsp = readJsp(path);
+            final Set<String> kinds = extractErrorKinds(jsp);
+            assertFalse(path + " should contain at least one /error/ redirect target", kinds.isEmpty());
+            for (final String kind : kinds) {
+                assertActionExists(kind, path);
+            }
+        }
+    }
+
+    /**
+     * The badAuth branch is the 401 error page. Redirecting an API client's 401 turns it into
+     * a 302 to an HTML page and destroys the status the client needs, so the branch must
+     * decide per client rather than redirecting unconditionally.
+     */
+    @Test
+    public void test_badAuthBranchDoesNotRedirectApiClients() throws Exception {
+        final String jsp = readJsp(REDIRECT_JSP_PATH);
+        assertTrue("the badAuth branch should tell an API client from a browser before redirecting", jsp.contains("isApiRequestUri"));
+        assertTrue("an API client should still receive the plain-text body that preserves its 401", jsp.contains("Bad Authentication."));
     }
 }

--- a/src/test/java/org/codelibs/fess/webapp/ErrorRedirectJspTest.java
+++ b/src/test/java/org/codelibs/fess/webapp/ErrorRedirectJspTest.java
@@ -50,9 +50,10 @@ public class ErrorRedirectJspTest extends UnitFessTestCase {
     private static final String REDIRECT_JSP_PATH = "src/main/webapp/WEB-INF/view/error/redirect.jsp";
 
     /**
-     * The design-editor "Use Default" copy. Not dispatched to -- {@code web.xml} names the
-     * {@code view} copy above at a fixed path -- but kept in step so a broken target cannot
-     * be restored from it.
+     * The design-editor "Use Default" copy. Neither dispatched to -- {@code web.xml} names the
+     * {@code view} copy above at a fixed path -- nor restorable from the editor, which only
+     * addresses the JSPs registered in {@code fess.xml}, and this one is not among them. It is
+     * scanned anyway because it is a second copy of the same redirect table and can drift.
      */
     private static final String ORIG_REDIRECT_JSP_PATH = "src/main/webapp/WEB-INF/orig/view/error/redirect.jsp";
 


### PR DESCRIPTION
Two independent bugs in the container error page, `WEB-INF/view/error/redirect.jsp`.

## 1. A genuine HTTP 400 showed the user the 404 page

The action class was named `ErrorBadrequrestAction`, so LastaFlute served it at
`/error/badrequrest/`. The error page redirects HTTP 400 to the correctly spelled
`/error/badrequest/`, which therefore resolved to no action and fell through to the
404 handler. Every genuine bad request rendered "Not Found".

Fixed by renaming the action to `ErrorBadrequestAction`, so it is served at the URL
the error page already points at.

Renaming the action rather than correcting the JSP to the misspelling, because the
rest of the codebase already speaks `badrequest`: `StaticThemeResponder.computeErrorStatus`
maps `badrequest` to 400 and the bundled theme's `error.js` does the same, while
`badrequrest` falls to their default 500 branch. Bending the JSP to the typo would fix
the default JSP mode and regress static-theme mode from 400 to 500.

Nothing in fess links to `/error/badrequrest/`: the misspelling occurred only inside
the action class itself. The one place that does name it is the UI test suite, which
pins it deliberately so that correcting the typo surfaces there rather than passing
unnoticed -- see the companion PR below.

## 2. A 401 was redirected, losing the status for API clients

The 401 branch redirected to `/error/system?message_key=errors.bad_authentication`.
Two problems:

- **The target does not exist in the default JSP mode.** `/error/system` is only served
  when a static theme is active, where the theme filter intercepts `/error/...` before
  routing. Otherwise no action resolves it and the redirect fell through to the 404 page.
- **The redirect destroyed the status.** It turned every 401 into a 302 to an HTML page,
  undoing #571 ("401 response should not be redirected"). `SearchEngineApiManager` returns
  401 for unauthorized access to the engine passthrough API, and its clients were handed a
  redirect instead of the status they need.

A single redirect cannot serve both an API client and a browser, so the branch now decides
per client:

- **API clients** get no redirect. The 401 the container is already rendering the page for
  survives, along with the plain-text body, exactly as before #571 was undone.
- **Browsers** get the themed error page, now via `/error/systemerror/`, a real route in
  both modes. This matches how `CacheAction` passes `message_key` to an existing error
  route. A static theme resolves it to the same 500 view and localised detail as the old
  target did; the JSP-mode action ignores the unknown parameter.

An API client is identified by matching the original request URI against the path prefixes
the `WebApiManager`s claim, which is how Fess already tells API requests from browser
requests. The check lives in `WebApiUtil` rather than in the JSP because the managers
cannot be consulted here: on an error dispatch the servlet path describes the error page,
not the original request, so only `jakarta.servlet.error.request_uri` still carries it. It
performs no component lookup and reads no configuration, so it cannot fail while an error
response is being rendered.

### Known gap, unchanged by this PR

A browser receiving a 401 still lands on the **system error** view. There is no 401 page
anywhere in the theme error views: `computeErrorStatus` and the theme's `PATH_TO_CODE`
have no 401 case, and the message bundles carry `error.title_*`/`error.body_*` for 400,
404, 429, 500 and 503 only. Adding a real 401 page is a product decision and a reasonable
follow-up; this PR does not address it.

## Tests

- `ErrorRedirectJspTest` (new) pins every `/error/...` redirect target in the JSP to the
  action class it resolves to. No compiler check covers this: one side is a string in a
  JSP, the other a Java class name. Verified to fail on both bugs before the fixes.
- `WebApiUtilTest` covers the API/browser path check, including context-path stripping and
  prefix boundaries, and pins the prefixes to the managers' real `getPathPrefix()` values so
  the copies cannot drift apart silently.

Targeted runs green: `ErrorRedirectJspTest`, `WebApiUtilTest`, `StaticThemeResponderTest`,
`FessHtmlPathTest`, `WebXmlTest` (86 tests). `mvn -o javadoc:jar` passes.

## Companion PR

The UI test suite deliberately pins the current buggy behaviour of bug 1, so it turns red
once this merges. codelibs/fess-test-ui#55 updates it.

Note that the suite runs 15.7.0 and snapshot side by side, so it cannot simply be re-pinned
to the corrected spelling either -- that would break the 15.7.0 builds, which still serve
the view at `/error/badrequrest/`. The companion PR instead detects which spelling is routed
and asserts the invariant that holds on both, so the suite keeps passing against every build
in the matrix. Merge order does not matter.

`_assert_error_system_falls_through_to_notfound` keeps passing unchanged: it navigates
directly to `/error/system`, which still resolves to no action in JSP mode, and never
exercises the 401 branch. After this PR it no longer pins anything redirect.jsp points at,
so the companion PR refreshes its prose rather than its assertion.

