### PR TITLE
test(theme/bootstrap): execute theme JS under vitest+jsdom, fixing h1/h5/h6 stripping

### DIFF
--- a/.github/workflows/theme-js.yml
+++ b/.github/workflows/theme-js.yml
@@ -1,0 +1,36 @@
+# Runs the executable unit tests for the bundled bootstrap theme JavaScript.
+# These live under src/test/js and are not part of the Maven build (they need
+# Node + jsdom, which the Java CI does not provide), so they get their own job.
+
+name: Theme JS
+
+on:
+  push:
+    branches:
+    - master
+    - "*.x"
+  pull_request:
+    branches:
+    - master
+    - "*.x"
+  workflow_dispatch:
+
+jobs:
+  theme-js:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: src/test/js
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: npm
+        cache-dependency-path: src/test/js/package-lock.json
+    - name: Install dependencies
+      run: npm ci
+    - name: Run theme JS tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ src/main/webapp/WEB-INF/project.properties
 /.apt_generated_tests/
 /.serena
 /.claude
+/src/test/js/node_modules/

--- a/src/main/webapp/themes/bootstrap/assets/advance.js
+++ b/src/main/webapp/themes/bootstrap/assets/advance.js
@@ -99,7 +99,7 @@ const BACKSLASH = String.fromCharCode(92);
  * @param {string} s
  * @returns {string}
  */
