### PR TITLE
fix(theme/bootstrap): make the copy-URL control a real button

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -165,9 +165,13 @@ function buildResultCard(d, queryId, order) {
   //   li#result{n}
   //     h3.title.text-truncate > a.link[data-uri,data-id,data-order]
   //     div.body > (div.me-3 > a.link.d-none.d-sm-flex > img.thumbnail)? + div.description
-  //     div.site.text-truncate > (i.far.fa-copy.url-copy)? + cite
+  //     div.site.text-truncate > (button.url-copy-btn > i.far.fa-copy.url-copy)? + cite
   //     div.more > a
   //     div.info > date + (size) + (cache)
+  // Deliberate divergence on the copy control: the JSP still emits it as a bare
+  // <i aria-hidden="true">, which is absent from the accessibility tree and
+  // unreachable by keyboard. This theme wraps the glyph in a real <button>, so
+  // a11y wins over tag-parity for that one row.
   const cfg = api.getConfig() || {};
   const features = cfg.features || {};
   const idx0 = order - 1;

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -235,24 +235,37 @@ function buildResultCard(d, queryId, order) {
   const site = el("div", { className: "site text-truncate" });
   if (features.clipboard_copy_icon) {
     const rawUrl = d.url_link || d.url || "";
+    // A real <button>, not an <i> carrying role="button": the element that takes
+    // focus has to be the one that carries the role and the accessible name, and
+    // only a button gets keyboard activation (Enter/Space) without hand-rolling a
+    // keydown handler. The previous markup also set aria-hidden="true" on the same
+    // element as role/aria-label, which removed the control from the accessibility
+    // tree entirely — so it was both invisible to assistive tech and unreachable by
+    // keyboard. The glyph inside stays aria-hidden and keeps the url-copy /
+    // url-copied classes, so each theme's existing colour rules apply unchanged.
     const copyIcon = el("i", {
-      className: "far fa-copy url-copy d-print-none",
-      attrs: { "aria-hidden": "true", "data-clipboard-text": rawUrl, role: "button", "aria-label": t("result.copy_url") + ": " + rawUrl }
+      className: "far fa-copy url-copy",
+      attrs: { "aria-hidden": "true" }
     });
-    copyIcon.addEventListener("click", () => {
+    const copyBtn = el("button", {
+      className: "url-copy-btn d-print-none",
+      attrs: { type: "button", "data-clipboard-text": rawUrl, "aria-label": t("result.copy_url") + ": " + rawUrl }
+    });
+    copyBtn.appendChild(copyIcon);
+    copyBtn.addEventListener("click", () => {
       copyToClipboard(rawUrl).then(() => {
         // JSP parity (js/search.js): swap the copy icon to a green checkmark for ~2s.
         copyIcon.classList.remove("url-copy", "far", "fa-copy");
         copyIcon.classList.add("url-copied", "fas", "fa-check");
-        copyIcon.setAttribute("aria-label", t("result.copied"));
+        copyBtn.setAttribute("aria-label", t("result.copied"));
         setTimeout(() => {
           copyIcon.classList.remove("url-copied", "fas", "fa-check");
           copyIcon.classList.add("url-copy", "far", "fa-copy");
-          copyIcon.setAttribute("aria-label", t("result.copy_url") + ": " + rawUrl);
+          copyBtn.setAttribute("aria-label", t("result.copy_url") + ": " + rawUrl);
         }, 2000);
       }).catch(() => { /* clipboard not available */ });
     });
-    site.appendChild(copyIcon);
+    site.appendChild(copyBtn);
     // JSP has whitespace between the copy icon and the cite — keep them from touching.
     site.appendChild(document.createTextNode(" "));
   }

--- a/src/main/webapp/themes/bootstrap/assets/styles.css
+++ b/src/main/webapp/themes/bootstrap/assets/styles.css
@@ -270,6 +270,11 @@ footer[role="contentinfo"] {
 #result .more { display: none; }
 /* Info line (date / size / cache / similar / favorite) is small. */
 #result .info { font-size: 80%; }
+/* The copy control is a <button> so it is focusable and keyboard-operable;
+   strip the UA's button chrome so it still reads as a bare icon. The glyph
+   inside keeps .url-copy/.url-copied, so the colour rules below still apply.
+   The focus ring comes from the global :focus-visible rule. */
+#result .url-copy-btn { background: none; border: 0; padding: 0; margin: 0; font: inherit; line-height: 1; color: inherit; cursor: pointer; }
 #result .url-copy { color: #007bff; }
 #result .url-copied { color: #2c974b; }
 #result .favorited { display: none; }

--- a/src/main/webapp/themes/bootstrap/theme.yml
+++ b/src/main/webapp/themes/bootstrap/theme.yml
@@ -2,7 +2,7 @@ apiVersion: fess.codelibs.org/v1
 kind: StaticTheme
 name: bootstrap
 displayName: "Bootstrap"
-version: "1.0.2"
+version: "1.0.3"
 author: "CodeLibs Project"
 description: "Reference static theme for Fess. Bootstrap 5-based vanilla-JS SPA exercising /api/v2/*."
 license: "Apache-2.0"

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -1355,6 +1356,27 @@ public class BundledBootstrapThemeTest {
                 "search.js must not put role=\"button\" + aria-label on the copy glyph");
         assertFalse(js.contains("\"aria-hidden\": \"true\", \"data-clipboard-text\": rawUrl"),
                 "search.js must not put aria-hidden on the element that carries the clipboard data");
+        // Order-independent guard: the two assertFalse checks above pin an exact byte order, so a
+        // mutation that keeps the <button> but reorders its attrs to smuggle aria-hidden back onto
+        // it evades them while reintroducing the exact WCAG 4.1.2 aria-hidden-focus defect. Extract
+        // the button's own option object and assert it never carries aria-hidden, in any order.
+        final Matcher copyBtnDef = Pattern.compile("const copyBtn = el\\(\"button\", \\{(.*?)\\}\\);", Pattern.DOTALL).matcher(js);
+        assertTrue(copyBtnDef.find(), "search.js must define the copy control via const copyBtn = el(\"button\", { ... })");
+        assertFalse(copyBtnDef.group(1).contains("aria-hidden"),
+                "the focusable copy <button> must never itself be aria-hidden (WCAG 4.1.2), regardless of attribute order");
+    }
+
+    /**
+     * R4-13 (CSS half): the copy control is a real {@code <button>}, so styles.css must strip the
+     * user-agent button chrome via {@code #result .url-copy-btn}. Without that reset the glyph renders
+     * inside a grey bordered box instead of as a bare icon — a visible regression that the JS-only
+     * a11y test above cannot catch.
+     */
+    @Test
+    public void test_stylesCss_copyButtonChromeReset() throws Exception {
+        final String css = Files.readString(THEME_DIR.resolve("assets/styles.css"), StandardCharsets.UTF_8);
+        assertTrue(css.contains("#result .url-copy-btn"),
+                "styles.css must reset the copy <button> chrome via #result .url-copy-btn (parity R4-13)");
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1318,10 +1318,43 @@ public class BundledBootstrapThemeTest {
     @Test
     public void test_searchJs_copyAndCacheArePrintHidden() throws Exception {
         final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
-        // Copy-URL button: className string must contain both the base class and d-print-none
-        assertTrue(js.contains("url-copy d-print-none"), "search.js copy-url button className must include d-print-none (parity R4 GAP-G)");
+        // Copy-URL button: d-print-none sits on the <button> wrapper; the glyph is its
+        // descendant, so display:none on the button hides the icon with it.
+        assertTrue(js.contains("url-copy-btn d-print-none"),
+                "search.js copy-url button className must include d-print-none (parity R4 GAP-G)");
         // Cache link: className string must contain d-print-none
         assertTrue(js.contains("cache d-print-none"), "search.js cache link className must include d-print-none (parity R4 GAP-G)");
+    }
+
+    /**
+     * R4-13: the copy-URL control must be a real {@code <button type="button">} that carries the
+     * accessible name, with the decorative glyph nested inside and kept aria-hidden.
+     *
+     * <p>The bug fixed here was an {@code <i>} carrying role="button" and aria-label on the same
+     * element as aria-hidden="true": the aria-hidden removed the control from the accessibility
+     * tree, so the role and label were dead, and with no tabindex or keydown handler it was
+     * unreachable by keyboard. Re-introducing that shape is a regression, not a simplification.</p>
+     */
+    @Test
+    public void test_searchJs_copyUrlControlIsARealButton() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        // The focusable element is a real <button type="button"> and owns the accessible name.
+        assertTrue(js.contains("const copyBtn = el(\"button\", {"),
+                "search.js copy-url control must be a real <button>, not an <i> with role=\"button\"");
+        assertTrue(js.contains("attrs: { type: \"button\", \"data-clipboard-text\": rawUrl"),
+                "search.js copy-url button must set type=\"button\" and carry the clipboard data");
+        assertTrue(js.contains("copyBtn.setAttribute(\"aria-label\""),
+                "search.js must retarget the aria-label on the <button>, not on the aria-hidden glyph");
+        // The glyph stays decorative, keeps the bare colour class, and lives inside the button.
+        assertTrue(js.contains("className: \"far fa-copy url-copy\","),
+                "search.js copy glyph must keep the bare url-copy class (colour rules) and not carry d-print-none itself");
+        assertTrue(js.contains("copyBtn.appendChild(copyIcon);"), "search.js copy glyph must be nested inside the button");
+        // Negative guards. A bare role: "button" is legitimate elsewhere (the facet-reset <a> in
+        // buildFacetGroup), so pin the exact contradictory pairs, never the bare token.
+        assertFalse(js.contains("role: \"button\", \"aria-label\": t(\"result.copy_url\")"),
+                "search.js must not put role=\"button\" + aria-label on the copy glyph");
+        assertFalse(js.contains("\"aria-hidden\": \"true\", \"data-clipboard-text\": rawUrl"),
+                "search.js must not put aria-hidden on the element that carries the clipboard data");
     }
 
     /**


### PR DESCRIPTION
The copy-URL control in the bundled `bootstrap` theme could not be used by keyboard, and did not exist for screen readers.

```js
const copyIcon = el("i", {
  className: "far fa-copy url-copy d-print-none",
  attrs: { "aria-hidden": "true", "data-clipboard-text": rawUrl, role: "button", "aria-label": … }
});
copyIcon.addEventListener("click", …);
```

Those attributes contradict each other. **`aria-hidden="true"` removes the element from the accessibility tree**, so the `role="button"` and `aria-label` declared on the very same element were dead — a screen reader never saw the control at all. And with no `tabindex` and only a `click` listener, it could not be reached or operated from the keyboard.

So it was **invisible to assistive technology and unusable without a mouse**. That is **WCAG 2.1 AA 2.1.1 Keyboard** and **4.1.2 Name, Role, Value** — not a marginal ratio, but a control that simply was not available.

## The fix

A real `<button type="button">`:

- the element that takes focus is the one that carries the role and the accessible name
- keyboard activation (Enter/Space) comes from the user agent, not a hand-rolled `keydown`
- the glyph inside stays `aria-hidden` and **keeps its `url-copy` / `url-copied` classes**, so the existing colour rules apply unchanged
- a small reset strips the UA button chrome so it still renders as a bare icon
- the focus ring comes from the global `:focus-visible` rule the theme already ships

## Verified against a live Fess

Serving a theme built from this same code, the accessibility tree — what a screen reader actually consumes — now reads:

```
link   "http://content/p/widget-l.html"              [ref_22]
button "URL をコピー: http://content/p/widget-l.html"  [ref_23] type="button"
link   "キャッシュ"                                    [ref_24]
```

Before the fix it did not appear in that tree at all. It is now in the interactive order, between the result link and the cache link, with a localized accessible name. Rendering is unchanged — still a bare icon, no border, no background, no padding box.

## Scope

Four files: the theme's `search.js`, a five-line CSS reset in `styles.css`, a `theme.yml` bump, and a regression test pinning the fixed shape. No main-source Java, no build impact.

`bootstrap` is the reference theme the themes in `codelibs/fess-themes` derive from, and this block was **byte-identical across all nine copies**. The same change is being made there, so the shared-core identity that several theme READMEs assert keeps holding.

`theme.yml` goes 1.0.1 → 1.0.2, following #3187 — this PR's base — which bumped 1.0.0 → 1.0.1 to match the companion fess-themes patch, exactly this situation.

