### PR TITLE
fix(theme): allow file:/smb: result links in the static theme

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -39,16 +39,20 @@ const FILETYPE_VALUES = [
 // passed to innerHTML.
 
 /**
- * Return `url` only when its scheme is in the http/https/ftp/ftps allowlist.
- * Any other scheme (e.g. javascript:, data:, vbscript:) returns "#" so that
- * setAttribute("href", safeHref(u)) can never inject executable content.
+ * Return `url` only when its scheme is one Fess serves: the web schemes plus the
+ * file-system schemes ProtocolHelper.isFileSystemPath() recognises
+ * (file/smb/smb1/storage/s3/gcs). Any other scheme (e.g. javascript:, data:,
+ * vbscript:, mailto:) returns "#" so that setAttribute("href", safeHref(u)) can
+ * never inject executable content.
  */
 function safeHref(url) {
   if (!url || typeof url !== "string") return "#";
   try {
     const u = new URL(url, location.href);
     if (u.protocol === "https:" || u.protocol === "http:" ||
-        u.protocol === "ftp:" || u.protocol === "ftps:") {
+        u.protocol === "ftp:" || u.protocol === "ftps:" ||
+        u.protocol === "file:" || u.protocol === "smb:" || u.protocol === "smb1:" ||
+        u.protocol === "storage:" || u.protocol === "s3:" || u.protocol === "gcs:") {
       return url;
     }
   } catch (e) {
@@ -101,9 +105,10 @@ function copyToClipboard(text) {
  * Build the /go/ click-tracking URL for a result link.
  *
  * Mirrors the JSP mousedown handler in src/main/webapp/js/search.js:111-127.
- * Returns "#" when the original URL is not in the http/https/ftp/ftps allowlist
- * so that safeHref semantics are preserved — the /go/ redirect would fail anyway
- * for unsafe schemes.
+ * Returns "#" only for schemes Fess never serves (javascript:, data:, vbscript:,
+ * mailto:, …). File-system schemes (file/smb/smb1/storage/s3/gcs) build a /go/
+ * link so GoAction's File Proxy can serve the document — the emitted href is
+ * always the same-origin /go/ path, never the raw URL.
  *
  * @param {string} originalUrl - the document's url_link / url value
  * @param {string} docId       - document identifier
@@ -113,12 +118,14 @@ function copyToClipboard(text) {
  * @returns {string} the /go/ redirect URL, or "#" for unsafe schemes
  */
 function buildGoUrl(originalUrl, docId, queryId, order, rt) {
-  // Validate scheme — same rules as safeHref; only build /go/ for safe schemes.
+  // Validate scheme — same rules as safeHref; only build /go/ for served schemes.
   if (!originalUrl || typeof originalUrl !== "string") return "#";
   try {
     const u = new URL(originalUrl, location.href);
     if (u.protocol !== "https:" && u.protocol !== "http:" &&
-        u.protocol !== "ftp:" && u.protocol !== "ftps:") {
+        u.protocol !== "ftp:" && u.protocol !== "ftps:" &&
+        u.protocol !== "file:" && u.protocol !== "smb:" && u.protocol !== "smb1:" &&
+        u.protocol !== "storage:" && u.protocol !== "s3:" && u.protocol !== "gcs:") {
       return "#";
     }
   } catch (e) {

--- a/src/main/webapp/themes/bootstrap/theme.yml
+++ b/src/main/webapp/themes/bootstrap/theme.yml
@@ -2,7 +2,7 @@ apiVersion: fess.codelibs.org/v1
 kind: StaticTheme
 name: bootstrap
 displayName: "Bootstrap"
-version: "1.0.4"
+version: "1.0.5"
 author: "CodeLibs Project"
 description: "Reference static theme for Fess. Bootstrap 5-based vanilla-JS SPA exercising /api/v2/*."
 license: "Apache-2.0"

--- a/src/test/js/themes/bootstrap/search.test.js
+++ b/src/test/js/themes/bootstrap/search.test.js
@@ -62,6 +62,15 @@ describe("buildGoUrl", () => {
     expect(buildGoUrl("data:text/html,x", "d1", "q1", 3, 1)).toBe("#");
   });
 
+  it("builds a /go/ URL for file:, smb: and s3: (file-system crawl results)", () => {
+    expect(buildGoUrl("file:///data/report.pdf", "d1", "q1", 2, 1700000000000))
+      .toBe("/go/?rt=1700000000000&docId=d1&queryId=q1&order=2");
+    expect(buildGoUrl("smb://host/share/file.docx", "d2", "q2", 1, 1700000000000))
+      .toBe("/go/?rt=1700000000000&docId=d2&queryId=q2&order=1");
+    expect(buildGoUrl("s3://bucket/key.txt", "d3", "q3", 1, 1700000000000))
+      .toBe("/go/?rt=1700000000000&docId=d3&queryId=q3&order=1");
+  });
+
   it("returns # for empty, null and non-string originalUrl", () => {
     expect(buildGoUrl("", "d1", "q1", 3, 1)).toBe("#");
     expect(buildGoUrl(null, "d1", "q1", 3, 1)).toBe("#");
@@ -85,6 +94,15 @@ describe("safeHref", () => {
     expect(safeHref("http://x.com")).toBe("http://x.com");
     expect(safeHref("ftp://x.com")).toBe("ftp://x.com");
     expect(safeHref("ftps://x.com")).toBe("ftps://x.com");
+  });
+
+  it("returns the URL for file/smb/smb1/storage/s3/gcs schemes (file-system crawls)", () => {
+    expect(safeHref("file:///data/report.pdf")).toBe("file:///data/report.pdf");
+    expect(safeHref("smb://host/share/f.docx")).toBe("smb://host/share/f.docx");
+    expect(safeHref("smb1://host/share/f.docx")).toBe("smb1://host/share/f.docx");
+    expect(safeHref("storage://area/obj")).toBe("storage://area/obj");
+    expect(safeHref("s3://bucket/key")).toBe("s3://bucket/key");
+    expect(safeHref("gcs://bucket/key")).toBe("gcs://bucket/key");
   });
 
   it("returns relative and fragment URLs unchanged (resolve to the page scheme)", () => {


### PR DESCRIPTION
## Problem

Reported at https://discuss.codelibs.org/t/bug-with-the-themes-or-maybe-layer-8-not-sure/2757 (Fess 15.7.0, Docker, file-system crawl): selecting the static theme makes file-system / SMB search results unclickable — the link "changes" to a dead `#`. The classic (non-theme) UI works.

## Root cause

The static-theme SPA builds each result link's `href` via `buildGoUrl()` (which emits the same-origin `/go/?…` path) and mirrors the raw URL into `data-uri`/`title` via `safeHref()`. Both gated the URL scheme with an allowlist limited to `http/https/ftp/ftps`.

`ViewHelper.getUrlLink()` yields `file:` for file-system crawls (and converts `smb:` → `file:`), so those results fell outside the allowlist and collapsed to `#`. The `/go/` endpoint — and therefore `GoAction`'s File Proxy (`search.file.proxy`, enabled by default) — was never reached.

The classic JSP UI has no such restriction: it routes every click through `/go/` regardless of scheme, and `GoAction` serves file-system content via the File Proxy. The client-side allowlist had simply diverged from the server — `GoAction.isValidRedirectUrl` rejects only `javascript:`/`data:`/`vbscript:`, and the backend `ChatClient.buildGoUrl` builds `/go/` for every scheme.

## Fix

Widen `buildGoUrl()` and `safeHref()` in the bootstrap theme's `search.js` to also admit the file-system schemes `ProtocolHelper.isFileSystemPath()` recognises: `file`, `smb`, `smb1`, `storage`, `s3`, `gcs`. `javascript:`/`data:`/`vbscript:`/`mailto:` stay rejected. The emitted `href` is always the same-origin `/go/` path (never the raw URL) and `GoAction` performs the authoritative server-side validation, so no new scheme reaches the DOM as an executable href.

`chat.js` is intentionally unchanged: the backend already supplies a `/go/` `go_url` for every chat source, so file-system sources were never affected.

## Tests

`src/test/js/themes/bootstrap/search.test.js` gains `file:`/`smb:`/`s3:` cases for `buildGoUrl` and `file/smb/smb1/storage/s3/gcs` cases for `safeHref` (fail before, pass after). The existing `javascript:`/`data:`/`mailto:`/`tel:` rejection cases are unchanged. The full vitest suite is green and coverage thresholds are met.

The downloadable themes carry the same regression and are fixed in the companion PR on `codelibs/fess-themes`.
