### PR TITLE
fix(theme/bootstrap): surface a missing DOM from isSafeHref and keep the shared asset headers theme-neutral

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/format.js
+++ b/src/main/webapp/themes/bootstrap/assets/format.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Common formatting utilities for the Fess bootstrap SPA.
+// Common formatting utilities for the Fess static theme SPA.
 // Importing is DOM-free; calling is not. Only formatFileSize / formatDate /
 // escapeHtml are pure — sanitizeHtml, renderHighlightedSnippet and
 // renderSnippetText parse via document, and isSafeHref needs window.location.
@@ -228,9 +228,17 @@ export function isSafeHref(value) {
   if (cleaned === "") return false;
   try {
     return SAFE_HREF_SCHEMES.has(new URL(cleaned, window.location.href).protocol);
-  } catch {
-    // Malformed URL — treat as unsafe.
-    return false;
+  } catch (e) {
+    // Malformed URL — treat as unsafe. new URL() reports an unparseable input
+    // as a TypeError and nothing else, so catching only that keeps every real
+    // browser input on this branch while letting an unexpected failure through.
+    if (e instanceof TypeError) return false;
+    // Anything else means the precondition this file's header states — a DOM
+    // with window.location — was not met: outside a browser, resolving the
+    // base throws ReferenceError. Swallowing it would answer "unsafe" for
+    // every URL, including safe ones, and a caller cannot tell that apart from
+    // a real verdict. Fail loudly instead of silently rejecting everything.
+    throw e;
   }
 }
 

