### PR TITLE
fix(theme/bootstrap): accessible copy-URL button and shared-asset hygiene

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/format.js
+++ b/src/main/webapp/themes/bootstrap/assets/format.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Common formatting utilities for the Fess bootstrap SPA.
+// Common formatting utilities for the Fess static theme SPA.
 // Importing is DOM-free; calling is not. Only formatFileSize / formatDate /
 // escapeHtml are pure — sanitizeHtml, renderHighlightedSnippet and
 // renderSnippetText parse via document, and isSafeHref needs window.location.
@@ -228,9 +228,14 @@ export function isSafeHref(value) {
   if (cleaned === "") return false;
   try {
     return SAFE_HREF_SCHEMES.has(new URL(cleaned, window.location.href).protocol);
-  } catch {
-    // Malformed URL — treat as unsafe.
-    return false;
+  } catch (e) {
+    if (e instanceof TypeError) {
+      // Malformed URL — treat as unsafe.
+      return false;
+    }
+    // A missing DOM (no window/location) is a broken environment, not an unsafe
+    // URL; surface it instead of laundering it into a false "unsafe" verdict.
+    throw e;
   }
 }
 

--- a/src/main/webapp/themes/bootstrap/assets/markdown.js
+++ b/src/main/webapp/themes/bootstrap/assets/markdown.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Minimal in-repo Markdown renderer for the Fess bootstrap SPA.
+// Minimal in-repo Markdown renderer for the Fess static theme SPA.
 // Produces HTML from a safe subset of Markdown. All input is HTML-escaped
 // before pattern substitution — no raw user strings appear in output.
 // The caller MUST pass the return value through sanitizeHtml() before

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -165,9 +165,13 @@ function buildResultCard(d, queryId, order) {
   //   li#result{n}
   //     h3.title.text-truncate > a.link[data-uri,data-id,data-order]
   //     div.body > (div.me-3 > a.link.d-none.d-sm-flex > img.thumbnail)? + div.description
-  //     div.site.text-truncate > (i.far.fa-copy.url-copy)? + cite
+  //     div.site.text-truncate > (button.url-copy-btn > i.far.fa-copy.url-copy)? + cite
   //     div.more > a
   //     div.info > date + (size) + (cache)
+  // Deliberate divergence on the copy control: the JSP still emits it as a bare
+  // <i aria-hidden="true">, which is absent from the accessibility tree and
+  // unreachable by keyboard. This theme wraps the glyph in a real <button>, so
+  // a11y wins over tag-parity for that one row.
   const cfg = api.getConfig() || {};
   const features = cfg.features || {};
   const idx0 = order - 1;
@@ -235,24 +239,37 @@ function buildResultCard(d, queryId, order) {
   const site = el("div", { className: "site text-truncate" });
   if (features.clipboard_copy_icon) {
     const rawUrl = d.url_link || d.url || "";
+    // A real <button>, not an <i> carrying role="button": the element that takes
+    // focus has to be the one that carries the role and the accessible name, and
+    // only a button gets keyboard activation (Enter/Space) without hand-rolling a
+    // keydown handler. The previous markup also set aria-hidden="true" on the same
+    // element as role/aria-label, which removed the control from the accessibility
+    // tree entirely — so it was both invisible to assistive tech and unreachable by
+    // keyboard. The glyph inside stays aria-hidden and keeps the url-copy /
+    // url-copied classes, so each theme's existing colour rules apply unchanged.
     const copyIcon = el("i", {
-      className: "far fa-copy url-copy d-print-none",
-      attrs: { "aria-hidden": "true", "data-clipboard-text": rawUrl, role: "button", "aria-label": t("result.copy_url") + ": " + rawUrl }
+      className: "far fa-copy url-copy",
+      attrs: { "aria-hidden": "true" }
     });
-    copyIcon.addEventListener("click", () => {
+    const copyBtn = el("button", {
+      className: "url-copy-btn d-print-none",
+      attrs: { type: "button", "data-clipboard-text": rawUrl, "aria-label": t("result.copy_url") + ": " + rawUrl }
+    });
+    copyBtn.appendChild(copyIcon);
+    copyBtn.addEventListener("click", () => {
       copyToClipboard(rawUrl).then(() => {
         // JSP parity (js/search.js): swap the copy icon to a green checkmark for ~2s.
         copyIcon.classList.remove("url-copy", "far", "fa-copy");
         copyIcon.classList.add("url-copied", "fas", "fa-check");
-        copyIcon.setAttribute("aria-label", t("result.copied"));
+        copyBtn.setAttribute("aria-label", t("result.copied"));
         setTimeout(() => {
           copyIcon.classList.remove("url-copied", "fas", "fa-check");
           copyIcon.classList.add("url-copy", "far", "fa-copy");
-          copyIcon.setAttribute("aria-label", t("result.copy_url") + ": " + rawUrl);
+          copyBtn.setAttribute("aria-label", t("result.copy_url") + ": " + rawUrl);
         }, 2000);
       }).catch(() => { /* clipboard not available */ });
     });
-    site.appendChild(copyIcon);
+    site.appendChild(copyBtn);
     // JSP has whitespace between the copy icon and the cite — keep them from touching.
     site.appendChild(document.createTextNode(" "));
   }
@@ -1294,27 +1311,6 @@ export function attach() {
       form.dispatchEvent(new Event("submit"));
     });
   }
-  const clearBtn = document.getElementById("facet-clear");
-  if (clearBtn) clearBtn.addEventListener("click", () => {
-    state.facets = {};
-    state.fields = {};
-    state.facetQueries = [];
-    // GEO-1: reset geo state and inputs
-    state.geo = { lat: "", lon: "", distance: "" };
-    ["geo-lat", "geo-lon", "geo-distance"].forEach(id => { const el = document.getElementById(id); if (el) el.value = ""; });
-    // Reset selects: label multi-select deselects all (selectedIndex = -1);
-    // sort and num return to their "all / default" first option (selectedIndex = 0).
-    const sortSel = document.getElementById("sortSearchOption");
-    if (sortSel) { sortSel.selectedIndex = 0; state.sort = sortSel.value || ""; }
-    const numSel = document.getElementById("numSearchOption");
-    if (numSel) { numSel.selectedIndex = 0; state.num = Number(numSel.value) || 10; }
-    const langSel = document.getElementById("langSearchOption");
-    if (langSel) { langSel.selectedIndex = -1; state.lang = []; }
-    const labelSel = document.getElementById("labelSearchOption");
-    if (labelSel) { Array.from(labelSel.options).forEach(o => { o.selected = false; }); }
-    runSearch();
-  });
-
   // Geo filter apply/clear is handled by the drawer's main Search / Clear buttons
   // (geo inputs were migrated into #searchOptions); no separate geo buttons.
 
@@ -1402,10 +1398,23 @@ function renderFacetQueryViews(body, env) {
   const views = cfg.facet_views || [];
   const countByValue = {};
   (env.facet_query || []).forEach(fq => { countByValue[fq.value] = fq.count; });
+  // Distinguish "no counts were sent" from "the count is 0": under rank fusion (and
+  // whenever facetResponse is null) the v2 API omits facet_query entirely, so
+  // countByValue is empty. A `> 0` filter would then drop every option and collapse the
+  // group to a bare header. hasOwnProperty (not a truthiness test — a real count of 0 is
+  // falsy) tells the two apart: when every option carries a count we suppress the zero
+  // ones and show badges; when counts are absent we fall back to the full, count-free,
+  // still-clickable list with no badges.
+  const hasCountsFor = queries =>
+    queries.length > 0 && queries.every(qy => Object.prototype.hasOwnProperty.call(countByValue, qy.value));
   views.forEach(view => {
     const groupTitleKey = view.group_name || "";
     const title = groupTitleKey.startsWith("labels.") ? t(groupTitleKey) : groupTitleKey;
-    const queries = (view.queries || []).filter(qy => Number(countByValue[qy.value]) > 0);
+    const allQueries = view.queries || [];
+    const withCounts = hasCountsFor(allQueries);
+    const queries = withCounts
+      ? allQueries.filter(qy => Number(countByValue[qy.value]) > 0 || (state.facetQueries || []).includes(qy.value))
+      : allQueries;
     // ul.list-group.mb-2 > li.list-group-item.text-uppercase(title) + entries.
     // A group with no matching results still renders its title li (JSP parity:
     // the sidebar keeps the group header even when empty).
@@ -1417,7 +1426,9 @@ function renderFacetQueryViews(body, env) {
       const a = el("a", { attrs: { href: "#" } });
       const label = qy.label_key && qy.label_key.startsWith("labels.") ? t(qy.label_key) : (qy.label_key || qy.value);
       a.appendChild(document.createTextNode(label + " "));
-      a.appendChild(el("span", { className: "badge rounded-pill text-bg-secondary float-end", text: String(countByValue[qy.value]) }));
+      if (withCounts) {
+        a.appendChild(el("span", { className: "badge rounded-pill text-bg-secondary float-end", text: String(Number(countByValue[qy.value]) || 0) }));
+      }
       a.addEventListener("click", ev => {
         ev.preventDefault();
         const arr = state.facetQueries ? [...state.facetQueries] : [];
@@ -1436,24 +1447,30 @@ function renderFacetQueryViews(body, env) {
 
 function renderFacets(env, labels) {
   const body = document.getElementById("facet-body");
-  const clearBtn = document.getElementById("facet-clear");
   if (!body) return;
   // Clear existing children without innerHTML = ""
   while (body.firstChild) body.removeChild(body.firstChild);
 
   // ZERO-RESULT: hide the whole facet sidebar (desktop aside + mobile filter button)
-  // when the search returned no documents — there is nothing to refine, so an empty
-  // sidebar is just noise. #facet-body keeps its base "d-none" (mobile-hidden) class;
-  // toggling "d-md-block" controls its desktop visibility. The mobile filter toggle
+  // only when the search returned no documents AND no filter is applied — there is
+  // nothing to refine, so an empty sidebar would be just noise. With a filter applied
+  // the zero may well have been CAUSED by it, and the sidebar carries the only controls
+  // that undo it (the active option itself, plus the reset link at its foot), so it
+  // stays mounted. #facet-body keeps its base "d-none" (mobile-hidden) class; toggling
+  // "d-md-block" controls its desktop visibility. The mobile filter toggle
   // (#facet-toggle-wrap) is hidden outright with "d-none".
   const mobileBody = document.getElementById("facet-body-mobile");
   const toggleWrap = document.getElementById("facet-toggle-wrap");
   const hasResults = (env.data || []).length > 0;
-  body.classList.toggle("d-md-block", hasResults);
-  if (toggleWrap) toggleWrap.classList.toggle("d-none", !hasResults);
-  if (!hasResults) {
+  const anyActive =
+    Object.values(state.facets).some(arr => Array.isArray(arr) && arr.length > 0) ||
+    Object.values(state.fields).some(arr => Array.isArray(arr) && arr.length > 0) ||
+    (Array.isArray(state.facetQueries) && state.facetQueries.length > 0);
+  const showFacets = hasResults || anyActive;
+  body.classList.toggle("d-md-block", showFacets);
+  if (toggleWrap) toggleWrap.classList.toggle("d-none", !showFacets);
+  if (!showFacets) {
     if (mobileBody) while (mobileBody.firstChild) mobileBody.removeChild(mobileBody.firstChild);
-    if (clearBtn) clearBtn.classList.add("d-none");
     return;
   }
 
@@ -1487,13 +1504,6 @@ function renderFacets(env, labels) {
   //    no separate field-based filetype group (that produced a duplicate
   //    "ファイル種別" with no counts).
   renderFacetQueryViews(body, env);
-
-  // Show clear button if any filter is active (optional control; may be absent).
-  const anyActive =
-    Object.values(state.facets).some(arr => Array.isArray(arr) && arr.length > 0) ||
-    Object.values(state.fields).some(arr => Array.isArray(arr) && arr.length > 0) ||
-    (Array.isArray(state.facetQueries) && state.facetQueries.length > 0);
-  if (clearBtn) clearBtn.classList.toggle("d-none", !anyActive);
 
   // Mirror the rendered facet groups into the mobile offcanvas (#facet-body-mobile).
   // The desktop aside (#facet-body) is the source of truth; clone its <ul> groups and

--- a/src/main/webapp/themes/bootstrap/assets/styles.css
+++ b/src/main/webapp/themes/bootstrap/assets/styles.css
@@ -270,6 +270,13 @@ footer[role="contentinfo"] {
 #result .more { display: none; }
 /* Info line (date / size / cache / similar / favorite) is small. */
 #result .info { font-size: 80%; }
+/* The copy control is a <button> so it is focusable and keyboard-operable;
+   strip the UA's button chrome so it still reads as a bare icon. The glyph
+   inside keeps .url-copy/.url-copied, so the colour rules below still apply.
+   vertical-align:middle keeps the inline-block button aligned with the adjacent
+   <cite> text (an inline <i> baseline-aligns differently). The focus ring comes
+   from the global :focus-visible rule. */
+#result .url-copy-btn { background: none; border: 0; padding: 0; margin: 0; font: inherit; line-height: 1; vertical-align: middle; color: inherit; cursor: pointer; }
 #result .url-copy { color: #007bff; }
 #result .url-copied { color: #2c974b; }
 #result .favorited { display: none; }

--- a/src/main/webapp/themes/bootstrap/theme.yml
+++ b/src/main/webapp/themes/bootstrap/theme.yml
@@ -2,7 +2,7 @@ apiVersion: fess.codelibs.org/v1
 kind: StaticTheme
 name: bootstrap
 displayName: "Bootstrap"
-version: "1.0.3"
+version: "1.0.4"
 author: "CodeLibs Project"
 description: "Reference static theme for Fess. Bootstrap 5-based vanilla-JS SPA exercising /api/v2/*."
 license: "Apache-2.0"

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -1236,8 +1236,10 @@ public class BundledBootstrapThemeTest {
     @Test
     public void test_searchJs_copyAndCacheArePrintHidden() throws Exception {
         final String js = Files.readString(THEME_DIR.resolve("assets/search.js"), StandardCharsets.UTF_8);
-        // Copy-URL button: className string must contain both the base class and d-print-none
-        assertTrue(js.contains("url-copy d-print-none"), "search.js copy-url button className must include d-print-none (parity R4 GAP-G)");
+        // Copy-URL button: d-print-none sits on the <button> wrapper; the glyph is its
+        // descendant, so display:none on the button hides the icon with it.
+        assertTrue(js.contains("url-copy-btn d-print-none"),
+                "search.js copy-url button className must include d-print-none (parity R4 GAP-G)");
         // Cache link: className string must contain d-print-none
         assertTrue(js.contains("cache d-print-none"), "search.js cache link className must include d-print-none (parity R4 GAP-G)");
     }

--- a/src/test/js/themes/bootstrap/format.nodom.test.js
+++ b/src/test/js/themes/bootstrap/format.nodom.test.js
@@ -1,0 +1,20 @@
+// @vitest-environment node
+// SPDX-License-Identifier: Apache-2.0
+// Runs format.js under the node environment (no jsdom) to prove that a missing
+// DOM surfaces as a thrown error rather than being laundered into "unsafe URL".
+// Importing format.js must succeed here — it uses window/document only when a
+// function is called, never at module scope.
+
+import { describe, it, expect } from "vitest";
+import { isSafeHref } from "../../../../main/webapp/themes/bootstrap/assets/format.js";
+
+describe("isSafeHref without a DOM", () => {
+  it("throws (not returns false) when window is unavailable", () => {
+    // In the node environment `window` is undefined, so `new URL(cleaned,
+    // window.location.href)` raises a ReferenceError — NOT a TypeError. The
+    // blanket catch used to swallow it and report the URL as unsafe; the fix
+    // only swallows TypeError (malformed URL) and rethrows everything else, so
+    // a broken environment can no longer masquerade as an unsafe link.
+    expect(() => isSafeHref("https://example.com/")).toThrow();
+  });
+});

--- a/src/test/js/themes/bootstrap/format.test.js
+++ b/src/test/js/themes/bootstrap/format.test.js
@@ -4,6 +4,8 @@
 // returns a DocumentFragment (not a string), so it is serialised through a
 // detached <div> to inspect the resulting markup — exactly how callers append it.
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import {
   escapeHtml,
@@ -219,5 +221,20 @@ describe("renderSnippetText: server snippet reduced to plain text", () => {
   it("returns empty string for empty input", () => {
     expect(renderSnippetText("")).toBe("");
     expect(renderSnippetText(null)).toBe("");
+  });
+});
+
+describe("shared-asset header comment is theme-neutral", () => {
+  const read = (rel) =>
+    readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8").split("\n");
+  it("format.js line 2 names no specific theme", () => {
+    const line2 = read("../../../../main/webapp/themes/bootstrap/assets/format.js")[1];
+    expect(line2).toContain("Fess static theme SPA");
+    expect(line2).not.toContain("bootstrap");
+  });
+  it("markdown.js line 2 names no specific theme", () => {
+    const line2 = read("../../../../main/webapp/themes/bootstrap/assets/markdown.js")[1];
+    expect(line2).toContain("Fess static theme SPA");
+    expect(line2).not.toContain("bootstrap");
   });
 });

--- a/src/test/js/themes/bootstrap/search.test.js
+++ b/src/test/js/themes/bootstrap/search.test.js
@@ -223,6 +223,26 @@ describe("buildResultCard", () => {
     // Escaped, so the address never becomes a child element.
     expect(desc.children.length).toBe(0);
   });
+
+  it("renders the copy-URL control as a real, accessible button", () => {
+    api.getConfig.mockReturnValue({ features: { clipboard_copy_icon: true } });
+    const li = buildResultCard(
+      { doc_id: "d7", title: "T", url: "https://ex.com/p" }, "q1", 1);
+    // The focusable element is a real <button>, in the a11y tree, carrying the
+    // accessible name and the clipboard payload — not an <i> with role="button".
+    const btn = li.querySelector("button.url-copy-btn");
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute("type")).toBe("button");
+    expect(btn.getAttribute("aria-hidden")).toBeNull();
+    expect(btn.getAttribute("aria-label")).toMatch(/./);
+    expect(btn.getAttribute("data-clipboard-text")).toBeTruthy();
+    expect(btn.classList.contains("d-print-none")).toBe(true);
+    // The glyph inside is purely decorative: aria-hidden, no role.
+    const glyph = btn.querySelector("i.fa-copy");
+    expect(glyph).toBeTruthy();
+    expect(glyph.getAttribute("aria-hidden")).toBe("true");
+    expect(glyph.getAttribute("role")).toBeNull();
+  });
 });
 
 describe("renderPopularWords", () => {
@@ -397,7 +417,6 @@ const SEARCH_FIXTURE = `
   <div id="facet-body" class="d-none"></div>
   <div id="facet-body-mobile"></div>
   <div id="facet-toggle-wrap"></div>
-  <a id="facet-clear" class="d-none"></a>
   <div id="active-chips" class="d-none"></div>
   <ul id="current-filters"></ul>
   <ul id="options-bar"></ul>
@@ -581,8 +600,27 @@ describe("runSearch — successful render", () => {
     // Filetype query view: html kept (count 7), pdf suppressed (count 0).
     expect(groups[1].textContent).toContain("labels.facet_filetype_html");
     expect(groups[1].textContent).not.toContain("labels.facet_filetype_pdf");
-    // No active filter → clear button hidden.
-    expect(document.getElementById("facet-clear").classList.contains("d-none")).toBe(true);
+    // Counts ARE present here, so the shown option carries a count badge.
+    expect(groups[1].querySelector(".badge")).not.toBeNull();
+  });
+
+  it("keeps every filetype query option (and drops badges) when the API omits facet_query", async () => {
+    // Under rank fusion (and whenever facetResponse is null) the v2 API omits
+    // facet_query entirely. The pre-fix code filtered options by `Number(count) > 0`,
+    // so with no counts every option was dropped and the group collapsed to a bare
+    // header. Recoverability fix: absent counts → keep the full clickable list, no badges.
+    installApiDispatch({ search: makeSearchEnv(SAMPLE_DOCS, { facet_query: undefined }) });
+    await runSearch();
+    await settle();
+    const body = document.getElementById("facet-body");
+    const groups = body.querySelectorAll("ul.list-group");
+    const filetype = Array.from(groups).find((g) => g.textContent.includes("labels.facet_filetype_html"));
+    expect(filetype).toBeTruthy();
+    // BOTH options survive (html AND pdf), unlike the counts-present zero-suppress path.
+    expect(filetype.textContent).toContain("labels.facet_filetype_html");
+    expect(filetype.textContent).toContain("labels.facet_filetype_pdf");
+    // No counts were sent → the group renders no badges at all.
+    expect(filetype.querySelector(".badge")).toBeNull();
   });
 
   it("mirrors the facet groups into the mobile offcanvas", async () => {
@@ -816,10 +854,9 @@ describe("runSearch — active filters, chips and current filters", () => {
     expect(document.activeElement).toBe(document.getElementById("sortSearchOption"));
   });
 
-  it("shows the facet clear button and a facet-reset link when filters are active", async () => {
+  it("shows a facet-reset link when filters are active", async () => {
     await runSearch();
     await settle();
-    expect(document.getElementById("facet-clear").classList.contains("d-none")).toBe(false);
     const reset = document.querySelector("#facet-body .facet-reset");
     expect(reset).not.toBeNull();
     const before = searchCalls();
@@ -1212,7 +1249,6 @@ describe("attach — wiring", () => {
     <div id="facet-body" class="d-none"></div>
     <div id="facet-body-mobile"></div>
     <div id="facet-toggle-wrap"></div>
-    <a id="facet-clear" class="d-none"></a>
     <div id="active-chips" class="d-none"></div>
     <ul id="current-filters"></ul>
     <ul id="options-bar"></ul>
@@ -1260,13 +1296,7 @@ describe("attach — wiring", () => {
     expect(navigate).toHaveBeenCalled();
     expect(navigate.mock.calls.at(-1)[0]).toContain("q=drawerq");
 
-    // 4. Facet "Clear" button → resets filters and re-runs the search.
-    const beforeSearch = searchCalls();
-    document.getElementById("facet-clear").click();
-    await vi.advanceTimersByTimeAsync(20);
-    expect(searchCalls()).toBe(beforeSearch + 1);
-
-    // 5. Header suggest: typing renders items after the 150ms debounce.
+    // 4. Header suggest: typing renders items after the 150ms debounce.
     const input = document.getElementById("query");
     input.value = "he";
     input.dispatchEvent(new Event("input"));
@@ -1275,14 +1305,14 @@ describe("attach — wiring", () => {
     expect(dropdown.querySelectorAll(".list-group-item").length).toBe(2);
     expect(dropdown.classList.contains("d-none")).toBe(false);
 
-    // 6. ArrowDown highlights the first item; Escape collapses the dropdown.
+    // 5. ArrowDown highlights the first item; Escape collapses the dropdown.
     input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
     expect(dropdown.querySelector(".list-group-item.active")).not.toBeNull();
     expect(input.getAttribute("aria-activedescendant")).toBe("suggest-item-0");
     input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     expect(dropdown.classList.contains("d-none")).toBe(true);
 
-    // 7. Dropdown mousedown selects the item and submits the header form.
+    // 6. Dropdown mousedown selects the item and submits the header form.
     input.value = "he";
     input.dispatchEvent(new Event("input"));
     await vi.advanceTimersByTimeAsync(150);

--- a/src/test/js/vitest.config.js
+++ b/src/test/js/vitest.config.js
@@ -28,7 +28,11 @@ export default defineConfig({
       // test drags coverage down and trips the gate, not just the loaded ones.
       all: true,
       include: [`${assets}/*.js`],
-      reporter: ["text", "text-summary"],
+      // skipFull:false so fully-covered files (e.g. format.js, router.js at 100%)
+      // still print in the text table. Vitest 4's text reporter defaults to
+      // skipFull:true, which hides them — making an instrumented, gated file look
+      // like it was excluded when it is actually covered.
+      reporter: [["text", { skipFull: false }], "text-summary"],
       // Regression gate: kept a few points below the achieved numbers so honest
       // refactors don't trip it, while a real coverage drop fails the build.
       thresholds: {


### PR DESCRIPTION
## Summary

Reapplies the still-needed content of #3191 and #3193 onto the current bootstrap Static theme (post-#3194), combined into one change.

### Accessibility — copy-URL control is now a real button (#3191)

The result copy-URL control was a single `<i>` carrying `aria-hidden="true"` together with `role="button"` and an `aria-label`, so it was removed from the accessibility tree and unreachable by keyboard (WCAG 2.1.1 Keyboard, 4.1.2 Name/Role/Value). It is now a real `<button class="url-copy-btn">` wrapping a decorative `aria-hidden` glyph, with a CSS chrome reset so it still renders as a bare icon.

### Shared-asset hygiene (#3193)

- `isSafeHref` no longer launders a missing DOM into a false "unsafe" verdict: the blanket `catch` now returns `false` only for a malformed-URL `TypeError` and re-throws anything else, so a broken (DOM-free) environment fails loudly instead of reporting every URL unsafe.
- The shared-asset header comment (line 2 of `format.js` / `markdown.js`) is now theme-neutral (`Fess static theme SPA`), so the file byte-matches the derived theme copies and can be verified with a plain checksum.

### Facet-query recoverability + hygiene (review follow-up)

A review of this change set found the canonical bootstrap theme lagging its derived themes (fess-themes) on the facet-query recoverability fix. Ported it here so the reference no longer trails its own derivatives:

- `renderFacetQueryViews` distinguishes an omitted `facet_query` (the v2 API omits it entirely under rank fusion / a null `facetResponse`) from a genuine zero count, via a `hasOwnProperty` probe instead of the `> 0` filter that dropped every option and collapsed the group to a bare header. Counts present → zero-suppress + badges; counts absent → full clickable list with no badges.
- `renderFacets` keeps the facet sidebar mounted at zero results when a filter is active, so the controls that undo the filter stay reachable. The dead `#facet-clear` handler (no such element in `index.html`) is removed.
- `.url-copy-btn` gains `vertical-align: middle` so the inline-block copy button aligns with the adjacent `<cite>`.
- Coverage: the text reporter uses `skipFull:false` so fully-covered files (`format.js`, `router.js` at 100%) stay visible in the coverage table instead of being hidden and looking excluded.

### Tests

Behavioral vitest (jsdom) cases for the accessible button and the `isSafeHref` missing-DOM throw, plus a source assertion for the neutral header comment. A facet-recoverability case (red on the pre-fix code) guards the new facet behaviour, and the now-dead `#facet-clear` fixtures/assertions are dropped. The one affected `BundledBootstrapThemeTest` assertion was updated to the new markup. `npm test` (theme JS, 412 tests) and `BundledBootstrapThemeTest` both pass.

`theme.yml`: 1.0.3 → 1.0.4 (the single bump for this PR covers the follow-up too; 1.0.4 has not shipped yet).

Supersedes #3191 and #3193.
