### PR TITLE
fix(go): fall back on malformed rt and hash parameters

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/go/GoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/go/GoAction.java
@@ -135,25 +135,21 @@ public class GoAction extends FessSearchAction {
         final String targetUrl = pathMappingHelper.replaceUrl(url);
 
         String hash;
-        if (StringUtil.isNotBlank(form.hash)) {
-            final String value = URLUtil.decode(form.hash, Constants.UTF_8);
-            if (targetUrl.indexOf('#') == -1) {
-                final StringBuilder buf = new StringBuilder(value.length() + 100);
-                for (final char c : value.toCharArray()) {
-                    if (CharUtil.isUrlChar(c) || c == ' ') {
-                        buf.append(c);
-                    } else {
-                        try {
-                            buf.append(URLEncoder.encode(String.valueOf(c), Constants.UTF_8));
-                        } catch (final UnsupportedEncodingException e) {
-                            // NOP
-                        }
+        final String value = decodeHash(form.hash);
+        if (value != null && targetUrl.indexOf('#') == -1) {
+            final StringBuilder buf = new StringBuilder(value.length() + 100);
+            for (final char c : value.toCharArray()) {
+                if (CharUtil.isUrlChar(c) || c == ' ') {
+                    buf.append(c);
+                } else {
+                    try {
+                        buf.append(URLEncoder.encode(String.valueOf(c), Constants.UTF_8));
+                    } catch (final UnsupportedEncodingException e) {
+                        // NOP
                     }
                 }
-                hash = buf.toString();
-            } else {
-                hash = StringUtil.EMPTY;
             }
+            hash = buf.toString();
         } else {
             hash = StringUtil.EMPTY;
         }
@@ -213,6 +209,31 @@ public class GoAction extends FessSearchAction {
             }
         }
         return systemHelper.getCurrentTimeAsLocalDateTime();
+    }
+
+    /**
+     * Resolves the URL fragment to append to the redirect target from the {@code hash} request parameter.
+     *
+     * <p>{@code hash} carries the fragment of the originating result URL in URL-encoded form, but it is
+     * a plain request parameter and therefore arbitrary user input: {@link GoForm} declares no format
+     * constraint on it. A value that is absent, blank or not decodable is treated as absent, so that a
+     * malformed parameter drops the fragment instead of failing the user's navigation with an error.</p>
+     *
+     * @param hash the raw {@code hash} parameter, a URL-encoded fragment (NullAllowed)
+     * @return the decoded fragment, or {@literal null} if {@code hash} is absent, blank or malformed
+     */
+    protected String decodeHash(final String hash) {
+        if (StringUtil.isNotBlank(hash)) {
+            try {
+                return URLUtil.decode(hash, Constants.UTF_8);
+            } catch (final IllegalArgumentException e) {
+                // Attacker-controlled input: log at debug only so a malformed hash cannot flood logs.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Invalid hash parameter: {}", hash, e);
+                }
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/go/GoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/go/GoAction.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.app.web.go;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.time.LocalDateTime;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
@@ -120,7 +121,7 @@ public class GoAction extends FessSearchAction {
                 clickLog.setUrlId((String) doc.get(fessConfig.getIndexFieldId()));
                 clickLog.setUrl(url);
                 clickLog.setRequestedAt(systemHelper.getCurrentTimeAsLocalDateTime());
-                clickLog.setQueryRequestedAt(DfTypeUtil.toLocalDateTime(Long.parseLong(form.rt)));
+                clickLog.setQueryRequestedAt(parseQueryRequestedAt(form.rt));
                 clickLog.setUserSessionId(userSessionId);
                 clickLog.setDocId(form.docId);
                 clickLog.setQueryId(form.queryId);
@@ -183,6 +184,35 @@ public class GoAction extends FessSearchAction {
             saveError(messages -> messages.addErrorsNotLoadFromServer(GLOBAL, targetUrl));
             return redirect(ErrorAction.class);
         }
+    }
+
+    /**
+     * Resolves the click log's query-requested timestamp from the {@code rt} request parameter.
+     *
+     * <p>{@code rt} carries the epoch millis of the originating search, but it is a plain
+     * request parameter and therefore arbitrary user input: {@link GoForm} declares no numeric
+     * constraint on it. A value that is absent or not a number is treated as absent and falls
+     * back to the current time, so that a malformed parameter degrades click telemetry instead
+     * of failing the user's navigation with an error.</p>
+     *
+     * <p>This matches the v2 API's {@code ClickHandler}, which likewise falls back to the
+     * current time whenever {@code rt} is not a number.</p>
+     *
+     * @param rt the raw {@code rt} parameter, epoch millis in string form (NullAllowed)
+     * @return the originating search time, or the current time if {@code rt} is absent or malformed
+     */
+    protected LocalDateTime parseQueryRequestedAt(final String rt) {
+        if (rt != null) {
+            try {
+                return DfTypeUtil.toLocalDateTime(Long.parseLong(rt));
+            } catch (final NumberFormatException e) {
+                // Attacker-controlled input: log at debug only so a malformed rt cannot flood logs.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Invalid rt parameter: {}", rt, e);
+                }
+            }
+        }
+        return systemHelper.getCurrentTimeAsLocalDateTime();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/go/GoForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/go/GoForm.java
@@ -46,16 +46,19 @@ public class GoForm {
     public String docId;
 
     /**
-     * Redirect target or return URL parameter.
-     * This is required and limited to 10000 characters to accommodate long URLs.
+     * Requested time of the originating search, in epoch milliseconds, recorded on the click log
+     * so that a click can be correlated with the search it came from.
+     * This is required and limited to 10000 characters. A malformed value is treated as absent
+     * and falls back to the time the click is handled.
      */
     @Size(max = 10000)
     @Required
     public String rt;
 
     /**
-     * Hash value for security or validation purposes.
-     * This field is optional and used for request verification.
+     * URL fragment of the target document, in URL-encoded form, appended to the redirect target.
+     * This field is optional. It is ignored when the target URL already carries a fragment, and a
+     * value that cannot be decoded is treated as absent.
      */
     public String hash;
 

--- a/src/test/java/org/codelibs/fess/app/web/go/GoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/go/GoActionTest.java
@@ -15,10 +15,16 @@
  */
 package org.codelibs.fess.app.web.go;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import org.codelibs.fess.helper.ProtocolHelper;
+import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.system.DBFluteSystem;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -50,6 +56,7 @@ public class GoActionTest extends UnitFessTestCase {
         ComponentUtil.register(protocolHelper, "protocolHelper");
 
         goAction = new TestableGoAction();
+        goAction.setSystemHelper(new FixedSystemHelper());
     }
 
     @Override
@@ -58,12 +65,90 @@ public class GoActionTest extends UnitFessTestCase {
         super.tearDown(testInfo);
     }
 
-    // Test class to expose protected method for testing
+    // Test class to expose protected methods for testing
     private static class TestableGoAction extends GoAction {
         @Override
         public boolean isFileSystemPath(final String url) {
             return super.isFileSystemPath(url);
         }
+
+        @Override
+        public LocalDateTime parseQueryRequestedAt(final String rt) {
+            return super.parseQueryRequestedAt(rt);
+        }
+
+        // systemHelper is injected via @Resource in production; set it directly for unit tests.
+        void setSystemHelper(final SystemHelper systemHelper) {
+            this.systemHelper = systemHelper;
+        }
+    }
+
+    /** Fixed instant used as "now" so the fallback is deterministic. */
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2020, 1, 2, 3, 4, 5);
+
+    /** SystemHelper returning a fixed "current time" so the fallback branch is assertable. */
+    private static class FixedSystemHelper extends SystemHelper {
+        @Override
+        public LocalDateTime getCurrentTimeAsLocalDateTime() {
+            return FIXED_NOW;
+        }
+    }
+
+    // ==================================================================================
+    //                                                            parseQueryRequestedAt Tests
+    //                                                            ===========================
+
+    /**
+     * Regression test: {@code rt} is an unconstrained request parameter, so a non-numeric
+     * value used to reach {@code Long.parseLong} unguarded and raise NumberFormatException,
+     * failing the user's navigation with an HTTP 500. A malformed value must instead be
+     * treated as absent and fall back to the current time.
+     */
+    @Test
+    public void test_parseQueryRequestedAt_malformed_fallsBackToCurrentTime() {
+        assertEquals(FIXED_NOW, goAction.parseQueryRequestedAt("not-a-number"));
+        assertEquals(FIXED_NOW, goAction.parseQueryRequestedAt(""));
+        assertEquals(FIXED_NOW, goAction.parseQueryRequestedAt(" "));
+        assertEquals(FIXED_NOW, goAction.parseQueryRequestedAt("123abc"));
+        assertEquals(FIXED_NOW, goAction.parseQueryRequestedAt("1.5"));
+        assertEquals(FIXED_NOW, goAction.parseQueryRequestedAt("1,000"));
+        // Numeric but outside long range: parseLong also rejects these.
+        assertEquals(FIXED_NOW, goAction.parseQueryRequestedAt("99999999999999999999999"));
+    }
+
+    /**
+     * A missing {@code rt} must not throw either. {@code @Required} normally rejects this before
+     * the action body runs, so this guards the method's own contract rather than the request flow.
+     */
+    @Test
+    public void test_parseQueryRequestedAt_null_fallsBackToCurrentTime() {
+        assertEquals(FIXED_NOW, goAction.parseQueryRequestedAt(null));
+    }
+
+    /**
+     * A well-formed {@code rt} must still be honoured, not silently replaced by the fallback.
+     *
+     * <p>DfTypeUtil converts via {@code DBFluteSystem.getFinalTimeZone()} (Fess registers a
+     * provider for it in FessCurtainBeforeHook), not via TimeZone.getDefault() at call time,
+     * so the expectation is read back through that same zone to keep this test independent of
+     * the host's time zone. That conversion zone differs from the v2 ClickHandler's UTC
+     * conversion; aligning the two would change stored timestamps and is out of scope here.
+     */
+    @Test
+    public void test_parseQueryRequestedAt_valid_usesRtValue() {
+        final long rtMs = 1718454896789L; // 2024-06-15T12:34:56.789Z (mid-year: no DST-overlap ambiguity)
+        final LocalDateTime actual = goAction.parseQueryRequestedAt(Long.toString(rtMs));
+        assertFalse(FIXED_NOW.equals(actual));
+        final ZoneId zone = DBFluteSystem.getFinalTimeZone().toZoneId();
+        assertEquals(rtMs, ZonedDateTime.of(actual, zone).toInstant().toEpochMilli());
+    }
+
+    /**
+     * Epoch 0 is a valid timestamp and must be parsed, not treated as absent.
+     */
+    @Test
+    public void test_parseQueryRequestedAt_zero_isParsed() {
+        assertFalse(FIXED_NOW.equals(goAction.parseQueryRequestedAt("0")));
     }
 
     // ==================================================================================

--- a/src/test/java/org/codelibs/fess/app/web/go/GoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/go/GoActionTest.java
@@ -77,6 +77,11 @@ public class GoActionTest extends UnitFessTestCase {
             return super.parseQueryRequestedAt(rt);
         }
 
+        @Override
+        public String decodeHash(final String hash) {
+            return super.decodeHash(hash);
+        }
+
         // systemHelper is injected via @Resource in production; set it directly for unit tests.
         void setSystemHelper(final SystemHelper systemHelper) {
             this.systemHelper = systemHelper;
@@ -145,10 +150,66 @@ public class GoActionTest extends UnitFessTestCase {
 
     /**
      * Epoch 0 is a valid timestamp and must be parsed, not treated as absent.
+     *
+     * <p>The exact epoch is asserted rather than merely "not the fallback": the latter alone also
+     * holds for any wrong-but-different instant, so it would not detect the value being mangled.
+     * As above, the expectation is read back through {@code DBFluteSystem.getFinalTimeZone()} to
+     * stay independent of the host's time zone.</p>
      */
     @Test
     public void test_parseQueryRequestedAt_zero_isParsed() {
-        assertFalse(FIXED_NOW.equals(goAction.parseQueryRequestedAt("0")));
+        final LocalDateTime actual = goAction.parseQueryRequestedAt("0");
+        assertFalse(FIXED_NOW.equals(actual));
+        final ZoneId zone = DBFluteSystem.getFinalTimeZone().toZoneId();
+        assertEquals(0L, ZonedDateTime.of(actual, zone).toInstant().toEpochMilli());
+    }
+
+    // ==================================================================================
+    //                                                                       decodeHash Tests
+    //                                                                       ================
+
+    /**
+     * Regression test: {@code hash} is an unconstrained request parameter, so a value with a
+     * malformed escape used to reach {@code URLDecoder} unguarded and raise
+     * IllegalArgumentException, failing the user's navigation with an HTTP 500. A malformed value
+     * must instead be treated as absent, which drops the fragment and leaves the redirect intact.
+     *
+     * <p>These are the values the container hands to {@code GoForm.hash} after decoding the query
+     * string of {@code /go?...&hash=%25}, {@code %25zz}, {@code %252} and {@code abc%25}: each
+     * {@code %25} is a well-formed escape, so the container decodes it to a bare {@code %}, which
+     * this action then decodes a second time. That double decode is what raised the error.</p>
+     */
+    @Test
+    public void test_decodeHash_malformed_treatedAsAbsent() {
+        assertNull(goAction.decodeHash("%")); // request: hash=%25
+        assertNull(goAction.decodeHash("%zz")); // request: hash=%25zz
+        assertNull(goAction.decodeHash("%2")); // request: hash=%252
+        assertNull(goAction.decodeHash("abc%")); // request: hash=abc%25
+    }
+
+    /**
+     * A well-formed {@code hash} must still be decoded, not dropped by the new guard.
+     */
+    @Test
+    public void test_decodeHash_valid_isDecoded() {
+        assertEquals("#", goAction.decodeHash("%23"));
+        assertEquals("#section", goAction.decodeHash("#section"));
+        assertEquals("a b", goAction.decodeHash("a%20b"));
+    }
+
+    /**
+     * An absent {@code hash} is optional and must be reported as absent rather than throwing.
+     *
+     * <p>The blank check is load-bearing for whitespace alone: {@code URLUtil.decode(" ")} returns
+     * {@code " "} rather than failing, so without it a blank fragment would be appended. A null or
+     * empty argument instead raises EmptyArgumentException, which is an IllegalArgumentException
+     * and so is already absorbed by the same catch that handles a malformed escape.</p>
+     */
+    @Test
+    public void test_decodeHash_blank_treatedAsAbsent() {
+        assertNull(goAction.decodeHash(null));
+        assertNull(goAction.decodeHash(""));
+        assertNull(goAction.decodeHash(" "));
     }
 
     // ==================================================================================


### PR DESCRIPTION
### Problem

`GoAction` passed two unconstrained request parameters straight to a parser that throws on
malformed input, on the unconditional path outside any `try`. Both failed the user's
navigation with an HTTP 500 instead of redirecting to the document.

**`rt`** was passed straight to `Long.parseLong` when appending a click log:

```java
clickLog.setQueryRequestedAt(DfTypeUtil.toLocalDateTime(Long.parseLong(form.rt)));
```

`rt` is a plain GET parameter carrying the epoch millis of the originating search, and
`GoForm` constrains it only with `@Required @Size(max = 10000)` — there is no numeric
constraint. The enclosing `try`/`catch` wraps only the document lookup, so a non-numeric
`rt` on a resolvable `docId` raised an uncaught `NumberFormatException`. This requires
search log to be enabled and the user to have a session, which is the default for a search
UI.

**`hash`** was URL-decoded without a guard:

```java
final String value = URLUtil.decode(form.hash, Constants.UTF_8);
```

`URLUtil.decode` catches only `UnsupportedEncodingException`, so `URLDecoder`'s
`IllegalArgumentException` propagates. `%25` is a well-formed escape, so the container
decodes it to a bare `%` and this action then decodes it a second time — that double decode
is what raises the error. `GoForm.hash` carries no annotations at all, and the decode sits
on the unconditional path, so this needs neither search log nor a session:

```
GET /go?docId=<valid>&queryId=x&rt=1&hash=%25   ->  HTTP 500
```

The two are the same defect: `NumberFormatException` is itself an `IllegalArgumentException`.

### Fix

Treat a malformed value as absent in both cases, so a bad parameter degrades a
non-essential feature rather than breaking the user's navigation:

- `rt` falls back to the current time, degrading click telemetry.
- `hash` drops the fragment, leaving the redirect intact.

The parsing is extracted into `parseQueryRequestedAt(String)` and `decodeHash(String)` so
both fallbacks are unit-testable. Malformed values are logged at debug only — they are
user-controlled, so logging at a higher level would let a crafted link flood the logs.

For `rt` this is not a new convention: the v2 API's `ClickHandler` already falls back to
`systemHelper.getCurrentTimeAsLocalDateTime()` whenever `rt` is not a number, and its
javadoc states that its behaviour matches v1's `GoAction` click-logging block. It is also
the established shape elsewhere in the web layer — `AdminWizardAction#getDefaultLong` and
`admin/searchlog/SearchForm#getPageSize` already guard their parses the same way.

Rejecting the request instead (e.g. a numeric constraint on `GoForm.rt`) was considered and
not chosen: validation failure routes to the error JSP, which would still fail the user's
navigation — the very symptom being fixed. Note `@Size` would not help either; it bounds
length, not character set.

### Behaviour change

| parameter | before | after |
| --- | --- | --- |
| valid `rt` | parsed (unchanged) | parsed (unchanged) |
| non-numeric / empty / out-of-long-range `rt` | **HTTP 500** | redirect proceeds; click logged with the current time |
| valid `hash` | decoded (unchanged) | decoded (unchanged) |
| blank `hash`, or target URL already has a fragment | no fragment (unchanged) | no fragment (unchanged) |
| undecodable `hash` | **HTTP 500** | redirect proceeds without the fragment |

Timestamps stored for valid `rt` values are unchanged, and a dropped fragment leaves the
target URL untouched — no dangling or doubled `#`.

### Documentation

`GoForm` described both fields incorrectly, which is plausibly why neither was guarded:

- `rt` was documented as a "Redirect target or return URL parameter ... limited to 10000
  characters to accommodate long URLs". It has never been a URL — it is epoch millis, and
  was parsed with `Long.parseLong` in the commit that introduced it. The `@Size(max = 10000)`
  it rationalises predates that description by about ten years.
- `hash` was documented as a "Hash value for security or validation purposes ... used for
  request verification". It is a URL fragment appended to the redirect target.

Both are corrected. The annotations are left unchanged.

### Tests

`GoActionTest` covers both helpers:

- `rt`: malformed values (`not-a-number`, empty, blank, `123abc`, `1.5`, `1,000`,
  out-of-long-range) and `null` must not throw and must fall back to the current time; a
  well-formed `rt` is still honoured; epoch `0` is parsed rather than treated as absent.
- `hash`: the values the container hands `GoForm.hash` for `hash=%25`, `%25zz`, `%252` and
  `abc%25` must be treated as absent; valid fragments are still decoded; blank is absent.

Each test fails against the pre-fix logic — the `rt` tests with the original
`NumberFormatException`, the `hash` test with the original `IllegalArgumentException`.

The `rt` tests read their expectation back through `DBFluteSystem.getFinalTimeZone()` — the
same zone `DfTypeUtil` converts with — so they do not depend on the host's time zone.
Verified under `Asia/Tokyo`, `UTC`, `America/Los_Angeles` and `Pacific/Kiritimati`.

`mvn -o test -Dtest=GoActionTest` → 23/23 pass. `mvn -o javadoc:jar` and
`mvn -o formatter:validate` pass.

### Out of scope

`GoAction` converts `rt` via `DfTypeUtil.toLocalDateTime`, which resolves to DBFlute's final
time zone (Fess registers a provider for it in `FessCurtainBeforeHook` that snapshots the JVM
default at class-load), whereas the v2 `ClickHandler` deliberately converts in UTC. The v2
handler also range-checks `rt` against `api.v2.click.max.rt`, which `GoAction` does not.
Both divergences are real but separate: aligning them would change stored timestamps, so the
existing conversion is preserved for valid values.

`decodeHash` also preserves an existing quirk: the fragment is decoded with `URLDecoder`'s
form-urlencoded semantics, so a literal `+` in a fragment becomes a space. That behaviour is
byte-identical before and after this change and is left alone.
