### PR TITLE
fix(theme): parse the server snippet instead of escaping it a second time

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/format.js
+++ b/src/main/webapp/themes/bootstrap/assets/format.js
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Common formatting utilities for the Fess bootstrap SPA.
-// No DOM access — pure functions, safe to import from any module.
+// Importing is DOM-free; calling is not. Only formatFileSize / formatDate /
+// escapeHtml are pure — sanitizeHtml and renderHighlightedSnippet parse via
+// document, and isSafeHref needs window.location.
 
 const UNITS = ["B", "KB", "MB", "GB", "TB", "PB"];
 
@@ -111,8 +113,10 @@ const ALLOWED_TAGS = new Set([
  * / .post, whose default is <strong>; <em> is accepted because deployments
  * override the pair to it. A pair configured to anything else is unwrapped
  * like any other disallowed tag — the text survives, only the highlight is
- * lost. Deliberately far narrower than ALLOWED_TAGS: everything else in a
- * snippet arrived escaped and must stay text.
+ * lost — unless it names a DROP_WITH_CONTENT member, which is dropped whole
+ * and takes the highlighted text with it. Deliberately far narrower than
+ * ALLOWED_TAGS: everything else in a snippet arrived escaped and must stay
+ * text.
  */
 const SNIPPET_TAGS = new Set(["STRONG", "EM"]);
 

--- a/src/main/webapp/themes/bootstrap/assets/format.js
+++ b/src/main/webapp/themes/bootstrap/assets/format.js
@@ -60,23 +60,31 @@ export function escapeHtml(s) {
 /**
  * Sanitize a server-supplied search snippet for safe innerHTML assignment.
  *
- * The server wraps matched terms in <strong> or <em>. This function escapes
- * all HTML first, then selectively restores only those two tag pairs.
- * All other markup (including any injected tags) remains escaped.
+ * `raw` is already HTML, not plain text. ViewHelper.getContentDescription()
+ * and .getContentTitle() run LaFunctions.h() over the whole field and then
+ * splice the highlight tags back in, so a `"` in the source arrives as the
+ * entity `&#034;` while <strong> arrives live. Escaping again here would turn
+ * that entity's `&` into `&amp;` and the browser would paint the literal text
+ * `&#034;`, so parse instead: entities decode back to their characters and
+ * only SNIPPET_TAGS survive as markup.
+ *
+ * Callers holding a field the server does NOT escape — `digest` — must
+ * escapeHtml() it first so it meets the same already-escaped contract.
  *
  * The return value is safe to assign to element.innerHTML.
  *
- * @param {string|null|undefined} raw
+ * @param {string|null|undefined} raw - server snippet HTML
  * @returns {string} sanitized HTML string
  */
 export function renderHighlightedSnippet(raw) {
   if (!raw) return "";
-  const escaped = escapeHtml(raw);
-  return escaped
-    .replaceAll("&lt;strong&gt;", "<strong>")
-    .replaceAll("&lt;/strong&gt;", "</strong>")
-    .replaceAll("&lt;em&gt;", "<em>")
-    .replaceAll("&lt;/em&gt;", "</em>");
+  const tpl = document.createElement("template");
+  // Safe for the same reason sanitizeHtml()'s assignment is: <template>
+  // content is inert, and sanitizeFragment() strips everything but
+  // SNIPPET_TAGS before the string is handed back for innerHTML.
+  tpl.innerHTML = String(raw); // eslint-disable-line no-unsanitized/property
+  sanitizeFragment(tpl.content, SNIPPET_TAGS);
+  return tpl.innerHTML;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,6 +103,18 @@ const ALLOWED_TAGS = new Set([
   "DL", "DT", "DD",
   "HR"
 ]);
+
+/**
+ * Tags a search snippet may carry as live markup, for renderHighlightedSnippet().
+ *
+ * The server escapes the whole field and restores only query.highlight.tag.pre
+ * / .post, whose default is <strong>; <em> is accepted because deployments
+ * override the pair to it. A pair configured to anything else is unwrapped
+ * like any other disallowed tag — the text survives, only the highlight is
+ * lost. Deliberately far narrower than ALLOWED_TAGS: everything else in a
+ * snippet arrived escaped and must stay text.
+ */
+const SNIPPET_TAGS = new Set(["STRONG", "EM"]);
 
 /**
  * Elements dropped whole, children included, rather than unwrapped like an
@@ -183,9 +203,10 @@ export function isSafeHref(value) {
  * Returns the node to keep, or null if the node should be removed entirely.
  *
  * @param {Node} node
+ * @param {Set<string>} allowedTags - uppercase tag names kept as markup
  * @returns {Node|null}
  */
-function sanitizeNode(node) {
+function sanitizeNode(node, allowedTags) {
   if (node.nodeType === Node.TEXT_NODE) return node;
 
   if (node.nodeType === Node.ELEMENT_NODE) {
@@ -197,11 +218,11 @@ function sanitizeNode(node) {
       return null;
     }
 
-    if (!ALLOWED_TAGS.has(tag)) {
+    if (!allowedTags.has(tag)) {
       // Disallowed tag: unwrap — keep its sanitized children in a fragment.
       const frag = document.createDocumentFragment();
       for (const child of Array.from(node.childNodes)) {
-        const kept = sanitizeNode(child);
+        const kept = sanitizeNode(child, allowedTags);
         if (kept) frag.appendChild(kept);
       }
       return frag.childNodes.length ? frag : null;
@@ -228,7 +249,7 @@ function sanitizeNode(node) {
     }
 
     for (const child of Array.from(node.childNodes)) {
-      const kept = sanitizeNode(child);
+      const kept = sanitizeNode(child, allowedTags);
       if (kept !== child) {
         if (kept) {
           node.replaceChild(kept, child);
@@ -246,6 +267,27 @@ function sanitizeNode(node) {
 }
 
 /**
+ * Sanitize every child of an already-parsed fragment in-place.
+ *
+ * @param {DocumentFragment} frag
+ * @param {Set<string>} allowedTags - uppercase tag names kept as markup
+ * @returns {DocumentFragment} the same fragment
+ */
+function sanitizeFragment(frag, allowedTags) {
+  for (const child of Array.from(frag.childNodes)) {
+    const kept = sanitizeNode(child, allowedTags);
+    if (kept !== child) {
+      if (kept) {
+        frag.replaceChild(kept, child);
+      } else {
+        frag.removeChild(child);
+      }
+    }
+  }
+  return frag;
+}
+
+/**
  * Parse an HTML string and return a sanitized DocumentFragment safe to
  * appendChild into the live DOM.
  *
@@ -258,21 +300,9 @@ function sanitizeNode(node) {
  */
 export function sanitizeHtml(html) {
   const tpl = document.createElement("template");
-  // This is the single intentional innerHTML assignment in the module.
-  // It is safe because <template> content is inert: scripts are not executed
+  // This is safe because <template> content is inert: scripts are not executed
   // and the fragment is not yet part of the live document.
   tpl.innerHTML = html; // eslint-disable-line no-unsanitized/property
 
-  const frag = tpl.content;
-  for (const child of Array.from(frag.childNodes)) {
-    const kept = sanitizeNode(child);
-    if (kept !== child) {
-      if (kept) {
-        frag.replaceChild(kept, child);
-      } else {
-        frag.removeChild(child);
-      }
-    }
-  }
-  return frag;
+  return sanitizeFragment(tpl.content, ALLOWED_TAGS);
 }

--- a/src/main/webapp/themes/bootstrap/assets/format.js
+++ b/src/main/webapp/themes/bootstrap/assets/format.js
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Common formatting utilities for the Fess bootstrap SPA.
 // Importing is DOM-free; calling is not. Only formatFileSize / formatDate /
-// escapeHtml are pure — sanitizeHtml and renderHighlightedSnippet parse via
-// document, and isSafeHref needs window.location.
+// escapeHtml are pure — sanitizeHtml, renderHighlightedSnippet and
+// renderSnippetText parse via document, and isSafeHref needs window.location.
 
 const UNITS = ["B", "KB", "MB", "GB", "TB", "PB"];
 
@@ -43,8 +43,9 @@ export function formatDate(isoString) {
 
 /**
  * Escape HTML special characters so a plain string is safe to assign to
- * element.textContent is always preferred, but this function is provided
- * for cases where a sanitized string must be embedded in a larger context.
+ * element.innerHTML. Assigning to element.textContent is always preferred,
+ * but this function is provided for cases where a string must be embedded in
+ * a larger HTML context.
  *
  * @param {string|null|undefined} s
  * @returns {string}
@@ -87,6 +88,37 @@ export function renderHighlightedSnippet(raw) {
   tpl.innerHTML = String(raw); // eslint-disable-line no-unsanitized/property
   sanitizeFragment(tpl.content, SNIPPET_TAGS);
   return tpl.innerHTML;
+}
+
+/**
+ * Reduce a server-supplied search snippet to plain text.
+ *
+ * Runs renderHighlightedSnippet()'s exact parse-and-sanitize path and differs
+ * only in what it hands back: the fragment's text instead of its HTML. Callers
+ * needing the text-only form of a field the UI also renders — an aria-label
+ * beside the visible snippet — must use this rather than stripping the
+ * highlight tags themselves, so the two can never disagree about what the
+ * server sent. A hand-rolled strip leaves the entities behind (`&#034;` reaches
+ * a screen reader literally) and keeps text the sanitizer drops whole (the
+ * DROP_WITH_CONTENT members), both of which the shared path gets right.
+ *
+ * `raw` must meet the same already-escaped contract renderHighlightedSnippet()
+ * documents. Fields the server does NOT escape — `title`, `url`, `digest` —
+ * are plain text already and must not be passed here: parsing would decode
+ * entities the server never wrote, turning a title that literally reads
+ * "AT&amp;T" into "AT&T".
+ *
+ * @param {string|null|undefined} raw - server snippet HTML
+ * @returns {string} plain text, entities decoded and markup removed
+ */
+export function renderSnippetText(raw) {
+  if (!raw) return "";
+  const tpl = document.createElement("template");
+  // Inert for the same reason renderHighlightedSnippet()'s assignment is, and
+  // the parsed string is never handed back as HTML here — only as text.
+  tpl.innerHTML = String(raw); // eslint-disable-line no-unsanitized/property
+  sanitizeFragment(tpl.content, SNIPPET_TAGS);
+  return tpl.content.textContent;
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +251,13 @@ function sanitizeNode(node, allowedTags) {
     if (DROP_WITH_CONTENT.has(tag)) {
       // See the DROP_WITH_CONTENT comment above for why each member is
       // dropped whole here instead of being unwrapped.
+      //
+      // This check must stay AHEAD of the unwrap branch below. No member of
+      // the set appears in ALLOWED_TAGS or SNIPPET_TAGS, so running the
+      // unwrap branch first would claim every one of them and leave this
+      // branch unreachable — silently reinstating the defect it fixes, with
+      // each raw-text element's own source promoted to a text node and
+      // painted as visible prose. Nothing else enforces the order.
       return null;
     }
 

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1,6 +1,6 @@
 import * as api from "./api.js";
 import { t, languageLabel } from "./i18n.js";
-import { formatFileSize, formatDate, renderHighlightedSnippet, sanitizeHtml } from "./format.js";
+import { escapeHtml, formatFileSize, formatDate, renderHighlightedSnippet, sanitizeHtml } from "./format.js";
 import { navigate } from "./router.js";
 
 /** Guard: prevent duplicate event-listener registration on hot-reload. */
@@ -214,7 +214,12 @@ function buildResultCard(d, queryId, order) {
     body.appendChild(thumbWrap);
   }
   const description = el("div", { className: "description" });
-  description.innerHTML = renderHighlightedSnippet(d.content_description || d.digest || "");
+  // content_description is server-escaped HTML; digest is the raw index field,
+  // so escape it here to meet the contract renderHighlightedSnippet() expects.
+  // Without that, a digest like "Michael Froh <msfroh@example.com>" would have
+  // the address parsed as a tag and dropped.
+  description.innerHTML = renderHighlightedSnippet(
+    d.content_description || escapeHtml(d.digest || ""));
   body.appendChild(description);
   li.appendChild(body);
 

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -1,6 +1,6 @@
 import * as api from "./api.js";
 import { t, languageLabel } from "./i18n.js";
-import { escapeHtml, formatFileSize, formatDate, renderHighlightedSnippet, sanitizeHtml } from "./format.js";
+import { escapeHtml, formatFileSize, formatDate, renderHighlightedSnippet, renderSnippetText, sanitizeHtml } from "./format.js";
 import { navigate } from "./router.js";
 
 /** Guard: prevent duplicate event-listener registration on hot-reload. */
@@ -140,16 +140,24 @@ function buildGoUrl(originalUrl, docId, queryId, order, rt) {
 }
 
 /**
- * Return the plain-text title for a result document, stripping any
- * server-injected highlight markup (<strong>/<em>) from content_title.
- * Safe to use in aria-label and other text-only contexts.
+ * Return the plain-text title for a result document: entities decoded and the
+ * server-injected highlight markup removed. The result is the same text the
+ * h3 below paints, so it is safe to use in aria-label and other text-only
+ * contexts.
  *
  * @param {Object} d - result document object
  * @returns {string}
  */
 function plainTitle(d) {
-  const raw = d.content_title || d.title || d.url || "";
-  return String(raw).replace(/<\/?(?:strong|em)>/g, "");
+  // content_title is server-escaped HTML with the highlight tags spliced in, so
+  // run it through the same parse path the visible title uses and the accessible
+  // name cannot diverge from what is on screen. title and url are raw index
+  // fields the server never escapes: parsing them would decode entities it never
+  // wrote, so a title literally reading "AT&amp;T" must be left alone. The
+  // branch mirrors buildResultCard()'s, down to an empty content_title falling
+  // through to title.
+  if (d.content_title) return renderSnippetText(d.content_title);
+  return d.title || d.url || "";
 }
 
 function buildResultCard(d, queryId, order) {

--- a/src/main/webapp/themes/bootstrap/theme.yml
+++ b/src/main/webapp/themes/bootstrap/theme.yml
@@ -2,7 +2,7 @@ apiVersion: fess.codelibs.org/v1
 kind: StaticTheme
 name: bootstrap
 displayName: "Bootstrap"
-version: "1.0.1"
+version: "1.0.2"
 author: "CodeLibs Project"
 description: "Reference static theme for Fess. Bootstrap 5-based vanilla-JS SPA exercising /api/v2/*."
 license: "Apache-2.0"

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1201,6 +1201,43 @@ public class BundledBootstrapThemeTest {
     }
 
     /**
+     * renderHighlightedSnippet must PARSE the server snippet, never escape it a
+     * second time. ViewHelper.getContentDescription()/.getContentTitle() already
+     * run LaFunctions.h() over the whole field and splice only the highlight tags
+     * back in, so a source <code>"</code> arrives as the entity &amp;#034;.
+     * Escaping again turns that entity's &amp; into &amp;amp; and the browser
+     * paints the literal text &amp;#034; -- the double-escape this guards.
+     */
+    @Test
+    public void test_formatJs_snippetIsParsedNotEscapedAgain() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
+        assertFalse(js.contains("const escaped = escapeHtml(raw);"),
+                "renderHighlightedSnippet must not escape the already-escaped server snippet again (double-escape: &#034; renders literally)");
+        assertFalse(js.contains(".replaceAll(\"&lt;strong&gt;\", \"<strong>\")"),
+                "the escape-then-restore approach is what double-escaped; the snippet must be parsed instead");
+        assertTrue(js.contains("const SNIPPET_TAGS = new Set([\"STRONG\", \"EM\"]);"),
+                "format.js must define SNIPPET_TAGS, the narrow allowlist of tags a snippet may carry as live markup");
+        assertTrue(js.contains("sanitizeFragment(tpl.content, SNIPPET_TAGS)"),
+                "renderHighlightedSnippet must parse in an inert <template> and keep only SNIPPET_TAGS");
+    }
+
+    /**
+     * The raw <code>digest</code> field must be escaped at the call site before it
+     * reaches renderHighlightedSnippet. content_description is server-escaped HTML,
+     * but digest is the raw index field and the server never escapes it -- feeding
+     * it in unescaped makes the parser eat any &lt;...&gt; it contains (a digest
+     * like "Michael Froh &lt;msfroh@example.com&gt;" silently loses the address).
+     */
+    @Test
+    public void test_searchJs_escapesRawDigestBeforeRendering() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("escapeHtml(d.digest || \"\")"),
+                "search.js must escape the raw digest field before renderHighlightedSnippet parses it");
+        assertFalse(js.contains("renderHighlightedSnippet(d.content_description || d.digest"),
+                "the raw digest must not be passed to renderHighlightedSnippet unescaped");
+    }
+
+    /**
      * R4-9: advance.js per-page fallback list must match JSP parity ([10,20,30,40,50,100]).
      * The shorter legacy list ([10,20,50,100]) must not appear as the fallback.
      */

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1238,6 +1238,67 @@ public class BundledBootstrapThemeTest {
     }
 
     /**
+     * renderSnippetText must reduce a snippet to text through the SAME parse path
+     * renderHighlightedSnippet uses, so a caller needing the text-only form of a
+     * field the UI also renders cannot drift from what is painted. Sharing
+     * sanitizeFragment + SNIPPET_TAGS is what buys that: the sanitizer's drops
+     * (the DROP_WITH_CONTENT members) are reflected in the text, and the entities
+     * decode exactly once.
+     */
+    @Test
+    public void test_formatJs_snippetTextSharesTheSnippetParsePath() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
+        assertTrue(js.contains("export function renderSnippetText(raw)"),
+                "format.js must export renderSnippetText, the text-only form of the snippet parse path");
+        assertTrue(js.contains("sanitizeFragment(tpl.content, SNIPPET_TAGS);\n  return tpl.content.textContent;"),
+                "renderSnippetText must return the sanitized fragment's textContent, so it shares renderHighlightedSnippet's parse+sanitize path rather than reimplementing it");
+    }
+
+    /**
+     * plainTitle() supplies the aria-label on each result's "more" link, and
+     * content_title is server-escaped HTML with the highlight tags spliced in.
+     * Stripping only those tags leaves every entity behind, so a title painted as
+     * <code>Tom &amp; Jerry "quoted"</code> in the h3 reached a screen reader as
+     * the literal <code>Tom &amp;amp; Jerry &amp;#034;quoted&amp;#034;</code>.
+     * It must run content_title through the shared parse path instead.
+     * <p>
+     * The title/url fallbacks must NOT be parsed: the server never escapes those
+     * raw index fields, so decoding them would corrupt a title that literally
+     * contains "&amp;amp;". The branch is what keeps both contracts.
+     */
+    @Test
+    public void test_searchJs_plainTitleParsesOnlyTheEscapedContentTitle() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
+        assertFalse(js.contains("String(raw).replace(/<\\/?(?:strong|em)>/g, \"\")"),
+                "plainTitle must not strip the highlight tags with a regex: it leaves the server's entities undecoded, so the aria-label diverges from the visible title");
+        final String formatImport = js.lines().filter(line -> line.contains("from \"./format.js\"")).findFirst().orElse("");
+        assertTrue(formatImport.contains("renderSnippetText"), "search.js must import renderSnippetText from format.js");
+        assertTrue(js.contains("if (d.content_title) return renderSnippetText(d.content_title);"),
+                "plainTitle must route the server-escaped content_title through renderSnippetText, the same parse path the visible title uses");
+        assertTrue(js.contains("return d.title || d.url || \"\";"),
+                "plainTitle must return the raw title/url fallbacks unparsed -- the server never escapes them, so parsing would decode entities it never wrote");
+    }
+
+    /**
+     * sanitizeNode's DROP_WITH_CONTENT check must stay AHEAD of the unwrap branch.
+     * No member of the set appears in ALLOWED_TAGS or SNIPPET_TAGS, so running the
+     * unwrap branch first would claim every one of them and leave the drop branch
+     * unreachable -- silently reinstating the defect #3187 fixed, with each
+     * raw-text element's own source promoted to a text node and painted as prose.
+     * Nothing but source order enforces this, hence the guard.
+     */
+    @Test
+    public void test_formatJs_dropWithContentPrecedesUnwrap() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
+        final int dropCheck = js.indexOf("if (DROP_WITH_CONTENT.has(tag)) {");
+        final int unwrapCheck = js.indexOf("if (!allowedTags.has(tag)) {");
+        assertTrue(dropCheck > 0, "format.js must keep the DROP_WITH_CONTENT check in sanitizeNode");
+        assertTrue(unwrapCheck > 0, "format.js must keep the disallowed-tag unwrap branch in sanitizeNode");
+        assertTrue(dropCheck < unwrapCheck,
+                "the DROP_WITH_CONTENT check must run before the unwrap branch, or it becomes unreachable and raw-text source resurfaces as visible text");
+    }
+
+    /**
      * R4-9: advance.js per-page fallback list must match JSP parity ([10,20,30,40,50,100]).
      * The shorter legacy list ([10,20,50,100]) must not appear as the fallback.
      */


### PR DESCRIPTION
## Problem

Search snippets render HTML entities as literal text — `&#034;` instead of `"`, and `&#039;` for every apostrophe. On a code-search deployment a Java line shows as:

```
    &#034;distasteful&#034;, &#034;distemper&#034;, &#034;distend&#034;,
```

## Cause

`content_description` / `content_title` arrive from `/api/v2/search` **already HTML-escaped**. `ViewHelper.getContentDescription()` / `.getContentTitle()` run `LaFunctions.h()` over the whole field (`ViewHelper.java:362`) and then splice only `query.highlight.tag.pre`/`.post` back in (`:378`). So a source `"` arrives as `&#034;` while `<strong>` arrives live — the field is escaped text plus live highlight markup.

`renderHighlightedSnippet()` treated it as plain text and escaped it again: `escapeHtml`'s `.replaceAll("&", "&amp;")` turned `&#034;` into `&amp;#034;`. The restore step only un-escaped `&lt;strong&gt;`, so nothing ever turned `&amp;` back into `&`, and the browser painted the literal text.

## Fix

Parse the snippet in an inert `<template>` and keep only the `<strong>`/`<em>` match tags, so entities decode exactly once. This reuses the module's existing parse-then-sanitize path rather than adding a second sanitizer: `sanitizeNode()` / `sanitizeFragment()` now take the allowed tag set as a parameter, with a narrow `SNIPPET_TAGS` for snippets.

`digest` needs the **opposite** treatment and is the reason "just delete the escape" is wrong. It is the raw index field and the server never escapes it, so parsing it as HTML makes the parser eat any markup it contains — a real digest like `Michael Froh <msfroh@example.com>` silently loses the address. It is now escaped once at the call site so it meets the same already-escaped contract.

This is a correctness fix, not a security fix: the old code was safe but over-escaped. The new path is safe *and* correct — it drops raw-text elements whole and strips all attributes, as before.

## Verification

- Real `buildResultCard()` driven with a real `/api/v2/search` document in headless Chrome: the gutter rows now render `"distasteful", "distemper"`, with the `<strong>` highlight intact.
- A module-level harness comparing the pinned pre-fix `format.js` against the fixed one: **before 6/15 → after 15/15**, covering entity decoding, highlight survival, the digest address, inert-script handling, attribute stripping, re-render idempotency, and empty/null.
- `mvn test -Dtest='org.codelibs.fess.theme.*Test'` → **208 pass**.
- The two new guards were run against the pre-fix assets first and **failed**, confirming they are real regression tests.

## Related

Every static theme ships its own copy of `format.js` with the identical defect; those copies are fixed in codelibs/fess-themes#35, which should land together with this.