-function quoteIfNeeded(s) {
+export function quoteIfNeeded(s) {
   s = s.trim();
   if (!s) return "";
   if (s.startsWith('"') && s.endsWith('"')) return s;
@@ -113,7 +113,7 @@ function quoteIfNeeded(s) {
  * @param {string} s
  * @returns {string[]}
  */
-function tokenize(s) {
+export function tokenize(s) {
   const tokens = [];
   const str = s.trim();
   let i = 0;
@@ -148,7 +148,7 @@ function tokenize(s) {
  *            site?:string, filetype?:string, occt?:string }} parts
  * @returns {string}
  */
-function compose(parts) {
+export function compose(parts) {
   const out = [];
 
   if (parts.all) {
@@ -217,7 +217,7 @@ const TIME_RANGES = [
  * server (QueryStringBuilder:242-244; advance.jsp:242-253).
  * Field is "timestamp"; values are appended to q as "timestamp:<value>".
  */
-const TIME_RANGE_QUERY = {
+export const TIME_RANGE_QUERY = {
   "1day":   "timestamp:[now-1d/d TO *]",
   "1week":  "timestamp:[now-1w/d TO *]",
   "1month": "timestamp:[now-1M/d TO *]",
@@ -238,7 +238,7 @@ const FILETYPE_OPTIONS_FALLBACK = [
   { value: "others",     labelKey: "labels.facet_filetype_others" },
 ];
 
-function buildFiletypeOptions(serverConfig) {
+export function buildFiletypeOptions(serverConfig) {
   const fromServer = serverConfig && Array.isArray(serverConfig.filetype_options) ? serverConfig.filetype_options : null;
   if (fromServer && fromServer.length > 0) {
     return [{ value: "", labelKey: "advance.any_filetype" },

--- a/src/main/webapp/themes/bootstrap/assets/app.js
+++ b/src/main/webapp/themes/bootstrap/assets/app.js
@@ -365,7 +365,7 @@ function attachBackToTop() {
 }
 
 /** Returns true when the current URL contains a non-empty q= parameter. */
-function hasSearchQuery() {
+export function hasSearchQuery() {
   return new URLSearchParams(location.search).get("q")?.trim().length > 0;
 }
 
@@ -377,7 +377,7 @@ function hasSearchQuery() {
  * The query is taken from whichever search box is populated (header or home),
  * falling back to the current URL's q= param.
  */
-function updateAdvanceLinks() {
+export function updateAdvanceLinks() {
   const headerVal = (document.getElementById("query") || {}).value;
   const homeVal = (document.getElementById("contentQuery") || {}).value;
   const urlParams = new URLSearchParams(location.search);
@@ -417,7 +417,7 @@ function attachAdvanceLinkSync() {
   updateAdvanceLinks();
 }
 
-function registerRoutes() {
+export function registerRoutes() {
   // Home route — "/" with no q= parameter shows the centered home view.
   router.register(
     path => (path === "/" || path === "/index" || path === "/index.html") && !hasSearchQuery(),
@@ -530,7 +530,7 @@ function registerRoutes() {
   );
 }
 
-async function main() {
+export async function main() {
   try {
     await api.init();
   } catch (e) {

--- a/src/main/webapp/themes/bootstrap/assets/auth.js
+++ b/src/main/webapp/themes/bootstrap/assets/auth.js
@@ -7,7 +7,7 @@ import { t } from "./i18n.js";
  * The `login_link` feature flag (from /api/v2/ui/config) can be false to
  * hide login UI entirely. Defaults to true when missing.
  */
-function isLoginLinkEnabled() {
+export function isLoginLinkEnabled() {
   const features = api.getConfig()?.features || {};
   return features.login_link !== false;
 }
@@ -57,7 +57,7 @@ export async function probeMe() {
  * @param {object} user - user payload from /api/v2/auth/me
  * @returns {HTMLElement} the dropdown wrapper div
  */
-function buildUserDropdown(user) {
+export function buildUserDropdown(user) {
   // Tag-parity with header.jsp logged-in block:
   //   div.dropdown
   //     > a#userMenu.nav-link.dropdown-toggle > i.fa.fa-fw.fa-user + span(name)
@@ -138,7 +138,7 @@ function buildUserDropdown(user) {
  * header.jsp parity: a.nav-link[/login] > i.fa.fa-fw.fa-sign-in + span(Login).
  * Default action opens the SPA login modal; with SSO it is a direct link.
  */
-function buildLoginLink() {
+export function buildLoginLink() {
   const cfg = api.getConfig() || {};
   const features = cfg.features || {};
   const a = document.createElement("a");
@@ -220,7 +220,7 @@ function setLoggedOut() {
  * @param {object|null} logoutEnv - the parsed response envelope from /auth/logout,
  *   or null when not available. May carry a csrf_token field if the server is new.
  */
-async function rotateCsrf(logoutEnv) {
+export async function rotateCsrf(logoutEnv) {
   // Prefer a token returned directly in the logout response body (no extra round-trip).
   if (logoutEnv && logoutEnv.csrf_token) {
     api.setCsrfToken(logoutEnv.csrf_token);

--- a/src/main/webapp/themes/bootstrap/assets/chat.js
+++ b/src/main/webapp/themes/bootstrap/assets/chat.js
@@ -37,7 +37,7 @@ let standaloneMounted = false;
  * @param {string} u
  * @returns {string}
  */
-function safeHref(u) {
+export function safeHref(u) {
   if (!u) return "#";
   try {
     const parsed = new URL(String(u), window.location.origin);
@@ -95,7 +95,7 @@ const PHASE_ORDER = ["intent", "search", "evaluate", "fetch", "answer"];
  *
  * @returns {{ strip: HTMLElement, advanceTo: (phase: string, hitCount?: number) => void, reset: () => void }}
  */
-function buildPhaseStrip() {
+export function buildPhaseStrip() {
   const strip = el("div", { className: "chat-phase-strip d-flex gap-2 align-items-center mb-2 flex-wrap" });
   const badges = {};
 
@@ -173,7 +173,7 @@ function buildPhaseStrip() {
  *
  * @returns {{ panel: HTMLElement, getFilters: () => { fields: string[], extraQ: string[] } }}
  */
-function buildFilterPanel(opts) {
+export function buildFilterPanel(opts) {
   // When embedded in the standalone card, the card-header already provides the
   // filter toggle, so the panel's own toggle/clear header row is suppressed to
   // avoid a duplicate "Filter" button (JSP parity: chat.jsp toggles from the header).
@@ -406,7 +406,7 @@ function buildWelcomeState() {
  * @param {string} [mimetype]
  * @returns {string}
  */
-function sourceIcon(url, mimetype) {
+export function sourceIcon(url, mimetype) {
   if (mimetype) {
     if (mimetype.indexOf("pdf") !== -1) return "fa-file-pdf-o";
     if (mimetype.indexOf("word") !== -1 || mimetype.indexOf("document") !== -1) return "fa-file-word-o";
@@ -438,7 +438,7 @@ function sourceIcon(url, mimetype) {
  * @param {string} [mimetype]
  * @returns {string}
  */
-function sourceTypeLabel(url, mimetype) {
+export function sourceTypeLabel(url, mimetype) {
   if (mimetype) {
     if (mimetype.indexOf("pdf") !== -1) return "PDF";
     if (mimetype.indexOf("word") !== -1 || mimetype.indexOf("document") !== -1) return "Word";
@@ -722,7 +722,7 @@ function buildStatusLozenge() {
 // Map SSE error_code → i18n text
 // ---------------------------------------------------------------------------
 
-function errorCodeToText(code) {
+export function errorCodeToText(code) {
   if (KNOWN_ERROR_CODES.includes(code)) {
     return t("error." + code);
   }

--- a/src/main/webapp/themes/bootstrap/assets/error.js
+++ b/src/main/webapp/themes/bootstrap/assets/error.js
@@ -40,7 +40,7 @@ const PATH_TO_CODE = {
  * @param {string} pathname - e.g. "/error/404", "/error/not_found", "/error/notFound"
  * @returns {string} - one of "400", "404", "429", "500", "503"
  */
-function codeFromPath(pathname) {
+export function codeFromPath(pathname) {
   const segments = pathname.split("/").filter(Boolean);
   for (let i = segments.length - 1; i >= 0; i--) {
     // Normalise: lowercase and remove underscores so snake_case and camelCase

--- a/src/main/webapp/themes/bootstrap/assets/format.js
+++ b/src/main/webapp/themes/bootstrap/assets/format.js
@@ -131,7 +131,7 @@ const ALLOWED_TAGS = new Set([
   "TABLE", "THEAD", "TBODY", "TR", "TH", "TD",
   "CODE", "PRE",
   "STRONG", "EM",
-  "H2", "H3", "H4",
+  "H1", "H2", "H3", "H4", "H5", "H6",
   "A",
   "DIV", "SPAN", "BLOCKQUOTE",
   "DL", "DT", "DD",

--- a/src/main/webapp/themes/bootstrap/assets/help.js
+++ b/src/main/webapp/themes/bootstrap/assets/help.js
@@ -17,7 +17,7 @@ import { sanitizeHtml } from "./format.js";
  * @param {string} locale - e.g. "en" or "ja"
  * @returns {Promise<{sections: Array<{id:string, title:string, html:string}>}>}
  */
-async function fetchHelpContent(locale) {
+export async function fetchHelpContent(locale) {
   const url = `/themes/bootstrap/help/${locale}.json`;
   try {
     const r = await fetch(url, { credentials: "same-origin" });
@@ -40,7 +40,7 @@ async function fetchHelpContent(locale) {
  * @param {HTMLElement} container
  * @param {{id:string, title:string, html:string}} section
  */
-function renderSection(container, section) {
+export function renderSection(container, section) {
   const sec = document.createElement("section");
   sec.id = `help-${section.id}`;
   sec.className = "help-section";

--- a/src/main/webapp/themes/bootstrap/assets/i18n.js
+++ b/src/main/webapp/themes/bootstrap/assets/i18n.js
@@ -5,7 +5,7 @@ const SUPPORTED = ["de", "en", "es", "fr", "hi", "id", "it", "ja", "ko", "nl", "
 let messages = {};
 let locale = "en";
 
-function pickLocale() {
+export function pickLocale() {
   const raw = (navigator.language || "en");
   // Case-insensitive exact match first (e.g. "pt-BR", "zh-CN").
   const lower = raw.toLowerCase();

--- a/src/main/webapp/themes/bootstrap/assets/markdown.js
+++ b/src/main/webapp/themes/bootstrap/assets/markdown.js
@@ -372,13 +372,14 @@ function inlineMarkdown(text) {
   // Matches the legacy marked.js gfm autolink behaviour.
   s = s.replace(/&lt;(https?:\/\/[^\s]+?)&gt;/g, (_m, url) => {
     // url is already HTML-escaped (& -> &amp;); restore for the scheme check only.
-    const raw = url.replace(/&amp;/g, "&").trim().toLowerCase();
-    // Defensive scheme re-check. Unreachable while the capturing regex above
-    // requires an http(s):// prefix (raw can never begin with javascript:/data:);
-    // kept as a safety net should that regex ever widen, and excluded from
-    // coverage because no input can drive it today.
+    const raw = url.replace(/&amp;/g, "&");
+    // Defensive scheme re-check via the shared allowlist, mirroring the
+    // [text](url) path above. Unreachable while the capturing regex requires an
+    // http(s):// prefix, but kept as a safety net should that regex ever widen —
+    // isSafeHref (allowlist + URL normalisation) stays correct where a denylist
+    // would not. Excluded from coverage: no input can drive the false branch today.
     /* v8 ignore next 3 */
-    if (/^javascript\s*:/i.test(raw) || /^data\s*:/i.test(raw)) {
+    if (!isSafeHref(raw)) {
       return "&lt;" + url + "&gt;";
     }
     return '<a href="' + url + '" target="_blank" rel="nofollow noopener noreferrer">' + url + "</a>";

--- a/src/main/webapp/themes/bootstrap/assets/markdown.js
+++ b/src/main/webapp/themes/bootstrap/assets/markdown.js
@@ -373,6 +373,11 @@ function inlineMarkdown(text) {
   s = s.replace(/&lt;(https?:\/\/[^\s]+?)&gt;/g, (_m, url) => {
     // url is already HTML-escaped (& -> &amp;); restore for the scheme check only.
     const raw = url.replace(/&amp;/g, "&").trim().toLowerCase();
+    // Defensive scheme re-check. Unreachable while the capturing regex above
+    // requires an http(s):// prefix (raw can never begin with javascript:/data:);
+    // kept as a safety net should that regex ever widen, and excluded from
+    // coverage because no input can drive it today.
+    /* v8 ignore next 3 */
     if (/^javascript\s*:/i.test(raw) || /^data\s*:/i.test(raw)) {
       return "&lt;" + url + "&gt;";
     }

--- a/src/main/webapp/themes/bootstrap/assets/profile.js
+++ b/src/main/webapp/themes/bootstrap/assets/profile.js
@@ -73,7 +73,7 @@ function makePasswordField(labelText, inputId, inputAttrs = {}) {
  * @param {object} err - ApiError (code/httpStatus/details) or NetworkError
  * @returns {string} a localized message safe to render via textContent
  */
-function localizePasswordError(err) {
+export function localizePasswordError(err) {
   if (err && err.name === "NetworkError") return t("error.network");
   const code = err && err.code;
   const httpStatus = err && err.httpStatus;

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -2002,4 +2002,4 @@ export const _state = state;
 // renderPopularWords is exported inline at its declaration (line ~1515); do NOT
 // re-export it here — a duplicate export is a module-level SyntaxError that aborts
 // the entire SPA bootstrap (app.js never runs, so the home view never renders).
-export { runSearch, el, buildResultCard, buildGoUrl, renderSearchOptions, syncSearchInputs };
+export { safeHref, runSearch, el, buildResultCard, buildGoUrl, renderSearchOptions, syncSearchInputs };

--- a/src/main/webapp/themes/bootstrap/theme.yml
+++ b/src/main/webapp/themes/bootstrap/theme.yml
@@ -2,7 +2,7 @@ apiVersion: fess.codelibs.org/v1
 kind: StaticTheme
 name: bootstrap
 displayName: "Bootstrap"
-version: "1.0.2"
+version: "1.0.3"
 author: "CodeLibs Project"
 description: "Reference static theme for Fess. Bootstrap 5-based vanilla-JS SPA exercising /api/v2/*."
 license: "Apache-2.0"

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -370,13 +370,6 @@ public class BundledBootstrapThemeTest {
     }
 
     @Test
-    public void test_markdownTablesBlockquote() throws Exception {
-        final String md = Files.readString(THEME_DIR.resolve("assets/markdown.js"), StandardCharsets.UTF_8);
-        assertTrue(md.contains("<table") && md.contains("<thead>") && md.contains("<tbody>"));
-        assertTrue(md.contains("<blockquote>") && md.contains("TABLE_DELIM_RE"));
-    }
-
-    @Test
     public void test_cacheJs_rendersBannerAndBaseAndCharset() throws Exception {
         final String js = Files.readString(THEME_DIR.resolve("assets/cache.js"), StandardCharsets.UTF_8);
         assertTrue(js.contains("labels.search_cache_msg"));
@@ -857,17 +850,6 @@ public class BundledBootstrapThemeTest {
         assertTrue(js.contains("resetFilters()"), "chat.js new-chat handler must call resetFilters() (parity-r3 T5 minor resetFilters)");
     }
 
-    /** R3-T5 minor: markdown.js must support nested lists and nested blockquotes. */
-    @Test
-    public void test_markdownJs_nestedListAndBlockquoteHandling() throws Exception {
-        final String md = Files.readString(THEME_DIR.resolve("assets/markdown.js"), StandardCharsets.UTF_8);
-        assertTrue(md.contains("renderList"), "markdown.js must define renderList for nested-list support (parity-r3 T5 minor)");
-        assertTrue(md.contains("indentDepth"),
-                "markdown.js must define indentDepth for nested-list nesting detection (parity-r3 T5 minor)");
-        assertTrue(md.contains("renderBlockquote"),
-                "markdown.js must define renderBlockquote for nested blockquote support (parity-r3 T5 minor)");
-    }
-
     /** R3-T5: all 7 new chat keys (5 phase + 2 fallback) must exist in messages.en.json. */
     @Test
     public void test_i18n_hasChatPhaseAndFallbackKeys() throws Exception {
@@ -1009,14 +991,6 @@ public class BundledBootstrapThemeTest {
                 "chat.js must no longer keep the strip visible after completion (parity #C)");
     }
 
-    @Test
-    public void test_markdownJs_h1ThroughH6() throws Exception {
-        final String md = Files.readString(THEME_DIR.resolve("assets/markdown.js"), StandardCharsets.UTF_8);
-        assertTrue(md.contains("/^(#{1,6}) (.+)$/"), "markdown.js HEADING_RE must accept # (h1) through ###### (h6) (parity #E)");
-        assertTrue(md.contains("Math.min(hm[1].length, 6)"), "markdown.js must clamp heading level to 6 (parity #E)");
-        assertFalse(md.contains("/^(#{2,4}) (.+)$/"), "markdown.js must no longer restrict headings to h2-h4 (parity #E)");
-    }
-
     // ── Parity Round 4 regression tests ────────────────────────────────────────
 
     /**
@@ -1142,62 +1116,6 @@ public class BundledBootstrapThemeTest {
         assertTrue(html.contains("id=\"labelSearchOption\""), "index.html must preserve id=\"labelSearchOption\" (parity R4 GAP-C)");
         assertTrue(html.contains("id=\"geoSearchOptionFieldset\""),
                 "index.html must preserve id=\"geoSearchOptionFieldset\" (parity R4 GAP-C)");
-    }
-
-    /**
-     * R4-7: markdown.js must handle horizontal rules (<hr>) and angle-bracket autolinks.
-     * HR_RE is the horizontal-rule line regex; the autolink regex operates on post-escape
-     * form (&lt;https?:…&gt;).
-     */
-    @Test
-    public void test_markdownJs_horizontalRuleAndAutolink() throws Exception {
-        final String md = Files.readString(THEME_DIR.resolve("assets/markdown.js"), StandardCharsets.UTF_8);
-        // Horizontal rule output
-        assertTrue(md.contains("<hr>"), "markdown.js must render horizontal rules as <hr> (parity R4 GAP-D2)");
-        // HR_RE constant name
-        assertTrue(md.contains("HR_RE"), "markdown.js must define HR_RE for horizontal-rule detection (parity R4 GAP-D2)");
-        // Autolink marker: the regex matches the post-escape form &lt;https?:
-        assertTrue(md.contains("&lt;(https?:"), "markdown.js autolink regex must match post-escape &lt;(https?: (parity R4 GAP-D2)");
-    }
-
-    /**
-     * R4-8: format.js ALLOWED_TAGS whitelist must include "HR" so sanitizeHtml
-     * does not strip horizontal rules produced by the markdown renderer.
-     */
-    @Test
-    public void test_formatJs_sanitizerAllowsHr() throws Exception {
-        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
-        assertTrue(js.contains("\"HR\""), "format.js ALLOWED_TAGS must contain \"HR\" (parity R4 GAP-D2)");
-    }
-
-    /**
-     * format.js must drop raw-text elements whole instead of unwrapping them:
-     * their child text is the element's own source, so unwrapping surfaces that
-     * source as visible prose. Guards the nine HTML raw-text elements plus
-     * NOSCRIPT and TEMPLATE, which are dropped for their own documented reasons.
-     */
-    @Test
-    public void test_formatJs_sanitizerDropsRawTextElementsWithContent() throws Exception {
-        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
-        assertTrue(js.contains("const DROP_WITH_CONTENT = new Set(["), "format.js must define the DROP_WITH_CONTENT set");
-        for (final String tag : new String[] { "IFRAME", "NOEMBED", "NOFRAMES", "PLAINTEXT", "SCRIPT", "STYLE", "TEXTAREA", "TITLE", "XMP",
-                "NOSCRIPT", "TEMPLATE" }) {
-            assertTrue(js.contains("\"" + tag + "\""), "format.js DROP_WITH_CONTENT must contain \"" + tag + "\"");
-        }
-    }
-
-    /**
-     * OBJECT and EMBED must stay out of DROP_WITH_CONTENT. An &lt;object&gt;'s
-     * children are fallback prose that the unwrap path already sanitizes
-     * recursively, so dropping them buys no safety and only discards content;
-     * &lt;embed&gt; is a void element, so it never has children and the entry
-     * would be inert. Re-adding either is a regression, not a hardening.
-     */
-    @Test
-    public void test_formatJs_sanitizerDoesNotDropObjectOrEmbedContent() throws Exception {
-        final String js = Files.readString(THEME_DIR.resolve("assets/format.js"), StandardCharsets.UTF_8);
-        assertFalse(js.contains("\"OBJECT\""), "format.js must not drop <object> fallback prose: the unwrap path already sanitizes it");
-        assertFalse(js.contains("\"EMBED\""), "format.js must not list \"EMBED\": it is a void element, so the entry can never fire");
     }
 
     /**

--- a/src/test/js/README.md
+++ b/src/test/js/README.md
@@ -1,0 +1,67 @@
+# Bundled bootstrap theme — JavaScript unit tests
+
+Executable unit tests for the JavaScript that ships with the bundled `bootstrap`
+static theme (`src/main/webapp/themes/bootstrap/assets/*.js`).
+
+## Why this exists
+
+`BundledBootstrapThemeTest.java` verifies theme JS by reading each file as text and
+asserting on substrings (`js.contains("...")`). That cannot observe what the code
+actually *does*: a heading regex can be present in source yet produce output that a
+later sanitizer strips. These tests instead **import and run the real, unmodified
+asset files** and assert on their behaviour.
+
+The theme JS is authored as native ES modules (`import`/`export`) that call browser
+APIs (`document`, `window`, `URL`, ...). JVM engines (Sai, Nashorn) cannot parse ES
+modules, and headless approaches without a DOM cannot exercise the sanitizer. So
+these tests run on Node with [vitest](https://vitest.dev) and a
+[jsdom](https://github.com/jsdom/jsdom) DOM.
+
+## Why here (`src/test/js/`) and not in the theme directory
+
+`src/main/webapp/themes/bootstrap/` is packaged into the WAR (and the `.deb`/`.rpm`
+distributions) and served to anonymous users by the servlet container. Placing
+`package.json` / `node_modules/` there would ship them and expose them over HTTP.
+`src/test/` is never packaged, so the tooling stays out of every artifact. This
+mirrors the existing non-shipped fixture at
+`src/test/resources/themes/fixture-minimal/`.
+
+## Running
+
+```bash
+cd src/test/js
+npm ci      # or: npm install
+npm test
+```
+
+`npm test` runs the suite under coverage and enforces the thresholds declared
+in `vitest.config.js` (it fails if coverage of the asset files under test
+drops below them). The same command runs in CI, so a coverage regression breaks
+the build.
+
+These tests are **not** part of the Maven build. They run in their own GitHub
+Actions workflow (`.github/workflows/theme-js.yml`). `mvn test` is unaffected.
+
+## Layout
+
+```
+src/test/js/
+├── package.json / package-lock.json / vitest.config.js
+├── helpers/                # dom.js (jsdom fixtures), net.js (fetch/stream stubs)
+└── themes/bootstrap/       # one *.test.js per shipped asset module
+    ├── format.test.js  markdown.test.js  pipeline.test.js
+    ├── api.test.js     router.test.js    i18n.test.js
+    ├── error.test.js   auth.test.js      chat.test.js
+    ├── advance.test.js cache.test.js     help.test.js
+    ├── profile.test.js search.test.js    app.test.js
+```
+
+Every JavaScript module shipped in `assets/` is imported and executed by a test
+here (the coverage gate uses `all: true`, so a new asset module with no test
+drags coverage down and fails the build). Tests import the shipped files by
+relative path; they are never copied.
+
+Sibling modules are mocked where a test needs to control I/O or config
+(`api.js`, `router.js`) and used for real where they work under jsdom
+(`i18n.js`, `format.js`, `markdown.js`). `i18n.t(key)` returns the key unchanged
+when no bundle is loaded, so tests assert on exact i18n keys.

--- a/src/test/js/helpers/dom.js
+++ b/src/test/js/helpers/dom.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Shared jsdom test helpers for the bootstrap theme JS tests.
+//
+// Not a *.test.js file, so Vitest does not collect it as a suite; test files
+// import from it.
+
+/**
+ * Reset the jsdom document to a known-empty body and restore the location to
+ * the default origin. Call in beforeEach so DOM-mutating modules start clean.
+ */
+export function resetDom() {
+  document.documentElement.lang = "";
+  document.title = "";
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
+}
+
+/**
+ * Set document.body.innerHTML to the given fixture and return the body, so a
+ * test can build the exact DOM a module's attach()/render function expects.
+ *
+ * @param {string} html
+ * @returns {HTMLElement} document.body
+ */
+export function mountBody(html) {
+  document.body.innerHTML = html;
+  return document.body;
+}
+
+/**
+ * Navigate the jsdom window without a full reload (pushState keeps the same
+ * document, which is what the theme's hash/pushState router relies on).
+ *
+ * @param {string} url - absolute or relative URL
+ */
+export function setLocation(url) {
+  window.history.pushState({}, "", url);
+}

--- a/src/test/js/helpers/net.js
+++ b/src/test/js/helpers/net.js
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Network stubs for the bootstrap theme JS tests: minimal Response-like objects
+// and a fetch installer. Node 22 provides global fetch; these let a test drive
+// it deterministically without real I/O.
+
+import { vi } from "vitest";
+
+/** A Response-like object whose json() resolves to `body`. */
+export function jsonResponse(body, { status = 200, ok } = {}) {
+  return {
+    ok: ok === undefined ? status >= 200 && status < 300 : ok,
+    status,
+    json: async () => body,
+  };
+}
+
+/** A Response-like object whose json() rejects (invalid JSON body). */
+export function badJsonResponse({ status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      throw new SyntaxError("Unexpected token");
+    },
+  };
+}
+
+/**
+ * A Response-like object exposing a readable body that yields `chunks`
+ * (strings, UTF-8 encoded) one per read(), for testing fetch-based SSE.
+ */
+export function streamResponse(chunks, { status = 200, ok = true } = {}) {
+  const encoder = new TextEncoder();
+  const queue = chunks.map((c) => encoder.encode(c));
+  let i = 0;
+  let cancelled = false;
+  return {
+    ok,
+    status,
+    json: async () => ({}),
+    body: {
+      getReader() {
+        return {
+          async read() {
+            if (cancelled || i >= queue.length) return { done: true, value: undefined };
+            return { done: false, value: queue[i++] };
+          },
+          cancel() {
+            cancelled = true;
+          },
+        };
+      },
+    },
+  };
+}
+
+/**
+ * Install a stub global fetch. `impl` receives (url, options) and returns a
+ * Response-like object (or rejects). Returns the vi mock for assertions.
+ * Pair with vi.unstubAllGlobals() in afterEach.
+ */
+export function installFetch(impl) {
+  const fn = vi.fn(impl);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}

--- a/src/test/js/package-lock.json
+++ b/src/test/js/package-lock.json
@@ -1,0 +1,2039 @@
+{
+  "name": "fess-theme-js-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fess-theme-js-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.10",
+        "jsdom": "^29.1.1",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/src/test/js/package.json
+++ b/src/test/js/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fess-theme-js-tests",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Executable unit tests for the bundled bootstrap static theme JavaScript. Not shipped; not part of the Maven build. See README.md.",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.10",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.10"
+  }
+}

--- a/src/test/js/themes/bootstrap/advance.test.js
+++ b/src/test/js/themes/bootstrap/advance.test.js
@@ -31,7 +31,7 @@ import {
   attach,
 } from "../../../../main/webapp/themes/bootstrap/assets/advance.js";
 import { navigate } from "../../../../main/webapp/themes/bootstrap/assets/router.js";
-import { setLocation } from "../../helpers/dom.js";
+import { resetDom, setLocation } from "../../helpers/dom.js";
 
 // ---------------------------------------------------------------------------
 // compose(parts) — the query builder
@@ -189,7 +189,7 @@ describe("attach: submit builds the /search URL", () => {
   afterEach(() => {
     navigate.mockClear();
     setLocation("/");
-    document.body.innerHTML = "";
+    resetDom();
   });
 
   it("does nothing when #advance-view is absent", () => {

--- a/src/test/js/themes/bootstrap/advance.test.js
+++ b/src/test/js/themes/bootstrap/advance.test.js
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Executable tests for advance.js — the advanced-search query builder and view.
+//
+// advance.js imports search.js and router.js at module load; both are mocked to
+// inert stubs so importing the real, unmodified asset stays side-effect-free and
+// the pure query-composition logic can be exercised directly. api.js is mocked so
+// getConfig() returns a controllable config for the attach() DOM flow.
+//
+// The real i18n.t() returns its key unchanged (messages are empty without init),
+// so option labels are the raw i18n keys — irrelevant to these query tests.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/search.js", () => ({
+  attachSuggest: () => {},
+  disableSubmitBriefly: () => {},
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/router.js", () => ({
+  navigate: vi.fn(),
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/api.js", () => ({
+  getConfig: vi.fn(() => ({})),
+}));
+
+import {
+  quoteIfNeeded,
+  tokenize,
+  compose,
+  buildFiletypeOptions,
+  TIME_RANGE_QUERY,
+  attach,
+} from "../../../../main/webapp/themes/bootstrap/assets/advance.js";
+import { navigate } from "../../../../main/webapp/themes/bootstrap/assets/router.js";
+import { setLocation } from "../../helpers/dom.js";
+
+// ---------------------------------------------------------------------------
+// compose(parts) — the query builder
+// ---------------------------------------------------------------------------
+
+describe("compose", () => {
+  it("none-words → one NOT per whitespace token", () => {
+    expect(compose({ none: "foo bar" })).toBe("NOT foo NOT bar");
+  });
+
+  it("any-words with >1 token → parenthesised OR group", () => {
+    expect(compose({ any: "a b c" })).toBe("(a OR b OR c)");
+  });
+
+  it("any-words with a single token → bare token, no parens/OR", () => {
+    expect(compose({ any: "solo" })).toBe("solo");
+  });
+
+  it("exact phrase → double-quoted", () => {
+    expect(compose({ exact: "fiscal year" })).toBe('"fiscal year"');
+  });
+
+  it("filetype → filetype:\"<canonical value>\" (word, never msword)", () => {
+    expect(compose({ filetype: "word" })).toBe('filetype:"word"');
+    expect(compose({ filetype: "excel" })).toBe('filetype:"excel"');
+    expect(compose({ filetype: "powerpoint" })).toBe('filetype:"powerpoint"');
+  });
+
+  it("occt prefix with an empty query → empty string (no bare allintitle:)", () => {
+    expect(compose({ occt: "allintitle" })).toBe("");
+    expect(compose({ occt: "allinurl" })).toBe("");
+  });
+
+  it("occt prefix is applied only when there is a query body", () => {
+    expect(compose({ all: "x", occt: "allintitle" })).toBe("allintitle:x");
+    expect(compose({ all: "x", occt: "allinurl" })).toBe("allinurl:x");
+  });
+
+  it("assembles every part in server order with the allintitle: prefix", () => {
+    expect(
+      compose({
+        all: "annual report",
+        exact: "fiscal year",
+        any: "2023 2024",
+        none: "draft old",
+        site: "example.com",
+        filetype: "word",
+        occt: "allintitle",
+      })
+    ).toBe(
+      'allintitle:annual report "fiscal year" (2023 OR 2024) NOT draft NOT old site:example.com filetype:"word"'
+    );
+  });
+
+  it("empty parts → empty string", () => {
+    expect(compose({})).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// quoteIfNeeded(s)
+// ---------------------------------------------------------------------------
+
+describe("quoteIfNeeded", () => {
+  it("escapes inner double-quotes with a backslash and wraps the whole", () => {
+    // Actual characters: "he said \"hi\""  (each inner " prefixed by one backslash)
+    expect(quoteIfNeeded('he said "hi"')).toBe('"he said \\"hi\\""');
+  });
+
+  it("passes an already-quoted phrase through unchanged", () => {
+    expect(quoteIfNeeded('"already quoted"')).toBe('"already quoted"');
+  });
+
+  it("returns empty string for empty / whitespace-only input", () => {
+    expect(quoteIfNeeded("")).toBe("");
+    expect(quoteIfNeeded("   ")).toBe("");
+  });
+
+  it("quotes a plain phrase", () => {
+    expect(quoteIfNeeded("plain")).toBe('"plain"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tokenize(s)
+// ---------------------------------------------------------------------------
+
+describe("tokenize", () => {
+  it("splits on whitespace and keeps quoted phrases whole (quotes retained)", () => {
+    expect(tokenize('foo "bar baz" qux')).toEqual(["foo", '"bar baz"', "qux"]);
+  });
+
+  it("collapses runs of whitespace and trims", () => {
+    expect(tokenize("  a   b  ")).toEqual(["a", "b"]);
+  });
+
+  it("keeps an unterminated quote as a single token", () => {
+    expect(tokenize('"unterminated')).toEqual(['"unterminated']);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    expect(tokenize("")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFiletypeOptions(serverConfig)
+// ---------------------------------------------------------------------------
+
+describe("buildFiletypeOptions", () => {
+  const canonicalValues = (opts) => opts.map((o) => o.value);
+
+  it("falls back to the canonical list when config is null/empty/empty-array", () => {
+    for (const cfg of [null, {}, { filetype_options: [] }]) {
+      const opts = buildFiletypeOptions(cfg);
+      expect(opts[0]).toEqual({ value: "", labelKey: "advance.any_filetype" });
+      expect(canonicalValues(opts)).toEqual(
+        expect.arrayContaining(["word", "excel", "powerpoint", "pdf", "html", "txt"])
+      );
+    }
+  });
+
+  it("prefixes a server-supplied list with the empty-value option", () => {
+    const opts = buildFiletypeOptions({ filetype_options: [{ value: "csv", label: "CSV" }] });
+    expect(opts).toHaveLength(2);
+    expect(opts[0]).toEqual({ value: "", labelKey: "advance.any_filetype" });
+    expect(opts[1].value).toBe("csv");
+    expect(opts[1].label).toBe("CSV");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TIME_RANGE_QUERY constant
+// ---------------------------------------------------------------------------
+
+describe("TIME_RANGE_QUERY", () => {
+  it("maps each range value to the server's date-math fragment", () => {
+    expect(TIME_RANGE_QUERY).toEqual({
+      "1day": "timestamp:[now-1d/d TO *]",
+      "1week": "timestamp:[now-1w/d TO *]",
+      "1month": "timestamp:[now-1M/d TO *]",
+      "1year": "timestamp:[now-1y/d TO *]",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attach() submit flow — timestamp date-math + unrelated-param preservation
+// ---------------------------------------------------------------------------
+
+describe("attach: submit builds the /search URL", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="advance-view"></div>';
+  });
+  afterEach(() => {
+    navigate.mockClear();
+    setLocation("/");
+    document.body.innerHTML = "";
+  });
+
+  it("does nothing when #advance-view is absent", () => {
+    document.body.innerHTML = "";
+    expect(() => attach()).not.toThrow();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("preserves unrelated params, drops advance-owned ones, appends timestamp date-math", () => {
+    // theme/keepme are unrelated (preserved); start is advance-owned (dropped).
+    setLocation("/advance?theme=custom&keepme=1&start=50");
+    attach();
+
+    document.getElementById("adv-all").value = "hello";
+    document.getElementById("adv-time").value = "1month";
+
+    const form = document.getElementById("advance-form");
+    form.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    const target = navigate.mock.calls[0][0];
+    expect(target.startsWith("/search?")).toBe(true);
+
+    const p = new URLSearchParams(target.slice(target.indexOf("?") + 1));
+    // timestamp date-math appended to the composed q
+    expect(p.get("q")).toBe("hello timestamp:[now-1M/d TO *]");
+    // unrelated params survive
+    expect(p.get("theme")).toBe("custom");
+    expect(p.get("keepme")).toBe("1");
+    // advance-owned param removed
+    expect(p.has("start")).toBe(false);
+  });
+});

--- a/src/test/js/themes/bootstrap/api.test.js
+++ b/src/test/js/themes/bootstrap/api.test.js
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the /api/v2 client. Each test imports a fresh copy of
+// the module (vi.resetModules) so its module-level state (config, csrfToken,
+// authenticated) never leaks between cases, and drives it through a stubbed
+// global fetch.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { jsonResponse, badJsonResponse, streamResponse, installFetch } from "../../helpers/net.js";
+
+const API_PATH = "../../../../main/webapp/themes/bootstrap/assets/api.js";
+
+/** Resolve `{ response: env }` from a stubbed fetch. */
+const envelope = (env) => jsonResponse({ response: env });
+
+let api;
+beforeEach(async () => {
+  vi.resetModules();
+  api = await import(API_PATH);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ApiError / NetworkError", () => {
+  it("ApiError carries code/httpStatus/details and is an Error", () => {
+    const e = new api.ApiError("BAD", "message", 404, { field: "x" });
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe("ApiError");
+    expect(e.code).toBe("BAD");
+    expect(e.httpStatus).toBe(404);
+    expect(e.details).toEqual({ field: "x" });
+  });
+
+  it("ApiError.details defaults to null", () => {
+    expect(new api.ApiError("X", "m", 500).details).toBeNull();
+  });
+
+  it("NetworkError takes its message from the cause, or a default", () => {
+    expect(new api.NetworkError(new Error("boom")).message).toBe("boom");
+    expect(new api.NetworkError().message).toBe("Network error");
+    expect(new api.NetworkError(new Error("x")).name).toBe("NetworkError");
+  });
+});
+
+describe("get", () => {
+  it("returns the unwrapped envelope on success", async () => {
+    installFetch(async () => envelope({ status: 0, hits: [1, 2] }));
+    await expect(api.get("/search")).resolves.toEqual({ status: 0, hits: [1, 2] });
+  });
+
+  it("builds the query string: skips null, repeats arrays", async () => {
+    const fetchMock = installFetch(async () => envelope({ status: 0 }));
+    await api.get("/search", { q: "x", skip: null, label: ["a", "b"] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v2/search?q=x&label=a&label=b");
+    expect(opts.method).toBe("GET");
+    expect(opts.headers.Accept).toBe("application/json");
+  });
+
+  it("throws ApiError from an error envelope", async () => {
+    installFetch(async () => jsonResponse({ response: { status: 1, error: { code: "E", message: "bad" } } }, { status: 400 }));
+    await expect(api.get("/x")).rejects.toMatchObject({ name: "ApiError", code: "E", httpStatus: 400 });
+  });
+
+  it("throws ApiError(PROTOCOL) when the envelope is missing", async () => {
+    installFetch(async () => jsonResponse({ nope: true }));
+    await expect(api.get("/x")).rejects.toMatchObject({ code: "PROTOCOL" });
+  });
+
+  it("throws ApiError(NETWORK) on invalid JSON", async () => {
+    installFetch(async () => badJsonResponse());
+    await expect(api.get("/x")).rejects.toMatchObject({ code: "NETWORK", message: "Invalid JSON" });
+  });
+
+  it("wraps a fetch rejection in NetworkError", async () => {
+    installFetch(async () => { throw new Error("offline"); });
+    await expect(api.get("/x")).rejects.toBeInstanceOf(api.NetworkError);
+  });
+
+  it("re-throws an AbortError unchanged (superseded request)", async () => {
+    installFetch(async () => { const e = new Error("aborted"); e.name = "AbortError"; throw e; });
+    await expect(api.get("/x")).rejects.toMatchObject({ name: "AbortError" });
+  });
+});
+
+describe("post", () => {
+  it("POSTs JSON with the CSRF header from module state", async () => {
+    api.setCsrfToken("tok-123");
+    const fetchMock = installFetch(async () => envelope({ status: 0, ok: true }));
+    await api.post("/favorites", { id: "d1" });
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v2/favorites");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["X-Fess-CSRF-Token"]).toBe("tok-123");
+    expect(opts.body).toBe(JSON.stringify({ id: "d1" }));
+  });
+
+  it("wraps any fetch rejection in NetworkError (no AbortError special case)", async () => {
+    installFetch(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; });
+    await expect(api.post("/x", {})).rejects.toBeInstanceOf(api.NetworkError);
+  });
+});
+
+describe("init + state accessors", () => {
+  it("init stores the config envelope and csrf token", async () => {
+    installFetch(async () => envelope({ status: 0, csrf_token: "abc", search: { enabled: true } }));
+    await api.init();
+    expect(api.getConfig()).toMatchObject({ csrf_token: "abc", search: { enabled: true } });
+    expect(api.getCsrfToken()).toBe("abc");
+  });
+
+  it("has null config and empty csrf before init", () => {
+    expect(api.getConfig()).toBeNull();
+    expect(api.getCsrfToken()).toBe("");
+  });
+
+  it("setCsrfToken coerces nullish to empty string", () => {
+    api.setCsrfToken("t");
+    expect(api.getCsrfToken()).toBe("t");
+    api.setCsrfToken(null);
+    expect(api.getCsrfToken()).toBe("");
+  });
+
+  it("setAuthenticated coerces to boolean; defaults false", () => {
+    expect(api.isAuthenticated()).toBe(false);
+    api.setAuthenticated("yes");
+    expect(api.isAuthenticated()).toBe(true);
+    api.setAuthenticated(0);
+    expect(api.isAuthenticated()).toBe(false);
+  });
+});
+
+describe("sseStream", () => {
+  /** Run a stream to completion, collecting events; resolves on eof or error. */
+  const collect = (chunks, opts) =>
+    new Promise((resolve) => {
+      const events = [];
+      installFetch(async () => streamResponse(chunks, opts));
+      api.sseStream(
+        "/chat/stream",
+        { q: "hi" },
+        (ev) => { events.push(ev); if (ev.type === "eof") resolve({ events }); },
+        (err) => resolve({ events, err })
+      );
+    });
+
+  it("parses framed events and emits a terminal eof", async () => {
+    const { events } = await collect([
+      "event: message\ndata: {\"text\":\"hi\"}\n\n",
+      "event: done\ndata: bye\n\n",
+    ]);
+    expect(events[0]).toEqual({ type: "message", data: { text: "hi" } });
+    expect(events[1]).toEqual({ type: "done", data: "bye" }); // non-JSON data → raw string
+    expect(events[events.length - 1]).toEqual({ type: "eof", data: null });
+  });
+
+  it("reassembles a frame split across reads and concatenates multi-data lines", async () => {
+    const { events } = await collect(["event: msg\nda", "ta: a\ndata: b\n\n"]);
+    expect(events[0]).toEqual({ type: "msg", data: "a\nb" });
+  });
+
+  it("flushes a trailing frame with no terminating blank line", async () => {
+    const { events } = await collect(["event: last\ndata: 7\n\n", "event: tail\ndata: 9"]);
+    expect(events).toContainEqual({ type: "tail", data: 9 });
+  });
+
+  it("reports an ApiError when the response is not ok", async () => {
+    const { err } = await collect([], { ok: false, status: 500 });
+    expect(err).toMatchObject({ name: "ApiError", httpStatus: 500 });
+  });
+
+  it("aborts with BUFFER_OVERFLOW past the 1 MiB cap", async () => {
+    const { err } = await collect(["x".repeat(1_048_577)]);
+    expect(err).toMatchObject({ code: "BUFFER_OVERFLOW" });
+  });
+});

--- a/src/test/js/themes/bootstrap/app.test.js
+++ b/src/test/js/themes/bootstrap/app.test.js
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for app.js — the bootstrap theme SPA boot module.
+//
+// app.js runs main() at import time when document.readyState === "complete"
+// (the jsdom default). To import the module WITHOUT booting the whole SPA, the
+// readyState getter is forced to "loading" BEFORE the (dynamic) import so app.js
+// takes the DOMContentLoaded-listener branch instead of calling main(). main()
+// is then called explicitly in the tests that exercise the boot flow.
+//
+// Every sibling module app.js imports is mocked to an inert stub so main() and
+// the route handlers are fully controllable and side-effect-free. format.js is
+// left REAL because renderHomeFlash / renderNotifications rely on its DOM-safe
+// text/sanitize construction. The real i18n.t() is replaced by an identity
+// stub, so text assertions target the caller-supplied string / i18n key.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resetDom } from "../../helpers/dom.js";
+
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/api.js", () => ({
+  init: vi.fn(async () => {}),
+  getConfig: vi.fn(() => ({ features: {} })),
+  get: vi.fn(async () => ({ popular_words: [] })),
+  post: vi.fn(async () => ({})),
+  isAuthenticated: vi.fn(() => false),
+  setAuthenticated: vi.fn(),
+  getCsrfToken: vi.fn(() => ""),
+  setCsrfToken: vi.fn(),
+  ApiError: class extends Error {},
+  NetworkError: class extends Error {},
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/i18n.js", () => ({
+  init: vi.fn(async () => {}),
+  t: (k) => k,
+  applyDom: () => {},
+  languageLabel: (v) => v,
+  getLocale: () => "en",
+  pickLocale: () => "en",
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/auth.js", () => ({
+  attach: vi.fn(async () => null),
+  isLoginLinkEnabled: () => false,
+  probeMe: vi.fn(async () => null),
+  buildUserDropdown: () => document.createElement("div"),
+  buildLoginLink: () => document.createElement("a"),
+  rotateCsrf: vi.fn(async () => {}),
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/search.js", () => ({
+  attach: vi.fn(),
+  runFromUrl: vi.fn(),
+  refresh: vi.fn(),
+  clearSearchState: vi.fn(),
+  attachSuggest: vi.fn(),
+  disableSubmitBriefly: vi.fn(),
+  renderPopularWords: vi.fn(),
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/chat.js", () => ({
+  attach: vi.fn(),
+  attachInline: vi.fn(),
+  attachStandalone: vi.fn(),
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/router.js", () => ({
+  register: vi.fn(),
+  navigate: vi.fn(),
+  attach: vi.fn(),
+  dispatch: vi.fn(),
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/error.js", () => ({ attach: vi.fn() }));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/profile.js", () => ({ attach: vi.fn() }));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/help.js", () => ({ attach: vi.fn(async () => {}) }));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/advance.js", () => ({ attach: vi.fn() }));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/cache.js", () => ({ attach: vi.fn() }));
+
+import * as api from "../../../../main/webapp/themes/bootstrap/assets/api.js";
+import * as i18n from "../../../../main/webapp/themes/bootstrap/assets/i18n.js";
+import * as auth from "../../../../main/webapp/themes/bootstrap/assets/auth.js";
+import * as search from "../../../../main/webapp/themes/bootstrap/assets/search.js";
+import * as chat from "../../../../main/webapp/themes/bootstrap/assets/chat.js";
+import * as router from "../../../../main/webapp/themes/bootstrap/assets/router.js";
+import * as errorView from "../../../../main/webapp/themes/bootstrap/assets/error.js";
+import * as profile from "../../../../main/webapp/themes/bootstrap/assets/profile.js";
+import * as help from "../../../../main/webapp/themes/bootstrap/assets/help.js";
+import * as advance from "../../../../main/webapp/themes/bootstrap/assets/advance.js";
+import * as cache from "../../../../main/webapp/themes/bootstrap/assets/cache.js";
+
+// CRITICAL: neutralize main() by making readyState report "loading" BEFORE the
+// dynamic import, so app.js registers a DOMContentLoaded listener instead of
+// auto-running main() at import time.
+Object.defineProperty(document, "readyState", { configurable: true, get: () => "loading" });
+const { renderHomeFlash, hasSearchQuery, updateAdvanceLinks, registerRoutes, main } = await import(
+  "../../../../main/webapp/themes/bootstrap/assets/app.js"
+);
+
+/** Set the current URL (search string) without a reload, so location.search reads it. */
+function setSearch(url) {
+  window.history.replaceState({}, "", url);
+}
+
+/** Let queued microtasks (deferred focus, async awaits) settle. */
+const flush = () => new Promise((r) => setTimeout(r));
+
+/** A full index-like fixture covering every id app.js and its route handlers touch. */
+function mountFullDom() {
+  document.body.innerHTML = `
+    <nav class="navbar fixed-top">
+      <ul id="header-nav" class="navbar-nav"></ul>
+      <a id="brand-link" class="d-inline-flex"></a>
+      <div id="search-form-wrap"></div>
+      <li id="chat-nav-item" class="d-none"></li>
+      <a id="chat-nav-link" href="/chat"><span data-i18n="nav.chat_ai_mode">Chat</span></a>
+    </nav>
+    <div id="home-notification"></div>
+    <div id="results-notification"></div>
+    <div id="advance-notification"></div>
+    <div id="home-view">
+      <h1>Home</h1>
+      <form id="home-search-form">
+        <input id="contentQuery">
+        <button type="submit" data-i18n="search.button"></button>
+      </form>
+      <select id="sortSearchOption"></select>
+      <select id="numSearchOption"></select>
+      <select id="langSearchOption" multiple></select>
+      <div id="home-popular-words"></div>
+      <div id="home-flash"></div>
+    </div>
+    <div id="results-view" hidden></div>
+    <div id="advance-view" hidden></div>
+    <div id="error-view" hidden></div>
+    <div id="profile-view" hidden></div>
+    <div id="help-view" hidden></div>
+    <div id="chat-view" hidden></div>
+    <div id="cache-view" hidden></div>
+    <input id="query">
+    <a class="adv" href="/search/advance">Advanced</a>
+    <div id="footer-copyright"></div>
+    <div id="back-to-top"></div>
+    <div id="searchOptions"></div>`;
+}
+
+beforeEach(() => {
+  resetDom();
+  vi.clearAllMocks();
+  // clearAllMocks wipes implementations set inside the mock factory, so restore
+  // the ones whose return values main()/handlers depend on.
+  api.getConfig.mockReturnValue({ features: {} });
+  api.get.mockResolvedValue({ popular_words: [] });
+  api.init.mockResolvedValue(undefined);
+  i18n.init.mockResolvedValue(undefined);
+  auth.attach.mockResolvedValue(null);
+  help.attach.mockResolvedValue(undefined);
+  setSearch("/");
+});
+afterEach(resetDom);
+
+// ---------------------------------------------------------------------------
+// renderHomeFlash (existing coverage — unchanged)
+// ---------------------------------------------------------------------------
+
+describe("renderHomeFlash", () => {
+  it("shows an info alert with the message text and no d-none", () => {
+    document.body.innerHTML = '<div id="home-flash"></div>';
+    renderHomeFlash("Hello");
+    const el = document.getElementById("home-flash");
+    expect(el.textContent).toBe("Hello");
+    expect(el.className).toContain("alert-info");
+    expect(el.classList.contains("d-none")).toBe(false);
+  });
+
+  it("uses the given level to pick the alert variant", () => {
+    document.body.innerHTML = '<div id="home-flash"></div>';
+    renderHomeFlash("bad", "danger");
+    const el = document.getElementById("home-flash");
+    expect(el.className).toContain("alert-danger");
+    expect(el.textContent).toBe("bad");
+  });
+
+  it("hides the region (d-none, empty) for a null message", () => {
+    document.body.innerHTML = '<div id="home-flash">stale</div>';
+    renderHomeFlash(null);
+    const el = document.getElementById("home-flash");
+    expect(el.classList.contains("d-none")).toBe(true);
+    expect(el.textContent).toBe("");
+  });
+
+  it("hides the region for a blank/whitespace message", () => {
+    document.body.innerHTML = '<div id="home-flash"></div>';
+    renderHomeFlash("   ");
+    const el = document.getElementById("home-flash");
+    expect(el.classList.contains("d-none")).toBe(true);
+    expect(el.textContent).toBe("");
+  });
+
+  it("inserts HTML-looking input as a literal text node (XSS-safe)", () => {
+    document.body.innerHTML = '<div id="home-flash"></div>';
+    renderHomeFlash("<b>x</b>");
+    const el = document.getElementById("home-flash");
+    expect(el.textContent).toBe("<b>x</b>");
+    expect(el.querySelector("b")).toBeNull();
+    expect(el.children.length).toBe(0);
+  });
+
+  it("does not throw when #home-flash is absent", () => {
+    expect(() => renderHomeFlash("hi")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasSearchQuery — reads location.search for a non-empty q=
+// ---------------------------------------------------------------------------
+
+describe("hasSearchQuery", () => {
+  it("returns true for a non-empty q= parameter", () => {
+    setSearch("/?q=hello");
+    expect(hasSearchQuery()).toBe(true);
+  });
+
+  it("returns false when q= is absent", () => {
+    setSearch("/");
+    expect(hasSearchQuery()).toBe(false);
+  });
+
+  it("returns false when q= is present but whitespace-only", () => {
+    setSearch("/?q=%20%20");
+    expect(hasSearchQuery()).toBe(false);
+  });
+
+  it("returns false when q= is empty", () => {
+    setSearch("/?q=");
+    expect(hasSearchQuery()).toBe(false);
+  });
+
+  it("returns true even when other params precede q=", () => {
+    setSearch("/?num=20&q=abc");
+    expect(hasSearchQuery()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateAdvanceLinks — forwards q/num/sort/lang/fields.label to /search/advance
+// ---------------------------------------------------------------------------
+
+describe("updateAdvanceLinks", () => {
+  it("forwards the header query and URL paging state onto the advance link", () => {
+    document.body.innerHTML =
+      '<input id="query" value="hello"><a class="adv" href="/search/advance">A</a>';
+    setSearch("/?num=20&sort=score&lang=en&fields.label=foo");
+    updateAdvanceLinks();
+    const href = document.querySelector("a.adv").getAttribute("href");
+    expect(href.startsWith("/search/advance?")).toBe(true);
+    const qs = new URLSearchParams(href.split("?")[1]);
+    expect(qs.get("q")).toBe("hello");
+    expect(qs.get("num")).toBe("20");
+    expect(qs.get("sort")).toBe("score");
+    expect(qs.getAll("lang")).toEqual(["en"]);
+    expect(qs.getAll("fields.label")).toEqual(["foo"]);
+  });
+
+  it("falls back to the URL q= when no input is populated", () => {
+    document.body.innerHTML = '<a class="adv" href="/search/advance">A</a>';
+    setSearch("/?q=urlq");
+    updateAdvanceLinks();
+    expect(document.querySelector("a.adv").getAttribute("href")).toBe("/search/advance?q=urlq");
+  });
+
+  it("prefers the header #query value over the home #contentQuery value", () => {
+    document.body.innerHTML =
+      '<input id="query" value="fromHeader"><input id="contentQuery" value="fromHome">' +
+      '<a class="adv" href="/search/advance">A</a>';
+    setSearch("/");
+    updateAdvanceLinks();
+    const qs = new URLSearchParams(
+      document.querySelector("a.adv").getAttribute("href").split("?")[1]
+    );
+    expect(qs.get("q")).toBe("fromHeader");
+  });
+
+  it("emits a bare /search/advance href when there is no query at all", () => {
+    document.body.innerHTML = '<a class="adv" href="/search/advance">A</a>';
+    setSearch("/");
+    updateAdvanceLinks();
+    expect(document.querySelector("a.adv").getAttribute("href")).toBe("/search/advance");
+  });
+
+  it("forwards multiple lang and fields.label values", () => {
+    document.body.innerHTML = '<a class="adv" href="/search/advance">A</a>';
+    setSearch("/?q=x&lang=en&lang=ja&fields.label=a&fields.label=b");
+    updateAdvanceLinks();
+    const qs = new URLSearchParams(
+      document.querySelector("a.adv").getAttribute("href").split("?")[1]
+    );
+    expect(qs.getAll("lang")).toEqual(["en", "ja"]);
+    expect(qs.getAll("fields.label")).toEqual(["a", "b"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerRoutes — the route table wired into router.register
+// ---------------------------------------------------------------------------
+
+describe("registerRoutes", () => {
+  /** @returns {[Function, Function][]} the (predicate, handler) pairs registered */
+  function registered() {
+    registerRoutes();
+    return router.register.mock.calls;
+  }
+
+  it("registers nine routes as (predicate, handler) pairs", () => {
+    const calls = registered();
+    expect(calls.length).toBe(9);
+    for (const [predicate, handler] of calls) {
+      expect(typeof predicate).toBe("function");
+      expect(typeof handler).toBe("function");
+    }
+  });
+
+  it("registers a home route matching '/' only when there is no q=", () => {
+    const calls = registered();
+    setSearch("/");
+    const homeRoute = calls.find(([p]) => p("/") === true);
+    expect(homeRoute).toBeTruthy();
+    // The home predicate must reject '/' once a q= is present (results take over).
+    const homePredicate = calls[0][0];
+    setSearch("/");
+    expect(homePredicate("/")).toBe(true);
+    setSearch("/?q=x");
+    expect(homePredicate("/")).toBe(false);
+  });
+
+  it("registers a search/results route matching /search and /index paths", () => {
+    const calls = registered();
+    const searchPredicate = calls[1][0];
+    expect(searchPredicate("/search")).toBe(true);
+    expect(searchPredicate("/")).toBe(true);
+    expect(searchPredicate("/index")).toBe(true);
+    expect(searchPredicate("/index.html")).toBe(true);
+    expect(searchPredicate("/profile")).toBe(false);
+  });
+
+  it("registers predicates covering profile, advance, help, chat, cache and error", () => {
+    const calls = registered();
+    const matches = (path) => calls.some(([p]) => p(path));
+    expect(matches("/profile")).toBe(true);
+    expect(matches("/advance")).toBe(true);
+    expect(matches("/search/advance")).toBe(true);
+    expect(matches("/help")).toBe(true);
+    expect(matches("/chat")).toBe(true);
+    expect(matches("/cache")).toBe(true);
+    expect(matches("/cache/?docId=1")).toBe(true);
+    expect(matches("/error")).toBe(true);
+    expect(matches("/error/404")).toBe(true);
+  });
+
+  it("registers a catch-all fallback predicate returning true for unknown paths", () => {
+    const calls = registered();
+    const fallback = calls[calls.length - 1][0];
+    expect(fallback("/totally-unknown")).toBe(true);
+    expect(fallback("")).toBe(true);
+  });
+
+  it("route handlers reveal the matching view and hide the rest (no throw)", async () => {
+    mountFullDom();
+    const calls = registered();
+    const hiddenState = () =>
+      Object.fromEntries(
+        ["home-view", "results-view", "advance-view", "profile-view", "help-view", "chat-view", "cache-view", "error-view"].map(
+          (id) => [id, document.getElementById(id).hasAttribute("hidden")]
+        )
+      );
+
+    // Home handler (index 0) reveals home-view and clears search state.
+    setSearch("/");
+    expect(() => calls[0][1]()).not.toThrow();
+    await flush();
+    expect(hiddenState()["home-view"]).toBe(false);
+    expect(hiddenState()["results-view"]).toBe(true);
+    expect(search.clearSearchState).toHaveBeenCalled();
+
+    // Results handler (index 1) reveals results-view and runs the URL search.
+    calls[1][1]();
+    expect(hiddenState()["results-view"]).toBe(false);
+    expect(hiddenState()["home-view"]).toBe(true);
+    expect(search.attach).toHaveBeenCalled();
+    expect(search.runFromUrl).toHaveBeenCalled();
+
+    // Profile handler.
+    calls[2][1]();
+    expect(hiddenState()["profile-view"]).toBe(false);
+    expect(profile.attach).toHaveBeenCalled();
+
+    // Advance handler.
+    calls[3][1]();
+    expect(hiddenState()["advance-view"]).toBe(false);
+    expect(advance.attach).toHaveBeenCalled();
+
+    // Help handler.
+    calls[4][1]();
+    expect(hiddenState()["help-view"]).toBe(false);
+    expect(help.attach).toHaveBeenCalled();
+
+    // Chat handler puts the nav link into "Search" mode and mounts standalone chat.
+    calls[5][1]();
+    expect(hiddenState()["chat-view"]).toBe(false);
+    expect(chat.attachStandalone).toHaveBeenCalled();
+    expect(document.getElementById("chat-nav-link").getAttribute("href")).toBe("/");
+
+    // Cache handler.
+    calls[6][1]();
+    expect(hiddenState()["cache-view"]).toBe(false);
+    expect(cache.attach).toHaveBeenCalled();
+
+    // Error handler.
+    calls[7][1]();
+    expect(hiddenState()["error-view"]).toBe(false);
+    expect(errorView.attach).toHaveBeenCalled();
+
+    // Fallback handler (index 8) also lands on the error view.
+    calls[8][1]();
+    expect(hiddenState()["error-view"]).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// main — the SPA boot sequence
+// ---------------------------------------------------------------------------
+
+describe("main", () => {
+  it("boots: awaits api/i18n init, attaches auth+search, wires the router (no throw)", async () => {
+    mountFullDom();
+    await expect(main()).resolves.toBeUndefined();
+
+    expect(api.init).toHaveBeenCalledTimes(1);
+    expect(i18n.init).toHaveBeenCalledTimes(1);
+    expect(auth.attach).toHaveBeenCalledTimes(1);
+    expect(search.attach).toHaveBeenCalledTimes(1);
+    // registerRoutes -> nine router.register calls, then attach + dispatch.
+    expect(router.register).toHaveBeenCalledTimes(9);
+    expect(router.attach).toHaveBeenCalledTimes(1);
+    expect(router.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders EOL + dev-mode warnings and reveals the chat nav item from config", async () => {
+    mountFullDom();
+    api.getConfig.mockReturnValue({
+      features: {
+        eoled: true,
+        eol_link: "https://example.test/eol",
+        development_mode: true,
+        installation_link: "https://example.test/install",
+        rag_chat_enabled: true,
+      },
+    });
+    await main();
+    // Two warning indicators inserted into #header-nav.
+    const warnings = document.querySelectorAll("#header-nav li.warning-indicator");
+    expect(warnings.length).toBe(2);
+    // Chat nav item revealed (d-none removed).
+    expect(document.getElementById("chat-nav-item").classList.contains("d-none")).toBe(false);
+  });
+
+  it("renders sanitized notification banners from config into the slots", async () => {
+    mountFullDom();
+    api.getConfig.mockReturnValue({
+      features: {},
+      notifications: { search_top: "<b>Top</b>", advance_search: "<i>Adv</i>" },
+    });
+    await main();
+    const home = document.getElementById("home-notification");
+    expect(home.classList.contains("d-none")).toBe(false);
+    expect(home.textContent).toContain("Top");
+    const adv = document.getElementById("advance-notification");
+    expect(adv.textContent).toContain("Adv");
+  });
+
+  it("renders the footer copyright with a CodeLibs link", async () => {
+    mountFullDom();
+    await main();
+    const footer = document.getElementById("footer-copyright");
+    const link = footer.querySelector("a");
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("href")).toBe("https://github.com/codelibs");
+  });
+
+  it("still completes when api.init() rejects (error is swallowed and logged)", async () => {
+    mountFullDom();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    api.init.mockRejectedValueOnce(new Error("config down"));
+    await expect(main()).resolves.toBeUndefined();
+    // Boot continued past the failed api.init.
+    expect(i18n.init).toHaveBeenCalledTimes(1);
+    expect(router.dispatch).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does not throw when booting against a minimal (mostly empty) DOM", async () => {
+    document.body.innerHTML = "";
+    await expect(main()).resolves.toBeUndefined();
+    expect(router.dispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/js/themes/bootstrap/app.test.js
+++ b/src/test/js/themes/bootstrap/app.test.js
@@ -14,7 +14,7 @@
 // stub, so text assertions target the caller-supplied string / i18n key.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { resetDom } from "../../helpers/dom.js";
+import { resetDom, setLocation } from "../../helpers/dom.js";
 
 vi.mock("../../../../main/webapp/themes/bootstrap/assets/api.js", () => ({
   init: vi.fn(async () => {}),
@@ -90,11 +90,6 @@ const { renderHomeFlash, hasSearchQuery, updateAdvanceLinks, registerRoutes, mai
   "../../../../main/webapp/themes/bootstrap/assets/app.js"
 );
 
-/** Set the current URL (search string) without a reload, so location.search reads it. */
-function setSearch(url) {
-  window.history.replaceState({}, "", url);
-}
-
 /** Let queued microtasks (deferred focus, async awaits) settle. */
 const flush = () => new Promise((r) => setTimeout(r));
 
@@ -148,7 +143,7 @@ beforeEach(() => {
   i18n.init.mockResolvedValue(undefined);
   auth.attach.mockResolvedValue(null);
   help.attach.mockResolvedValue(undefined);
-  setSearch("/");
+  setLocation("/");
 });
 afterEach(resetDom);
 
@@ -210,27 +205,27 @@ describe("renderHomeFlash", () => {
 
 describe("hasSearchQuery", () => {
   it("returns true for a non-empty q= parameter", () => {
-    setSearch("/?q=hello");
+    setLocation("/?q=hello");
     expect(hasSearchQuery()).toBe(true);
   });
 
   it("returns false when q= is absent", () => {
-    setSearch("/");
+    setLocation("/");
     expect(hasSearchQuery()).toBe(false);
   });
 
   it("returns false when q= is present but whitespace-only", () => {
-    setSearch("/?q=%20%20");
+    setLocation("/?q=%20%20");
     expect(hasSearchQuery()).toBe(false);
   });
 
   it("returns false when q= is empty", () => {
-    setSearch("/?q=");
+    setLocation("/?q=");
     expect(hasSearchQuery()).toBe(false);
   });
 
   it("returns true even when other params precede q=", () => {
-    setSearch("/?num=20&q=abc");
+    setLocation("/?num=20&q=abc");
     expect(hasSearchQuery()).toBe(true);
   });
 });
@@ -243,7 +238,7 @@ describe("updateAdvanceLinks", () => {
   it("forwards the header query and URL paging state onto the advance link", () => {
     document.body.innerHTML =
       '<input id="query" value="hello"><a class="adv" href="/search/advance">A</a>';
-    setSearch("/?num=20&sort=score&lang=en&fields.label=foo");
+    setLocation("/?num=20&sort=score&lang=en&fields.label=foo");
     updateAdvanceLinks();
     const href = document.querySelector("a.adv").getAttribute("href");
     expect(href.startsWith("/search/advance?")).toBe(true);
@@ -257,7 +252,7 @@ describe("updateAdvanceLinks", () => {
 
   it("falls back to the URL q= when no input is populated", () => {
     document.body.innerHTML = '<a class="adv" href="/search/advance">A</a>';
-    setSearch("/?q=urlq");
+    setLocation("/?q=urlq");
     updateAdvanceLinks();
     expect(document.querySelector("a.adv").getAttribute("href")).toBe("/search/advance?q=urlq");
   });
@@ -266,7 +261,7 @@ describe("updateAdvanceLinks", () => {
     document.body.innerHTML =
       '<input id="query" value="fromHeader"><input id="contentQuery" value="fromHome">' +
       '<a class="adv" href="/search/advance">A</a>';
-    setSearch("/");
+    setLocation("/");
     updateAdvanceLinks();
     const qs = new URLSearchParams(
       document.querySelector("a.adv").getAttribute("href").split("?")[1]
@@ -276,14 +271,14 @@ describe("updateAdvanceLinks", () => {
 
   it("emits a bare /search/advance href when there is no query at all", () => {
     document.body.innerHTML = '<a class="adv" href="/search/advance">A</a>';
-    setSearch("/");
+    setLocation("/");
     updateAdvanceLinks();
     expect(document.querySelector("a.adv").getAttribute("href")).toBe("/search/advance");
   });
 
   it("forwards multiple lang and fields.label values", () => {
     document.body.innerHTML = '<a class="adv" href="/search/advance">A</a>';
-    setSearch("/?q=x&lang=en&lang=ja&fields.label=a&fields.label=b");
+    setLocation("/?q=x&lang=en&lang=ja&fields.label=a&fields.label=b");
     updateAdvanceLinks();
     const qs = new URLSearchParams(
       document.querySelector("a.adv").getAttribute("href").split("?")[1]
@@ -315,14 +310,14 @@ describe("registerRoutes", () => {
 
   it("registers a home route matching '/' only when there is no q=", () => {
     const calls = registered();
-    setSearch("/");
+    setLocation("/");
     const homeRoute = calls.find(([p]) => p("/") === true);
     expect(homeRoute).toBeTruthy();
     // The home predicate must reject '/' once a q= is present (results take over).
     const homePredicate = calls[0][0];
-    setSearch("/");
+    setLocation("/");
     expect(homePredicate("/")).toBe(true);
-    setSearch("/?q=x");
+    setLocation("/?q=x");
     expect(homePredicate("/")).toBe(false);
   });
 
@@ -360,62 +355,57 @@ describe("registerRoutes", () => {
   it("route handlers reveal the matching view and hide the rest (no throw)", async () => {
     mountFullDom();
     const calls = registered();
-    const hiddenState = () =>
-      Object.fromEntries(
-        ["home-view", "results-view", "advance-view", "profile-view", "help-view", "chat-view", "cache-view", "error-view"].map(
-          (id) => [id, document.getElementById(id).hasAttribute("hidden")]
-        )
-      );
+    const isHidden = (id) => document.getElementById(id).hasAttribute("hidden");
 
     // Home handler (index 0) reveals home-view and clears search state.
-    setSearch("/");
+    setLocation("/");
     expect(() => calls[0][1]()).not.toThrow();
     await flush();
-    expect(hiddenState()["home-view"]).toBe(false);
-    expect(hiddenState()["results-view"]).toBe(true);
+    expect(isHidden("home-view")).toBe(false);
+    expect(isHidden("results-view")).toBe(true);
     expect(search.clearSearchState).toHaveBeenCalled();
 
     // Results handler (index 1) reveals results-view and runs the URL search.
     calls[1][1]();
-    expect(hiddenState()["results-view"]).toBe(false);
-    expect(hiddenState()["home-view"]).toBe(true);
+    expect(isHidden("results-view")).toBe(false);
+    expect(isHidden("home-view")).toBe(true);
     expect(search.attach).toHaveBeenCalled();
     expect(search.runFromUrl).toHaveBeenCalled();
 
     // Profile handler.
     calls[2][1]();
-    expect(hiddenState()["profile-view"]).toBe(false);
+    expect(isHidden("profile-view")).toBe(false);
     expect(profile.attach).toHaveBeenCalled();
 
     // Advance handler.
     calls[3][1]();
-    expect(hiddenState()["advance-view"]).toBe(false);
+    expect(isHidden("advance-view")).toBe(false);
     expect(advance.attach).toHaveBeenCalled();
 
     // Help handler.
     calls[4][1]();
-    expect(hiddenState()["help-view"]).toBe(false);
+    expect(isHidden("help-view")).toBe(false);
     expect(help.attach).toHaveBeenCalled();
 
     // Chat handler puts the nav link into "Search" mode and mounts standalone chat.
     calls[5][1]();
-    expect(hiddenState()["chat-view"]).toBe(false);
+    expect(isHidden("chat-view")).toBe(false);
     expect(chat.attachStandalone).toHaveBeenCalled();
     expect(document.getElementById("chat-nav-link").getAttribute("href")).toBe("/");
 
     // Cache handler.
     calls[6][1]();
-    expect(hiddenState()["cache-view"]).toBe(false);
+    expect(isHidden("cache-view")).toBe(false);
     expect(cache.attach).toHaveBeenCalled();
 
     // Error handler.
     calls[7][1]();
-    expect(hiddenState()["error-view"]).toBe(false);
+    expect(isHidden("error-view")).toBe(false);
     expect(errorView.attach).toHaveBeenCalled();
 
     // Fallback handler (index 8) also lands on the error view.
     calls[8][1]();
-    expect(hiddenState()["error-view"]).toBe(false);
+    expect(isHidden("error-view")).toBe(false);
   });
 });
 

--- a/src/test/js/themes/bootstrap/auth.test.js
+++ b/src/test/js/themes/bootstrap/auth.test.js
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+// Executable tests for the bootstrap theme auth.js.
+//
+// api.js is mocked so config and network are driven per test; the real i18n.js
+// and format.js are used. The real i18n.t() returns the requested key unchanged
+// (messages are empty without init), so the tests assert exact i18n keys.
+//
+// Silent catches in the source mean behaviour is only observable through side
+// effects (api.setAuthenticated / api.setCsrfToken calls, DOM mutations, and
+// dispatched CustomEvents); the assertions target those.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/api.js", () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  getConfig: vi.fn(),
+  setAuthenticated: vi.fn(),
+  setCsrfToken: vi.fn(),
+  ApiError: class extends Error {},
+  NetworkError: class extends Error {},
+}));
+
+import * as api from "../../../../main/webapp/themes/bootstrap/assets/api.js";
+import {
+  isLoginLinkEnabled,
+  buildUserDropdown,
+  buildLoginLink,
+  rotateCsrf,
+  probeMe,
+  attach,
+} from "../../../../main/webapp/themes/bootstrap/assets/auth.js";
+import { resetDom } from "../../helpers/dom.js";
+
+/** Let queued microtasks/timers settle so async submit handlers complete. */
+const flush = () => new Promise((r) => setTimeout(r));
+
+beforeEach(() => {
+  resetDom();
+  vi.clearAllMocks();
+  // Default: no config unless a test overrides it.
+  api.getConfig.mockReturnValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isLoginLinkEnabled", () => {
+  it("returns true when getConfig() is null (missing config)", () => {
+    api.getConfig.mockReturnValue(null);
+    expect(isLoginLinkEnabled()).toBe(true);
+  });
+
+  it("returns true when config has no features ({})", () => {
+    api.getConfig.mockReturnValue({});
+    expect(isLoginLinkEnabled()).toBe(true);
+  });
+
+  it("returns false only when login_link === false", () => {
+    api.getConfig.mockReturnValue({ features: { login_link: false } });
+    expect(isLoginLinkEnabled()).toBe(false);
+  });
+
+  it("returns true for a truthy login_link value (e.g. an SSO URL)", () => {
+    api.getConfig.mockReturnValue({ features: { login_link: "/sso" } });
+    expect(isLoginLinkEnabled()).toBe(true);
+  });
+});
+
+describe("buildUserDropdown", () => {
+  it("renders the toggle (#userMenu) and always a #logout-btn", () => {
+    const w = buildUserDropdown({ name: "Al" });
+    expect(w.querySelector("#userMenu")).not.toBeNull();
+    expect(w.querySelector("#logout-btn")).not.toBeNull();
+    // Detached node: not attached to the live document.
+    expect(w.isConnected).toBe(false);
+  });
+
+  it("uses user.name for #user-name", () => {
+    const w = buildUserDropdown({ name: "Al", username: "ignored" });
+    expect(w.querySelector("#user-name").textContent).toBe("Al");
+  });
+
+  it("falls back name -> username -> user_id -> empty string", () => {
+    expect(buildUserDropdown({ username: "u1" }).querySelector("#user-name").textContent).toBe("u1");
+    expect(buildUserDropdown({ user_id: "uid7" }).querySelector("#user-name").textContent).toBe("uid7");
+    expect(buildUserDropdown({}).querySelector("#user-name").textContent).toBe("");
+  });
+
+  it("includes the profile item unless editable === false", () => {
+    expect(buildUserDropdown({ name: "Al" }).querySelector('a[href="/profile"]')).not.toBeNull();
+    expect(buildUserDropdown({ name: "Al", editable: true }).querySelector('a[href="/profile"]')).not.toBeNull();
+    expect(buildUserDropdown({ name: "Al", editable: false }).querySelector('a[href="/profile"]')).toBeNull();
+  });
+
+  it("includes the admin item only when admin === true", () => {
+    expect(buildUserDropdown({ name: "Al", admin: true }).querySelector('a[href="/admin/"]')).not.toBeNull();
+    // Truthy-but-not-true values do not qualify (strict ===).
+    expect(buildUserDropdown({ name: "Al", admin: 1 }).querySelector('a[href="/admin/"]')).toBeNull();
+    expect(buildUserDropdown({ name: "Al" }).querySelector('a[href="/admin/"]')).toBeNull();
+  });
+
+  it("labels items with the exact i18n keys", () => {
+    const w = buildUserDropdown({ name: "Al", admin: true });
+    expect(w.querySelector('a[href="/profile"]').textContent).toBe("nav.profile");
+    expect(w.querySelector('a[href="/admin/"]').textContent).toBe("nav.administration");
+    expect(w.querySelector("#logout-btn").textContent).toBe("auth.logout");
+  });
+});
+
+describe("buildLoginLink", () => {
+  it("links directly to features.login_link when SSO is enabled", () => {
+    api.getConfig.mockReturnValue({ features: { sso_enabled: true, login_link: "/sso" } });
+    const a = buildLoginLink();
+    expect(a.getAttribute("href")).toBe("/sso");
+    expect(a.id).toBe("login-btn");
+    // Direct link: no modal wiring.
+    expect(a.hasAttribute("data-bs-toggle")).toBe(false);
+    expect(a.hasAttribute("data-bs-target")).toBe(false);
+  });
+
+  it("opens the login modal when SSO is not fully configured", () => {
+    api.getConfig.mockReturnValue({});
+    const a = buildLoginLink();
+    expect(a.getAttribute("href")).toBe("/login");
+    expect(a.getAttribute("data-bs-toggle")).toBe("modal");
+    expect(a.getAttribute("data-bs-target")).toBe("#login-modal");
+    expect(a.querySelector("span").textContent).toBe("auth.login");
+  });
+
+  it("opens the modal when sso_enabled is set but login_link is missing", () => {
+    api.getConfig.mockReturnValue({ features: { sso_enabled: true } });
+    const a = buildLoginLink();
+    expect(a.getAttribute("href")).toBe("/login");
+    expect(a.getAttribute("data-bs-target")).toBe("#login-modal");
+  });
+});
+
+describe("rotateCsrf", () => {
+  it("uses the token from the logout envelope without an extra request", async () => {
+    await rotateCsrf({ csrf_token: "X" });
+    expect(api.setCsrfToken).toHaveBeenCalledWith("X");
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to GET /ui/config when the envelope has no token", async () => {
+    api.get.mockResolvedValue({ csrf_token: "Y" });
+    await rotateCsrf(null);
+    expect(api.get).toHaveBeenCalledWith("/ui/config");
+    expect(api.setCsrfToken).toHaveBeenCalledWith("Y");
+  });
+
+  it("swallows a failed fallback fetch (no throw, token left as-is)", async () => {
+    api.get.mockRejectedValue(new Error("boom"));
+    await expect(rotateCsrf(null)).resolves.toBeUndefined();
+    expect(api.setCsrfToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("probeMe", () => {
+  it("renders the user dropdown and marks authenticated when logged in", async () => {
+    document.body.innerHTML = '<ul id="auth-controls"></ul>';
+    api.getConfig.mockReturnValue({});
+    const user = { name: "Al", admin: true };
+    api.get.mockResolvedValue({ authenticated: true, user });
+
+    const result = await probeMe();
+
+    expect(result).toEqual(user);
+    expect(api.get).toHaveBeenCalledWith("/auth/me");
+    expect(api.setAuthenticated).toHaveBeenCalledWith(true);
+    expect(document.getElementById("user-dropdown")).not.toBeNull();
+    expect(document.getElementById("userMenu")).not.toBeNull();
+    expect(document.querySelector('#user-dropdown a[href="/admin/"]')).not.toBeNull();
+  });
+
+  it("treats AUTH_REQUIRED as logged out and shows the login link", async () => {
+    document.body.innerHTML = '<ul id="auth-controls"></ul>';
+    api.getConfig.mockReturnValue({});
+    api.get.mockRejectedValue({ code: "AUTH_REQUIRED" });
+
+    const result = await probeMe();
+
+    expect(result).toBeNull();
+    expect(api.setAuthenticated).toHaveBeenCalledWith(false);
+    expect(document.getElementById("login-btn")).not.toBeNull();
+    expect(document.getElementById("user-dropdown")).toBeNull();
+  });
+
+  it("surfaces a network/server (5xx) error without flipping auth state", async () => {
+    document.body.innerHTML = '<div id="results-meta"></div><ul id="auth-controls"></ul>';
+    let networkEvent = null;
+    document.addEventListener("fess:auth:network-error", (e) => { networkEvent = e; });
+    api.get.mockRejectedValue({ httpStatus: 503 });
+
+    const result = await probeMe();
+
+    expect(result).toBeNull();
+    // Auth state is unknown, not confirmed gone — must NOT be set to false.
+    expect(api.setAuthenticated).not.toHaveBeenCalledWith(false);
+    expect(document.getElementById("results-meta").textContent).toBe("error.network");
+    expect(networkEvent).not.toBeNull();
+    expect(networkEvent.detail.error).toEqual({ httpStatus: 503 });
+    // No login link rendered in the network-error branch.
+    expect(document.getElementById("login-btn")).toBeNull();
+  });
+});
+
+describe("attach — login form submit", () => {
+  const LOGIN_FIXTURE = `
+    <ul id="auth-controls"></ul>
+    <form id="login-form">
+      <input id="login-username" value="bob">
+      <input id="login-password" value="pw">
+    </form>
+    <div id="login-error" class="d-none"></div>`;
+
+  beforeEach(() => {
+    api.getConfig.mockReturnValue({});
+    // Initial probeMe() fired by attach() resolves to a clean logged-out state.
+    api.get.mockRejectedValue({ code: "AUTH_REQUIRED" });
+  });
+
+  it("logs in: posts credentials, rotates CSRF, renders the dropdown", async () => {
+    document.body.innerHTML = LOGIN_FIXTURE;
+    await attach(); // attach() returns probeMe() — await the initial probe.
+    api.post.mockResolvedValue({ user: { name: "Bob" }, csrf_token: "Z" });
+
+    let loginEvent = null;
+    document.addEventListener("fess:auth:login", (e) => { loginEvent = e; });
+
+    document.getElementById("login-form").dispatchEvent(new Event("submit"));
+    await flush();
+
+    expect(api.post).toHaveBeenCalledWith("/auth/login", { username: "bob", password: "pw" });
+    expect(api.setCsrfToken).toHaveBeenCalledWith("Z");
+    expect(document.getElementById("user-dropdown")).not.toBeNull();
+    expect(document.querySelector("#user-dropdown #user-name").textContent).toBe("Bob");
+    expect(loginEvent).not.toBeNull();
+  });
+
+  it("shows the rate-limited message on HTTP 429", async () => {
+    document.body.innerHTML = LOGIN_FIXTURE;
+    await attach();
+    api.post.mockRejectedValue({ httpStatus: 429 });
+
+    document.getElementById("login-form").dispatchEvent(new Event("submit"));
+    await flush();
+
+    const err = document.getElementById("login-error");
+    expect(err.textContent).toBe("auth.error_rate_limited");
+    expect(err.classList.contains("d-none")).toBe(false);
+  });
+
+  it("shows the invalid-credentials message on a generic failure", async () => {
+    document.body.innerHTML = LOGIN_FIXTURE;
+    await attach();
+    api.post.mockRejectedValue({ code: "BAD_CREDENTIALS" });
+
+    document.getElementById("login-form").dispatchEvent(new Event("submit"));
+    await flush();
+
+    const err = document.getElementById("login-error");
+    expect(err.textContent).toBe("auth.error_invalid_credentials");
+    expect(err.classList.contains("d-none")).toBe(false);
+  });
+});

--- a/src/test/js/themes/bootstrap/cache.test.js
+++ b/src/test/js/themes/bootstrap/cache.test.js
@@ -12,7 +12,7 @@
 // the .catch — a false pass rendering the error view — so the stub is load-bearing.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { setLocation } from "../../helpers/dom.js";
+import { resetDom, setLocation } from "../../helpers/dom.js";
 
 const API = "../../../../main/webapp/themes/bootstrap/assets/api.js";
 const CACHE = "../../../../main/webapp/themes/bootstrap/assets/cache.js";
@@ -39,7 +39,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   setLocation("/");
-  document.body.innerHTML = "";
+  resetDom();
 });
 
 describe("attach: guards", () => {

--- a/src/test/js/themes/bootstrap/cache.test.js
+++ b/src/test/js/themes/bootstrap/cache.test.js
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Executable tests for cache.js — the SPA cache viewer.
+//
+// cache.js carries module-level state (_currentBlobUrl, _routeListenerAttached),
+// so every test does vi.resetModules() + a fresh dynamic import to start clean.
+// api.js is mocked (get is a vi.fn resolved/rejected per test); i18n.t and
+// format.formatDate are the real modules. The real i18n.t() returns its key
+// unchanged (no init), so the rendered text is the exact i18n key.
+//
+// jsdom has no URL.createObjectURL/revokeObjectURL; both are stubbed. Without the
+// createObjectURL stub the happy path throws inside the .then and is swallowed by
+// the .catch — a false pass rendering the error view — so the stub is load-bearing.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setLocation } from "../../helpers/dom.js";
+
+const API = "../../../../main/webapp/themes/bootstrap/assets/api.js";
+const CACHE = "../../../../main/webapp/themes/bootstrap/assets/cache.js";
+
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/api.js", () => ({
+  get: vi.fn(),
+  ApiError: class extends Error {},
+}));
+
+/** Import a fresh cache.js plus the mocked api after resetting module state. */
+async function freshModules() {
+  vi.resetModules();
+  const api = await import(API);
+  const cache = await import(CACHE);
+  return { api, cache };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '<section id="cache-view"></section>';
+  URL.createObjectURL = vi.fn(() => "blob:mock");
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setLocation("/");
+  document.body.innerHTML = "";
+});
+
+describe("attach: guards", () => {
+  it("does nothing when #cache-view is absent", async () => {
+    document.body.innerHTML = "";
+    const { cache } = await freshModules();
+    setLocation("/cache?docId=abc");
+    expect(() => cache.attach()).not.toThrow();
+  });
+
+  it("renders a not-found alert when docId is missing", async () => {
+    const { api, cache } = await freshModules();
+    setLocation("/cache");
+    cache.attach();
+
+    const alert = document.querySelector("#cache-view .alert.alert-warning");
+    expect(alert).not.toBeNull();
+    expect(alert.textContent).toBe("labels.cache_not_found");
+    // No fetch attempted without a docId.
+    expect(api.get).not.toHaveBeenCalled();
+  });
+});
+
+describe("attach: happy path", () => {
+  const env = {
+    doc_id: "abc",
+    mimetype: "text/html",
+    content: "<html><head></head><body>x</body></html>",
+    url: "https://site/p",
+    created: "2024-01-01T00:00:00",
+  };
+
+  it("forwards non-empty hq terms and renders heading, metadata, and a sandboxed iframe", async () => {
+    const { api, cache } = await freshModules();
+    api.get.mockResolvedValue(env);
+
+    setLocation("/cache?docId=abc&hq=foo&hq=");
+    cache.attach();
+
+    const host = document.getElementById("cache-view");
+    await vi.waitFor(() => expect(host.querySelector("iframe.cache-frame")).not.toBeNull());
+
+    // hq: empty values filtered out, non-empty forwarded to the cache API.
+    expect(api.get).toHaveBeenCalledWith("/cache/abc", { hq: ["foo"] });
+
+    // Heading.
+    expect(host.querySelector("h2").textContent).toBe("labels.cache_title");
+
+    // Metadata rows (dt=i18n key, dd=value).
+    const dl = host.querySelector("dl.cache-meta");
+    expect(dl).not.toBeNull();
+    const dds = Array.from(dl.querySelectorAll("dd")).map((d) => d.textContent);
+    expect(dds).toEqual(
+      expect.arrayContaining([
+        "https://site/p", // url
+        "text/html;charset=utf-8", // charset-augmented mimetype
+        "abc", // doc id
+        "2024-01-01 00:00", // formatDate(created)
+      ])
+    );
+
+    // Sandboxed iframe: exactly the two popup tokens, never scripts/same-origin.
+    // jsdom stores an assigned iframe.sandbox as a plain string property (it does
+    // not reflect to the attribute); a real browser reflects it into the sandbox
+    // DOMTokenList. String() reads the value identically in both.
+    const iframe = host.querySelector("iframe.cache-frame");
+    expect(String(iframe.sandbox)).toBe("allow-popups allow-popups-to-escape-sandbox");
+    expect(String(iframe.sandbox)).not.toContain("allow-scripts");
+    expect(String(iframe.sandbox)).not.toContain("allow-same-origin");
+    expect(iframe.getAttribute("src")).toBe("blob:mock");
+  });
+
+  it("injects a <base href> for the document URL into the blob content", async () => {
+    const { api, cache } = await freshModules();
+    api.get.mockResolvedValue(env);
+
+    setLocation("/cache?docId=abc");
+    cache.attach();
+
+    const host = document.getElementById("cache-view");
+    await vi.waitFor(() => expect(host.querySelector("iframe.cache-frame")).not.toBeNull());
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    const blobArg = URL.createObjectURL.mock.calls[0][0];
+    const text = await blobArg.text();
+    expect(text).toContain('<base href="https://site/p">');
+  });
+});
+
+describe("attach: error path", () => {
+  it("shows cache_not_found on a 404 rejection", async () => {
+    const { api, cache } = await freshModules();
+    api.get.mockRejectedValue({ httpStatus: 404 });
+
+    setLocation("/cache?docId=missing");
+    cache.attach();
+
+    const host = document.getElementById("cache-view");
+    await vi.waitFor(() =>
+      expect(host.querySelector(".alert.alert-warning")).not.toBeNull()
+    );
+    expect(host.querySelector(".alert.alert-warning").textContent).toBe("labels.cache_not_found");
+  });
+
+  it("shows the generic server error for a non-404 rejection", async () => {
+    const { api, cache } = await freshModules();
+    api.get.mockRejectedValue({ code: "X" });
+
+    setLocation("/cache?docId=boom");
+    cache.attach();
+
+    const host = document.getElementById("cache-view");
+    await vi.waitFor(() =>
+      expect(host.querySelector(".alert.alert-warning")).not.toBeNull()
+    );
+    expect(host.querySelector(".alert.alert-warning").textContent).toBe("error.server");
+  });
+});

--- a/src/test/js/themes/bootstrap/chat.test.js
+++ b/src/test/js/themes/bootstrap/chat.test.js
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the bootstrap theme chat module (chat.js).
+//
+// The pure/DOM-builder helpers (safeHref, sourceIcon, sourceTypeLabel,
+// errorCodeToText, buildPhaseStrip, buildFilterPanel) are exported for test and
+// exercised through the real, unmodified asset via a static import. The stateful
+// attach* entry points hold module-level singletons (currentStream, sessionId,
+// inlineMounted, standaloneMounted, routeListenerAttached) with no reset hook, so
+// those tests use vi.resetModules() + a dynamic import to get a fresh instance.
+//
+// ./api.js is mocked so getConfig()/sseStream()/getCsrfToken() are controllable;
+// i18n.js/format.js/markdown.js run for real. With empty i18n messages, t(key)
+// returns the key unchanged, so assertions match exact i18n keys.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resetDom, mountBody } from "../../helpers/dom.js";
+
+const CHAT_PATH = "../../../../main/webapp/themes/bootstrap/assets/chat.js";
+
+// Controllable stand-in for the /api/v2 client. chat.js only reads
+// api.getConfig(), api.sseStream() and api.getCsrfToken().
+const apiMock = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  getCsrfToken: vi.fn(),
+  sseStream: vi.fn(),
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/api.js", () => apiMock);
+
+import {
+  safeHref,
+  sourceIcon,
+  sourceTypeLabel,
+  errorCodeToText,
+  buildPhaseStrip,
+  buildFilterPanel,
+} from "../../../../main/webapp/themes/bootstrap/assets/chat.js";
+
+beforeEach(() => {
+  resetDom();
+  apiMock.getConfig.mockReset().mockReturnValue(null);
+  apiMock.getCsrfToken.mockReset().mockReturnValue("");
+  apiMock.sseStream.mockReset().mockReturnValue({ abort() {} });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// jsdom's default document URL — the base safeHref resolves relative URLs against.
+const ORIGIN = "http://localhost:3000";
+
+// ---------------------------------------------------------------------------
+// safeHref
+// ---------------------------------------------------------------------------
+
+describe("safeHref", () => {
+  it("keeps an absolute http(s) URL", () => {
+    expect(safeHref("https://x/y")).toBe("https://x/y");
+    expect(safeHref("http://a.example/p")).toBe("http://a.example/p");
+  });
+
+  it("keeps a mailto: URL", () => {
+    expect(safeHref("mailto:a@b")).toBe("mailto:a@b");
+  });
+
+  it("resolves a relative URL against window.location.origin", () => {
+    expect(safeHref("/foo/bar")).toBe(ORIGIN + "/foo/bar");
+    expect(safeHref("foo")).toBe(ORIGIN + "/foo");
+  });
+
+  it("rejects a javascript: scheme", () => {
+    expect(safeHref("javascript:alert(1)")).toBe("#");
+  });
+
+  it("rejects other non-allowlisted schemes (ftp, data)", () => {
+    expect(safeHref("ftp://host/file")).toBe("#");
+    expect(safeHref("data:text/html,<b>x</b>")).toBe("#");
+  });
+
+  it("returns '#' for empty / nullish input", () => {
+    expect(safeHref("")).toBe("#");
+    expect(safeHref(null)).toBe("#");
+    expect(safeHref(undefined)).toBe("#");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sourceIcon
+// ---------------------------------------------------------------------------
+
+describe("sourceIcon", () => {
+  it("maps mimetype to a Font Awesome class", () => {
+    expect(sourceIcon(undefined, "application/pdf")).toBe("fa-file-pdf-o");
+    expect(sourceIcon(undefined, "application/msword")).toBe("fa-file-word-o");
+    expect(sourceIcon(undefined, "text/x-document")).toBe("fa-file-word-o");
+    expect(sourceIcon(undefined, "application/vnd.ms-excel")).toBe("fa-file-excel-o");
+    expect(sourceIcon(undefined, "application/x-spreadsheet")).toBe("fa-file-excel-o");
+    expect(sourceIcon(undefined, "application/vnd.ms-powerpoint")).toBe("fa-file-powerpoint-o");
+    expect(sourceIcon(undefined, "application/x-presentation")).toBe("fa-file-powerpoint-o");
+    expect(sourceIcon(undefined, "image/png")).toBe("fa-file-image-o");
+    expect(sourceIcon(undefined, "text/plain")).toBe("fa-file-text-o");
+  });
+
+  it("matches word/document before excel/powerpoint: OpenDocument mimetypes hit the Word icon", () => {
+    // Quirk: the substring "document" (in every *.opendocument.* /
+    // *.officedocument.* mimetype) matches the word branch, which is tested
+    // before the spreadsheet/presentation branches. So ODS/ODP resolve to Word.
+    expect(sourceIcon(undefined, "application/vnd.oasis.opendocument.spreadsheet")).toBe("fa-file-word-o");
+    expect(sourceIcon(undefined, "application/vnd.oasis.opendocument.presentation")).toBe("fa-file-word-o");
+    // Extension-based routing is unaffected — it takes the .xlsx/.pptx path.
+    expect(sourceIcon("book.ods")).toBe("fa-file-o"); // .ods not in the extension switch
+  });
+
+  it("maps url extension when no mimetype is given", () => {
+    expect(sourceIcon("a/b.docx")).toBe("fa-file-word-o");
+    expect(sourceIcon("doc.pdf")).toBe("fa-file-pdf-o");
+    expect(sourceIcon("sheet.xlsx")).toBe("fa-file-excel-o");
+    expect(sourceIcon("deck.pptx")).toBe("fa-file-powerpoint-o");
+    expect(sourceIcon("pic.png")).toBe("fa-file-image-o");
+    expect(sourceIcon("notes.md")).toBe("fa-file-text-o");
+    expect(sourceIcon("x.html")).toBe("fa-globe");
+    expect(sourceIcon("x.htm")).toBe("fa-globe");
+  });
+
+  it("mimetype takes precedence over the url extension", () => {
+    // .html would map to fa-globe, but the pdf mimetype wins.
+    expect(sourceIcon("page.html", "application/pdf")).toBe("fa-file-pdf-o");
+  });
+
+  it("strips a query string before matching the extension", () => {
+    expect(sourceIcon("file.pdf?x=1")).toBe("fa-file-pdf-o");
+  });
+
+  it("falls back to fa-file-o for unknown extension / no input", () => {
+    expect(sourceIcon("x.xyz")).toBe("fa-file-o");
+    expect(sourceIcon(undefined, undefined)).toBe("fa-file-o");
+    expect(sourceIcon(undefined, "application/octet-stream")).toBe("fa-file-o");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sourceTypeLabel
+// ---------------------------------------------------------------------------
+
+describe("sourceTypeLabel", () => {
+  it("maps mimetype to a human label", () => {
+    expect(sourceTypeLabel(undefined, "application/pdf")).toBe("PDF");
+    expect(sourceTypeLabel(undefined, "application/msword")).toBe("Word");
+    expect(sourceTypeLabel(undefined, "application/vnd.ms-excel")).toBe("Excel");
+    expect(sourceTypeLabel(undefined, "application/vnd.ms-powerpoint")).toBe("PowerPoint");
+    expect(sourceTypeLabel(undefined, "image/gif")).toBe("Image");
+  });
+
+  it("maps url extension when no mimetype is given", () => {
+    expect(sourceTypeLabel("a.docx")).toBe("Word");
+    expect(sourceTypeLabel("a.pdf")).toBe("PDF");
+    expect(sourceTypeLabel("a.xls")).toBe("Excel");
+    expect(sourceTypeLabel("a.ppt")).toBe("PowerPoint");
+    expect(sourceTypeLabel("a.jpeg")).toBe("Image");
+    expect(sourceTypeLabel("a.md")).toBe("Text");
+    expect(sourceTypeLabel("a.html")).toBe("Web");
+  });
+
+  it("mimetype takes precedence over the url extension", () => {
+    expect(sourceTypeLabel("page.html", "application/pdf")).toBe("PDF");
+  });
+
+  it("falls back to the i18n document label for unknown input", () => {
+    expect(sourceTypeLabel("x.xyz")).toBe("labels.chat_source_type_document");
+    expect(sourceTypeLabel(undefined, undefined)).toBe("labels.chat_source_type_document");
+    // Note: unlike sourceIcon, sourceTypeLabel has no text/* mimetype branch,
+    // so a text mimetype with no url falls through to the default label.
+    expect(sourceTypeLabel(undefined, "text/plain")).toBe("labels.chat_source_type_document");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// errorCodeToText
+// ---------------------------------------------------------------------------
+
+describe("errorCodeToText", () => {
+  it("maps every known error code to error.<code>", () => {
+    for (const code of [
+      "rate_limit",
+      "auth_error",
+      "service_unavailable",
+      "timeout",
+      "context_length_exceeded",
+      "model_not_found",
+      "invalid_response",
+      "connection_error",
+    ]) {
+      expect(errorCodeToText(code)).toBe("error." + code);
+    }
+  });
+
+  it("falls back to error.server for unknown / missing codes", () => {
+    expect(errorCodeToText("bogus")).toBe("error.server");
+    expect(errorCodeToText(undefined)).toBe("error.server");
+    expect(errorCodeToText("")).toBe("error.server");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPhaseStrip
+// ---------------------------------------------------------------------------
+
+describe("buildPhaseStrip", () => {
+  const badge = (strip, phase) => strip.querySelector(`[data-step="${phase}"]`);
+
+  it("builds one badge per phase in order", () => {
+    const { strip, advanceTo, complete, reset } = buildPhaseStrip();
+    expect(typeof advanceTo).toBe("function");
+    expect(typeof complete).toBe("function");
+    expect(typeof reset).toBe("function");
+    expect(strip.classList.contains("chat-phase-strip")).toBe(true);
+    const steps = [...strip.querySelectorAll(".chat-step")].map((b) => b.getAttribute("data-step"));
+    expect(steps).toEqual(["intent", "search", "evaluate", "fetch", "answer"]);
+    // Fresh strip: every badge is bg-secondary.
+    for (const p of steps) expect(badge(strip, p).classList.contains("bg-secondary")).toBe(true);
+  });
+
+  it("advanceTo marks prior phases success, current primary, later secondary", () => {
+    const { strip, advanceTo } = buildPhaseStrip();
+    advanceTo("evaluate");
+    expect(badge(strip, "intent").classList.contains("bg-success")).toBe(true);
+    expect(badge(strip, "search").classList.contains("bg-success")).toBe(true);
+    expect(badge(strip, "evaluate").classList.contains("bg-primary")).toBe(true);
+    expect(badge(strip, "fetch").classList.contains("bg-secondary")).toBe(true);
+    expect(badge(strip, "answer").classList.contains("bg-secondary")).toBe(true);
+  });
+
+  it("advanceTo ignores an unknown phase", () => {
+    const { strip, advanceTo } = buildPhaseStrip();
+    advanceTo("nope");
+    // Unchanged: all still bg-secondary.
+    for (const p of ["intent", "search", "evaluate", "fetch", "answer"]) {
+      expect(badge(strip, p).classList.contains("bg-secondary")).toBe(true);
+    }
+  });
+
+  it("complete('search', n) turns the badge success and adds one hit-count span", () => {
+    const { strip, complete } = buildPhaseStrip();
+    complete("search", 42);
+    const b = badge(strip, "search");
+    expect(b.classList.contains("bg-success")).toBe(true);
+    expect(b.classList.contains("bg-primary")).toBe(false);
+    const counts = b.querySelectorAll(".chat-hit-count");
+    expect(counts.length).toBe(1);
+    // countText comes from t("labels.chat_hit_count", {count}); with empty i18n
+    // the key has no {count} placeholder, so it renders the key verbatim.
+    expect(counts[0].textContent).toBe(" (labels.chat_hit_count)");
+  });
+
+  it("complete replaces (does not stack) the hit-count span", () => {
+    const { strip, complete } = buildPhaseStrip();
+    complete("search", 1);
+    complete("search", 2);
+    expect(badge(strip, "search").querySelectorAll(".chat-hit-count").length).toBe(1);
+  });
+
+  it("complete without a hit count adds no span", () => {
+    const { strip, complete } = buildPhaseStrip();
+    complete("evaluate");
+    const b = badge(strip, "evaluate");
+    expect(b.classList.contains("bg-success")).toBe(true);
+    expect(b.querySelectorAll(".chat-hit-count").length).toBe(0);
+  });
+
+  it("reset returns all badges to secondary and removes hit counts", () => {
+    const { strip, advanceTo, complete, reset } = buildPhaseStrip();
+    advanceTo("answer");
+    complete("search", 7);
+    reset();
+    for (const p of ["intent", "search", "evaluate", "fetch", "answer"]) {
+      const b = badge(strip, p);
+      expect(b.classList.contains("bg-secondary")).toBe(true);
+      expect(b.classList.contains("bg-primary")).toBe(false);
+      expect(b.classList.contains("bg-success")).toBe(false);
+    }
+    expect(badge(strip, "search").querySelectorAll(".chat-hit-count").length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFilterPanel
+// ---------------------------------------------------------------------------
+
+describe("buildFilterPanel", () => {
+  it("returns a hidden placeholder panel with empty filters when nothing is configured", () => {
+    apiMock.getConfig.mockReturnValue(null);
+    const { panel, getFilters, resetFilters } = buildFilterPanel();
+    expect(panel.hidden).toBe(true);
+    expect(getFilters()).toEqual({ fields: [], extraQ: [] });
+    // resetFilters is a callable no-op so the New Chat handler can call it freely.
+    expect(() => resetFilters()).not.toThrow();
+  });
+
+  it("also treats an empty-object config as no filters", () => {
+    apiMock.getConfig.mockReturnValue({});
+    const { panel, getFilters } = buildFilterPanel();
+    expect(panel.hidden).toBe(true);
+    expect(getFilters()).toEqual({ fields: [], extraQ: [] });
+  });
+
+  it("renders label options and facet-view queries as checkboxes", () => {
+    apiMock.getConfig.mockReturnValue({
+      label_options: [
+        { value: "label1", label: "Label One" },
+        { value: "label2", label: "Label Two" },
+      ],
+      facet_views: [
+        { title: "Time", queries: [{ label: "Recent", value: "ts:[now-1M TO now]" }] },
+      ],
+    });
+    const { panel } = buildFilterPanel();
+    expect(panel.hidden).toBe(false);
+    const labelCbs = panel.querySelectorAll('input[data-filter-type="label"]');
+    const exqCbs = panel.querySelectorAll('input[data-filter-type="ex_q"]');
+    expect(labelCbs.length).toBe(2);
+    expect(exqCbs.length).toBe(1);
+    expect(labelCbs[0].getAttribute("data-filter-value")).toBe("label1");
+    expect(exqCbs[0].getAttribute("data-filter-value")).toBe("ts:[now-1M TO now]");
+  });
+
+  it("collects checked label/ex_q values into getFilters().fields / .extraQ", () => {
+    apiMock.getConfig.mockReturnValue({
+      label_options: [{ value: "label1", label: "One" }],
+      facet_views: [{ title: "T", queries: [{ label: "R", value: "exq1" }] }],
+    });
+    const { panel, getFilters } = buildFilterPanel();
+    expect(getFilters()).toEqual({ fields: [], extraQ: [] });
+
+    const labelCb = panel.querySelector('input[data-filter-type="label"]');
+    const exqCb = panel.querySelector('input[data-filter-type="ex_q"]');
+    labelCb.checked = true;
+    exqCb.checked = true;
+    expect(getFilters()).toEqual({ fields: ["label1"], extraQ: ["exq1"] });
+  });
+
+  it("updates the count badge and toggles d-none as checkboxes change", () => {
+    apiMock.getConfig.mockReturnValue({
+      label_options: [{ value: "label1", label: "One" }],
+      facet_views: [{ title: "T", queries: [{ label: "R", value: "exq1" }] }],
+    });
+    const { panel } = buildFilterPanel();
+    const mainBadge = panel.querySelector(".badge.bg-primary");
+    expect(mainBadge.textContent).toBe("0");
+    expect(mainBadge.classList.contains("d-none")).toBe(true);
+
+    const labelCb = panel.querySelector('input[data-filter-type="label"]');
+    const exqCb = panel.querySelector('input[data-filter-type="ex_q"]');
+    labelCb.checked = true;
+    labelCb.dispatchEvent(new Event("change"));
+    exqCb.checked = true;
+    exqCb.dispatchEvent(new Event("change"));
+    expect(mainBadge.textContent).toBe("2");
+    expect(mainBadge.classList.contains("d-none")).toBe(false);
+  });
+
+  it("resetFilters unchecks everything and restores the badge", () => {
+    apiMock.getConfig.mockReturnValue({
+      label_options: [{ value: "label1", label: "One" }],
+      facet_views: [{ title: "T", queries: [{ label: "R", value: "exq1" }] }],
+    });
+    const { panel, getFilters, resetFilters } = buildFilterPanel();
+    const mainBadge = panel.querySelector(".badge.bg-primary");
+    const labelCb = panel.querySelector('input[data-filter-type="label"]');
+    const exqCb = panel.querySelector('input[data-filter-type="ex_q"]');
+    labelCb.checked = true;
+    labelCb.dispatchEvent(new Event("change"));
+    exqCb.checked = true;
+    exqCb.dispatchEvent(new Event("change"));
+
+    resetFilters();
+    expect(getFilters()).toEqual({ fields: [], extraQ: [] });
+    expect(labelCb.checked).toBe(false);
+    expect(exqCb.checked).toBe(false);
+    expect(mainBadge.textContent).toBe("0");
+    expect(mainBadge.classList.contains("d-none")).toBe(true);
+  });
+
+  it("accepts label options given as plain strings", () => {
+    apiMock.getConfig.mockReturnValue({ label_options: ["plainLabel"] });
+    const { panel } = buildFilterPanel();
+    const cb = panel.querySelector('input[data-filter-type="label"]');
+    expect(cb.getAttribute("data-filter-value")).toBe("plainLabel");
+  });
+
+  it("accepts facet-view queries given as an object map", () => {
+    apiMock.getConfig.mockReturnValue({
+      facet_views: [{ title: "T", queries: { Recent: "q1", Old: "q2" } }],
+    });
+    const { panel, getFilters } = buildFilterPanel();
+    const cbs = panel.querySelectorAll('input[data-filter-type="ex_q"]');
+    expect([...cbs].map((c) => c.getAttribute("data-filter-value"))).toEqual(["q1", "q2"]);
+    cbs[1].checked = true;
+    expect(getFilters()).toEqual({ fields: [], extraQ: ["q2"] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attach flow — request-body contract (stateful; fresh module per test)
+// ---------------------------------------------------------------------------
+
+describe("attachInline / attachStandalone submit", () => {
+  const enterKey = (opts = {}) => new KeyboardEvent("keydown", { key: "Enter", bubbles: true, ...opts });
+
+  it("attachInline: Enter posts {message} to /chat/stream via sseStream", async () => {
+    vi.resetModules();
+    apiMock.getConfig.mockReturnValue({ features: { rag_chat_enabled: true } });
+    const chat = await import(CHAT_PATH);
+    mountBody('<div id="chat-column" class="d-none"></div>');
+    chat.attachInline();
+
+    const input = document.getElementById("chat-input-inline");
+    expect(input).not.toBeNull();
+    input.value = "hello world";
+    input.dispatchEvent(enterKey());
+
+    expect(apiMock.sseStream).toHaveBeenCalledTimes(1);
+    const [url, body, onEvent, onError] = apiMock.sseStream.mock.calls[0];
+    expect(url).toBe("/chat/stream");
+    expect(body).toEqual({ message: "hello world" });
+    expect(typeof onEvent).toBe("function");
+    expect(typeof onError).toBe("function");
+  });
+
+  it("attachInline: Shift+Enter inserts a newline and does not submit", async () => {
+    vi.resetModules();
+    apiMock.getConfig.mockReturnValue({ features: { rag_chat_enabled: true } });
+    const chat = await import(CHAT_PATH);
+    mountBody('<div id="chat-column"></div>');
+    chat.attachInline();
+
+    const input = document.getElementById("chat-input-inline");
+    input.value = "line";
+    input.dispatchEvent(enterKey({ shiftKey: true }));
+    expect(apiMock.sseStream).not.toHaveBeenCalled();
+  });
+
+  it("attachInline: an active IME composition suppresses the Enter submit", async () => {
+    vi.resetModules();
+    apiMock.getConfig.mockReturnValue({ features: { rag_chat_enabled: true } });
+    const chat = await import(CHAT_PATH);
+    mountBody('<div id="chat-column"></div>');
+    chat.attachInline();
+
+    const input = document.getElementById("chat-input-inline");
+    input.value = "かな";
+    input.dispatchEvent(new Event("compositionstart"));
+    input.dispatchEvent(enterKey());
+    expect(apiMock.sseStream).not.toHaveBeenCalled();
+
+    // After composition ends, Enter submits normally.
+    input.dispatchEvent(new Event("compositionend"));
+    input.dispatchEvent(enterKey());
+    expect(apiMock.sseStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("attachInline: no-op when rag chat is disabled", async () => {
+    vi.resetModules();
+    apiMock.getConfig.mockReturnValue({ features: { rag_chat_enabled: false } });
+    const chat = await import(CHAT_PATH);
+    mountBody('<div id="chat-column" class="d-none"></div>');
+    chat.attachInline();
+    expect(document.getElementById("chat-input-inline")).toBeNull();
+  });
+
+  it("attachInline: no-op when #chat-column is absent", async () => {
+    vi.resetModules();
+    apiMock.getConfig.mockReturnValue({ features: { rag_chat_enabled: true } });
+    const chat = await import(CHAT_PATH);
+    mountBody("<div></div>");
+    expect(() => chat.attachInline()).not.toThrow();
+    expect(apiMock.sseStream).not.toHaveBeenCalled();
+  });
+
+  it("attachStandalone: Enter posts {message, fields.label, extra_queries} from active filters", async () => {
+    vi.resetModules();
+    apiMock.getConfig.mockReturnValue({
+      features: { rag_chat_enabled: true },
+      label_options: [{ value: "lblA", label: "A" }],
+      facet_views: [{ title: "T", queries: [{ label: "R", value: "exq1" }] }],
+    });
+    const chat = await import(CHAT_PATH);
+    mountBody('<div id="chat-view" hidden></div>');
+    chat.attachStandalone();
+
+    document.querySelector('input[data-filter-type="label"]').checked = true;
+    document.querySelector('input[data-filter-type="ex_q"]').checked = true;
+
+    const ta = document.getElementById("standalone-chat-input");
+    expect(ta).not.toBeNull();
+    ta.value = "q text";
+    ta.dispatchEvent(enterKey());
+
+    expect(apiMock.sseStream).toHaveBeenCalledTimes(1);
+    const [url, body] = apiMock.sseStream.mock.calls[0];
+    expect(url).toBe("/chat/stream");
+    expect(body).toEqual({
+      message: "q text",
+      fields: { label: ["lblA"] },
+      extra_queries: ["exq1"],
+    });
+  });
+
+  it("attachStandalone: send button with no active filters posts just {message}", async () => {
+    vi.resetModules();
+    apiMock.getConfig.mockReturnValue({ features: { rag_chat_enabled: true } });
+    const chat = await import(CHAT_PATH);
+    mountBody('<div id="chat-view" hidden></div>');
+    chat.attachStandalone();
+
+    const ta = document.getElementById("standalone-chat-input");
+    ta.value = "just a question";
+    document.getElementById("standalone-send-btn").dispatchEvent(new Event("click"));
+
+    expect(apiMock.sseStream).toHaveBeenCalledTimes(1);
+    expect(apiMock.sseStream.mock.calls[0][1]).toEqual({ message: "just a question" });
+  });
+
+  it("attachStandalone: renders the disabled notice when rag chat is off", async () => {
+    vi.resetModules();
+    apiMock.getConfig.mockReturnValue({ features: { rag_chat_enabled: false } });
+    const chat = await import(CHAT_PATH);
+    mountBody('<div id="chat-view" hidden></div>');
+    chat.attachStandalone();
+
+    const view = document.getElementById("chat-view");
+    const alert = view.querySelector(".alert.alert-warning");
+    expect(alert).not.toBeNull();
+    expect(alert.textContent).toBe("chat.disabled");
+    expect(document.getElementById("standalone-chat-input")).toBeNull();
+  });
+});

--- a/src/test/js/themes/bootstrap/error.test.js
+++ b/src/test/js/themes/bootstrap/error.test.js
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// error.js: pure path→code mapping plus a DOM smoke test of the rendered view.
+// The real i18n.t() returns the requested key unchanged (messages are empty
+// without init), which lets us assert exactly which i18n key each element uses.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { codeFromPath, attach } from "../../../../main/webapp/themes/bootstrap/assets/error.js";
+import { resetDom, setLocation } from "../../helpers/dom.js";
+
+beforeEach(resetDom);
+afterEach(() => setLocation("/"));
+
+describe("codeFromPath", () => {
+  it.each([
+    ["/error/400", "400"],
+    ["/error/404", "404"],
+    ["/error/not_found", "404"],
+    ["/error/notFound", "404"], // camelCase collapses like snake_case
+    ["/error/bad_request", "400"],
+    ["/error/busy", "429"], // busy → 429, never 503
+    ["/error/503", "503"],
+    ["/error/service_unavailable", "503"],
+    ["/error/system", "500"],
+    ["/error/unknown", "500"], // no match → default 500
+    ["/", "500"],
+  ])("%s → %s", (path, code) => {
+    expect(codeFromPath(path)).toBe(code);
+  });
+
+  it("scans segments in reverse (last match wins)", () => {
+    expect(codeFromPath("/error/404/not_found")).toBe("404");
+  });
+});
+
+describe("attach", () => {
+  it("renders title/body from the code's i18n keys and a home link", () => {
+    document.body.innerHTML = '<div id="error-view"></div>';
+    setLocation("/error/404");
+    attach();
+    const view = document.getElementById("error-view");
+    expect(view.querySelector(".error-title").textContent).toBe("error.title_404");
+    expect(view.querySelector(".error-body").textContent).toBe("error.body_404");
+    const home = view.querySelector(".error-actions a");
+    expect(home.getAttribute("href")).toBe("/");
+    expect(home.hasAttribute("data-spa")).toBe(true);
+  });
+
+  it("prefers the x-fess-error-code meta over the path", () => {
+    document.head.innerHTML = '<meta name="x-fess-error-code" content="429">';
+    document.body.innerHTML = '<div id="error-view"></div>';
+    setLocation("/error/404");
+    attach();
+    expect(document.querySelector(".error-title").textContent).toBe("error.title_429");
+  });
+
+  it("puts the ?url value into the DOM as text, not markup", () => {
+    document.body.innerHTML = '<div id="error-view"></div>';
+    setLocation("/error/404?url=%3Cimg%20src%3Dx%3E");
+    attach();
+    const dd = document.querySelector(".error-detail dd");
+    expect(dd.textContent).toBe("<img src=x>");
+    expect(dd.querySelector("img")).toBeNull();
+  });
+
+  it("does nothing when #error-view is absent", () => {
+    expect(() => attach()).not.toThrow();
+  });
+});

--- a/src/test/js/themes/bootstrap/format.test.js
+++ b/src/test/js/themes/bootstrap/format.test.js
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the bundled bootstrap theme's formatting/sanitizing
+// utilities. These import and execute the real, shipped format.js. sanitizeHtml
+// returns a DocumentFragment (not a string), so it is serialised through a
+// detached <div> to inspect the resulting markup — exactly how callers append it.
+
+import { describe, it, expect } from "vitest";
+import {
+  escapeHtml,
+  formatFileSize,
+  formatDate,
+  isSafeHref,
+  sanitizeHtml,
+  renderHighlightedSnippet,
+  renderSnippetText,
+} from "../../../../main/webapp/themes/bootstrap/assets/format.js";
+
+/** Serialise the DocumentFragment sanitizeHtml() returns into an HTML string. */
+const clean = (html) => {
+  const host = document.createElement("div");
+  host.appendChild(sanitizeHtml(html));
+  return host.innerHTML;
+};
+
+describe("escapeHtml", () => {
+  it("escapes all five HTML metacharacters", () => {
+    expect(escapeHtml("<a href=\"x\">&'</a>")).toBe(
+      "&lt;a href=&quot;x&quot;&gt;&amp;&#39;&lt;/a&gt;"
+    );
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(escapeHtml(null)).toBe("");
+    expect(escapeHtml(undefined)).toBe("");
+  });
+});
+
+describe("formatFileSize", () => {
+  it.each([
+    [0, "0 B"],
+    [1023, "1023 B"],
+    [1024, "1.0 KB"],
+    [1048576, "1.0 MB"],
+  ])("formats %d bytes as %s", (bytes, expected) => {
+    expect(formatFileSize(bytes)).toBe(expected);
+  });
+
+  it("returns empty string for invalid or negative input", () => {
+    expect(formatFileSize(null)).toBe("");
+    expect(formatFileSize("")).toBe("");
+    expect(formatFileSize("abc")).toBe("");
+    expect(formatFileSize(-1)).toBe("");
+  });
+});
+
+describe("formatDate", () => {
+  it("formats an ISO string as YYYY-MM-DD HH:MM in local time", () => {
+    // Construct the expectation from the same Date the code uses so the test is
+    // independent of the runner's timezone.
+    const d = new Date("2026-07-17T09:05:00");
+    const pad = (x) => String(x).padStart(2, "0");
+    const expected =
+      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+      `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    expect(formatDate("2026-07-17T09:05:00")).toBe(expected);
+  });
+
+  it("returns empty string for empty or invalid input", () => {
+    expect(formatDate("")).toBe("");
+    expect(formatDate(null)).toBe("");
+    expect(formatDate("not-a-date")).toBe("");
+  });
+});
+
+describe("isSafeHref", () => {
+  it.each(["https://example.com", "http://example.com", "mailto:a@b.com", "/relative/path", "#frag"])(
+    "accepts %s",
+    (href) => expect(isSafeHref(href)).toBe(true)
+  );
+
+  it.each([
+    "javascript:alert(1)",
+    "java\tscript:alert(1)", // tab-obfuscated scheme must still be rejected
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "http://%", // malformed: new URL() throws, so the catch branch returns false
+    "",
+  ])("rejects %s", (href) => expect(isSafeHref(href)).toBe(false));
+
+  it("rejects non-string input", () => {
+    expect(isSafeHref(null)).toBe(false);
+    expect(isSafeHref(undefined)).toBe(false);
+  });
+});
+
+describe("sanitizeHtml: allowed markup (replaces test_formatJs_sanitizerAllowsHr)", () => {
+  it("keeps <hr>", () => {
+    expect(clean("<hr>")).toBe("<hr>");
+  });
+
+  it("keeps safe structural markup", () => {
+    expect(clean("<p>text</p>")).toBe("<p>text</p>");
+    expect(clean("<ul><li>a</li></ul>")).toBe("<ul><li>a</li></ul>");
+  });
+
+  it("unwraps a disallowed inline tag but keeps its text", () => {
+    // <b> is not in ALLOWED_TAGS (only STRONG/EM are), so it is unwrapped.
+    expect(clean("<p><b>bold</b></p>")).toBe("<p>bold</p>");
+  });
+});
+
+describe("sanitizeHtml: DROP_WITH_CONTENT drops the whole subtree (replaces test_formatJs_sanitizerDropsRawTextElementsWithContent)", () => {
+  const DROPPED = [
+    "IFRAME", "NOEMBED", "NOFRAMES", "PLAINTEXT", "SCRIPT",
+    "STYLE", "TEXTAREA", "TITLE", "XMP", "NOSCRIPT", "TEMPLATE",
+  ];
+  it.each(DROPPED)("%s: the element and its content are both removed", (tag) => {
+    const t = tag.toLowerCase();
+    const out = clean(`<div>KEEP<${t}>EVIL</${t}></div>`);
+    expect(out).toContain("KEEP");
+    expect(out).not.toContain("EVIL");
+    expect(out.toLowerCase()).not.toContain(`<${t}`);
+  });
+});
+
+describe("sanitizeHtml: object/embed are NOT dropped whole (replaces test_formatJs_sanitizerDoesNotDropObjectOrEmbedContent)", () => {
+  it("preserves <object> fallback prose by unwrapping it", () => {
+    const out = clean("<div><object>fallback prose</object></div>");
+    expect(out).toContain("fallback prose");
+  });
+
+  it("does not leave an <embed> element (void, unwrapped to nothing)", () => {
+    const out = clean('<div>KEEP<embed src="x"></div>');
+    expect(out).toContain("KEEP");
+    expect(out.toLowerCase()).not.toContain("<embed");
+  });
+});
+
+describe("sanitizeHtml: attribute and scheme filtering", () => {
+  it("strips event-handler attributes", () => {
+    const out = clean('<img src="x" onerror="alert(1)">');
+    expect(out).not.toContain("onerror");
+  });
+
+  it("drops a javascript: href", () => {
+    const out = clean('<a href="javascript:alert(1)">x</a>');
+    expect(out).not.toContain("javascript:");
+    expect(out).toContain("x");
+  });
+
+  it("keeps a safe href and marks external links", () => {
+    const out = clean('<a href="https://example.com">x</a>');
+    expect(out).toContain('href="https://example.com"');
+    expect(out).toContain('rel="nofollow noopener noreferrer"');
+    expect(out).toContain('target="_blank"');
+  });
+
+  it("keeps a safe non-external href without adding target/rel", () => {
+    // A relative link is safe but not external, so it gets neither target
+    // nor rel (exercises the non-external branch of the href handler).
+    expect(clean('<a href="/local/path">x</a>')).toBe('<a href="/local/path">x</a>');
+  });
+
+  it("drops a droppable child while unwrapping its disallowed parent", () => {
+    // <b> unwraps; its comment child is removed rather than surfaced.
+    expect(clean("<b>keep<!-- secret --></b>")).toBe("keep");
+  });
+
+  it("removes comment nodes", () => {
+    expect(clean("<p>a</p><!-- secret -->")).toBe("<p>a</p>");
+  });
+
+  it("unwraps a disallowed element at the top level (no wrapper)", () => {
+    // Exercises the fragment-level replace path: the top-level node is itself
+    // disallowed and unwraps to its sanitized children.
+    expect(clean("<b>bold</b>")).toBe("bold");
+  });
+});
+
+describe("renderHighlightedSnippet: server snippet is parsed, not re-escaped", () => {
+  it("keeps the highlight tags <strong>/<em>", () => {
+    expect(renderHighlightedSnippet("a <strong>b</strong> c")).toBe("a <strong>b</strong> c");
+    expect(renderHighlightedSnippet("<em>x</em>")).toBe("<em>x</em>");
+  });
+
+  it("unwraps any tag outside SNIPPET_TAGS", () => {
+    expect(renderHighlightedSnippet("<p>x</p>")).toBe("x");
+  });
+
+  it("drops a raw-text element whole (no source leak)", () => {
+    expect(renderHighlightedSnippet("<script>alert(1)</script>tail")).toBe("tail");
+  });
+
+  it("decodes server entities without double-escaping", () => {
+    // The server sends a literal quote as the entity &#034;; parsing decodes it
+    // back to " rather than painting the literal text &#034;.
+    expect(renderHighlightedSnippet("&#034;q&#034;")).toBe('"q"');
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(renderHighlightedSnippet("")).toBe("");
+    expect(renderHighlightedSnippet(null)).toBe("");
+  });
+});
+
+describe("renderSnippetText: server snippet reduced to plain text", () => {
+  it("strips markup and keeps the text", () => {
+    expect(renderSnippetText("a <strong>b</strong> c")).toBe("a b c");
+  });
+
+  it("drops raw-text element content entirely", () => {
+    expect(renderSnippetText("<script>x</script>after")).toBe("after");
+  });
+
+  it("decodes entities to their characters", () => {
+    expect(renderSnippetText("AT&amp;T")).toBe("AT&T");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(renderSnippetText("")).toBe("");
+    expect(renderSnippetText(null)).toBe("");
+  });
+});

--- a/src/test/js/themes/bootstrap/help.test.js
+++ b/src/test/js/themes/bootstrap/help.test.js
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the bootstrap theme help-page renderer. The real
+// i18n.t() returns each key unchanged (messages are empty without init), so the
+// error path asserts the exact i18n key; the real format.sanitizeHtml() runs so
+// the section-body sanitation is exercised end to end. A stubbed global fetch
+// drives fetchHelpContent's locale/fallback logic deterministically.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  fetchHelpContent,
+  renderSection,
+  attach,
+} from "../../../../main/webapp/themes/bootstrap/assets/help.js";
+import { resetDom } from "../../helpers/dom.js";
+import { installFetch, jsonResponse } from "../../helpers/net.js";
+
+beforeEach(resetDom);
+afterEach(() => vi.unstubAllGlobals());
+
+describe("fetchHelpContent", () => {
+  it("GETs {locale}.json with same-origin credentials and returns parsed JSON", async () => {
+    const body = { sections: [{ id: "a", title: "A", html: "<p>a</p>" }] };
+    const fetchMock = installFetch(async () => jsonResponse(body));
+
+    await expect(fetchHelpContent("en")).resolves.toEqual(body);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/themes/bootstrap/help/en.json");
+    expect(opts).toEqual({ credentials: "same-origin" });
+  });
+
+  it("falls back to en.json when the primary (ja) bundle is not ok", async () => {
+    const en = { sections: [{ id: "en", title: "EN", html: "" }] };
+    const fetchMock = installFetch(async (url) =>
+      url.includes("/ja.json")
+        ? jsonResponse(null, { ok: false, status: 404 })
+        : jsonResponse(en)
+    );
+
+    await expect(fetchHelpContent("ja")).resolves.toEqual(en);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("/themes/bootstrap/help/ja.json");
+    expect(fetchMock.mock.calls[1][0]).toBe("/themes/bootstrap/help/en.json");
+  });
+
+  it("rejects without any fallback when the en bundle itself is not ok", async () => {
+    const fetchMock = installFetch(async () => jsonResponse(null, { ok: false, status: 500 }));
+
+    await expect(fetchHelpContent("en")).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no second (fallback) request for "en"
+  });
+});
+
+describe("renderSection", () => {
+  it("builds section#help-<id>.help-section with a text-only h2 and sanitized body", () => {
+    const container = document.createElement("div");
+
+    renderSection(container, {
+      id: "intro",
+      title: "<b>x</b>",
+      html: "<p>ok</p><script>bad</script>",
+    });
+
+    const sec = container.querySelector("section");
+    expect(sec.id).toBe("help-intro");
+    expect(sec.className).toBe("help-section");
+
+    // Title is inserted via textContent — the markup is literal text, not a node.
+    const h2 = sec.querySelector("h2");
+    expect(h2.textContent).toBe("<b>x</b>");
+    expect(h2.querySelector("b")).toBeNull();
+
+    // Body is sanitized: the <p> survives, the <script> is dropped whole.
+    expect(sec.querySelector("p").textContent).toBe("ok");
+    expect(sec.querySelector("script")).toBeNull();
+  });
+});
+
+describe("attach", () => {
+  it("does nothing (and does not throw) when #help-view is absent", async () => {
+    await expect(attach()).resolves.toBeUndefined();
+  });
+
+  it("renders fetched sections and removes the loading indicator", async () => {
+    document.body.innerHTML = '<div id="help-view"></div>';
+    installFetch(async () =>
+      jsonResponse({ sections: [{ id: "intro", title: "T", html: "<p>hello</p>" }] })
+    );
+
+    await attach();
+
+    const view = document.getElementById("help-view");
+    const sec = view.querySelector("#help-intro");
+    expect(sec).not.toBeNull();
+    expect(sec.querySelector("h2").textContent).toBe("T");
+    expect(sec.querySelector("p").textContent).toBe("hello");
+    expect(view.querySelector(".text-muted")).toBeNull(); // loading <p> removed
+  });
+
+  it("shows an error paragraph (t('error.server')) when the fetch fails", async () => {
+    document.body.innerHTML = '<div id="help-view"></div>';
+    installFetch(async () => jsonResponse(null, { ok: false, status: 500 }));
+
+    await attach();
+
+    const view = document.getElementById("help-view");
+    const err = view.querySelector(".text-danger");
+    expect(err).not.toBeNull();
+    expect(err.textContent).toBe("error.server");
+    expect(view.querySelector(".text-muted")).toBeNull(); // loading <p> removed
+  });
+});

--- a/src/test/js/themes/bootstrap/i18n.test.js
+++ b/src/test/js/themes/bootstrap/i18n.test.js
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the bootstrap theme i18n loader.
+//
+// The pure describes (pickLocale / t / languageLabel / applyDom) use a single
+// static import: that instance is never init()ed, so its `messages` stays {}
+// and its `locale` stays "en". With empty messages the real t(key) returns the
+// key string unchanged, which lets us assert exact i18n keys.
+//
+// The init-driven cases import a FRESH module (vi.resetModules) and drive a
+// stubbed global fetch, because init() mutates module-level `messages`/`locale`
+// and the shared document (<html lang>, <title>). resetDom() between tests
+// keeps that document mutation from leaking.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { installFetch, jsonResponse } from "../../helpers/net.js";
+import { resetDom } from "../../helpers/dom.js";
+import {
+  pickLocale,
+  t,
+  languageLabel,
+  applyDom,
+} from "../../../../main/webapp/themes/bootstrap/assets/i18n.js";
+
+const I18N = "../../../../main/webapp/themes/bootstrap/assets/i18n.js";
+
+/** navigator.language is read-only; redefine it for pickLocale/init. */
+function setLanguage(value) {
+  Object.defineProperty(navigator, "language", { value, configurable: true });
+}
+
+beforeEach(resetDom);
+afterEach(() => vi.unstubAllGlobals());
+
+describe("pickLocale", () => {
+  it.each([
+    ["ja-JP", "ja"],       // primary-subtag match
+    ["de-AT", "de"],       // primary-subtag match
+    ["pt-BR", "pt-BR"],    // case-insensitive exact match
+    ["PT-br", "pt-BR"],    // exact match, differing case
+    ["zh-CN", "zh-CN"],    // exact match
+    ["en-US", "en"],       // primary-subtag match
+    ["xx", "en"],          // no match → English fallback
+    ["xx-YY", "en"],       // no primary match → English fallback
+  ])("navigator.language %s → %s", (lang, expected) => {
+    setLanguage(lang);
+    expect(pickLocale()).toBe(expected);
+  });
+
+  it("falls back to en when navigator.language is empty", () => {
+    setLanguage("");
+    expect(pickLocale()).toBe("en");
+  });
+});
+
+describe("t", () => {
+  it("returns the key unchanged when the message is missing", () => {
+    expect(t("some.unknown.key")).toBe("some.unknown.key");
+  });
+
+  it("substitutes a named param: {x}", () => {
+    expect(t("a {x} b", { x: "Z" })).toBe("a Z b");
+  });
+
+  it("substitutes positional params from an array: {0}-{1}", () => {
+    expect(t("{0}-{1}", ["p", "q"])).toBe("p-q");
+  });
+
+  it("renders a null or undefined value as an empty string", () => {
+    expect(t("{v}", { v: null })).toBe("");
+    expect(t("{v}", { v: undefined })).toBe("");
+  });
+
+  it("leaves placeholders untouched when params is omitted", () => {
+    expect(t("a {x} b")).toBe("a {x} b");
+  });
+});
+
+describe("languageLabel", () => {
+  it("empty value → fallback, then value, then ''", () => {
+    expect(languageLabel("", "Fallback")).toBe("Fallback");
+    expect(languageLabel("")).toBe("");
+  });
+
+  it("uses Intl.DisplayNames for a code with no theme i18n key", () => {
+    const name = languageLabel("ar");
+    expect(name).not.toBe("ar");
+    expect(name.length).toBeGreaterThan(0);
+  });
+
+  it("normalises underscore variants (pt_BR) before Intl lookup", () => {
+    const name = languageLabel("pt_BR");
+    expect(name).not.toBe("pt_BR");
+    expect(name).not.toBe("pt-BR");
+  });
+
+  it("prefers a theme i18n key when the loaded messages define one", async () => {
+    vi.resetModules();
+    installFetch(async () => jsonResponse({ "labels.lang_ar": "Arabic (custom)" }));
+    setLanguage("en");
+    const m = await import(I18N);
+    await m.init();
+    expect(m.languageLabel("ar")).toBe("Arabic (custom)");
+  });
+});
+
+describe("applyDom", () => {
+  it("sets textContent / placeholder / aria-label / alt from data-i18n* keys", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<span data-i18n="k.text">old</span>' +
+      '<input data-i18n-placeholder="k.ph">' +
+      '<button data-i18n-aria-label="k.aria">b</button>' +
+      '<img data-i18n-alt="k.alt">';
+    applyDom(root);
+    expect(root.querySelector("[data-i18n]").textContent).toBe("k.text");
+    expect(root.querySelector("[data-i18n-placeholder]").getAttribute("placeholder")).toBe("k.ph");
+    expect(root.querySelector("[data-i18n-aria-label]").getAttribute("aria-label")).toBe("k.aria");
+    expect(root.querySelector("[data-i18n-alt]").getAttribute("alt")).toBe("k.alt");
+  });
+
+  it("leaves a subtree with no data-i18n* markers unchanged", () => {
+    const root = document.createElement("div");
+    root.innerHTML = "<p>plain</p>";
+    expect(() => applyDom(root)).not.toThrow();
+    expect(root.querySelector("p").textContent).toBe("plain");
+  });
+});
+
+describe("init", () => {
+  it("resolves the locale, loads its bundle, and sets <html lang>, title, and the DOM", async () => {
+    vi.resetModules();
+    const fetchMock = installFetch(async () =>
+      jsonResponse({ "page.title": "My Fess", "k.hello": "Hello" })
+    );
+    setLanguage("ja-JP");
+    document.body.innerHTML = '<span data-i18n="k.hello">x</span>';
+    const m = await import(I18N);
+    await m.init();
+    expect(m.getLocale()).toBe("ja");
+    expect(document.documentElement.lang).toBe("ja");
+    expect(document.title).toBe("My Fess");
+    expect(document.querySelector("[data-i18n]").textContent).toBe("Hello");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/themes/bootstrap/i18n/messages.ja.json",
+      { credentials: "same-origin" }
+    );
+  });
+
+  it("falls back to the English bundle when the primary locale bundle is not ok", async () => {
+    vi.resetModules();
+    const calls = [];
+    installFetch(async (url) => {
+      calls.push(url);
+      if (url.includes("messages.de.json")) return jsonResponse({}, { ok: false, status: 404 });
+      return jsonResponse({ "page.title": "EN Title" });
+    });
+    setLanguage("de-DE"); // → primary "de"
+    const m = await import(I18N);
+    await m.init();
+    expect(m.getLocale()).toBe("en");
+    expect(document.documentElement.lang).toBe("en");
+    expect(document.title).toBe("EN Title");
+    expect(calls[0]).toContain("messages.de.json");
+    expect(calls[1]).toContain("messages.en.json");
+  });
+
+  it("leaves messages empty (no throw) when both primary and English fetches fail", async () => {
+    vi.resetModules();
+    installFetch(async () => { throw new Error("offline"); });
+    setLanguage("fr-FR"); // → primary "fr"
+    const m = await import(I18N);
+    await expect(m.init()).resolves.toBeUndefined();
+    // English fallback also failed → locale stays at the picked "fr", messages {}.
+    expect(m.getLocale()).toBe("fr");
+    expect(document.documentElement.lang).toBe("fr");
+    expect(m.t("any.key")).toBe("any.key");
+  });
+});

--- a/src/test/js/themes/bootstrap/markdown.test.js
+++ b/src/test/js/themes/bootstrap/markdown.test.js
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the bundled bootstrap theme's Markdown renderer.
+// These import and execute the real, shipped markdown.js (which in turn imports
+// format.js) rather than string-matching its source. parseMarkdown returns an
+// HTML string, so no DOM serialisation is needed here — the pipeline through
+// sanitizeHtml is exercised separately in pipeline.test.js.
+
+import { describe, it, expect } from "vitest";
+import { parseMarkdown } from "../../../../main/webapp/themes/bootstrap/assets/markdown.js";
+
+describe("parseMarkdown: ATX headings h1-h6 (replaces test_markdownJs_h1ThroughH6)", () => {
+  it.each([
+    ["#", "h1"],
+    ["##", "h2"],
+    ["###", "h3"],
+    ["####", "h4"],
+    ["#####", "h5"],
+    ["######", "h6"],
+  ])("%s renders as <%s>", (hashes, tag) => {
+    expect(parseMarkdown(`${hashes} Title`)).toBe(`<${tag}>Title</${tag}>`);
+  });
+
+  it("clamps to h6: seven hashes are not a heading", () => {
+    // HEADING_RE only accepts 1-6 hashes followed by a space, so a 7-hash line
+    // is a plain paragraph, never <h7>.
+    const out = parseMarkdown("####### Title");
+    expect(out).not.toMatch(/<h7/);
+    expect(out).toBe("<p>####### Title</p>");
+  });
+});
+
+describe("parseMarkdown: horizontal rules and autolinks (replaces test_markdownJs_horizontalRuleAndAutolink)", () => {
+  it.each(["---", "***", "___"])("%s renders as <hr>", (rule) => {
+    expect(parseMarkdown(rule)).toBe("<hr>");
+  });
+
+  it("wraps a bare <https://...> as an external anchor", () => {
+    expect(parseMarkdown("<https://example.com/a>")).toBe(
+      '<p><a href="https://example.com/a" target="_blank" rel="nofollow noopener noreferrer">https://example.com/a</a></p>'
+    );
+  });
+
+  it("does not autolink a javascript: angle-bracket URL", () => {
+    const out = parseMarkdown("<javascript:alert(1)>");
+    expect(out).not.toContain("<a ");
+  });
+});
+
+describe("parseMarkdown: tables and blockquotes (replaces test_markdownTablesBlockquote)", () => {
+  it("renders a GFM table with thead and tbody", () => {
+    const out = parseMarkdown("| a | b |\n|---|---|\n| 1 | 2 |");
+    expect(out).toBe(
+      '<table class="table"><thead><tr><th>a</th><th>b</th></tr></thead>' +
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+    );
+  });
+
+  it("renders a simple blockquote", () => {
+    expect(parseMarkdown("> quoted")).toBe("<blockquote>quoted</blockquote>");
+  });
+});
+
+describe("parseMarkdown: nested lists and blockquotes (replaces test_markdownJs_nestedListAndBlockquoteHandling)", () => {
+  it("nests an indented unordered sub-list inside its parent item", () => {
+    expect(parseMarkdown("- a\n  - b")).toBe("<ul><li>a<ul><li>b</li></ul></li></ul>");
+  });
+
+  it("nests an ordered sub-list", () => {
+    expect(parseMarkdown("1. a\n  1. b")).toBe("<ol><li>a<ol><li>b</li></ol></li></ol>");
+  });
+
+  it("nests a blockquote via a doubled marker", () => {
+    expect(parseMarkdown("> outer\n>> inner")).toBe(
+      "<blockquote>outer<br><blockquote>inner</blockquote></blockquote>"
+    );
+  });
+
+  it("still nests when an item skips an indent level", () => {
+    // A sub-item indented past the next level exercises the deep-jump branch of
+    // the list renderer; b must still render nested under a.
+    const out = parseMarkdown("- a\n    - b");
+    expect(out.startsWith("<ul><li>a")).toBe(true);
+    expect(out).toContain("<li>b</li>");
+  });
+});
+
+describe("parseMarkdown: inline constructs", () => {
+  it("renders **bold** and *italic*", () => {
+    expect(parseMarkdown("**b** and *i*")).toBe("<p><strong>b</strong> and <em>i</em></p>");
+  });
+
+  it("renders __bold__ and _italic_ underscore variants", () => {
+    expect(parseMarkdown("__b__ and _i_")).toBe("<p><strong>b</strong> and <em>i</em></p>");
+  });
+
+  it("renders inline `code` without applying emphasis inside it", () => {
+    expect(parseMarkdown("use `a**b**c` here")).toBe("<p>use <code>a**b**c</code> here</p>");
+  });
+
+  it("renders a fenced code block, escaping its contents", () => {
+    expect(parseMarkdown("```\n<b>&\n```")).toBe("<pre><code>&lt;b&gt;&amp;</code></pre>");
+  });
+
+  it("renders a heading line embedded in a multi-line paragraph block", () => {
+    // A block whose lines are not uniformly headings/list/quote/table falls to
+    // the mixed-paragraph path, which still renders an individual heading line.
+    const out = parseMarkdown("intro\n## Mid\noutro");
+    expect(out).toContain("<h2>Mid</h2>");
+  });
+
+  it("keeps a safe [text](https) link and marks it external", () => {
+    expect(parseMarkdown("[t](https://example.com)")).toBe(
+      '<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">t</a></p>'
+    );
+  });
+
+  it("drops a javascript: link, leaving only its text", () => {
+    const out = parseMarkdown("[t](javascript:alert(1))");
+    expect(out).not.toContain("<a ");
+    expect(out).toContain("t");
+  });
+
+  it("escapes raw HTML so no live tag is emitted", () => {
+    const out = parseMarkdown("<img src=x onerror=alert(1)>");
+    expect(out).not.toContain("<img");
+    expect(out).toContain("&lt;img");
+  });
+
+  it("returns empty string for empty or non-string input", () => {
+    expect(parseMarkdown("")).toBe("");
+    expect(parseMarkdown(null)).toBe("");
+    expect(parseMarkdown(undefined)).toBe("");
+  });
+});

--- a/src/test/js/themes/bootstrap/pipeline.test.js
+++ b/src/test/js/themes/bootstrap/pipeline.test.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Cross-module contract: chat.js renders assistant Markdown by piping
+// parseMarkdown() straight into sanitizeHtml() (chat.js:561-563). Neither
+// module can be judged in isolation — markdown.js emits <h1>..<h6>, but what
+// the user actually sees is whatever survives the sanitizer's ALLOWED_TAGS
+// whitelist. This file exercises the real two-module pipeline end to end.
+//
+// This is precisely the class of defect a source string-match cannot catch:
+// markdown.js's HEADING_RE literally contains "#{1,6}", yet headings the
+// whitelist omits are silently stripped before display.
+
+import { describe, it, expect } from "vitest";
+import { parseMarkdown } from "../../../../main/webapp/themes/bootstrap/assets/markdown.js";
+import { sanitizeHtml } from "../../../../main/webapp/themes/bootstrap/assets/format.js";
+
+/** The exact chat.js pipeline: parseMarkdown -> sanitizeHtml -> append. */
+const renderInto = (md) => {
+  const bubble = document.createElement("div");
+  bubble.appendChild(sanitizeHtml(parseMarkdown(md)));
+  return bubble;
+};
+
+/** Serialised HTML the pipeline puts into the chat bubble. */
+const render = (md) => renderInto(md).innerHTML;
+
+describe("chat pipeline: every heading level markdown emits must survive the sanitizer", () => {
+  it.each([
+    ["#", "h1"],
+    ["##", "h2"],
+    ["###", "h3"],
+    ["####", "h4"],
+    ["#####", "h5"],
+    ["######", "h6"],
+  ])("%s renders as a visible <%s>", (hashes, tag) => {
+    // markdown.js produces <hN>; if ALLOWED_TAGS omits hN the sanitizer
+    // unwraps it and the heading text collapses to a bare paragraph-less
+    // string. Assert the tag actually reaches the DOM.
+    expect(render(`${hashes} Heading`)).toBe(`<${tag}>Heading</${tag}>`);
+  });
+});
+
+describe("chat pipeline: block constructs survive intact", () => {
+  it("keeps a GFM table with its class and structure", () => {
+    expect(render("| a | b |\n|---|---|\n| 1 | 2 |")).toBe(
+      '<table class="table"><thead><tr><th>a</th><th>b</th></tr></thead>' +
+        "<tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+    );
+  });
+
+  it("keeps a blockquote", () => {
+    expect(render("> quoted")).toBe("<blockquote>quoted</blockquote>");
+  });
+
+  it("keeps bold/italic emphasis", () => {
+    expect(render("**b** and *i*")).toBe("<p><strong>b</strong> and <em>i</em></p>");
+  });
+
+  it("keeps a fenced code block", () => {
+    expect(render("```\nx = 1\n```")).toBe("<pre><code>x = 1</code></pre>");
+  });
+});
+
+describe("chat pipeline: unsafe content never reaches the DOM", () => {
+  it("renders a safe external link with its href and text", () => {
+    const out = render("[docs](https://example.com/a)");
+    expect(out).toContain('href="https://example.com/a"');
+    expect(out).toContain(">docs</a>");
+  });
+
+  it("strips a javascript: link to plain text", () => {
+    const out = render("[x](javascript:alert(1))");
+    expect(out).not.toContain("<a");
+    expect(out).not.toContain("javascript:");
+  });
+
+  it("never emits a live <script> element from raw HTML in the markdown", () => {
+    // markdown.js escapes raw HTML to inert text, so the string "alert(1)"
+    // legitimately survives as escaped prose; what must never exist is a live
+    // <script> node. Assert on the DOM, not the serialised text.
+    const bubble = renderInto("A <script>alert(1)</script> B");
+    expect(bubble.querySelector("script")).toBeNull();
+  });
+
+  it("never emits a live element carrying an onerror handler", () => {
+    const bubble = renderInto('<img src=x onerror="alert(1)">');
+    expect(bubble.querySelector("img")).toBeNull();
+    expect(bubble.querySelector("[onerror]")).toBeNull();
+  });
+});

--- a/src/test/js/themes/bootstrap/profile.test.js
+++ b/src/test/js/themes/bootstrap/profile.test.js
@@ -64,12 +64,14 @@ describe("localizePasswordError", () => {
 // ---------------------------------------------------------------------------
 // attach(): DOM scaffold.
 // ---------------------------------------------------------------------------
-describe("attach (structure)", () => {
-  const mountProfile = () => {
-    document.body.innerHTML = '<div id="profile-view"></div>';
-    attach();
-  };
 
+// Mount the #profile-view container and run attach(); shared by both attach blocks.
+const mountProfile = () => {
+  document.body.innerHTML = '<div id="profile-view"></div>';
+  attach();
+};
+
+describe("attach (structure)", () => {
   it("does nothing (and does not throw) when #profile-view is absent", () => {
     expect(() => attach()).not.toThrow();
     expect(document.getElementById("password-form")).toBeNull();
@@ -99,10 +101,6 @@ describe("attach (structure)", () => {
 // assertions flush via vi.waitFor / fake-timer advance.
 // ---------------------------------------------------------------------------
 describe("attach (submit)", () => {
-  const mountProfile = () => {
-    document.body.innerHTML = '<div id="profile-view"></div>';
-    attach();
-  };
   const setPasswords = (oldP, newP, confP) => {
     document.getElementById("old-password").value = oldP;
     document.getElementById("new-password").value = newP;

--- a/src/test/js/themes/bootstrap/profile.test.js
+++ b/src/test/js/themes/bootstrap/profile.test.js
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the profile / password-change view. api.js and
+// router.js are mocked (router.js carries module state; api.post is driven per
+// test), while i18n.js stays real — its t() returns each key unchanged, so the
+// error-mapping table asserts exact i18n keys. One isolated test seeds a real
+// i18n bundle to prove positional {0} substitution of min_length.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resetDom } from "../../helpers/dom.js";
+import { installFetch, jsonResponse } from "../../helpers/net.js";
+
+// vi.mock is hoisted, so the paths must be string literals (not the consts below).
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/api.js", () => ({ post: vi.fn() }));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/router.js", () => ({ navigate: vi.fn() }));
+
+import * as api from "../../../../main/webapp/themes/bootstrap/assets/api.js";
+import * as router from "../../../../main/webapp/themes/bootstrap/assets/router.js";
+import {
+  localizePasswordError,
+  attach,
+} from "../../../../main/webapp/themes/bootstrap/assets/profile.js";
+
+const I18N = "../../../../main/webapp/themes/bootstrap/assets/i18n.js";
+const PROFILE = "../../../../main/webapp/themes/bootstrap/assets/profile.js";
+
+beforeEach(() => {
+  resetDom();
+  api.post.mockReset();
+  router.navigate.mockReset();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// localizePasswordError: error-code / reason → localized message key.
+// ---------------------------------------------------------------------------
+describe("localizePasswordError", () => {
+  it.each([
+    [{ name: "NetworkError" }, "error.network"],
+    [{ code: "RATE_LIMITED" }, "auth.error_rate_limited"],
+    [{ httpStatus: 429 }, "auth.error_rate_limited"],
+    [{ details: { reason: "invalid_current_password" } }, "profile.error_wrong_current"],
+    [{ details: { reason: "errors.password_length", min_length: 8 } }, "profile.error_password_length"],
+    [{ details: { reason: "errors.password_no_uppercase" } }, "profile.error_password_no_uppercase"],
+    [{ details: { reason: "errors.password_no_lowercase" } }, "profile.error_password_no_lowercase"],
+    [{ details: { reason: "errors.password_no_digit" } }, "profile.error_password_no_digit"],
+    [{ details: { reason: "errors.password_no_special_char" } }, "profile.error_password_no_special_char"],
+    [{ details: { reason: "errors.password_is_blacklisted" } }, "profile.error_password_blacklisted"],
+    [{ details: { reason: "errors.blank_password" } }, "profile.error_blank_password"],
+    [{ details: { reason: "new_password_required" } }, "profile.error_blank_password"],
+    [{ details: { reason: "current_password_required" } }, "profile.error_blank_password"],
+    [{ details: { reason: "password_mismatch" } }, "profile.error_mismatch"],
+    [{ code: "AUTH_REQUIRED" }, "profile.error_wrong_current"],
+    [{ httpStatus: 401 }, "profile.error_wrong_current"],
+    [{ code: "SOMETHING_UNMAPPED" }, "error.server"],
+    [null, "error.server"],
+  ])("%o → %s", (err, key) => {
+    expect(localizePasswordError(err)).toBe(key);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attach(): DOM scaffold.
+// ---------------------------------------------------------------------------
+describe("attach (structure)", () => {
+  const mountProfile = () => {
+    document.body.innerHTML = '<div id="profile-view"></div>';
+    attach();
+  };
+
+  it("does nothing (and does not throw) when #profile-view is absent", () => {
+    expect(() => attach()).not.toThrow();
+    expect(document.getElementById("password-form")).toBeNull();
+  });
+
+  it("renders the password-change form scaffold with the expected controls", () => {
+    mountProfile();
+
+    expect(document.getElementById("password-form")).not.toBeNull();
+
+    const pwInputs = document.querySelectorAll('#password-form input[type="password"]');
+    expect(pwInputs.length).toBe(3);
+    expect(document.getElementById("old-password")).not.toBeNull();
+    expect(document.getElementById("new-password").getAttribute("minlength")).toBe("8");
+    expect(document.getElementById("confirm-password")).not.toBeNull();
+
+    expect(document.querySelector('#password-form button[type="submit"]')).not.toBeNull();
+    expect(document.querySelector("#password-form a.btn-secondary").getAttribute("href")).toBe("/");
+
+    expect(document.getElementById("profile-error").classList.contains("d-none")).toBe(true);
+    expect(document.getElementById("profile-success").classList.contains("d-none")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attach(): form-submit flows. The submit handler is async, so post-dispatch
+// assertions flush via vi.waitFor / fake-timer advance.
+// ---------------------------------------------------------------------------
+describe("attach (submit)", () => {
+  const mountProfile = () => {
+    document.body.innerHTML = '<div id="profile-view"></div>';
+    attach();
+  };
+  const setPasswords = (oldP, newP, confP) => {
+    document.getElementById("old-password").value = oldP;
+    document.getElementById("new-password").value = newP;
+    document.getElementById("confirm-password").value = confP;
+  };
+  const submitForm = () =>
+    document
+      .getElementById("password-form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+
+  it("shows a mismatch error and never calls the API when new != confirm", () => {
+    mountProfile();
+    setPasswords("current", "aaaaaaaa", "bbbbbbbb");
+
+    submitForm();
+
+    const err = document.getElementById("profile-error");
+    expect(err.classList.contains("d-none")).toBe(false);
+    expect(err.textContent).toBe("profile.error_mismatch");
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("on success shows the success alert and resets the form", async () => {
+    api.post.mockResolvedValue({});
+    mountProfile();
+    setPasswords("current", "newpass1", "newpass1");
+
+    submitForm();
+
+    const ok = document.getElementById("profile-success");
+    await vi.waitFor(() => expect(ok.classList.contains("d-none")).toBe(false));
+    expect(ok.textContent).toBe("profile.success");
+    expect(api.post).toHaveBeenCalledTimes(1);
+    expect(document.getElementById("new-password").value).toBe(""); // form.reset()
+  });
+
+  it("navigates home 2s after a re_login_required success", async () => {
+    vi.useFakeTimers();
+    api.post.mockResolvedValue({ re_login_required: true });
+    mountProfile();
+    setPasswords("current", "newpass1", "newpass1");
+
+    submitForm();
+    await vi.advanceTimersByTimeAsync(2000); // flush microtasks, then fire the 2s timer
+
+    expect(router.navigate).toHaveBeenCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("shows the localized API error when the request rejects", async () => {
+    api.post.mockRejectedValue({ code: "RATE_LIMITED" });
+    mountProfile();
+    setPasswords("current", "newpass1", "newpass1");
+
+    submitForm();
+
+    const err = document.getElementById("profile-error");
+    await vi.waitFor(() => expect(err.classList.contains("d-none")).toBe(false));
+    expect(err.textContent).toBe("auth.error_rate_limited");
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Positional substitution: seed a real i18n bundle in an isolated module graph
+// so the {0} placeholder actually renders min_length. Kept last so its
+// resetModules never disturbs the statically-imported suites above.
+// ---------------------------------------------------------------------------
+describe("localizePasswordError (positional substitution)", () => {
+  it("substitutes min_length into the localized password-length message", async () => {
+    vi.resetModules(); // fresh, seedable i18n singleton (api/router stay mocked via vi.mock)
+    const i18n = await import(I18N);
+    installFetch(async () => jsonResponse({ "profile.error_password_length": "Minimum {0} characters" }));
+    Object.defineProperty(navigator, "language", { value: "en", configurable: true });
+    await i18n.init();
+    const freshProfile = await import(PROFILE);
+
+    const msg = freshProfile.localizePasswordError({
+      details: { reason: "errors.password_length", min_length: 8 },
+    });
+    expect(msg).toContain("8");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/test/js/themes/bootstrap/router.test.js
+++ b/src/test/js/themes/bootstrap/router.test.js
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the predicate-driven SPA router.
+//
+// The module keeps a mutable `routes` array plus an `_attached` guard as
+// module-level state. Two styles are used below:
+//   - register / navigate / dispatch describes import a FRESH module per test
+//     (vi.resetModules) so routes never leak between cases.
+//   - the attach describe holds ONE dynamically-imported instance and calls
+//     attach() exactly once (beforeAll). attach() registers real listeners on
+//     the shared jsdom document/window that persist across the whole file even
+//     through vi.resetModules, so re-attaching per test would accumulate
+//     duplicate listeners. Its tests use DISTINCT paths so the routes that pile
+//     up on that single instance never cross-match.
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { resetDom, setLocation } from "../../helpers/dom.js";
+
+const ROUTER = "../../../../main/webapp/themes/bootstrap/assets/router.js";
+
+/** Dispatch a cancelable, bubbling click on `el` and return the event. */
+function clickEvent(el) {
+  const ev = new window.MouseEvent("click", { bubbles: true, cancelable: true });
+  el.dispatchEvent(ev);
+  return ev;
+}
+
+describe("register + dispatch", () => {
+  let r;
+  beforeEach(async () => {
+    vi.resetModules();
+    setLocation("/");
+    r = await import(ROUTER);
+  });
+  afterEach(() => setLocation("/"));
+
+  it("runs the handler whose predicate matches the current pathname", () => {
+    setLocation("/search");
+    let seen = null;
+    r.register((p) => p === "/search", (p) => { seen = p; });
+    r.dispatch();
+    expect(seen).toBe("/search");
+  });
+
+  it("first matching route wins; later matches do not run", () => {
+    setLocation("/x");
+    const order = [];
+    r.register((p) => p === "/x", () => order.push("a"));
+    r.register((p) => p === "/x", () => order.push("b"));
+    r.dispatch();
+    expect(order).toEqual(["a"]);
+  });
+
+  it("runs nothing (and does not throw) when no predicate matches", () => {
+    setLocation("/nomatch");
+    let ran = false;
+    r.register((p) => p === "/other", () => { ran = true; });
+    expect(() => r.dispatch()).not.toThrow();
+    expect(ran).toBe(false);
+  });
+
+  it("strips a trailing slash before matching (/search/ → /search)", () => {
+    setLocation("/search/");
+    let seen = null;
+    r.register((p) => p === "/search", (p) => { seen = p; });
+    r.dispatch();
+    expect(seen).toBe("/search");
+  });
+
+  it("normalises the root pathname to '/' (empty-after-strip fallback)", () => {
+    setLocation("/");
+    let seen = null;
+    r.register((p) => p === "/", (p) => { seen = p; });
+    r.dispatch();
+    expect(seen).toBe("/");
+  });
+
+  it("fires fess:route:change with detail.path BEFORE running the handler", () => {
+    setLocation("/evt");
+    const order = [];
+    const onChange = (e) => order.push(["event", e.detail.path]);
+    document.addEventListener("fess:route:change", onChange);
+    r.register((p) => p === "/evt", (p) => order.push(["handler", p]));
+    try {
+      r.dispatch();
+    } finally {
+      document.removeEventListener("fess:route:change", onChange);
+    }
+    expect(order).toEqual([["event", "/evt"], ["handler", "/evt"]]);
+  });
+
+  it("still fires the route-change event when no route matches", () => {
+    setLocation("/lonely");
+    let detailPath = null;
+    const onChange = (e) => { detailPath = e.detail.path; };
+    document.addEventListener("fess:route:change", onChange);
+    try {
+      r.dispatch();
+    } finally {
+      document.removeEventListener("fess:route:change", onChange);
+    }
+    expect(detailPath).toBe("/lonely");
+  });
+});
+
+describe("navigate", () => {
+  let r;
+  beforeEach(async () => {
+    vi.resetModules();
+    setLocation("/");
+    r = await import(ROUTER);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setLocation("/");
+  });
+
+  it("uses pushState by default, updates the URL, then dispatches", () => {
+    const push = vi.spyOn(history, "pushState");
+    const replace = vi.spyOn(history, "replaceState");
+    let seen = null;
+    r.register((p) => p === "/go", (p) => { seen = p; });
+    r.navigate("/go");
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith(null, "", "/go");
+    expect(replace).not.toHaveBeenCalled();
+    expect(location.pathname).toBe("/go");
+    expect(seen).toBe("/go");
+  });
+
+  it("uses replaceState (not pushState) when opts.replace is true", () => {
+    const push = vi.spyOn(history, "pushState");
+    const replace = vi.spyOn(history, "replaceState");
+    let seen = null;
+    r.register((p) => p === "/rep", (p) => { seen = p; });
+    r.navigate("/rep", { replace: true });
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(replace).toHaveBeenCalledWith(null, "", "/rep");
+    expect(push).not.toHaveBeenCalled();
+    expect(location.pathname).toBe("/rep");
+    expect(seen).toBe("/rep");
+  });
+});
+
+describe("attach", () => {
+  // One instance, attached once. Real listeners on document/window persist for
+  // the whole file, so every test here targets a DISTINCT path.
+  let r;
+  beforeAll(async () => {
+    vi.resetModules();
+    r = await import(ROUTER);
+    r.attach();
+  });
+  beforeEach(() => {
+    resetDom();
+    setLocation("/");
+  });
+  afterEach(() => setLocation("/"));
+
+  it("intercepts an <a data-spa> click: preventDefault + navigate", () => {
+    let seen = null;
+    r.register((p) => p === "/spa-a", (p) => { seen = p; });
+    document.body.innerHTML = '<a id="lnk" href="/spa-a" data-spa>go</a>';
+    const ev = clickEvent(document.getElementById("lnk"));
+    expect(ev.defaultPrevented).toBe(true);
+    expect(location.pathname).toBe("/spa-a");
+    expect(seen).toBe("/spa-a");
+  });
+
+  it("ignores external anchors (http/https/protocol-relative href)", () => {
+    for (const href of ["https://x.example/y", "http://x.example/y", "//x.example/y"]) {
+      setLocation("/");
+      document.body.innerHTML = `<a id="ext" href="${href}" data-spa>ext</a>`;
+      const ev = clickEvent(document.getElementById("ext"));
+      expect(ev.defaultPrevented).toBe(false);
+      expect(location.pathname).toBe("/");
+    }
+  });
+
+  it("ignores clicks that are not on a data-spa anchor", () => {
+    document.body.innerHTML = '<a id="plain" href="/plain">no-spa</a>';
+    const ev = clickEvent(document.getElementById("plain"));
+    expect(ev.defaultPrevented).toBe(false);
+    expect(location.pathname).toBe("/");
+  });
+
+  it("re-dispatches on popstate (browser back/forward)", () => {
+    let seen = null;
+    r.register((p) => p === "/pop", (p) => { seen = p; });
+    setLocation("/pop");
+    window.dispatchEvent(new window.PopStateEvent("popstate"));
+    expect(seen).toBe("/pop");
+  });
+
+  it("is idempotent: a second attach() adds no duplicate click listener", () => {
+    r.attach(); // guarded no-op; must NOT add a second listener
+    r.register((p) => p === "/idem", () => {});
+    document.body.innerHTML = '<a id="i" href="/idem" data-spa>x</a>';
+    let changeCount = 0;
+    const onChange = () => { changeCount += 1; };
+    document.addEventListener("fess:route:change", onChange);
+    try {
+      clickEvent(document.getElementById("i"));
+    } finally {
+      document.removeEventListener("fess:route:change", onChange);
+    }
+    // A single click → exactly one navigate → one dispatch → one route:change.
+    expect(changeCount).toBe(1);
+    expect(location.pathname).toBe("/idem");
+  });
+});

--- a/src/test/js/themes/bootstrap/search.test.js
+++ b/src/test/js/themes/bootstrap/search.test.js
@@ -1,0 +1,1299 @@
+// SPDX-License-Identifier: Apache-2.0
+// Behavioural tests for the bootstrap theme's search.js. api.js and router.js are
+// mocked so getConfig/get/isAuthenticated and navigate() are controllable; i18n.js
+// and format.js run for real. The real i18n.t() returns its key unchanged (messages
+// are empty without init), so assertions match exact i18n keys.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resetDom, mountBody, setLocation } from "../../helpers/dom.js";
+
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/api.js", () => ({
+  getConfig: vi.fn(() => null),
+  get: vi.fn(async () => ({})),
+  post: vi.fn(async () => ({})),
+  isAuthenticated: vi.fn(() => false),
+}));
+vi.mock("../../../../main/webapp/themes/bootstrap/assets/router.js", () => ({
+  navigate: vi.fn(),
+}));
+
+import * as api from "../../../../main/webapp/themes/bootstrap/assets/api.js";
+import { navigate } from "../../../../main/webapp/themes/bootstrap/assets/router.js";
+import {
+  safeHref,
+  buildGoUrl,
+  el,
+  buildResultCard,
+  renderPopularWords,
+  disableSubmitBriefly,
+  clearSearchState,
+  runFromUrl,
+  runSearch,
+  renderSearchOptions,
+  initSearchOptions,
+  attachSuggest,
+  syncSearchInputs,
+  refresh,
+  attach,
+  _state,
+} from "../../../../main/webapp/themes/bootstrap/assets/search.js";
+
+beforeEach(() => {
+  resetDom();
+  vi.clearAllMocks();
+  api.getConfig.mockReturnValue(null);
+  clearSearchState();
+});
+afterEach(() => setLocation("/"));
+
+describe("buildGoUrl", () => {
+  it("builds a /go/ URL with rt, docId, queryId and order", () => {
+    expect(buildGoUrl("https://ex.com/d", "d1", "q1", 3, 1700000000000))
+      .toBe("/go/?rt=1700000000000&docId=d1&queryId=q1&order=3");
+  });
+
+  it("appends an encoded &hash= for a #fragment URL", () => {
+    expect(buildGoUrl("https://ex.com/d#sec-2", "d1", "q1", 3, 1700000000000))
+      .toBe("/go/?rt=1700000000000&docId=d1&queryId=q1&order=3&hash=%23sec-2");
+  });
+
+  it("returns # for javascript: and data: schemes", () => {
+    expect(buildGoUrl("javascript:alert(1)", "d1", "q1", 3, 1)).toBe("#");
+    expect(buildGoUrl("data:text/html,x", "d1", "q1", 3, 1)).toBe("#");
+  });
+
+  it("returns # for empty, null and non-string originalUrl", () => {
+    expect(buildGoUrl("", "d1", "q1", 3, 1)).toBe("#");
+    expect(buildGoUrl(null, "d1", "q1", 3, 1)).toBe("#");
+    expect(buildGoUrl(42, "d1", "q1", 3, 1)).toBe("#");
+  });
+
+  it("percent-encodes docId and queryId with special characters", () => {
+    expect(buildGoUrl("https://ex.com/d", "a b&c", "q 1", 3, 1))
+      .toBe("/go/?rt=1&docId=a%20b%26c&queryId=q%201&order=3");
+  });
+
+  it("defaults order to 0 when omitted", () => {
+    expect(buildGoUrl("https://ex.com/d", "d1", "q1", undefined, 1))
+      .toBe("/go/?rt=1&docId=d1&queryId=q1&order=0");
+  });
+});
+
+describe("safeHref", () => {
+  it("returns the URL for http/https/ftp/ftps schemes", () => {
+    expect(safeHref("https://x.com")).toBe("https://x.com");
+    expect(safeHref("http://x.com")).toBe("http://x.com");
+    expect(safeHref("ftp://x.com")).toBe("ftp://x.com");
+    expect(safeHref("ftps://x.com")).toBe("ftps://x.com");
+  });
+
+  it("returns relative and fragment URLs unchanged (resolve to the page scheme)", () => {
+    expect(safeHref("/relative")).toBe("/relative");
+    expect(safeHref("relative")).toBe("relative");
+    expect(safeHref("#frag")).toBe("#frag");
+  });
+
+  it("returns # for mailto: and tel: (not in the search.js allowlist)", () => {
+    expect(safeHref("mailto:a@b.com")).toBe("#");
+    expect(safeHref("tel:12345")).toBe("#");
+  });
+
+  it("returns # for javascript:, data: and vbscript: schemes", () => {
+    expect(safeHref("javascript:alert(1)")).toBe("#");
+    expect(safeHref("data:text/html,x")).toBe("#");
+    expect(safeHref("vbscript:msgbox")).toBe("#");
+  });
+
+  it("returns # for a malformed URL, empty/null and non-string input", () => {
+    expect(safeHref("http://[bad")).toBe("#");
+    expect(safeHref("")).toBe("#");
+    expect(safeHref(null)).toBe("#");
+    expect(safeHref(42)).toBe("#");
+  });
+});
+
+describe("el", () => {
+  it("creates a detached element with className, text, attrs and dataset", () => {
+    const node = el("div", {
+      className: "c1 c2",
+      text: "hello",
+      attrs: { id: "x", "data-uri": "u" },
+      dataset: { docId: "d1" },
+    });
+    expect(node.tagName).toBe("DIV");
+    expect(node.className).toBe("c1 c2");
+    expect(node.textContent).toBe("hello");
+    expect(node.getAttribute("id")).toBe("x");
+    expect(node.getAttribute("data-uri")).toBe("u");
+    expect(node.dataset.docId).toBe("d1");
+    expect(node.parentNode).toBeNull();
+  });
+
+  it("returns a bare element when no opts are given", () => {
+    const node = el("span");
+    expect(node.tagName).toBe("SPAN");
+    expect(node.className).toBe("");
+    expect(node.textContent).toBe("");
+  });
+});
+
+describe("buildResultCard", () => {
+  it("builds a detached li#result{order-1} with docId/queryId dataset and title/cite", () => {
+    api.getConfig.mockReturnValue({ features: {} });
+    _state.requestedTime = 1700000000000;
+    const li = buildResultCard(
+      { doc_id: "d1", title: "Hello", url: "https://ex.com/p" }, "q1", 1);
+
+    expect(li.parentNode).toBeNull();
+    expect(li.tagName).toBe("LI");
+    expect(li.id).toBe("result0");
+    expect(li.dataset.docId).toBe("d1");
+    expect(li.dataset.queryId).toBe("q1");
+
+    const a = li.querySelector("h3 a");
+    expect(a.textContent).toBe("Hello");
+    expect(a.getAttribute("href"))
+      .toBe("/go/?rt=1700000000000&docId=d1&queryId=q1&order=1");
+    expect(li.querySelector("cite").textContent).toBe("https://ex.com/p");
+    // No thumbnail / cache / similar for a minimal doc.
+    expect(li.querySelector("img.thumbnail")).toBeNull();
+    expect(li.querySelector("a.cache")).toBeNull();
+    expect(li.querySelector("a.similar")).toBeNull();
+    // No content_title/description/digest → empty description.
+    expect(li.querySelector(".description").textContent).toBe("");
+  });
+
+  it("tolerates a null config (features default to {})", () => {
+    api.getConfig.mockReturnValue(null);
+    expect(() => buildResultCard({ doc_id: "d", title: "T", url: "https://e.com" }, "q", 1))
+      .not.toThrow();
+  });
+
+  it("renders content_title as highlighted markup via innerHTML", () => {
+    api.getConfig.mockReturnValue({ features: {} });
+    const li = buildResultCard(
+      { doc_id: "d2", content_title: "A <strong>hi</strong> B", url: "https://e.com" }, "q", 2);
+    const a = li.querySelector("h3 a");
+    expect(a.querySelector("strong")).not.toBeNull();
+    expect(a.innerHTML).toContain("<strong>hi</strong>");
+    expect(a.textContent).toBe("A hi B");
+  });
+
+  it("renders a thumbnail only when features.thumbnail_enabled and d.thumbnail are set", () => {
+    api.getConfig.mockReturnValue({ features: { thumbnail_enabled: true } });
+    const li = buildResultCard(
+      { doc_id: "d2", title: "T", url: "https://e.com", thumbnail: "y" }, "q2", 2);
+    const img = li.querySelector("img.thumbnail");
+    expect(img).not.toBeNull();
+    expect(img.getAttribute("src")).toBe("/thumbnail/?docId=d2&queryId=q2");
+  });
+
+  it("omits the thumbnail when the feature is off even if d.thumbnail is set", () => {
+    api.getConfig.mockReturnValue({ features: {} });
+    const li = buildResultCard(
+      { doc_id: "d2", title: "T", url: "https://e.com", thumbnail: "y" }, "q2", 2);
+    expect(li.querySelector("img.thumbnail")).toBeNull();
+  });
+
+  it("renders a cache link when has_cache is truthy", () => {
+    api.getConfig.mockReturnValue({ features: {} });
+    const li = buildResultCard(
+      { doc_id: "d3", title: "T", url: "https://e.com", has_cache: "true" }, "q", 1);
+    const cache = li.querySelector("a.cache");
+    expect(cache).not.toBeNull();
+    expect(cache.getAttribute("href")).toContain("/cache/?docId=d3");
+  });
+
+  it("renders a similar link only when similar_docs_count > 1", () => {
+    api.getConfig.mockReturnValue({ features: {} });
+    const many = buildResultCard(
+      { doc_id: "d4", title: "T", url: "https://e.com", similar_docs_count: 3 }, "q", 1);
+    expect(many.querySelector("a.similar")).not.toBeNull();
+    const one = buildResultCard(
+      { doc_id: "d5", title: "T", url: "https://e.com", similar_docs_count: 1 }, "q", 1);
+    expect(one.querySelector("a.similar")).toBeNull();
+  });
+
+  it("escapes a raw digest rather than dropping it (angle-bracket address preserved)", () => {
+    api.getConfig.mockReturnValue({ features: {} });
+    const li = buildResultCard(
+      { doc_id: "d6", title: "T", url: "https://e.com", digest: "Michael <msfroh@example.com>" }, "q", 1);
+    const desc = li.querySelector(".description");
+    expect(desc.textContent).toBe("Michael <msfroh@example.com>");
+    // Escaped, so the address never becomes a child element.
+    expect(desc.children.length).toBe(0);
+  });
+});
+
+describe("renderPopularWords", () => {
+  it("renders a label span plus one data-spa anchor per word and removes d-none", () => {
+    mountBody('<div id="pw" class="d-none"></div>');
+    const target = document.getElementById("pw");
+    renderPopularWords(["a", "b"], target);
+
+    expect(target.classList.contains("d-none")).toBe(false);
+    const spans = target.querySelectorAll("span");
+    expect(spans.length).toBe(1);
+    expect(spans[0].className).toBe("me-2");
+    const anchors = target.querySelectorAll("a");
+    expect(anchors.length).toBe(2);
+    expect(anchors[0].getAttribute("href")).toBe("/search?q=a");
+    expect(anchors[0].hasAttribute("data-spa")).toBe(true);
+    expect(anchors[1].getAttribute("href")).toBe("/search?q=b");
+  });
+
+  it("percent-encodes a word containing a space", () => {
+    mountBody('<div id="pw"></div>');
+    const target = document.getElementById("pw");
+    renderPopularWords(["c d"], target);
+    expect(target.querySelector("a").getAttribute("href")).toBe("/search?q=c%20d");
+  });
+
+  it("clears children and adds d-none for an empty or null word list", () => {
+    mountBody('<div id="pw"></div>');
+    const target = document.getElementById("pw");
+    renderPopularWords(["seed"], target);
+    renderPopularWords([], target);
+    expect(target.classList.contains("d-none")).toBe(true);
+    expect(target.children.length).toBe(0);
+    renderPopularWords(["seed"], target);
+    renderPopularWords(null, target);
+    expect(target.classList.contains("d-none")).toBe(true);
+    expect(target.children.length).toBe(0);
+  });
+
+  it("does not throw when targetEl is null", () => {
+    expect(() => renderPopularWords(["a"], null)).not.toThrow();
+  });
+});
+
+describe("disableSubmitBriefly", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("disables the button immediately and re-enables it after 3000ms", () => {
+    vi.useFakeTimers();
+    const btn = document.createElement("button");
+    disableSubmitBriefly(btn);
+    expect(btn.disabled).toBe(true);
+    vi.advanceTimersByTime(2999);
+    expect(btn.disabled).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("does not throw when btn is null", () => {
+    expect(() => disableSubmitBriefly(null)).not.toThrow();
+  });
+});
+
+describe("clearSearchState / _state", () => {
+  it("resets every state field to its initial value and clears inputs", () => {
+    mountBody(`
+      <input id="query" value="stale">
+      <input id="contentQuery" value="stale">
+      <select id="numSearchOption"><option value="10">10</option><option value="50" selected>50</option></select>
+      <select id="sortSearchOption"><option value="">def</option><option value="z" selected>z</option></select>
+    `);
+    const s = _state;
+    s.q = "x"; s.start = 5; s.num = 50; s.sort = "z"; s.lang = ["ja"]; s.sdh = "h";
+    s.facets = { a: [1] }; s.fields = { label: ["x"] }; s.facetQueries = ["fq"]; s.exQ = ["e"];
+    s.geo = { lat: "1", lon: "2", distance: "3" }; s.requestedTime = 99; s.highlightParams = "&hl";
+
+    const ref = _state;
+    clearSearchState();
+
+    expect(_state.q).toBe("");
+    expect(_state.start).toBe(0);
+    expect(_state.num).toBe(10);
+    expect(_state.sort).toBe("");
+    expect(_state.lang).toEqual([]);
+    expect(_state.sdh).toBe("");
+    expect(_state.facets).toEqual({});
+    expect(_state.fields).toEqual({});
+    expect(_state.facetQueries).toEqual([]);
+    expect(_state.exQ).toEqual([]);
+    expect(_state.geo).toEqual({ lat: "", lon: "", distance: "" });
+    expect(_state.requestedTime).toBe(0);
+    expect(_state.highlightParams).toBe("");
+
+    // Inputs cleared; drawer selects reset to their default index.
+    expect(document.getElementById("query").value).toBe("");
+    expect(document.getElementById("contentQuery").value).toBe("");
+    expect(document.getElementById("numSearchOption").selectedIndex).toBe(0);
+    expect(document.getElementById("sortSearchOption").selectedIndex).toBe(0);
+
+    // The exported _state alias points at the same object.
+    expect(ref).toBe(_state);
+  });
+});
+
+describe("runFromUrl", () => {
+  it("resets in-memory filter stores and navigates home for a filter-less URL", async () => {
+    api.getConfig.mockReturnValue(null);
+    api.get.mockResolvedValue({ data: [] });
+    _state.facets = { label: ["x"] };
+    _state.facetQueries = ["fq"];
+    _state.sdh = "hash";
+    _state.fields = { label: ["y"] };
+    setLocation("/search?num=10");
+
+    runFromUrl();
+    await Promise.resolve();
+
+    expect(_state.facets).toEqual({});
+    expect(_state.facetQueries).toEqual([]);
+    expect(_state.sdh).toBe("");
+    expect(_state.fields).toEqual({});
+    expect(navigate).toHaveBeenCalledWith("/", { replace: true });
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("hydrates state from a full search URL, syncs inputs, and issues the search", async () => {
+    api.getConfig.mockReturnValue(null);
+    api.get.mockResolvedValue({ data: [], query_id: "q" });
+    mountBody('<input id="query"><input id="contentQuery"><ul id="results"></ul><div id="results-meta"></div><div id="empty-state"></div>');
+    setLocation("/search?q=foo&start=20&num=50&sort=x&lang=ja&lang=en&fields.label=A&ex_q=cl");
+
+    runFromUrl();
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(_state.q).toBe("foo");
+    expect(_state.start).toBe(20);
+    expect(_state.num).toBe(50);
+    expect(_state.sort).toBe("x");
+    expect(_state.lang).toEqual(["ja", "en"]);
+    expect(_state.fields).toEqual({ label: ["A"] });
+    expect(_state.exQ).toEqual(["cl"]);
+
+    expect(document.getElementById("query").value).toBe("foo");
+    expect(document.getElementById("contentQuery").value).toBe("foo");
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(api.get).toHaveBeenCalled();
+    const searchCall = api.get.mock.calls.find((c) => c[0] === "/search");
+    expect(searchCall).toBeTruthy();
+    expect(searchCall[1]).toMatchObject({
+      q: "foo", start: 20, num: 50, sort: "x",
+      lang: ["ja", "en"], "fields.label": ["A"], "ex_q": ["cl"],
+    });
+  });
+});
+
+// ─── Shared fixture + api dispatch for runSearch and its render machinery ─────
+
+/**
+ * Full DOM fixture with every id runSearch/renderResults/renderFacets/
+ * renderPagination and the option renderers reach for.
+ */
+const SEARCH_FIXTURE = `
+  <input id="query"><input id="contentQuery">
+  <input id="queryId"><input id="rt">
+  <div id="search-loading" class="d-none"></div>
+  <div id="search-error" class="d-none"></div>
+  <div id="results-warning" class="d-none"></div>
+  <div id="results-status"></div>
+  <div id="similar-doc-banner" class="d-none"></div>
+  <ul id="results"></ul>
+  <div id="results-meta"></div>
+  <div id="empty-state" class="d-none"><span id="empty-did-not-match"></span></div>
+  <div id="results-popular-words" class="d-none"></div>
+  <nav id="subfooter" class="d-none"><ul id="pagination"></ul></nav>
+  <div id="facet-body" class="d-none"></div>
+  <div id="facet-body-mobile"></div>
+  <div id="facet-toggle-wrap"></div>
+  <a id="facet-clear" class="d-none"></a>
+  <div id="active-chips" class="d-none"></div>
+  <ul id="current-filters"></ul>
+  <ul id="options-bar"></ul>
+  <div id="related-queries" class="d-none"></div>
+  <div id="related-content" class="d-none"></div>
+  <select id="sortSearchOption"></select>
+  <select id="numSearchOption"></select>
+  <select id="langSearchOption"></select>
+  <fieldset id="labelSearchOptionFieldset"><select id="labelSearchOption"></select></fieldset>
+`;
+
+/** A representative api config the option renderers + facets consume. */
+const FULL_CFG = {
+  features: { popular_word: true, display_label_type: true },
+  sort_options: [
+    { value: "", label_key: "labels.search_result_sort_score_desc" },
+    { value: "last_modified.desc", label_key: "labels.search_result_sort_last_modified_desc" },
+  ],
+  num_options: [10, 20, 50],
+  lang_options: [{ value: "ja" }, { value: "en" }],
+  label_options: [{ value: "lblA", label: "Label A" }, { value: "lblB", label: "Label B" }],
+  facet_views: [
+    {
+      group_name: "labels.facet_filetype_title",
+      queries: [
+        { value: "filetype:html", label_key: "labels.facet_filetype_html" },
+        { value: "filetype:pdf", label_key: "labels.facet_filetype_pdf" },
+      ],
+    },
+  ],
+};
+
+/** Build a realistic /search envelope. `docs` become result cards. */
+function makeSearchEnv(docs, extra = {}) {
+  return {
+    query_id: "qid-1",
+    requested_time: 1700000000000,
+    highlight_params: "&hl.q=foo",
+    partial: false,
+    record_count: docs.length ? 42 : 0,
+    record_count_relation: "EQUAL_TO",
+    start_record_number: 1,
+    end_record_number: docs.length,
+    exec_time: 0.05,
+    page_number: 1,
+    page_numbers: ["1", "2", "3", "4", "5"],
+    prev_page: false,
+    next_page: docs.length > 0,
+    data: docs,
+    facet_field: [
+      {
+        name: "label",
+        result: [
+          { value: "lblA", count: 5 },
+          { value: "lblB", count: 3 },
+          { value: "lblZ", count: 0 },
+        ],
+      },
+    ],
+    facet_query: [
+      { value: "filetype:html", count: 7 },
+      { value: "filetype:pdf", count: 0 },
+    ],
+    ...extra,
+  };
+}
+
+const SAMPLE_DOCS = [
+  { doc_id: "d1", title: "Doc One", url: "https://ex.com/1", last_modified: "2023-01-02T00:00:00Z", content_length: 1234, has_cache: "true" },
+  { doc_id: "d2", content_title: "Doc <strong>Two</strong>", url: "https://ex.com/2", digest: "second digest" },
+];
+
+/**
+ * Install an api.get implementation that dispatches per endpoint. Pass
+ * overrides to replace the /search envelope or related payloads.
+ */
+function installApiDispatch(overrides = {}) {
+  const searchEnv = "search" in overrides ? overrides.search : makeSearchEnv(SAMPLE_DOCS);
+  api.get.mockImplementation(async (path) => {
+    if (path === "/search") return searchEnv;
+    if (path === "/labels") return { labels: overrides.labels || [{ value: "lblA", label: "Label A" }, { value: "lblB", label: "Label B" }] };
+    if (path === "/popular-words") return { popular_words: overrides.popularWords || ["alpha", "beta", "gamma", "delta"] };
+    if (path === "/related-queries") return { queries: overrides.relatedQueries || ["rq1", "rq2"] };
+    if (path === "/related-content") return { content: "content" in overrides ? overrides.content : "<p>related</p>" };
+    if (path === "/favorites") return { data: overrides.favorites || [] };
+    if (path === "/suggest-words") return { suggest_words: overrides.suggestWords || [{ text: "sug1" }, { text: "sug2" }] };
+    return {};
+  });
+}
+
+/** Await a couple of macrotasks so fire-and-forget helpers (popular words, related) settle. */
+const settle = () => new Promise((r) => setTimeout(r, 20));
+
+describe("runSearch — successful render", () => {
+  beforeEach(() => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    installApiDispatch();
+    mountBody(SEARCH_FIXTURE);
+    _state.q = "foo";
+  });
+
+  it("renders one result card per hit with correct ids and titles", async () => {
+    await runSearch();
+    await settle();
+
+    const cards = document.querySelectorAll("#results > li");
+    expect(cards.length).toBe(2);
+    expect(document.getElementById("result0")).not.toBeNull();
+    expect(document.getElementById("result1")).not.toBeNull();
+    expect(document.querySelector("#result0 h3 a").textContent).toBe("Doc One");
+    // content_title on the second doc keeps its highlight markup.
+    expect(document.querySelector("#result1 h3 a strong")).not.toBeNull();
+    expect(document.getElementById("result0").dataset.docId).toBe("d1");
+  });
+
+  it("toggles the loading indicator off and leaves results-meta empty on success", async () => {
+    await runSearch();
+    await settle();
+    expect(document.getElementById("search-loading").classList.contains("d-none")).toBe(true);
+    expect(document.getElementById("empty-state").classList.contains("d-none")).toBe(true);
+    expect(document.getElementById("results-meta").textContent).toBe("");
+  });
+
+  it("populates the results-status banner and the hidden queryId/rt fields", async () => {
+    await runSearch();
+    await settle();
+    const status = document.getElementById("results-status").textContent;
+    expect(status).toContain("labels.search_result_status");
+    expect(status).toContain("labels.search_result_time");
+    expect(document.getElementById("queryId").value).toBe("qid-1");
+    expect(document.getElementById("rt").value).toBe("1700000000000");
+  });
+
+  it("sets document.title from the query", async () => {
+    await runSearch();
+    await settle();
+    expect(document.title).toBe("page.search_title");
+  });
+
+  it("requests /search with facet.field=label and configured facet.query values", async () => {
+    await runSearch();
+    await settle();
+    const call = api.get.mock.calls.find((c) => c[0] === "/search");
+    expect(call).toBeTruthy();
+    expect(call[1]).toMatchObject({
+      q: "foo",
+      start: 0,
+      num: 10,
+      "facet.field": ["label"],
+      "facet.query": ["filetype:html", "filetype:pdf"],
+    });
+    expect(call[2]).toHaveProperty("signal");
+  });
+
+  it("requests the auxiliary endpoints (popular-words, labels, related)", async () => {
+    await runSearch();
+    await settle();
+    const paths = api.get.mock.calls.map((c) => c[0]);
+    expect(paths).toContain("/popular-words");
+    expect(paths).toContain("/labels");
+    expect(paths).toContain("/related-queries");
+    expect(paths).toContain("/related-content");
+  });
+
+  it("renders the label facet group and the filetype query view, suppressing zero counts", async () => {
+    await runSearch();
+    await settle();
+    const body = document.getElementById("facet-body");
+    expect(body.classList.contains("d-md-block")).toBe(true);
+    const groups = body.querySelectorAll("ul.list-group");
+    expect(groups.length).toBe(2);
+    // Label group title + Label A / Label B (lblZ count 0 suppressed).
+    expect(groups[0].querySelector("li.text-uppercase").textContent).toBe("labels.facet_label_title");
+    const labelText = groups[0].textContent;
+    expect(labelText).toContain("Label A");
+    expect(labelText).toContain("Label B");
+    expect(labelText).not.toContain("lblZ");
+    // Filetype query view: html kept (count 7), pdf suppressed (count 0).
+    expect(groups[1].textContent).toContain("labels.facet_filetype_html");
+    expect(groups[1].textContent).not.toContain("labels.facet_filetype_pdf");
+    // No active filter → clear button hidden.
+    expect(document.getElementById("facet-clear").classList.contains("d-none")).toBe(true);
+  });
+
+  it("mirrors the facet groups into the mobile offcanvas", async () => {
+    await runSearch();
+    await settle();
+    const mobile = document.getElementById("facet-body-mobile");
+    expect(mobile.querySelectorAll("ul.list-group").length).toBe(2);
+  });
+
+  it("renders pagination: disabled prev, five numbered pages, enabled next", async () => {
+    await runSearch();
+    await settle();
+    expect(document.getElementById("subfooter").classList.contains("d-none")).toBe(false);
+    const items = document.querySelectorAll("#pagination > li");
+    expect(items.length).toBe(7); // prev + 5 + next
+    expect(items[0].className).toContain("disabled"); // prev
+    expect(items[1].className).toContain("active"); // page 1
+    expect(items[items.length - 1].className).not.toContain("disabled"); // next
+    // Far pages (4,5) carry the responsive-hide classes.
+    expect(items[4].className).toContain("d-none");
+  });
+
+  it("renders related queries and sanitized related content", async () => {
+    await runSearch();
+    await settle();
+    const rq = document.getElementById("related-queries");
+    expect(rq.classList.contains("d-none")).toBe(false);
+    expect(rq.textContent).toContain("rq1");
+    expect(rq.textContent).toContain("rq2");
+    const rc = document.getElementById("related-content");
+    expect(rc.classList.contains("d-none")).toBe(false);
+    expect(rc.textContent).toContain("related");
+  });
+
+  it("renders results popular words when the feature is enabled", async () => {
+    await runSearch();
+    await settle();
+    const rpw = document.getElementById("results-popular-words");
+    expect(rpw.classList.contains("d-none")).toBe(false);
+    expect(rpw.querySelectorAll("a[data-spa]").length).toBe(4);
+  });
+
+  it("renders the options bar with sort/num/lang/label items", async () => {
+    await runSearch();
+    await settle();
+    const items = document.querySelectorAll("#options-bar > li");
+    expect(items.length).toBe(4);
+    expect(document.getElementById("options-bar").textContent).toContain("search.menu_sort");
+    expect(document.getElementById("options-bar").textContent).toContain("search.menu_labels");
+  });
+
+  it("shows the partial-results warning when env.partial is set", async () => {
+    installApiDispatch({ search: makeSearchEnv(SAMPLE_DOCS, { partial: true }) });
+    await runSearch();
+    await settle();
+    const warn = document.getElementById("results-warning");
+    expect(warn.classList.contains("d-none")).toBe(false);
+    expect(warn.textContent).toBe("labels.process_time_is_exceeded");
+  });
+
+  it("uses the _over status key when record_count_relation is not EQUAL_TO", async () => {
+    installApiDispatch({ search: makeSearchEnv(SAMPLE_DOCS, { record_count_relation: "GREATER_THAN_OR_EQUAL_TO" }) });
+    await runSearch();
+    await settle();
+    expect(document.getElementById("results-status").textContent).toContain("labels.search_result_status_over");
+  });
+
+  it("dispatches fess:search:after with the envelope", async () => {
+    const spy = vi.fn();
+    document.addEventListener("fess:search:after", spy);
+    await runSearch();
+    await settle();
+    document.removeEventListener("fess:search:after", spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail.query_id).toBe("qid-1");
+  });
+});
+
+describe("runSearch — zero results", () => {
+  beforeEach(() => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    installApiDispatch({ search: makeSearchEnv([], { prev_page: false, next_page: false, page_numbers: [] }) });
+    mountBody(SEARCH_FIXTURE);
+    _state.q = "zzz";
+  });
+
+  it("shows the empty state and clears the results list and status", async () => {
+    await runSearch();
+    await settle();
+    expect(document.getElementById("empty-state").classList.contains("d-none")).toBe(false);
+    expect(document.getElementById("empty-did-not-match").textContent).toBe("search.did_not_match");
+    expect(document.querySelectorAll("#results > li").length).toBe(0);
+    expect(document.getElementById("results-status").textContent).toBe("");
+  });
+
+  it("hides the facet sidebar, mobile toggle and pagination", async () => {
+    await runSearch();
+    await settle();
+    expect(document.getElementById("facet-body").classList.contains("d-md-block")).toBe(false);
+    expect(document.getElementById("facet-toggle-wrap").classList.contains("d-none")).toBe(true);
+    expect(document.getElementById("subfooter").classList.contains("d-none")).toBe(true);
+    expect(document.getElementById("results-popular-words").classList.contains("d-none")).toBe(true);
+  });
+
+  it("does NOT clear related queries — loadRelated still populates them", async () => {
+    await runSearch();
+    await settle();
+    // The zero-result branch must leave related alone so the async loadRelated wins.
+    const rq = document.getElementById("related-queries");
+    expect(rq.classList.contains("d-none")).toBe(false);
+    expect(rq.textContent).toContain("rq1");
+  });
+});
+
+describe("runSearch — error handling", () => {
+  beforeEach(() => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    mountBody(SEARCH_FIXTURE);
+    _state.q = "foo";
+    api.get.mockResolvedValue({ data: [] });
+  });
+
+  const errBox = () => document.getElementById("search-error");
+
+  it("shows the invalid_request message in the visible banner", async () => {
+    api.get.mockRejectedValueOnce(Object.assign(new Error("bad query"), { code: "invalid_request" }));
+    await runSearch();
+    expect(errBox().textContent).toBe("bad query");
+    expect(errBox().classList.contains("d-none")).toBe(false);
+  });
+
+  it("treats httpStatus 400 as an invalid request", async () => {
+    api.get.mockRejectedValueOnce(Object.assign(new Error("http 400"), { httpStatus: 400 }));
+    await runSearch();
+    expect(errBox().textContent).toBe("http 400");
+    expect(errBox().classList.contains("d-none")).toBe(false);
+  });
+
+  it("shows error.network for a NetworkError", async () => {
+    api.get.mockRejectedValueOnce(Object.assign(new Error("net"), { name: "NetworkError" }));
+    await runSearch();
+    expect(errBox().textContent).toBe("error.network");
+  });
+
+  it("shows error.auth_required for AUTH_REQUIRED", async () => {
+    api.get.mockRejectedValueOnce(Object.assign(new Error("auth"), { code: "AUTH_REQUIRED" }));
+    await runSearch();
+    expect(errBox().textContent).toBe("error.auth_required");
+  });
+
+  it("shows error.server for a generic failure and clears the spinner", async () => {
+    api.get.mockRejectedValueOnce(new Error("boom"));
+    await runSearch();
+    expect(errBox().textContent).toBe("error.server");
+    expect(document.getElementById("search-loading").classList.contains("d-none")).toBe(true);
+  });
+
+  it("swallows an AbortError without showing the error banner", async () => {
+    api.get.mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }));
+    await runSearch();
+    expect(errBox().classList.contains("d-none")).toBe(true);
+    expect(errBox().textContent).toBe("");
+  });
+
+  it("falls back to #results-meta when there is no #search-error element", async () => {
+    errBox().remove();
+    api.get.mockRejectedValueOnce(new Error("boom"));
+    await runSearch();
+    expect(document.getElementById("results-meta").textContent).toBe("error.server");
+  });
+});
+
+describe("runSearch — active filters, chips and current filters", () => {
+  beforeEach(() => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    installApiDispatch({ search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1" }]) });
+    mountBody(SEARCH_FIXTURE);
+    _state.q = "foo";
+    _state.sort = "last_modified.desc";
+    _state.num = 50;
+    _state.lang = ["ja"];
+    _state.fields = { label: ["lblB"], filetype: ["pdf"] };
+    _state.facets = { label: ["lblA"] };
+    _state.facetQueries = ["filetype:html"];
+  });
+
+  it("renders an active chip per filter (facet, filetype and facet-query)", async () => {
+    await runSearch();
+    await settle();
+    const chips = document.getElementById("active-chips");
+    expect(chips.classList.contains("d-none")).toBe(false);
+    const text = chips.textContent;
+    expect(text).toContain("facet.active_filters:");
+    expect(text).toContain("label: lblA");
+    expect(text).toContain("label: lblB");
+    expect(text).toContain("labels.facet_filetype_title: labels.facet_filetype_pdf");
+    // facet-query chip
+    expect(text).toContain("labels.facet_filetype_title: labels.facet_filetype_html");
+  });
+
+  it("re-runs the search and drops the filter when a chip remove button is clicked", async () => {
+    await runSearch();
+    await settle();
+    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    // First chip is the label:lblA facet; its remove button clears it.
+    const removeBtn = document.querySelector("#active-chips .active-chip-remove");
+    removeBtn.click();
+    await settle();
+    const after = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    expect(after).toBe(before + 1);
+  });
+
+  it("renders current-filters badges for sort, non-default num, lang and label", async () => {
+    await runSearch();
+    await settle();
+    // sort + non-default num + lang(ja) + label(lblB) → four badges.
+    const badges = document.querySelectorAll("#current-filters > li");
+    expect(badges.length).toBe(4);
+    const text = document.getElementById("current-filters").textContent;
+    expect(text).toContain("labels.search_result_sort_last_modified_desc");
+    expect(text).toContain("search.num_format");
+    expect(text).toContain("labels.lang_ja");
+    expect(text).toContain("Label B");
+  });
+
+  it("focuses the drawer control when a current-filter badge is clicked", async () => {
+    await runSearch();
+    await settle();
+    const btn = document.querySelector("#current-filters button");
+    btn.click(); // sort badge → focuses #sortSearchOption; just assert no throw
+    expect(document.activeElement).toBe(document.getElementById("sortSearchOption"));
+  });
+
+  it("shows the facet clear button and a facet-reset link when filters are active", async () => {
+    await runSearch();
+    await settle();
+    expect(document.getElementById("facet-clear").classList.contains("d-none")).toBe(false);
+    const reset = document.querySelector("#facet-body .facet-reset");
+    expect(reset).not.toBeNull();
+    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    reset.click();
+    await settle();
+    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+    expect(_state.facets).toEqual({});
+    expect(_state.facetQueries).toEqual([]);
+  });
+
+  it("marks the active facet entries with the active class", async () => {
+    await runSearch();
+    await settle();
+    const active = document.querySelectorAll("#facet-body li.list-group-item.active");
+    expect(active.length).toBeGreaterThanOrEqual(2); // lblA facet + filetype:html query view
+  });
+});
+
+describe("runSearch — facet and pagination click handlers", () => {
+  beforeEach(() => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    mountBody(SEARCH_FIXTURE);
+    window.scrollTo = () => {};
+    _state.q = "foo";
+    _state.num = 10;
+  });
+
+  it("toggles a facet value and re-runs the search when a facet entry is clicked", async () => {
+    installApiDispatch({ search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1" }]) });
+    await runSearch();
+    await settle();
+    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    document.querySelector("#facet-body ul li.list-group-item a").click();
+    await settle();
+    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+    expect(_state.facets.label).toContain("lblA");
+    expect(_state.start).toBe(0);
+  });
+
+  it("advances the page offset and re-runs when the next link is clicked", async () => {
+    installApiDispatch({ search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1" }], { prev_page: true, next_page: true, page_number: 2 }) });
+    _state.start = 10;
+    await runSearch();
+    await settle();
+    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    document.querySelector("#pagination li:last-child a").click();
+    await settle();
+    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+    expect(_state.start).toBe(20);
+  });
+
+  it("jumps to a specific page when a numbered page link is clicked", async () => {
+    installApiDispatch({ search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1" }], { prev_page: true, next_page: true, page_number: 2 }) });
+    _state.start = 10;
+    await runSearch();
+    await settle();
+    // Third page number link → start = (3-1)*10 = 20.
+    const pageLinks = document.querySelectorAll("#pagination li.page-item:not([aria-label]) a");
+    pageLinks[2].click();
+    await settle();
+    expect(_state.start).toBe(20);
+  });
+
+  it("does nothing when the disabled prev link is clicked", async () => {
+    installApiDispatch({ search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1" }], { prev_page: false, next_page: true }) });
+    _state.start = 0;
+    await runSearch();
+    await settle();
+    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    document.querySelector("#pagination li:first-child a").click();
+    await settle();
+    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before);
+  });
+});
+
+describe("runSearch — favorites and similar docs", () => {
+  it("renders the favorite star, syncs favorited state and toggles on click", async () => {
+    api.getConfig.mockReturnValue({ ...FULL_CFG, features: { ...FULL_CFG.features, user_favorite: true } });
+    api.isAuthenticated.mockReturnValue(true);
+    installApiDispatch({
+      search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1", favorite_count: 2 }]),
+      favorites: ["d1"],
+    });
+    api.post.mockResolvedValue({ favorite: false, count: 1 });
+    mountBody(SEARCH_FIXTURE);
+    _state.q = "foo";
+    await runSearch();
+    await settle();
+
+    const btn = document.querySelector(".favorite-btn");
+    expect(btn).not.toBeNull();
+    // syncFavorites flipped it to favorited (solid star + pressed).
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+    expect(btn.querySelector("i").className).toBe("fas fa-star");
+    // Clicking posts to the favorite endpoint.
+    btn.click();
+    await settle();
+    const call = api.post.mock.calls.find((c) => c[0].includes("/documents/d1/favorite"));
+    expect(call).toBeTruthy();
+    expect(call[1]).toMatchObject({ query_id: "qid-1" });
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("shows the similar-doc banner when state.sdh is set and clears it on close", async () => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    installApiDispatch({ search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1" }]) });
+    mountBody(SEARCH_FIXTURE);
+    _state.q = "foo";
+    _state.sdh = "hash-1";
+    await runSearch();
+    await settle();
+    const banner = document.getElementById("similar-doc-banner");
+    expect(banner.classList.contains("d-flex")).toBe(true);
+    expect(banner.textContent).toContain("labels.similar_doc_result_status");
+    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    banner.querySelector("button.btn-close").click();
+    await settle();
+    expect(_state.sdh).toBe("");
+    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+  });
+
+  it("renders a similar link that starts a similarity search on click", async () => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    installApiDispatch({ search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1", similar_docs_count: 3, similar_docs_hash: "h1" }]) });
+    mountBody(SEARCH_FIXTURE);
+    _state.q = "foo";
+    await runSearch();
+    await settle();
+    const link = document.querySelector("#result0 a.similar");
+    expect(link).not.toBeNull();
+    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    link.click();
+    await settle();
+    expect(_state.sdh).toBe("h1");
+    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+  });
+});
+
+describe("refresh", () => {
+  it("re-runs the current search", async () => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    installApiDispatch();
+    mountBody(SEARCH_FIXTURE);
+    _state.q = "foo";
+    refresh();
+    await settle();
+    expect(api.get.mock.calls.some((c) => c[0] === "/search")).toBe(true);
+    expect(document.querySelectorAll("#results > li").length).toBe(2);
+  });
+});
+
+describe("syncSearchInputs", () => {
+  it("writes the query into both the header and home inputs", () => {
+    mountBody('<input id="query"><input id="contentQuery">');
+    syncSearchInputs("hello world");
+    expect(document.getElementById("query").value).toBe("hello world");
+    expect(document.getElementById("contentQuery").value).toBe("hello world");
+  });
+
+  it("does not throw when the inputs are absent", () => {
+    expect(() => syncSearchInputs("x")).not.toThrow();
+  });
+});
+
+describe("renderSearchOptions / initSearchOptions", () => {
+  beforeEach(() => {
+    mountBody(SEARCH_FIXTURE);
+  });
+
+  it("populates sort, num, lang and label selects from config", () => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    _state.sort = "last_modified.desc";
+    _state.num = 20;
+    _state.lang = ["ja"];
+    _state.fields = { label: ["lblB"] };
+    renderSearchOptions();
+
+    const sort = document.getElementById("sortSearchOption");
+    expect(sort.options.length).toBe(2); // placeholder + last_modified.desc
+    expect(sort.value).toBe("last_modified.desc");
+
+    const num = document.getElementById("numSearchOption");
+    expect(Array.from(num.options).map((o) => o.value)).toEqual(["10", "20", "50"]);
+    expect(num.value).toBe("20");
+
+    const lang = document.getElementById("langSearchOption");
+    expect(lang.hasAttribute("multiple")).toBe(true);
+    expect(lang.getAttribute("size")).toBe("4");
+    // Intl.DisplayNames resolves the human names for ja/en.
+    const langText = lang.textContent;
+    expect(langText).toContain("Japanese");
+    expect(langText).toContain("English");
+    expect(Array.from(lang.selectedOptions).map((o) => o.value)).toContain("ja");
+
+    const label = document.getElementById("labelSearchOption");
+    expect(Array.from(label.options).map((o) => o.textContent)).toEqual(["Label A", "Label B"]);
+    expect(Array.from(label.selectedOptions).map((o) => o.value)).toEqual(["lblB"]);
+    expect(document.getElementById("labelSearchOptionFieldset").classList.contains("d-none")).toBe(false);
+  });
+
+  it("falls back to a single default sort option when config has none", () => {
+    api.getConfig.mockReturnValue({ features: {} });
+    _state.sort = "";
+    renderSearchOptions();
+    const sort = document.getElementById("sortSearchOption");
+    // placeholder (value="") + the score.desc fallback.
+    expect(Array.from(sort.options).map((o) => o.value)).toEqual(["", "score.desc"]);
+  });
+
+  it("falls back to [10,20,50] num options when config has none", () => {
+    api.getConfig.mockReturnValue({ features: {} });
+    renderSearchOptions();
+    expect(Array.from(document.getElementById("numSearchOption").options).map((o) => o.value)).toEqual(["10", "20", "50"]);
+  });
+
+  it("does not add its own All-Languages option when the server supplies an all sentinel", () => {
+    api.getConfig.mockReturnValue({ features: {}, lang_options: [{ value: "all" }, { value: "ja" }] });
+    _state.lang = [];
+    renderSearchOptions();
+    const opts = Array.from(document.getElementById("langSearchOption").options);
+    // server "all" is mapped to value="" — exactly one empty-value option, not two.
+    expect(opts.filter((o) => o.value === "").length).toBe(1);
+  });
+
+  it("hides the label fieldset when display_label_type is disabled", () => {
+    api.getConfig.mockReturnValue({ features: { display_label_type: false }, label_options: [{ value: "lblA", label: "A" }] });
+    renderSearchOptions();
+    expect(document.getElementById("labelSearchOptionFieldset").classList.contains("d-none")).toBe(true);
+    expect(document.getElementById("labelSearchOption").options.length).toBe(0);
+  });
+
+  it("initSearchOptions delegates to renderSearchOptions", () => {
+    api.getConfig.mockReturnValue(FULL_CFG);
+    initSearchOptions();
+    expect(document.getElementById("numSearchOption").options.length).toBe(3);
+  });
+});
+
+describe("attachSuggest", () => {
+  afterEach(() => vi.useRealTimers());
+
+  function mountSuggest() {
+    mountBody('<form><input id="sg"><ul id="sgd" class="d-none"></ul></form>');
+    return { input: document.getElementById("sg"), dd: document.getElementById("sgd"), form: document.querySelector("form") };
+  }
+
+  it("renders suggestion items after the 150ms debounce and marks the input expanded", async () => {
+    vi.useFakeTimers();
+    api.get.mockResolvedValue({ suggest_words: [{ text: "sug1" }, { text: "sug2" }] });
+    const { input, dd } = mountSuggest();
+    attachSuggest(input, dd);
+    input.value = "he";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    const items = dd.querySelectorAll("li.list-group-item");
+    expect(items.length).toBe(2);
+    expect(items[0].textContent).toBe("sug1");
+    expect(items[0].id).toBe("sg-suggest-0");
+    expect(dd.classList.contains("d-none")).toBe(false);
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("requests /suggest-words with the debounced query and default fields", async () => {
+    vi.useFakeTimers();
+    api.get.mockResolvedValue({ suggest_words: [{ text: "x" }] });
+    const { input, dd } = mountSuggest();
+    attachSuggest(input, dd);
+    input.value = "  foo  ";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    const call = api.get.mock.calls.find((c) => c[0] === "/suggest-words");
+    expect(call[1]).toMatchObject({ q: "foo", num: 10, fn: ["_default", "content", "title"] });
+  });
+
+  it("includes lang params when opts.lang is a getter returning codes", async () => {
+    vi.useFakeTimers();
+    api.get.mockResolvedValue({ suggest_words: [{ text: "x" }] });
+    const { input, dd } = mountSuggest();
+    attachSuggest(input, dd, { lang: () => ["ja", "en"] });
+    input.value = "foo";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    const call = api.get.mock.calls.find((c) => c[0] === "/suggest-words");
+    expect(call[1].lang).toEqual(["ja", "en"]);
+  });
+
+  it("hides the dropdown when the query becomes empty", async () => {
+    vi.useFakeTimers();
+    api.get.mockResolvedValue({ suggest_words: [{ text: "x" }] });
+    const { input, dd } = mountSuggest();
+    attachSuggest(input, dd);
+    input.value = "";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(dd.classList.contains("d-none")).toBe(true);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("hides the dropdown when the API returns no suggestions", async () => {
+    vi.useFakeTimers();
+    api.get.mockResolvedValue({ suggest_words: [] });
+    const { input, dd } = mountSuggest();
+    attachSuggest(input, dd);
+    input.value = "he";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(dd.classList.contains("d-none")).toBe(true);
+  });
+
+  it("fills the input and keeps focus on mousedown-select (no submit by default)", async () => {
+    vi.useFakeTimers();
+    api.get.mockResolvedValue({ suggest_words: [{ text: "picked" }] });
+    const { input, dd, form } = mountSuggest();
+    const submitSpy = vi.fn();
+    form.addEventListener("submit", (e) => { e.preventDefault(); submitSpy(); });
+    attachSuggest(input, dd);
+    input.value = "pi";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    dd.querySelector("li").dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    expect(input.value).toBe("picked");
+    expect(dd.classList.contains("d-none")).toBe(true);
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
+
+  it("submits the form on select when submitOnSelect is set", async () => {
+    vi.useFakeTimers();
+    api.get.mockResolvedValue({ suggest_words: [{ text: "picked" }] });
+    const { input, dd, form } = mountSuggest();
+    const submitSpy = vi.fn();
+    form.addEventListener("submit", (e) => { e.preventDefault(); submitSpy(); });
+    attachSuggest(input, dd, { submitOnSelect: true });
+    input.value = "pi";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    dd.querySelector("li").dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    expect(input.value).toBe("picked");
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the dropdown on blur after the grace delay", async () => {
+    vi.useFakeTimers();
+    api.get.mockResolvedValue({ suggest_words: [{ text: "x" }] });
+    const { input, dd } = mountSuggest();
+    attachSuggest(input, dd);
+    input.value = "he";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(dd.classList.contains("d-none")).toBe(false);
+    input.dispatchEvent(new Event("blur"));
+    await vi.advanceTimersByTimeAsync(120);
+    expect(dd.classList.contains("d-none")).toBe(true);
+  });
+
+  it("is a no-op when input or dropdown is missing", () => {
+    expect(() => attachSuggest(null, document.createElement("ul"))).not.toThrow();
+    expect(() => attachSuggest(document.createElement("input"), null)).not.toThrow();
+  });
+});
+
+// attach() has a module-level `attached` guard, so its body runs exactly once
+// for the whole test module. All the wiring it installs is therefore exercised
+// inside this single test (subsequent resetDom() calls drop the wired elements).
+describe("attach — wiring", () => {
+  afterEach(() => vi.useRealTimers());
+
+  const ATTACH_FIXTURE = `
+    <form id="search-form">
+      <input id="query">
+      <button id="searchButton" type="button"></button>
+    </form>
+    <ul id="suggest-dropdown" class="d-none"></ul>
+    <div id="home-view"></div>
+    <input id="contentQuery">
+    <input id="queryId"><input id="rt">
+    <button id="searchOptionsClearButton"></button>
+    <div id="searchOptions"><button type="submit">go</button></div>
+    <input id="geo-lat"><input id="geo-lon"><input id="geo-distance">
+    <div id="popular-words" class="d-none"></div>
+    <div id="search-loading" class="d-none"></div>
+    <div id="search-error" class="d-none"></div>
+    <div id="results-warning" class="d-none"></div>
+    <div id="results-status"></div>
+    <div id="similar-doc-banner" class="d-none"></div>
+    <ul id="results"></ul>
+    <div id="results-meta"></div>
+    <div id="empty-state" class="d-none"><span id="empty-did-not-match"></span></div>
+    <div id="results-popular-words" class="d-none"></div>
+    <nav id="subfooter" class="d-none"><ul id="pagination"></ul></nav>
+    <div id="facet-body" class="d-none"></div>
+    <div id="facet-body-mobile"></div>
+    <div id="facet-toggle-wrap"></div>
+    <a id="facet-clear" class="d-none"></a>
+    <div id="active-chips" class="d-none"></div>
+    <ul id="current-filters"></ul>
+    <ul id="options-bar"></ul>
+    <div id="related-queries" class="d-none"></div>
+    <div id="related-content" class="d-none"></div>
+    <select id="sortSearchOption"></select>
+    <select id="numSearchOption"></select>
+    <select id="langSearchOption"></select>
+    <fieldset id="labelSearchOptionFieldset"><select id="labelSearchOption"></select></fieldset>
+  `;
+
+  it("wires the header form, drawer buttons, facet clear and header suggest", async () => {
+    vi.useFakeTimers();
+    api.getConfig.mockReturnValue(FULL_CFG);
+    installApiDispatch();
+    setLocation("/"); // no q → attach() loads popular words and populates the input from nothing
+    mountBody(ATTACH_FIXTURE);
+
+    attach();
+    await vi.advanceTimersByTimeAsync(0); // flush loadPopularWords / renderSearchOptions
+
+    // attach() populated the option selects from config.
+    expect(document.getElementById("numSearchOption").options.length).toBe(3);
+    // and rendered popular words.
+    expect(document.getElementById("popular-words").querySelectorAll("a[data-spa]").length).toBe(4);
+
+    // 1. Header form submit → navigate to /search?q=..., syncs inputs, disables the button.
+    document.getElementById("query").value = "hello";
+    document.getElementById("search-form").dispatchEvent(new Event("submit", { cancelable: true }));
+    expect(navigate).toHaveBeenCalled();
+    expect(navigate.mock.calls.at(-1)[0]).toContain("q=hello");
+    expect(document.getElementById("contentQuery").value).toBe("hello");
+    expect(document.getElementById("searchButton").disabled).toBe(true);
+
+    // 2. Drawer "Clear" button → resets the option selects (no re-search).
+    const numSel = document.getElementById("numSearchOption");
+    numSel.selectedIndex = 2;
+    document.getElementById("searchOptionsClearButton").click();
+    expect(numSel.selectedIndex).toBe(0);
+
+    // 3. Drawer "Search" button → navigate using the home query (home-view visible).
+    navigate.mockClear();
+    document.getElementById("contentQuery").value = "drawerq";
+    document.querySelector('#searchOptions button[type="submit"]').click();
+    expect(navigate).toHaveBeenCalled();
+    expect(navigate.mock.calls.at(-1)[0]).toContain("q=drawerq");
+
+    // 4. Facet "Clear" button → resets filters and re-runs the search.
+    const beforeSearch = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    document.getElementById("facet-clear").click();
+    await vi.advanceTimersByTimeAsync(20);
+    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(beforeSearch + 1);
+
+    // 5. Header suggest: typing renders items after the 150ms debounce.
+    const input = document.getElementById("query");
+    input.value = "he";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    const dropdown = document.getElementById("suggest-dropdown");
+    expect(dropdown.querySelectorAll(".list-group-item").length).toBe(2);
+    expect(dropdown.classList.contains("d-none")).toBe(false);
+
+    // 6. ArrowDown highlights the first item; Escape collapses the dropdown.
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(dropdown.querySelector(".list-group-item.active")).not.toBeNull();
+    expect(input.getAttribute("aria-activedescendant")).toBe("suggest-item-0");
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(dropdown.classList.contains("d-none")).toBe(true);
+
+    // 7. Dropdown mousedown selects the item and submits the header form.
+    input.value = "he";
+    input.dispatchEvent(new Event("input"));
+    await vi.advanceTimersByTimeAsync(150);
+    navigate.mockClear();
+    dropdown.querySelector(".list-group-item").dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    expect(input.value).toBe("sug1");
+    expect(navigate).toHaveBeenCalled(); // submit handler navigated
+  });
+
+  it("is idempotent — a second attach() call is a quiet no-op", () => {
+    expect(() => attach()).not.toThrow();
+  });
+});

--- a/src/test/js/themes/bootstrap/search.test.js
+++ b/src/test/js/themes/bootstrap/search.test.js
@@ -299,7 +299,6 @@ describe("clearSearchState / _state", () => {
     s.facets = { a: [1] }; s.fields = { label: ["x"] }; s.facetQueries = ["fq"]; s.exQ = ["e"];
     s.geo = { lat: "1", lon: "2", distance: "3" }; s.requestedTime = 99; s.highlightParams = "&hl";
 
-    const ref = _state;
     clearSearchState();
 
     expect(_state.q).toBe("");
@@ -321,9 +320,6 @@ describe("clearSearchState / _state", () => {
     expect(document.getElementById("contentQuery").value).toBe("");
     expect(document.getElementById("numSearchOption").selectedIndex).toBe(0);
     expect(document.getElementById("sortSearchOption").selectedIndex).toBe(0);
-
-    // The exported _state alias points at the same object.
-    expect(ref).toBe(_state);
   });
 });
 
@@ -355,7 +351,7 @@ describe("runFromUrl", () => {
     setLocation("/search?q=foo&start=20&num=50&sort=x&lang=ja&lang=en&fields.label=A&ex_q=cl");
 
     runFromUrl();
-    await new Promise((r) => setTimeout(r, 5));
+    await new Promise((r) => setTimeout(r));
 
     expect(_state.q).toBe("foo");
     expect(_state.start).toBe(20);
@@ -492,8 +488,11 @@ function installApiDispatch(overrides = {}) {
   });
 }
 
-/** Await a couple of macrotasks so fire-and-forget helpers (popular words, related) settle. */
-const settle = () => new Promise((r) => setTimeout(r, 20));
+/** Yield a macrotask so fire-and-forget helpers (popular words, related) settle. */
+const settle = () => new Promise((r) => setTimeout(r));
+
+/** How many "/search" API calls have been made so far. */
+const searchCalls = () => api.get.mock.calls.filter((c) => c[0] === "/search").length;
 
 describe("runSearch — successful render", () => {
   beforeEach(() => {
@@ -787,12 +786,12 @@ describe("runSearch — active filters, chips and current filters", () => {
   it("re-runs the search and drops the filter when a chip remove button is clicked", async () => {
     await runSearch();
     await settle();
-    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const before = searchCalls();
     // First chip is the label:lblA facet; its remove button clears it.
     const removeBtn = document.querySelector("#active-chips .active-chip-remove");
     removeBtn.click();
     await settle();
-    const after = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const after = searchCalls();
     expect(after).toBe(before + 1);
   });
 
@@ -823,10 +822,10 @@ describe("runSearch — active filters, chips and current filters", () => {
     expect(document.getElementById("facet-clear").classList.contains("d-none")).toBe(false);
     const reset = document.querySelector("#facet-body .facet-reset");
     expect(reset).not.toBeNull();
-    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const before = searchCalls();
     reset.click();
     await settle();
-    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+    expect(searchCalls()).toBe(before + 1);
     expect(_state.facets).toEqual({});
     expect(_state.facetQueries).toEqual([]);
   });
@@ -852,10 +851,10 @@ describe("runSearch — facet and pagination click handlers", () => {
     installApiDispatch({ search: makeSearchEnv([{ doc_id: "d1", title: "T", url: "https://e.com/1" }]) });
     await runSearch();
     await settle();
-    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const before = searchCalls();
     document.querySelector("#facet-body ul li.list-group-item a").click();
     await settle();
-    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+    expect(searchCalls()).toBe(before + 1);
     expect(_state.facets.label).toContain("lblA");
     expect(_state.start).toBe(0);
   });
@@ -865,10 +864,10 @@ describe("runSearch — facet and pagination click handlers", () => {
     _state.start = 10;
     await runSearch();
     await settle();
-    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const before = searchCalls();
     document.querySelector("#pagination li:last-child a").click();
     await settle();
-    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+    expect(searchCalls()).toBe(before + 1);
     expect(_state.start).toBe(20);
   });
 
@@ -889,10 +888,10 @@ describe("runSearch — facet and pagination click handlers", () => {
     _state.start = 0;
     await runSearch();
     await settle();
-    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const before = searchCalls();
     document.querySelector("#pagination li:first-child a").click();
     await settle();
-    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before);
+    expect(searchCalls()).toBe(before);
   });
 });
 
@@ -935,11 +934,11 @@ describe("runSearch — favorites and similar docs", () => {
     const banner = document.getElementById("similar-doc-banner");
     expect(banner.classList.contains("d-flex")).toBe(true);
     expect(banner.textContent).toContain("labels.similar_doc_result_status");
-    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const before = searchCalls();
     banner.querySelector("button.btn-close").click();
     await settle();
     expect(_state.sdh).toBe("");
-    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+    expect(searchCalls()).toBe(before + 1);
   });
 
   it("renders a similar link that starts a similarity search on click", async () => {
@@ -951,11 +950,11 @@ describe("runSearch — favorites and similar docs", () => {
     await settle();
     const link = document.querySelector("#result0 a.similar");
     expect(link).not.toBeNull();
-    const before = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const before = searchCalls();
     link.click();
     await settle();
     expect(_state.sdh).toBe("h1");
-    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(before + 1);
+    expect(searchCalls()).toBe(before + 1);
   });
 });
 
@@ -1262,10 +1261,10 @@ describe("attach — wiring", () => {
     expect(navigate.mock.calls.at(-1)[0]).toContain("q=drawerq");
 
     // 4. Facet "Clear" button → resets filters and re-runs the search.
-    const beforeSearch = api.get.mock.calls.filter((c) => c[0] === "/search").length;
+    const beforeSearch = searchCalls();
     document.getElementById("facet-clear").click();
     await vi.advanceTimersByTimeAsync(20);
-    expect(api.get.mock.calls.filter((c) => c[0] === "/search").length).toBe(beforeSearch + 1);
+    expect(searchCalls()).toBe(beforeSearch + 1);
 
     // 5. Header suggest: typing renders items after the 150ms debounce.
     const input = document.getElementById("query");

--- a/src/test/js/vitest.config.js
+++ b/src/test/js/vitest.config.js
@@ -1,0 +1,42 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+// The bundled bootstrap theme JS is authored as native ES modules that call
+// browser APIs (document, window, URL, ...). jsdom supplies a spec-compliant
+// DOM so the real, unmodified asset files can be imported and executed here.
+//
+// Those asset files live in src/main/webapp/... — outside this directory — so
+// the Vitest root is the repository root. That lets coverage instrument the
+// real shipped files (v8 only instruments files under the root) while the tests
+// keep importing them by relative path.
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const assets = "src/main/webapp/themes/bootstrap/assets";
+
+export default defineConfig({
+  root: repoRoot,
+  // Keep Vite's cache inside the (git-ignored) test node_modules rather than
+  // creating a node_modules/.vite at the repo root, which root:repoRoot would
+  // otherwise do.
+  cacheDir: fileURLToPath(new URL("./node_modules/.vitest", import.meta.url)),
+  server: { fs: { allow: [repoRoot] } },
+  test: {
+    environment: "jsdom",
+    include: ["src/test/js/themes/**/*.test.js"],
+    coverage: {
+      provider: "v8",
+      // Instrument every shipped asset (all:true) so a new module without a
+      // test drags coverage down and trips the gate, not just the loaded ones.
+      all: true,
+      include: [`${assets}/*.js`],
+      reporter: ["text", "text-summary"],
+      // Regression gate: kept a few points below the achieved numbers so honest
+      // refactors don't trip it, while a real coverage drop fails the build.
+      thresholds: {
+        statements: 78,
+        lines: 80,
+        functions: 78,
+        branches: 60,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

`BundledBootstrapThemeTest` verified the bundled bootstrap theme's JavaScript by reading each file as text and asserting on substrings (`js.contains("...")`). That cannot observe what the code actually *does* — a construct can be present in source yet produce output that is stripped downstream.

This PR adds an executable vitest+jsdom test harness that imports and runs the **real, shipped** asset files, fixes a live rendering bug the tests immediately caught, and now puts **every** theme JS module under executable test with an enforced coverage gate.

## The bug (fixed here)

`parseMarkdown()` emits `<h1>`..`<h6>`, and `chat.js` pipes every rendered assistant message through `sanitizeHtml()`. But the sanitizer's `ALLOWED_TAGS` whitelist listed only `H2`/`H3`/`H4`, so **h1, h5 and h6 headings were silently unwrapped and lost before display**. The former string-match test `test_markdownJs_h1ThroughH6` asserted the *source* regex accepts `#{1,6}` and passed the whole time, never observing that the output was discarded. Fix: add `H1`/`H5`/`H6` to `ALLOWED_TAGS`; bootstrap theme version bumped `1.0.2` → `1.0.3`.

## Test harness — all 14 modules

Executable tests under `src/test/js/` (vitest + jsdom, Node 22) that import the unmodified asset files. **Every JavaScript module shipped in `assets/` now has a test** (`all: true` coverage, so a new module without a test fails the build):

| Module | What is exercised |
|---|---|
| format / markdown / pipeline | escaping, file-size/date, `isSafeHref`, `sanitizeHtml` (subtree drop, attr/scheme filtering), snippet sanitizers; `parseMarkdown`; the `parseMarkdown → sanitizeHtml` chat pipeline |
| api | `/api/v2` client: envelope unwrap, error/network taxonomy, CSRF, SSE frame parsing via a fake stream reader |
| router / i18n | hash router (push/replace/dispatch/data-spa intercept); locale resolution, substitution, `applyDom`, `init` |
| error / auth / profile | path→code mapping + rendered view; login/probe flows + dropdown/CSRF; password-error localization + submit flow |
| advance / chat | query composition (none→NOT, OR-grouping, filetype quoting, timestamp date-math); chat request-body/phase/filter model, source-icon mapping |
| cache / help | sandboxed-iframe + `<base>` injection + hq forwarding; help fetch/fallback + sanitized sections |
| search / app | `runSearch` result/facet/pagination/related rendering through a full DOM fixture; suggest; boot (`main`) + route registration + home flash |

To make buried pure logic testable, behaviour-preserving `export` keywords were added to already-standalone functions (no logic changes; the Java string-match suite still passes 120/120).

## Coverage (enforced by `npm test`)

Across the 14 modules: **84% lines, 82% functions, 81% statements, 65% branches** (format/markdown/i18n/profile/help at/near 100%; the DOM-heavy `chat.js`/`advance.js` are the lowest at ~67–70% lines). `vitest.config.js` declares thresholds, so a coverage regression fails the build. **407 tests, all passing.**

### Why Node + jsdom, and why `src/test/js/`

The theme JS is native ES modules calling browser APIs; JVM engines can't parse ES modules and DOM-less runners can't exercise the sanitizer. `src/main/webapp/themes/bootstrap/` is packaged into the WAR/deb/rpm and served to anonymous users, so tooling there would ship and be exposed — `src/test/` never packages, mirroring the existing `src/test/resources/themes/fixture-minimal/`.

## CI and build impact

- New workflow `.github/workflows/theme-js.yml` runs `npm ci && npm test` under `src/test/js` on Node 22 (green).
- The Maven build (`maven.yml`) is **unchanged**; `node_modules/` and the Vite cache are git-ignored.

## Verification

- `src/test/js`: `npm ci` + `npm test` → 407 passed, coverage thresholds met.
- `BundledBootstrapThemeTest.java` compiles and runs green (120/120) against the modified sources.

## Follow-ups (separate repos / out of scope)

- The same `H2`/`H3`/`H4`-only whitelist exists in all 10 derived themes in `codelibs/fess-themes`.
- Minor pre-existing quirks surfaced by the new tests (not fixed here): `chat.js` source-icon maps OpenDocument/OOXML spreadsheet/presentation mimetypes to the Word icon (the "document" substring is matched first); `search.js`'s private `safeHref` allowlist differs from `format.js`'s `isSafeHref` (ftp vs mailto/tel).