--- a/src/main/webapp/themes/bootstrap/assets/markdown.js
+++ b/src/main/webapp/themes/bootstrap/assets/markdown.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Minimal in-repo Markdown renderer for the Fess bootstrap SPA.
+// Minimal in-repo Markdown renderer for the Fess static theme SPA.
 // Produces HTML from a safe subset of Markdown. All input is HTML-escaped
 // before pattern substitution — no raw user strings appear in output.
 // The caller MUST pass the return value through sanitizeHtml() before

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1280,6 +1280,52 @@ public class BundledBootstrapThemeTest {
     }
 
     /**
+     * isSafeHref resolves its argument against {@code window.location}, so calling
+     * it without a DOM throws ReferenceError. A blanket catch turned that into
+     * {@code false} -- the very answer it gives for {@code javascript:}, and
+     * indistinguishable from it: every URL, safe or not, is reported unsafe and
+     * nothing says why.
+     * <p>
+     * new URL() reports an unparseable input as a TypeError and nothing else, so
+     * catching only TypeError keeps every real browser input on the "unsafe"
+     * branch while a broken environment surfaces instead of failing closed in
+     * silence.
+     */
+    @Test
+    public void test_formatJs_isSafeHrefSurfacesAMissingDomInsteadOfReportingUnsafe() throws Exception {
+        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
+        final int start = js.indexOf("export function isSafeHref(value) {");
+        assertTrue(start >= 0, "format.js must export isSafeHref");
+        final String fn = js.substring(start, js.indexOf("\n}\n", start));
+        assertTrue(fn.contains("if (e instanceof TypeError) return false;"),
+                "isSafeHref must treat only a TypeError -- what new URL() throws for a malformed URL -- as an unsafe verdict");
+        assertTrue(fn.contains("throw e;"),
+                "isSafeHref must rethrow what is not a URL parse failure, so a missing DOM cannot masquerade as an unsafe-URL verdict");
+        assertFalse(fn.contains("} catch {"),
+                "isSafeHref must not blanket-catch: that reports the ReferenceError from a missing window.location as an unsafe URL");
+    }
+
+    /**
+     * format.js and markdown.js are duplicated verbatim into every derived static
+     * theme, so the copies can only be kept honest by byte-comparing them against
+     * these. Line 2 was the one line that named the theme, forcing a "compare from
+     * line 3 onward" convention -- brittle, because it silently stops covering
+     * line 2 the moment a header line is added or removed. Keeping the shared
+     * headers theme-neutral lets the whole file be compared as-is.
+     */
+    @Test
+    public void test_sharedAssetHeadersNameNoSpecificTheme() throws Exception {
+        for (final String asset : new String[] { "format.js", "markdown.js" }) {
+            final String js = Files.readString(THEME_DIR.resolve("assets/" + asset), StandardCharsets.UTF_8);
+            final String line2 = js.lines().skip(1).findFirst().orElse("");
+            assertTrue(line2.contains("Fess static theme SPA"),
+                    asset + " line 2 must describe the file theme-neutrally so every derived copy stays byte-identical, but was: " + line2);
+            assertFalse(line2.contains("bootstrap"), asset
+                    + " line 2 must not name the bootstrap theme: the derived copies differ only here, and a theme-specific name is what forces the brittle compare-from-line-3 convention");
+        }
+    }
+
+    /**
      * sanitizeNode's DROP_WITH_CONTENT check must stay AHEAD of the unwrap branch.
      * No member of the set appears in ALLOWED_TAGS or SNIPPET_TAGS, so running the
      * unwrap branch first would claim every one of them and leave the drop branch


### PR DESCRIPTION
## Why

Two defects in the static-theme shared assets. Neither is user-visible today; both are the kind that get copied.

### 1. `isSafeHref()` cannot report a missing DOM

`isSafeHref()` resolves its argument against `window.location`, so calling it without a DOM throws `ReferenceError`. The blanket `catch { return false; }` turned that into `false` — the very answer it gives for `javascript:`, and indistinguishable from it. Outside a browser, **every** URL was reported unsafe, safe ones included, and nothing said why:

```
BASE  | "https://example.com/"  -> returned false   <- safe URL, reported unsafe
BASE  | "javascript:alert(1)"   -> returned false   <- same answer, different reason
FIXED | "https://example.com/"  -> THREW ReferenceError
FIXED | "javascript:alert(1)"   -> THREW ReferenceError
```

`new URL()` reports an unparseable input as a `TypeError` and nothing else, so this catches only `TypeError` and rethrows the rest. That keeps the narrow contract — *don't catch what you didn't anticipate* — rather than special-casing `window`.

**No behaviour change for any real browser input.** Malformed URLs still return `false` via the `TypeError` branch; only a broken environment now surfaces.

### 2. Shared asset headers named the theme

`format.js` and `markdown.js` are duplicated verbatim into every derived static theme, so copies can only be kept honest by byte-comparing them. Line 2 was the one line naming `bootstrap`, which forced a "compare from line 3 onward" convention — brittle, since it silently stops covering line 2 the moment a header line is added or removed. Line 2 is the *only* theme mention in either file, so making it theme-neutral is all that divergence ever was.

## Tests

`BundledBootstrapThemeTest` is plain JUnit 5 and string-matches theme asset source. Both fixed sites had **zero** coverage; two tests added:

- `test_formatJs_isSafeHrefSurfacesAMissingDomInsteadOfReportingUnsafe`
- `test_sharedAssetHeadersNameNoSpecificTheme`

Verified `129/129` pass, and that both new tests **fail against the pre-fix source** (a test that passes either way guards nothing):

```
[ERROR] test_formatJs_isSafeHrefSurfacesAMissingDomInsteadOfReportingUnsafe
  isSafeHref must treat only a TypeError -- what new URL() throws for a
  malformed URL -- as an unsafe verdict ==> expected: <true> but was: <false>
[ERROR] test_sharedAssetHeadersNameNoSpecificTheme
  format.js line 2 must describe the file theme-neutrally ... but was:
  // Common formatting utilities for the Fess bootstrap SPA.
```

Also exercised in headless Chrome over `http://` — 18/18 pass, confirming `isSafeHref` is unchanged for https / relative / mailto / `javascript:` / obfuscated `java\tscript:` / `data:` / malformed / empty / non-string input, and that `plainTitle`'s snippet handling from #3192 is intact (`What&#039;s new` → `What's new`; a literal `&#039;` survives; the raw `title`/`url` fallbacks stay undecoded).

`mvn -o javadoc:jar` passes (CI gate that `mvn test` skips).

## Follow-up

**fess-themes needs a matching port, and it is larger than this PR.** The nine derived copies of `format.js` / `markdown.js` currently diverge from canonical on more than line 2:

- **This PR's changes**: line-2 text (today `HelpDesk SPA`, `DocSearch SPA`, `Mosaic SPA`, `Storefront SPA`, and a stale `Fess bootstrap SPA` in codesearch) and the `isSafeHref` catch.
- **#3192 was only partially ported.** `renderSnippetText` is exported in **0** of the derived `format.js` copies, and the regex strip `#3192` removed still lives in `mosaic/assets/search.js` (two sites: `:182` and `:652`), `storefront/assets/search.js:218`, and `docsearch/assets/search.js:154`. Those copies still hand an undecoded, entity-laden title to `aria-label`.

So porting only this PR would **not** make the copies byte-identical; the `renderSnippetText` half of #3192 has to land there too. Scoped separately.

No conflict with #3191 — verified clean via `git merge-tree --write-tree`.
