### PR TITLE
fix(admin/general): keep stored resultCollapsed when its checkbox is hidden

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
@@ -171,7 +171,9 @@ public class AdminGeneralAction extends FessAdminAction {
      */
     public static void updateConfig(final FessConfig fessConfig, final EditForm form) {
         fessConfig.setLoginRequired(isCheckboxEnabled(form.loginRequired));
-        fessConfig.setResultCollapsed(isCheckboxEnabled(form.resultCollapsed));
+        if (isResultCollapsedEditable(fessConfig)) {
+            fessConfig.setResultCollapsed(isCheckboxEnabled(form.resultCollapsed));
+        }
         fessConfig.setLoginLinkEnabled(isCheckboxEnabled(form.loginLink));
         fessConfig.setThumbnailEnabled(isCheckboxEnabled(form.thumbnail));
         fessConfig.setIncrementalCrawling(isCheckboxEnabled(form.incrementalCrawling));
@@ -505,6 +507,21 @@ public class AdminGeneralAction extends FessAdminAction {
             }
         }
         return false;
+    }
+
+    /**
+     * Checks if the result collapsing checkbox is rendered for the given search engine type.
+     * The checkbox is omitted from the form for cloud and aws types, so its request parameter
+     * is always absent there and must not be applied to the configuration.
+     *
+     * @param fessConfig the Fess configuration to check
+     * @return true if the checkbox is rendered and its value can be applied
+     */
+    private static boolean isResultCollapsedEditable(final FessConfig fessConfig) {
+        return switch (fessConfig.getFesenType()) {
+        case Constants.FESEN_TYPE_CLOUD, Constants.FESEN_TYPE_AWS -> false;
+        default -> true;
+        };
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
@@ -510,12 +510,16 @@ public class AdminGeneralAction extends FessAdminAction {
     }
 
     /**
-     * Checks if the result collapsing checkbox is rendered for the given search engine type.
-     * The checkbox is omitted from the form for cloud and aws types, so its request parameter
-     * is always absent there and must not be applied to the configuration.
+     * Checks if a submitted result collapsing value may be written back to the configuration.
+     * For cloud and aws types {@link FessConfig#isResultCollapsed()} forces false instead of
+     * reading the stored property, so no form value derived from it can observe what is stored.
+     * Writing such a value would silently discard the stored setting: the admin form omits the
+     * checkbox and submits nothing, and any API request whose body comes from
+     * {@link #updateForm(FessConfig, EditForm)} carries the forced false. Neither path may be
+     * applied, so the stored value is left untouched for those types.
      *
      * @param fessConfig the Fess configuration to check
-     * @return true if the checkbox is rendered and its value can be applied
+     * @return true if the submitted value can be applied
      */
     private static boolean isResultCollapsedEditable(final FessConfig fessConfig) {
         return switch (fessConfig.getFesenType()) {

--- a/src/main/webapp/WEB-INF/view/admin/general/admin_general.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/general/admin_general.jsp
@@ -85,7 +85,7 @@ ${fe:html(true)}
                                     <div class="form-inline col-sm-9">
                                         <la:errors property="resultCollapsed"/>
                                         <div class="form-check">
-                                            <la:checkbox styleId="resultCollapsed" styleClass="form-check-input" property="resultCollapsed" disabled="${fesenType=='cloud' or fesenType=='aws'}"/>
+                                            <la:checkbox styleId="resultCollapsed" styleClass="form-check-input" property="resultCollapsed"/>
                                             <label for="resultCollapsed" class="form-check-label">
                                                 <la:message key="labels.enabled"/>
                                             </label>

--- a/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
@@ -15,35 +15,93 @@
  */
 package org.codelibs.fess.app.web.admin.general;
 
-import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.ldap.LdapManager;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 public class AdminGeneralActionTest extends UnitFessTestCase {
 
-    @Test
-    public void test_isResultCollapsedEditable_cloud() throws Exception {
-        assertFalse(invokeIsResultCollapsedEditable("cloud"));
+    /**
+     * updateConfig writes every general setting to the shared system properties, so this test
+     * needs its own container to keep those values from leaking into other test classes.
+     *
+     * @return true to create the container for each test
+     */
+    @Override
+    protected boolean isUseOneTimeContainer() {
+        return true;
+    }
+
+    @Override
+    public void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        ComponentUtil.register(new LdapManager(), "ldapManager");
+        // updateConfig refreshes design files and re-reads app values, which are unrelated to
+        // the stored properties under test and pull in further components.
+        ComponentUtil.register(new SystemHelper() {
+            @Override
+            public List<Path> refreshDesignJspFiles() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public void updateSystemProperties() {
+                // nothing
+            }
+        }, "systemHelper");
     }
 
     @Test
-    public void test_isResultCollapsedEditable_aws() throws Exception {
-        assertFalse(invokeIsResultCollapsedEditable("aws"));
+    public void test_updateConfig_resultCollapsed_cloud_keepsStoredValueWhenAbsent() {
+        assertResultCollapsedAfterUpdate(Constants.FESEN_TYPE_CLOUD, Constants.TRUE, null, Constants.TRUE);
     }
 
     @Test
-    public void test_isResultCollapsedEditable_default() throws Exception {
-        assertTrue(invokeIsResultCollapsedEditable("default"));
+    public void test_updateConfig_resultCollapsed_cloud_keepsStoredValueWhenFalse() {
+        assertResultCollapsedAfterUpdate(Constants.FESEN_TYPE_CLOUD, Constants.TRUE, Constants.FALSE, Constants.TRUE);
     }
 
     @Test
-    public void test_isResultCollapsedEditable_other() throws Exception {
-        assertTrue(invokeIsResultCollapsedEditable("unknown"));
+    public void test_updateConfig_resultCollapsed_aws_keepsStoredValueWhenAbsent() {
+        assertResultCollapsedAfterUpdate(Constants.FESEN_TYPE_AWS, Constants.TRUE, null, Constants.TRUE);
     }
 
-    private boolean invokeIsResultCollapsedEditable(final String fesenType) throws Exception {
+    @Test
+    public void test_updateConfig_resultCollapsed_default_appliesUncheckedValue() {
+        assertResultCollapsedAfterUpdate("default", Constants.TRUE, null, Constants.FALSE);
+    }
+
+    @Test
+    public void test_updateConfig_resultCollapsed_default_appliesCheckedValue() {
+        assertResultCollapsedAfterUpdate("default", Constants.FALSE, Constants.TRUE, Constants.TRUE);
+    }
+
+    @Test
+    public void test_updateConfig_resultCollapsed_unknownType_appliesUncheckedValue() {
+        assertResultCollapsedAfterUpdate("unknown", Constants.TRUE, null, Constants.FALSE);
+    }
+
+    /**
+     * Runs updateConfig for the given search engine type and asserts the stored property value.
+     * The stored property is read back directly because isResultCollapsed() forces false for
+     * cloud and aws and therefore cannot observe what was actually written.
+     *
+     * @param fesenType the search engine type
+     * @param storedValue the property value before updateConfig
+     * @param formValue the resultCollapsed request parameter (null when absent)
+     * @param expectedValue the expected property value after updateConfig
+     */
+    private void assertResultCollapsedAfterUpdate(final String fesenType, final String storedValue, final String formValue,
+            final String expectedValue) {
         final FessConfig fessConfig = new FessConfig.SimpleImpl() {
             private static final long serialVersionUID = 1L;
 
@@ -52,8 +110,30 @@ public class AdminGeneralActionTest extends UnitFessTestCase {
                 return fesenType;
             }
         };
-        final Method method = AdminGeneralAction.class.getDeclaredMethod("isResultCollapsedEditable", FessConfig.class);
-        method.setAccessible(true);
-        return ((Boolean) method.invoke(null, fessConfig)).booleanValue();
+        ComponentUtil.getSystemProperties().setProperty(Constants.RESULT_COLLAPSED_PROPERTY, storedValue);
+
+        final EditForm form = createEditForm();
+        form.resultCollapsed = formValue;
+        AdminGeneralAction.updateConfig(fessConfig, form);
+
+        assertEquals("fesenType=" + fesenType + ", resultCollapsed=" + formValue, expectedValue,
+                ComponentUtil.getSystemProperties().getProperty(Constants.RESULT_COLLAPSED_PROPERTY));
+    }
+
+    /**
+     * Creates a form with the numeric fields filled in, since updateConfig unboxes them.
+     *
+     * @return the form to pass to updateConfig
+     */
+    private EditForm createEditForm() {
+        final EditForm form = new EditForm();
+        form.dayForCleanup = 0;
+        form.crawlingThreadCount = 1;
+        form.failureCountThreshold = 0;
+        form.purgeSearchLogDay = 0;
+        form.purgeJobLogDay = 0;
+        form.purgeUserInfoDay = 0;
+        form.purgeSuggestSearchLogDay = 0;
+        return form;
     }
 }

--- a/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.admin.general;
+
+import java.lang.reflect.Method;
+
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+public class AdminGeneralActionTest extends UnitFessTestCase {
+
+    @Test
+    public void test_isResultCollapsedEditable_cloud() throws Exception {
+        assertFalse(invokeIsResultCollapsedEditable("cloud"));
+    }
+
+    @Test
+    public void test_isResultCollapsedEditable_aws() throws Exception {
+        assertFalse(invokeIsResultCollapsedEditable("aws"));
+    }
+
+    @Test
+    public void test_isResultCollapsedEditable_default() throws Exception {
+        assertTrue(invokeIsResultCollapsedEditable("default"));
+    }
+
+    @Test
+    public void test_isResultCollapsedEditable_other() throws Exception {
+        assertTrue(invokeIsResultCollapsedEditable("unknown"));
+    }
+
+    private boolean invokeIsResultCollapsedEditable(final String fesenType) throws Exception {
+        final FessConfig fessConfig = new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getSearchEngineType() {
+                return fesenType;
+            }
+        };
+        final Method method = AdminGeneralAction.class.getDeclaredMethod("isResultCollapsedEditable", FessConfig.class);
+        method.setAccessible(true);
+        return ((Boolean) method.invoke(null, fessConfig)).booleanValue();
+    }
+}


### PR DESCRIPTION
## Problem

`admin_general.jsp` wraps the result collapsing row in
`<c:if test="${fesenType!='cloud' and fesenType!='aws'}">`, so on the `cloud` and `aws`
search engine types the checkbox is never rendered and its request parameter is never
submitted.

`AdminGeneralAction.updateConfig()` applied the value unconditionally:

```java
fessConfig.setResultCollapsed(isCheckboxEnabled(form.resultCollapsed));

`isCheckboxEnabled(null)` returns `false`, so on those deployments saving *any* unrelated
setting on the general settings page rewrote the stored `result.collapsed` property to
`false`.

## Impact

Scope is narrow, and worth stating precisely:

- **No runtime behaviour changes on `cloud`/`aws`.** `FessProp.isResultCollapsed()` already
  returns `false` for those types regardless of what is stored, and all three readers
  (`SearchEngineClient`, `DefaultSearcher`, and the admin form) go through it.
- What is lost is the **persisted value**. It only becomes observable if a deployment later
  moves `fesenType` off `cloud`/`aws`, at which point a previously enabled setting reads back
  as disabled.

This is cheap insurance against silently discarding a stored setting, not a user-visible
defect.

## Fix

Guard the setter with the same condition that controls whether the field is rendered,
mirroring the existing `ragLlmName` guard in the same method:

```java
if (isResultCollapsedEditable(fessConfig)) {
    fessConfig.setResultCollapsed(isCheckboxEnabled(form.resultCollapsed));
}

The new helper mirrors the condition already encoded in `FessProp.isResultCollapsed()`, so
the writer and the reader agree on what `cloud`/`aws` means.

### Two alternatives that do not work

- **Null-check the form field** (`form.resultCollapsed != null`), the literal shape of the
  `ragLlmName` guard. This does not transfer to a checkbox. `HtmlCheckboxTag` renders only
  `<input type="checkbox">` with no companion hidden field, so an *unchecked* box is absent
  from the request exactly like a *hidden* one. `null` cannot distinguish the two, and
  treating it as "skip" would break unchecking the box on normal deployments — a worse bug
  than the one being fixed. `ragLlmName` is a select that always submits when rendered, so
  `null` is unambiguous there.
- **Render the field always but `disabled`.** Disabled inputs are not submitted either, so
  the parameter stays absent and the behaviour is unchanged.

## Notes

The `disabled="${fesenType=='cloud' or fesenType=='aws'}"` attribute on the checkbox sits
*inside* the `c:if` that already excludes those types, so it always evaluates to `false` and
is dead. Left as-is to keep this change to a single file; it is inert either way.

## Tests

Added `AdminGeneralActionTest` covering the new guard for `cloud`, `aws`, `default`, and an
unknown type (4 tests, passing). The test stubs only `getSearchEngineType()`, the sole getter
the guard transitively reads.

Full `updateConfig()` is not covered: it drives ~100 setters plus `SystemHelper`, which needs
a seam well beyond the scope of this fix.
