### PR TITLE
fix(api/v2): release login lockouts on schedule and restore the audit trail

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
@@ -140,6 +140,12 @@ public class LoginHandler {
 
         if (!limiter.allow(LoginRateLimiter.Scope.IP, clientIp, ipLimit, 60)) {
             limiter.lockOut(LoginRateLimiter.Scope.IP, clientIp, lockoutSec);
+            // The rate-limit gates used to be completely silent, so an operator investigating
+            // "login stopped working" had nothing in fess.log to go on. ActivityHelper has no
+            // activity type for a throttled attempt and inventing one would change the audit
+            // schema, so the record goes to the ordinary log instead.
+            logger.warn("[v2/login] refused by the ip rate limit: clientIp={}, limit={}/min, lockoutSeconds={}", clientIp, ipLimit,
+                    lockoutSec);
             res.setHeader("Retry-After", Integer.toString(lockoutSec));
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many login attempts (ip)");
             return;
@@ -185,6 +191,11 @@ public class LoginHandler {
             // credential rejection, with no Retry-After, so the response cannot be used to probe
             // a per-user counter. The IP-scope gate above still returns 429 + Retry-After.
             limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
+            // The response is deliberately indistinguishable from a credential rejection, so the
+            // server log is the only place the throttling is visible. No LOGIN_FAILURE audit
+            // record is written here: no credential was actually checked.
+            logger.warn("[v2/login] refused by the user rate limit: username={}, clientIp={}, limit={}/min, lockoutSeconds={}", username,
+                    clientIp, userLimit, lockoutSec);
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
             return;
         }
@@ -227,6 +238,13 @@ public class LoginHandler {
         try {
             assist.login(new LocalUserCredential(username, password), op -> {});
         } catch (final LoginFailureException e) {
+            // Mirror LoginAction.login(): log the rejection and write the LOGIN_FAILURE record to
+            // audit.log. Without this the v2 endpoint left no trace of failed authentication at
+            // all, so brute-force attempts against the SPA login form were undetectable.
+            if (logger.isInfoEnabled()) {
+                logger.info("[v2/login] login failed: username={}, reason={}", username, e.getMessage());
+            }
+            recordLoginFailureActivity(username, password);
             // Credential rejection consumes the USER slot exactly once, on the failure path
             // (keyed by (clientIp, username)). When the window is exhausted we also stamp a
             // lockUntil so subsequent requests from this (IP,user) are refused even after the
@@ -234,6 +252,8 @@ public class LoginHandler {
             // or not), with no Retry-After, so the per-user counter state never leaks.
             if (!limiter.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60)) {
                 limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
+                logger.warn("[v2/login] user rate limit exhausted; locking out: username={}, clientIp={}, limit={}/min, lockoutSeconds={}",
+                        username, clientIp, userLimit, lockoutSec);
             }
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
             return;
@@ -246,6 +266,11 @@ public class LoginHandler {
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");
             return;
         }
+
+        // Mirror LoginAction.login(): write the LOGIN record to audit.log as soon as the
+        // credentials are verified — before the session/CSRF work below — so the record survives
+        // a later failure in that machinery.
+        recordLoginActivity(assist);
 
         // A-1: emit account-switch audit log AFTER successful credential verification so
         // that an unauthenticated attacker with a stolen session cookie cannot trigger a
@@ -287,6 +312,44 @@ public class LoginHandler {
             addReturnTo(payload, returnTo);
         }
         ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
+    }
+
+    /**
+     * Writes the {@code LOGIN} activity record for a just-authenticated user, mirroring
+     * {@code LoginAction.login()} so the v2 endpoint produces the same audit.log line as the
+     * classic flow.
+     *
+     * <p>Audit-sink failures are logged and swallowed: the credentials have already been
+     * verified at this point, so turning a broken audit sink into a {@code 500} would revoke an
+     * authentication that actually succeeded.</p>
+     *
+     * @param assist the login assist holding the freshly bound user bean
+     */
+    private void recordLoginActivity(final FessLoginAssist assist) {
+        try {
+            ComponentUtil.getActivityHelper().login(assist.getSavedUserBean());
+        } catch (final RuntimeException e) {
+            logger.warn("[v2/login] failed to write the LOGIN audit record", e);
+        }
+    }
+
+    /**
+     * Writes the {@code LOGIN_FAILURE} activity record for a rejected credential, mirroring
+     * {@code LoginAction.login()}. Only the credential class and the user id reach the log —
+     * {@code ActivityHelper} never reads the password out of the credential.
+     *
+     * <p>Audit-sink failures are logged and swallowed so the caller still receives the generic
+     * {@code 401} rather than a {@code 500} that would disclose an internal fault.</p>
+     *
+     * @param username the submitted user name
+     * @param password the submitted password (never written to the audit record)
+     */
+    private void recordLoginFailureActivity(final String username, final String password) {
+        try {
+            ComponentUtil.getActivityHelper().loginFailure(OptionalThing.of(new LocalUserCredential(username, password)));
+        } catch (final RuntimeException e) {
+            logger.warn("[v2/login] failed to write the LOGIN_FAILURE audit record", e);
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
@@ -139,13 +139,20 @@ public class LoginHandler {
         final String clientIp = resolveClientIp(req);
 
         if (!limiter.allow(LoginRateLimiter.Scope.IP, clientIp, ipLimit, 60)) {
-            limiter.lockOut(LoginRateLimiter.Scope.IP, clientIp, lockoutSec);
             // The rate-limit gates used to be completely silent, so an operator investigating
             // "login stopped working" had nothing in fess.log to go on. ActivityHelper has no
             // activity type for a throttled attempt and inventing one would change the audit
             // schema, so the record goes to the ordinary log instead.
-            logger.warn("[v2/login] refused by the ip rate limit: clientIp={}, limit={}/min, lockoutSeconds={}", clientIp, ipLimit,
-                    lockoutSec);
+            //
+            // Only the request that actually arms the lockout is a new security event. Every
+            // later request during the same lockout also reaches this branch, so logging them
+            // all at WARN would let a client that keeps retrying pump the log without bound.
+            if (limiter.lockOut(LoginRateLimiter.Scope.IP, clientIp, lockoutSec)) {
+                logger.warn("[v2/login] ip rate limit exceeded; locking out for {}s: clientIp={}, limit={}/min", lockoutSec, clientIp,
+                        ipLimit);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("[v2/login] refused a retry during the active ip lockout: clientIp={}", clientIp);
+            }
             res.setHeader("Retry-After", Integer.toString(lockoutSec));
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many login attempts (ip)");
             return;
@@ -190,12 +197,18 @@ public class LoginHandler {
             // NOT disclose the per-user rate-limit state. Return a generic 401 identical to a
             // credential rejection, with no Retry-After, so the response cannot be used to probe
             // a per-user counter. The IP-scope gate above still returns 429 + Retry-After.
-            limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
             // The response is deliberately indistinguishable from a credential rejection, so the
             // server log is the only place the throttling is visible. No LOGIN_FAILURE audit
-            // record is written here: no credential was actually checked.
-            logger.warn("[v2/login] refused by the user rate limit: username={}, clientIp={}, limit={}/min, lockoutSeconds={}", username,
-                    clientIp, userLimit, lockoutSec);
+            // record is written here: no credential was actually checked. As with the ip gate,
+            // only the request that arms the lockout is logged at WARN — and this gate needs
+            // that guard the most, because the client is told nothing about the throttling and
+            // therefore has no reason to back off.
+            if (limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec)) {
+                logger.warn("[v2/login] user rate limit exceeded; locking out for {}s: username={}, clientIp={}, limit={}/min", lockoutSec,
+                        username, clientIp, userLimit);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("[v2/login] refused a retry during the active user lockout: username={}, clientIp={}", username, clientIp);
+            }
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
             return;
         }
@@ -251,9 +264,15 @@ public class LoginHandler {
             // sliding window expires. The response is a generic 401 in BOTH cases (exhausted
             // or not), with no Retry-After, so the per-user counter state never leaks.
             if (!limiter.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60)) {
-                limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
-                logger.warn("[v2/login] user rate limit exhausted; locking out: username={}, clientIp={}, limit={}/min, lockoutSeconds={}",
-                        username, clientIp, userLimit, lockoutSec);
+                if (limiter.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec)) {
+                    logger.warn("[v2/login] user rate limit exhausted; locking out for {}s: username={}, clientIp={}, limit={}/min",
+                            lockoutSec, username, clientIp, userLimit);
+                } else if (logger.isDebugEnabled()) {
+                    // The peek() gate above admitted this request, so an active lockout here
+                    // means a concurrent request armed it in between — already reported.
+                    logger.debug("[v2/login] user bucket exhausted while a lockout was already active: username={}, clientIp={}", username,
+                            clientIp);
+                }
             }
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid credentials");
             return;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiter.java
@@ -372,13 +372,22 @@ public class LoginRateLimiter {
      * when no lockout is active the stored deadline is already in the past, so
      * {@code now + lockoutSeconds} is unconditionally the larger value.</p>
      *
+     * <p>The return value tells the caller whether this particular call armed the lockout.
+     * Callers invoke this method on every refused request, so without it they cannot tell the
+     * one request that triggered the lockout from the stream of retries that follow — and
+     * logging each refusal at WARN would let a locked-out client generate unbounded log volume.
+     * The decision is taken inside the same synchronized block that stamps the deadline, so
+     * concurrent callers cannot both observe {@code true} for the same lockout window.</p>
+     *
      * @param scope rate-limit scope (e.g. IP, USER, CHAT) that the lockout applies to
      * @param key bucket key being locked out (e.g. IP address or username); ignored when {@code null} or empty
      * @param lockoutSeconds duration of the lockout in seconds; ignored when {@code <= 0}
+     * @return {@code true} if this call armed a new lockout, {@code false} if the call was
+     *         ignored (disabled or missing key) or a lockout was already active
      */
-    public void lockOut(final Scope scope, final String key, final int lockoutSeconds) {
+    public boolean lockOut(final Scope scope, final String key, final int lockoutSeconds) {
         if (key == null || key.isEmpty() || lockoutSeconds <= 0) {
-            return;
+            return false;
         }
         final String mapKey = scope.name() + ":" + key;
         final long now = clock.getAsLong();
@@ -394,9 +403,10 @@ public class LoginRateLimiter {
             if (now < e.lockUntilEpochMs) {
                 // Already locked out: keep the original deadline so the advertised
                 // Retry-After stays truthful instead of self-extending on every retry.
-                return;
+                return false;
             }
             e.lockUntilEpochMs = now + (long) lockoutSeconds * 1_000L;
+            return true;
         }
     }
 

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiter.java
@@ -367,17 +367,40 @@ public class LoginRateLimiter {
      * once the previous one has elapsed.</p>
      *
      * <p>m-21: a shorter {@code lockoutSeconds} value supplied in a second call still never
-     * shrinks an existing longer lockout — the stricter deadline always wins. The guard
-     * above subsumes the former {@code Math.max}: an active lockout is left untouched, and
-     * when no lockout is active the stored deadline is already in the past, so
-     * {@code now + lockoutSeconds} is unconditionally the larger value.</p>
+     * shrinks an existing longer lockout. Note that the guard is <em>first deadline wins</em>,
+     * not "stricter deadline wins": while a lockout is active the incoming
+     * {@code lockoutSeconds} is not consulted at all, so a <em>longer</em> value is ignored
+     * too. Since callers re-read the duration from configuration on every request, raising
+     * {@code theme.api.login.lockout.seconds} does not lengthen a lockout that is already
+     * running; the new value applies from the next lockout onwards. The guard still subsumes
+     * the former {@code Math.max} for the m-21 direction: when no lockout is active the
+     * stored deadline is already in the past, so {@code now + lockoutSeconds} is
+     * unconditionally the larger value.</p>
+     *
+     * <p><b>Release is only as prompt as the sliding window allows.</b> {@link #allow} and
+     * {@link #peek} return early while locked out, <em>before</em> the window-pruning step, so
+     * the recorded hits are frozen for the duration of the lockout. When
+     * {@code lockoutSeconds <= windowSeconds} those hits are therefore still in-window at the
+     * moment the lockout expires, the next request is refused again, and the caller arms a
+     * fresh lockout: effective release is about {@code windowSeconds + lockoutSeconds} and the
+     * advertised {@code Retry-After} <em>understates</em> it. The loop is bounded — a refused
+     * request records no new hit — and at the shipped defaults ({@code lockoutSeconds = 900},
+     * window {@code 60}) it cannot occur. Callers advertise the configured duration rather
+     * than the remaining time, so {@code Retry-After} over-states the wait on every retry
+     * after the first; this class exposes no remaining-time accessor.</p>
      *
      * <p>The return value tells the caller whether this particular call armed the lockout.
      * Callers invoke this method on every refused request, so without it they cannot tell the
      * one request that triggered the lockout from the stream of retries that follow — and
      * logging each refusal at WARN would let a locked-out client generate unbounded log volume.
-     * The decision is taken inside the same synchronized block that stamps the deadline, so
-     * concurrent callers cannot both observe {@code true} for the same lockout window.</p>
+     * It is a best-effort signal for log volume, not an exactly-once guarantee: the entry is
+     * resolved under the {@code entries} monitor and stamped under the entry monitor, so a
+     * concurrent {@link #clear} (successful login), {@link #sweep} or eviction that unmaps the
+     * entry in between can make the stamp land on a detached {@code Entry} — the call then
+     * reports {@code true} although no lockout is in effect, and a second caller can report
+     * {@code true} for the same key. Suppression is also keyed per {@code (scope, key)}, and
+     * both key components are caller-supplied (client IP and user name), so the "one WARN per
+     * lockout" bound holds per bucket, not per client.</p>
      *
      * @param scope rate-limit scope (e.g. IP, USER, CHAT) that the lockout applies to
      * @param key bucket key being locked out (e.g. IP address or username); ignored when {@code null} or empty

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiter.java
@@ -355,8 +355,22 @@ public class LoginRateLimiter {
     }
 
     /**
-     * m-21: uses Math.max so that a shorter lockoutSeconds value supplied in a second
-     * call never shrinks an existing longer lockout — the stricter deadline always wins.
+     * Locks out (scope, key) for {@code lockoutSeconds}, starting now.
+     *
+     * <p><b>An already-active lockout is never extended.</b> Every caller re-invokes this
+     * method on each refused request, and {@link #allow}/{@link #peek} keep returning
+     * {@code false} for the whole lockout — so re-stamping the deadline from the current
+     * time would push the release point forward on every retry and a client that kept
+     * polling would never be released, contradicting the {@code Retry-After:
+     * lockoutSeconds} header the callers advertise (RFC 9110). Calls that arrive while
+     * {@code now < lockUntilEpochMs} are therefore no-ops; a fresh lockout is armed only
+     * once the previous one has elapsed.</p>
+     *
+     * <p>m-21: a shorter {@code lockoutSeconds} value supplied in a second call still never
+     * shrinks an existing longer lockout — the stricter deadline always wins. The guard
+     * above subsumes the former {@code Math.max}: an active lockout is left untouched, and
+     * when no lockout is active the stored deadline is already in the past, so
+     * {@code now + lockoutSeconds} is unconditionally the larger value.</p>
      *
      * @param scope rate-limit scope (e.g. IP, USER, CHAT) that the lockout applies to
      * @param key bucket key being locked out (e.g. IP address or username); ignored when {@code null} or empty
@@ -377,7 +391,12 @@ public class LoginRateLimiter {
             e = existing;
         }
         synchronized (e) {
-            e.lockUntilEpochMs = Math.max(e.lockUntilEpochMs, now + (long) lockoutSeconds * 1_000L);
+            if (now < e.lockUntilEpochMs) {
+                // Already locked out: keep the original deadline so the advertised
+                // Retry-After stays truthful instead of self-extending on every retry.
+                return;
+            }
+            e.lockUntilEpochMs = now + (long) lockoutSeconds * 1_000L;
         }
     }
 

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
@@ -73,7 +73,11 @@ public class LogoutHandler {
             return;
         }
         try {
-            ComponentUtil.getComponent(FessLoginAssist.class).logout();
+            final FessLoginAssist assist = ComponentUtil.getComponent(FessLoginAssist.class);
+            // Mirror LogoutAction.index(): the LOGOUT record must be written BEFORE logout()
+            // drops the user bean, otherwise the audit line degrades to "user:-".
+            recordLogoutActivity(assist);
+            assist.logout();
         } catch (final Exception e) {
             // logout is idempotent — no session or unavailable login subsystem; log WARN for
             // actual logout failures but still respond 200 ok (caller's intent is satisfied).
@@ -88,5 +92,24 @@ public class LogoutHandler {
             }
         }
         ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, Map.of("ok", true));
+    }
+
+    /**
+     * Writes the {@code LOGOUT} activity record, mirroring {@code LogoutAction.index()} so the
+     * v2 endpoint produces the same audit.log line as the classic flow. When no user is bound
+     * the record still carries {@code user:-}, matching the classic behaviour for an
+     * already-anonymous caller.
+     *
+     * <p>Audit-sink failures are logged and swallowed so the actual logout still runs and the
+     * endpoint stays idempotent.</p>
+     *
+     * @param assist the login assist still holding the user bean to be logged out
+     */
+    private void recordLogoutActivity(final FessLoginAssist assist) {
+        try {
+            ComponentUtil.getActivityHelper().logout(assist.getSavedUserBean());
+        } catch (final RuntimeException e) {
+            logger.warn("[v2/logout] failed to write the LOGOUT audit record", e);
+        }
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
@@ -241,7 +241,15 @@ public class PasswordChangeHandler {
             }
         }
         if (rate != null && userLimit > 0 && !rate.peek(LoginRateLimiter.Scope.USER, userId, userLimit, 60)) {
-            rate.lockOut(LoginRateLimiter.Scope.USER, userId, lockoutSec);
+            // Only the request that arms the lockout is a new security event; every later
+            // request during the same lockout reaches this branch too, so logging them all at
+            // WARN would let a stolen-session attacker pump the log without bound.
+            if (rate.lockOut(LoginRateLimiter.Scope.USER, userId, lockoutSec)) {
+                logger.warn("/api/v2/auth/password: rate limit exceeded; locking out for {}s: userId={}, limit={}/min", lockoutSec, userId,
+                        userLimit);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("/api/v2/auth/password: refused a retry during the active lockout: userId={}", userId);
+            }
             res.setHeader("Retry-After", Integer.toString(Math.max(lockoutSec, 1)));
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many password-change attempts");
             return;
@@ -263,7 +271,14 @@ public class PasswordChangeHandler {
             // Wrong current_password: consume one user-bucket slot. If the bucket has just
             // been exhausted, escalate to 429 with Retry-After (same pattern as LoginHandler).
             if (rate != null && userLimit > 0 && !rate.allow(LoginRateLimiter.Scope.USER, userId, userLimit, 60)) {
-                rate.lockOut(LoginRateLimiter.Scope.USER, userId, lockoutSec);
+                if (rate.lockOut(LoginRateLimiter.Scope.USER, userId, lockoutSec)) {
+                    logger.warn("/api/v2/auth/password: rate limit exhausted; locking out for {}s: userId={}, limit={}/min", lockoutSec,
+                            userId, userLimit);
+                } else if (logger.isDebugEnabled()) {
+                    // The peek() gate above admitted this request, so an active lockout here
+                    // means a concurrent request armed it in between — already reported.
+                    logger.debug("/api/v2/auth/password: bucket exhausted while a lockout was already active: userId={}", userId);
+                }
                 res.setHeader("Retry-After", Integer.toString(Math.max(lockoutSec, 1)));
                 ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.RATE_LIMITED, "too many password-change attempts");
                 return;
@@ -310,9 +325,12 @@ public class PasswordChangeHandler {
         // Other concurrent sessions for the same user are NOT invalidated — this is a
         // known limitation (requires a Fess-wide session registry, follow-up item).
         //
-        // MINOR-4: call assist.logout() first so that remember-me cookies are cleared and
-        // any audit events are recorded — matching the LogoutHandler pattern. Failures are
-        // swallowed so that session.invalidate() still runs regardless.
+        // MINOR-4: call assist.logout() first so that remember-me cookies are cleared —
+        // matching the LogoutHandler pattern. Failures are swallowed so that
+        // session.invalidate() still runs regardless. Note that assist.logout() writes no
+        // audit record of its own: the LOGOUT activity is emitted by the caller (LogoutAction
+        // in the classic flow, LogoutHandler on the v2 path), and a password change is not a
+        // logout event, so none is written here.
         try {
             assist.logout();
         } catch (final Exception e) {

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -27,6 +27,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.codelibs.fess.api.v2.SessionCsrfTokenManager;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.entity.FessUser;
@@ -36,6 +44,7 @@ import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.lastaflute.web.login.credential.LoginCredential;
 import org.lastaflute.web.login.exception.LoginFailureException;
 import org.lastaflute.web.login.option.LoginOpCall;
@@ -676,6 +685,127 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // Oversized return_to (10001 chars) must be silently dropped.
         addReturnTo.invoke(new LoginHandler(new LoginRateLimiter()), payload, "/".repeat(10001));
         assertNull(payload.get("return_to"), "return_to exceeding 10000 chars must be silently dropped");
+    }
+
+    // ── rate-limit logging must not flood: one WARN per lockout, DEBUG for retries ──
+
+    @Test
+    public void login_ipLockoutWarnsOnceAndDebugsTheRetriesInsideTheWindow() throws Throwable {
+        // A client refused by the IP gate keeps POSTing, and every refused request reaches the
+        // logging statement. Logging each one at WARN would let a locked-out attacker generate
+        // unbounded WARN volume. Only the request that actually arms the lockout is a new
+        // security event; the rest are retries against a lockout already reported.
+        final int ipLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerIpPerMinuteAsInteger();
+        final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+        final long lockoutMs = lockoutSec * 1_000L;
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+        final LoginHandler handler = new LoginHandler(rl);
+        final String ip = "203.0.113.77";
+        for (int i = 0; i < ipLimit; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.IP, ip, ipLimit, 60));
+        }
+
+        final List<LogEvent> events = captureLogEvents(LoginHandler.class.getName(), () -> {
+            for (int i = 0; i < 5; i++) {
+                // Stay well inside the lockout window so no retry can arm a second lockout.
+                now[0] = t0 + lockoutMs / 8 * i;
+                final CapturingResponse res = new CapturingResponse();
+                handler.handle(loginPost(ip, "u"), res);
+                assertEquals(429, res.status, res.body());
+            }
+        });
+
+        org.junit.jupiter.api.Assertions.assertEquals(1L, countEvents(events, Level.WARN, ip),
+                "exactly one WARN must be emitted per lockout, not one per refused request: " + formatEvents(events));
+        org.junit.jupiter.api.Assertions.assertEquals(4L, countEvents(events, Level.DEBUG, ip),
+                "the four retries inside the lockout must be logged at DEBUG: " + formatEvents(events));
+    }
+
+    @Test
+    public void login_userLockoutWarnsOnceAndDebugsTheRetriesInsideTheWindow() throws Throwable {
+        // Same contract on the USER gate. This one matters more: the response is a generic 401
+        // with no Retry-After, so a locked-out client has no way to know it should back off and
+        // will keep retrying — exactly the pattern that turns a per-refusal WARN into a flood.
+        final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+        final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+        final long lockoutMs = lockoutSec * 1_000L;
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+        final LoginHandler handler = new LoginHandler(rl);
+        final String ip = "203.0.113.78";
+        final String userKey = handler.userScopeKey(ip, "erin");
+        for (int i = 0; i < userLimit; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60));
+        }
+
+        final List<LogEvent> events = captureLogEvents(LoginHandler.class.getName(), () -> {
+            for (int i = 0; i < 5; i++) {
+                now[0] = t0 + lockoutMs / 8 * i;
+                final CapturingResponse res = new CapturingResponse();
+                handler.handle(loginPost(ip, "erin"), res);
+                assertEquals(401, res.status, res.body());
+            }
+        });
+
+        org.junit.jupiter.api.Assertions.assertEquals(1L, countEvents(events, Level.WARN, "erin"),
+                "exactly one WARN must be emitted per user lockout: " + formatEvents(events));
+        org.junit.jupiter.api.Assertions.assertEquals(4L, countEvents(events, Level.DEBUG, "erin"),
+                "the four retries inside the user lockout must be logged at DEBUG: " + formatEvents(events));
+    }
+
+    /**
+     * Attaches a DEBUG-level capturing appender to {@code loggerName}, runs {@code body}, then
+     * restores the original appender set and level. Only events emitted by {@code loggerName}
+     * itself are retained, so the surrounding framework chatter is filtered out.
+     */
+    private static List<LogEvent> captureLogEvents(final String loggerName, final Executable body) throws Throwable {
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        final LoggerConfig loggerCfg = ctx.getConfiguration().getLoggerConfig(loggerName);
+        final Level originalLevel = loggerCfg.getLevel();
+        final List<LogEvent> captured = new ArrayList<>();
+        final String appenderName = "login-handler-capture";
+        final AbstractAppender appender =
+                new AbstractAppender(appenderName, null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
+                    @Override
+                    public void append(final LogEvent event) {
+                        if (loggerName.equals(event.getLoggerName())) {
+                            captured.add(event.toImmutable());
+                        }
+                    }
+                };
+        appender.start();
+        loggerCfg.addAppender(appender, Level.DEBUG, null);
+        loggerCfg.setLevel(Level.DEBUG);
+        ctx.updateLoggers();
+        try {
+            body.execute();
+        } finally {
+            loggerCfg.removeAppender(appenderName);
+            loggerCfg.setLevel(originalLevel);
+            ctx.updateLoggers();
+            appender.stop();
+        }
+        return captured;
+    }
+
+    /**
+     * Counts captured events at {@code level} whose formatted message mentions {@code marker}.
+     * Matching on the bucket key rather than on fixed wording keeps the assertion robust to
+     * message rewording while still excluding unrelated lines from the same logger.
+     */
+    private static long countEvents(final List<LogEvent> events, final Level level, final String marker) {
+        return events.stream()
+                .filter(e -> level.equals(e.getLevel()))
+                .filter(e -> e.getMessage().getFormattedMessage().contains(marker))
+                .count();
+    }
+
+    /** Renders captured events for assertion failure messages. */
+    private static String formatEvents(final List<LogEvent> events) {
+        return events.stream().map(e -> e.getLevel() + " " + e.getMessage().getFormattedMessage()).toList().toString();
     }
 
     // ── audit.log: v2 login must leave the same activity records as LoginAction ──

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -276,6 +276,27 @@ public class LoginHandlerTest extends UnitFessTestCase {
                 .withRemoteAddr(remoteAddr);
     }
 
+    /**
+     * Same as {@link #loginPost} but backed by an in-memory session, so the post-success branch
+     * (session rotation plus CSRF issue/rotate) can run to completion.
+     */
+    private static StubRequest loginPostWithSession(final String remoteAddr, final String username) {
+        return new StubRequestWithSession("POST", "/api/v2/auth/login")
+                .withJsonBody("{\"username\":\"" + username + "\",\"password\":\"p\"}")
+                .withRemoteAddr(remoteAddr);
+    }
+
+    /**
+     * Registers everything a run-to-completion login needs: a credential-accepting assist for
+     * {@code username}, the CSRF manager the success branch rotates, and a recording activity
+     * helper writing into {@code audit}.
+     */
+    private static void registerSuccessfulLoginComponents(final String username, final List<String> audit) {
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        ComponentUtil.register(new StubLoginAssist(username, false), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.register(new SessionCsrfTokenManager(), SessionCsrfTokenManager.class.getCanonicalName());
+    }
+
     @Test
     public void login_ipLockoutIsNotExtendedByRetriesDuringTheLockout() throws Exception {
         // Regression, driven through handle(): the IP gate calls lockOut() on EVERY refused
@@ -295,6 +316,12 @@ public class LoginHandlerTest extends UnitFessTestCase {
         final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
         final LoginHandler handler = new LoginHandler(rl);
         final String ip = "198.51.100.7";
+        // A credential-rejecting assist plus a recording audit sink turn the final assertion
+        // from "not a 429" into positive proof that the request reached credential verification:
+        // the gates write no activity record, only the credential check does.
+        final List<String> audit = new ArrayList<>();
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        ComponentUtil.register(new StubLoginAssist("u", true), FessLoginAssist.class.getCanonicalName());
         // Saturate the IP bucket so the very next request trips the IP gate.
         for (int i = 0; i < ipLimit; i++) {
             assertTrue(rl.allow(LoginRateLimiter.Scope.IP, ip, ipLimit, 60));
@@ -315,13 +342,15 @@ public class LoginHandlerTest extends UnitFessTestCase {
         }
 
         // Just past the advertised deadline the client MUST be admitted through the IP gate
-        // again (it then falls through to the test-DI-unavailable login subsystem).
+        // again, all the way into credential verification.
         now[0] = t0 + lockoutMs + 1_000L;
         final CapturingResponse after = new CapturingResponse();
         handler.handle(loginPost(ip, "u"), after);
-        org.junit.jupiter.api.Assertions.assertNotEquals(429, after.status, "the IP lockout must expire " + lockoutSec
+        assertEquals(401, after.status, "the IP lockout must expire " + lockoutSec
                 + "s after it was applied, even though the client retried meanwhile: " + after.body());
         org.junit.jupiter.api.Assertions.assertNull(after.getHeader("Retry-After"), after.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("action:LOGIN_FAILURE\tclass:LocalUserCredential\tuser:u"), audit,
+                "only the released request may reach credential verification; the refused ones write nothing");
     }
 
     @Test
@@ -338,6 +367,12 @@ public class LoginHandlerTest extends UnitFessTestCase {
         final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
         final LoginHandler handler = new LoginHandler(rl);
         final String ip = "198.51.100.9";
+        // The gate and a credential rejection both answer 401, so status alone cannot tell them
+        // apart. The audit sink can: gates write nothing, credential verification writes
+        // LOGIN_FAILURE — which is what turns the closing assertion into positive proof.
+        final List<String> audit = new ArrayList<>();
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        ComponentUtil.register(new StubLoginAssist("erin", true), FessLoginAssist.class.getCanonicalName());
         // Saturate the (clientIp, username) composite bucket the handler computes.
         final String userKey = handler.userScopeKey(ip, "erin");
         for (int i = 0; i < userLimit; i++) {
@@ -356,15 +391,98 @@ public class LoginHandlerTest extends UnitFessTestCase {
             assertEquals(401, retry.status, "retry " + i + " inside the lockout must still be refused: " + retry.body());
         }
 
-        // Past the lockout the user must get past the USER gate again — the request then
-        // reaches the (test-DI-unavailable) login subsystem, so any status other than the
-        // 401 produced by the gate (and other than a 429 IP-gate trip) proves recovery.
+        // Past the lockout the user must get past the USER gate again. The response is still a
+        // 401 — the stub rejects the password — but the LOGIN_FAILURE record proves the request
+        // was refused by the credential check rather than by the gate.
         now[0] = t0 + lockoutMs + 1_000L;
         final CapturingResponse after = new CapturingResponse();
         handler.handle(loginPost(ip, "erin"), after);
         org.junit.jupiter.api.Assertions.assertNotEquals(429, after.status, after.body());
-        org.junit.jupiter.api.Assertions.assertNotEquals(401, after.status, "the USER lockout must expire " + lockoutSec
-                + "s after it was applied, even though the client retried meanwhile: " + after.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("action:LOGIN_FAILURE\tclass:LocalUserCredential\tuser:erin"), audit,
+                "the USER lockout must expire " + lockoutSec + "s after it was applied, letting the request through to "
+                        + "credential verification even though the client retried meanwhile: " + after.body());
+    }
+
+    // ── Release: once the window elapses the client can actually log in again ────
+
+    @Test
+    public void login_userRegainsAccessWithASuccessfulLoginAfterTheLockoutElapses() throws Exception {
+        // The headline promise of the no-self-extension fix is that service is RESTORED, and
+        // only a real 200 proves that. The sibling not-extended tests stop at "the gate let the
+        // request through"; this one runs the whole flow to the success envelope, so a
+        // regression that releases the gate but breaks recovery some other way cannot hide.
+        final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+        final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+        final long lockoutMs = lockoutSec * 1_000L;
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+        final LoginHandler handler = new LoginHandler(rl);
+        final String ip = "198.51.100.21";
+        final List<String> audit = new ArrayList<>();
+        registerSuccessfulLoginComponents("heidi", audit);
+        final String userKey = handler.userScopeKey(ip, "heidi");
+        for (int i = 0; i < userLimit; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60));
+        }
+
+        // Trip the gate, then retry inside the window — still refused, and (the defect) each
+        // retry used to push the release point another lockoutSeconds away.
+        final CapturingResponse first = new CapturingResponse();
+        handler.handle(loginPostWithSession(ip, "heidi"), first);
+        assertEquals(401, first.status, first.body());
+        now[0] = t0 + lockoutMs / 2;
+        final CapturingResponse retry = new CapturingResponse();
+        handler.handle(loginPostWithSession(ip, "heidi"), retry);
+        assertEquals(401, retry.status, retry.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of(), audit, "no credential was checked while the gate was refusing: " + audit);
+
+        // Past the deadline the very same credentials must authenticate.
+        now[0] = t0 + lockoutMs + 1_000L;
+        final CapturingResponse after = new CapturingResponse();
+        handler.handle(loginPostWithSession(ip, "heidi"), after);
+        assertEquals(200, after.status, "the user must be able to log in again once the lockout elapsed: " + after.body());
+        assertTrue(after.body().contains("\"status\":0"), after.body());
+        assertTrue(after.body().contains("csrf_token"), after.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("action:LOGIN\tuser:heidi\tpermissions:-"), audit,
+                "the released attempt must be a genuine authentication, not a gate that merely stopped refusing");
+    }
+
+    @Test
+    public void login_ipRegainsAccessWithASuccessfulLoginAfterTheLockoutElapses() throws Exception {
+        // Same release property on the IP gate, which is the one that advertises Retry-After:
+        // the header is a promise that a client honouring it gets served, so the run-to-success
+        // assertion is what actually holds the endpoint to it.
+        final int ipLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerIpPerMinuteAsInteger();
+        final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+        final long lockoutMs = lockoutSec * 1_000L;
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+        final LoginHandler handler = new LoginHandler(rl);
+        final String ip = "198.51.100.22";
+        final List<String> audit = new ArrayList<>();
+        registerSuccessfulLoginComponents("ivan", audit);
+        for (int i = 0; i < ipLimit; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.IP, ip, ipLimit, 60));
+        }
+
+        final CapturingResponse first = new CapturingResponse();
+        handler.handle(loginPostWithSession(ip, "ivan"), first);
+        assertEquals(429, first.status, first.body());
+        org.junit.jupiter.api.Assertions.assertEquals(Integer.toString(lockoutSec), first.getHeader("Retry-After"), first.body());
+        now[0] = t0 + lockoutMs / 2;
+        final CapturingResponse retry = new CapturingResponse();
+        handler.handle(loginPostWithSession(ip, "ivan"), retry);
+        assertEquals(429, retry.status, retry.body());
+
+        now[0] = t0 + lockoutMs + 1_000L;
+        final CapturingResponse after = new CapturingResponse();
+        handler.handle(loginPostWithSession(ip, "ivan"), after);
+        assertEquals(200, after.status, "the client must be served once the advertised Retry-After elapsed: " + after.body());
+        assertTrue(after.body().contains("csrf_token"), after.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("action:LOGIN\tuser:ivan\tpermissions:-"), audit,
+                "the released attempt must be a genuine authentication");
     }
 
     // ── A-1: account-switch audit log must not fire on credential failure ────────
@@ -757,6 +875,101 @@ public class LoginHandlerTest extends UnitFessTestCase {
     }
 
     /**
+     * Registers a credential-rejecting {@link FessLoginAssist} that plays a concurrent request
+     * while the handler is inside {@code assist.login()}: the returned stub drains the remaining
+     * USER slots on {@code rl}, and optionally arms the lockout itself, before rejecting.
+     *
+     * <p>This is what makes the post-failure escalation reachable single-threaded. The handler's
+     * {@code peek()} gate evaluates the same predicate over the same deque a few lines earlier,
+     * so {@code allow()} can only refuse on the failure path when another request consumed the
+     * remaining slots in between.</p>
+     *
+     * @param rl the very limiter instance the handler under test was constructed with
+     * @param userKey the composite (clientIp, username) key the handler computes
+     * @param userLimit per-window slot count to drain
+     * @param armLockout when true the concurrent request also stamps the lockout, so the
+     *                   handler's own {@code lockOut()} finds one already active
+     */
+    private static void registerConcurrentlyDrainingAssist(final LoginRateLimiter rl, final String userKey, final int userLimit,
+            final int lockoutSec, final boolean armLockout) {
+        ComponentUtil.register(new StubLoginAssist("frank", true).withConcurrentRequestDuringLogin(() -> {
+            for (int i = 0; i < userLimit; i++) {
+                rl.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60);
+            }
+            if (armLockout) {
+                rl.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
+            }
+        }), FessLoginAssist.class.getCanonicalName());
+    }
+
+    @Test
+    public void login_credentialFailureArmsTheLockoutWhenAConcurrentRequestDrainedTheBucket() throws Throwable {
+        // The escalation inside catch(LoginFailureException) fires when the bucket runs out on
+        // the failure path. Nothing else in the handler logs that transition, so without this
+        // test the branch — WARN plus the lockOut() that backs the "even after the sliding
+        // window expires" promise — was never executed by the suite at all.
+        final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+        final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+        final long[] now = { 1_000_000L };
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+        final LoginHandler handler = new LoginHandler(rl);
+        final String ip = "198.51.100.31";
+        final String userKey = handler.userScopeKey(ip, "frank");
+        final List<String> audit = new ArrayList<>();
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        registerConcurrentlyDrainingAssist(rl, userKey, userLimit, lockoutSec, false);
+
+        final List<LogEvent> events = captureLogEvents(LoginHandler.class.getName(), () -> {
+            final CapturingResponse res = new CapturingResponse();
+            handler.handle(loginPost(ip, "frank"), res);
+            // The response is the same generic 401 as any credential rejection: the per-user
+            // counter state must never leak, not even once the bucket is exhausted.
+            assertEquals(401, res.status, res.body());
+            assertTrue(res.body().contains("\"code\":\"auth_required\""), res.body());
+            org.junit.jupiter.api.Assertions.assertNull(res.getHeader("Retry-After"), res.body());
+        });
+
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("action:LOGIN_FAILURE\tclass:LocalUserCredential\tuser:frank"), audit,
+                "the request must have reached credential verification, not a gate");
+        org.junit.jupiter.api.Assertions.assertEquals(1L, countEvents(events, Level.WARN, "exhausted"),
+                "the request that armed the lockout on the failure path must log exactly one WARN: " + formatEvents(events));
+        org.junit.jupiter.api.Assertions.assertEquals(0L, countEvents(events, Level.DEBUG, "frank"),
+                "nothing may be logged at DEBUG when this call armed the lockout: " + formatEvents(events));
+
+        // Past the sliding window the frozen hits no longer count, so a bucket still refusing
+        // here can only be refusing because the escalation stamped a lockout.
+        now[0] += 61_000L;
+        assertFalse(rl.peek(LoginRateLimiter.Scope.USER, userKey, userLimit, 60),
+                "the escalation must arm a lockout that outlives the sliding window");
+    }
+
+    @Test
+    public void login_credentialFailureDebugsWhenTheConcurrentRequestAlreadyArmedTheLockout() throws Throwable {
+        // Companion of the WARN case: the concurrent request both drained the bucket and armed
+        // the lockout, so the handler's own lockOut() is a no-op and the refusal has already
+        // been reported. Logging it at WARN again would double-count a single lockout.
+        final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+        final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+        final LoginRateLimiter rl = new LoginRateLimiter();
+        final LoginHandler handler = new LoginHandler(rl);
+        final String ip = "198.51.100.32";
+        final String userKey = handler.userScopeKey(ip, "frank");
+        ComponentUtil.register(recordingActivityHelper(new ArrayList<>()), "activityHelper");
+        registerConcurrentlyDrainingAssist(rl, userKey, userLimit, lockoutSec, true);
+
+        final List<LogEvent> events = captureLogEvents(LoginHandler.class.getName(), () -> {
+            final CapturingResponse res = new CapturingResponse();
+            handler.handle(loginPost(ip, "frank"), res);
+            assertEquals(401, res.status, res.body());
+        });
+
+        org.junit.jupiter.api.Assertions.assertEquals(0L, countEvents(events, Level.WARN, "frank"),
+                "a lockout armed by the concurrent request must not be reported a second time: " + formatEvents(events));
+        org.junit.jupiter.api.Assertions.assertEquals(1L, countEvents(events, Level.DEBUG, "frank"),
+                "the already-locked case must be visible at DEBUG: " + formatEvents(events));
+    }
+
+    /**
      * Attaches a DEBUG-level capturing appender to {@code loggerName}, runs {@code body}, then
      * restores the original appender set and level. Only events emitted by {@code loggerName}
      * itself are retained, so the surrounding framework chatter is filtered out.
@@ -868,6 +1081,64 @@ public class LoginHandlerTest extends UnitFessTestCase {
         assertTrue(res.body().contains("csrf_token"), res.body());
     }
 
+    @Test
+    public void login_auditFailureOnCredentialRejectionStillReturnsTheGeneric401() throws Exception {
+        // Third audit sink, same contract as the two above: the LOGIN_FAILURE write happens
+        // inside the catch(LoginFailureException) block, so an exception escaping it would
+        // propagate out of handle() and the container would answer 500 instead of the generic
+        // 401 — telling an attacker that this particular username/IP is interesting, and
+        // handing them a way to distinguish rejected credentials from a healthy rejection.
+        ComponentUtil.register(new ActivityHelper() {
+            @Override
+            public void loginFailure(final OptionalThing<LoginCredential> credential) {
+                throw new IllegalStateException("audit sink is down");
+            }
+        }, "activityHelper");
+        ComponentUtil.register(new StubLoginAssist("bob", true), FessLoginAssist.class.getCanonicalName());
+        final CapturingResponse res = new CapturingResponse();
+        new LoginHandler(new LoginRateLimiter())
+                .handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"wrong\"}"), res);
+        assertEquals(401, res.status, res.body());
+        assertTrue(res.body().contains("\"code\":\"auth_required\""), res.body());
+    }
+
+    @Test
+    public void login_throttleGatesWriteNoAuditRecord() throws Exception {
+        // Deliberate decision, pinned so a future change cannot quietly reverse it: a request
+        // refused by the IP gate or by the USER peek() gate had no credential checked, so there
+        // is nothing to report as a LOGIN_FAILURE. Emitting one would let a client that never
+        // guessed a password inflate audit.log and make the trail overstate how many
+        // authentication attempts actually took place. The stub rejects credentials, so a gate
+        // that leaked a request through into verification would show up as a record here.
+        final List<String> audit = new ArrayList<>();
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        ComponentUtil.register(new StubLoginAssist("gwen", true), FessLoginAssist.class.getCanonicalName());
+        final int ipLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerIpPerMinuteAsInteger();
+        final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+        final LoginRateLimiter rl = new LoginRateLimiter();
+        final LoginHandler handler = new LoginHandler(rl);
+
+        final String ipGatedIp = "198.51.100.55";
+        for (int i = 0; i < ipLimit; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.IP, ipGatedIp, ipLimit, 60));
+        }
+        final CapturingResponse ipRefused = new CapturingResponse();
+        handler.handle(loginPost(ipGatedIp, "gwen"), ipRefused);
+        assertEquals(429, ipRefused.status, ipRefused.body());
+
+        // A different IP so the IP bucket is fresh and the request reaches the USER gate.
+        final String userGatedIp = "198.51.100.56";
+        for (int i = 0; i < userLimit; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, handler.userScopeKey(userGatedIp, "gwen"), userLimit, 60));
+        }
+        final CapturingResponse userRefused = new CapturingResponse();
+        handler.handle(loginPost(userGatedIp, "gwen"), userRefused);
+        assertEquals(401, userRefused.status, userRefused.body());
+
+        org.junit.jupiter.api.Assertions.assertEquals(List.of(), audit,
+                "a request refused by a rate-limit gate must leave no activity record: " + audit);
+    }
+
     /**
      * Builds an {@link ActivityHelper} that renders real LTSV records into {@code sink} instead
      * of writing to the audit logger. {@code time}/{@code ip} are stripped so the expectation is
@@ -904,6 +1175,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
     private static class StubLoginAssist extends FessLoginAssist {
         private final String userId;
         private final boolean rejectCredential;
+        private transient Runnable concurrentRequest = () -> {};
         private FessUserBean bound;
 
         StubLoginAssist(final String userId, final boolean rejectCredential) {
@@ -911,8 +1183,24 @@ public class LoginHandlerTest extends UnitFessTestCase {
             this.rejectCredential = rejectCredential;
         }
 
+        /**
+         * Runs {@code hook} at the start of {@link #login}, i.e. while the handler is between
+         * its {@code peek()} gate and the {@code allow()} call on the credential-failure path.
+         * Tests use it to play the concurrent request that drains the bucket in that window —
+         * the only way the post-failure escalation can be reached, and reachable here without
+         * spawning a thread.
+         *
+         * @param hook action simulating a request that arrives during credential verification
+         * @return this stub (fluent)
+         */
+        StubLoginAssist withConcurrentRequestDuringLogin(final Runnable hook) {
+            this.concurrentRequest = hook;
+            return this;
+        }
+
         @Override
         public void login(final LoginCredential credential, final LoginOpCall opLambda) {
+            concurrentRequest.run();
             if (rejectCredential) {
                 throw new LoginFailureException("stubbed credential rejection");
             }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -247,6 +247,105 @@ public class LoginHandlerTest extends UnitFessTestCase {
         assertTrue(rl.allow(LoginRateLimiter.Scope.USER, "bob", 5, 60));
     }
 
+    // ── Self-extending lockout: driven end-to-end through handle() ───────────────
+
+    /** Builds a well-formed login POST from {@code remoteAddr} for {@code username}. */
+    private static StubRequest loginPost(final String remoteAddr, final String username) {
+        return new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"" + username + "\",\"password\":\"p\"}")
+                .withRemoteAddr(remoteAddr);
+    }
+
+    @Test
+    public void login_ipLockoutIsNotExtendedByRetriesDuringTheLockout() throws Exception {
+        // Regression, driven through handle(): the IP gate calls lockOut() on EVERY refused
+        // request, and allow() keeps returning false for the whole lockout — so each retry
+        // used to re-stamp the deadline from "now", pushing the release point forward
+        // indefinitely. The 429 advertises "Retry-After: <lockoutSeconds>"; that promise must
+        // hold even when the client keeps POSTing before it elapses.
+        //
+        // The sibling test_userLockoutResetsAfterWindowExpires only pokes the limiter
+        // directly (allow()/lockOut()), so it never observes the handler's re-stamping and
+        // stayed green while this defect was live. This test drives the real handler.
+        final int ipLimit = org.codelibs.fess.util.ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerIpPerMinuteAsInteger();
+        final int lockoutSec = org.codelibs.fess.util.ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+        final long lockoutMs = lockoutSec * 1_000L;
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+        final LoginHandler handler = new LoginHandler(rl);
+        final String ip = "198.51.100.7";
+        // Saturate the IP bucket so the very next request trips the IP gate.
+        for (int i = 0; i < ipLimit; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.IP, ip, ipLimit, 60));
+        }
+
+        final CapturingResponse first = new CapturingResponse();
+        handler.handle(loginPost(ip, "u"), first);
+        assertEquals(429, first.status, first.body());
+        org.junit.jupiter.api.Assertions.assertEquals(Integer.toString(lockoutSec), first.getHeader("Retry-After"),
+                "the 429 promises release after lockoutSeconds");
+
+        // The client keeps retrying inside the lockout window (quarter-window apart).
+        for (int i = 1; i <= 3; i++) {
+            now[0] = t0 + lockoutMs / 4 * i;
+            final CapturingResponse retry = new CapturingResponse();
+            handler.handle(loginPost(ip, "u"), retry);
+            assertEquals(429, retry.status, "retry " + i + " inside the lockout must still be refused: " + retry.body());
+        }
+
+        // Just past the advertised deadline the client MUST be admitted through the IP gate
+        // again (it then falls through to the test-DI-unavailable login subsystem).
+        now[0] = t0 + lockoutMs + 1_000L;
+        final CapturingResponse after = new CapturingResponse();
+        handler.handle(loginPost(ip, "u"), after);
+        org.junit.jupiter.api.Assertions.assertNotEquals(429, after.status, "the IP lockout must expire " + lockoutSec
+                + "s after it was applied, even though the client retried meanwhile: " + after.body());
+        org.junit.jupiter.api.Assertions.assertNull(after.getHeader("Retry-After"), after.body());
+    }
+
+    @Test
+    public void login_userLockoutIsNotExtendedByRetriesDuringTheLockout() throws Exception {
+        // Same defect on the USER gate, which is worse for the victim: it answers with a
+        // generic 401 "invalid credentials" and no Retry-After, so a locked-out user cannot
+        // even tell they are locked out — they just retry, and every retry used to push the
+        // release point another lockoutSeconds into the future.
+        final int userLimit = org.codelibs.fess.util.ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+        final int lockoutSec = org.codelibs.fess.util.ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+        final long lockoutMs = lockoutSec * 1_000L;
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+        final LoginHandler handler = new LoginHandler(rl);
+        final String ip = "198.51.100.9";
+        // Saturate the (clientIp, username) composite bucket the handler computes.
+        final String userKey = handler.userScopeKey(ip, "erin");
+        for (int i = 0; i < userLimit; i++) {
+            assertTrue(rl.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60));
+        }
+
+        final CapturingResponse first = new CapturingResponse();
+        handler.handle(loginPost(ip, "erin"), first);
+        assertEquals(401, first.status, first.body());
+        org.junit.jupiter.api.Assertions.assertNull(first.getHeader("Retry-After"), "user-scope exhaustion must not advertise Retry-After");
+
+        for (int i = 1; i <= 3; i++) {
+            now[0] = t0 + lockoutMs / 4 * i;
+            final CapturingResponse retry = new CapturingResponse();
+            handler.handle(loginPost(ip, "erin"), retry);
+            assertEquals(401, retry.status, "retry " + i + " inside the lockout must still be refused: " + retry.body());
+        }
+
+        // Past the lockout the user must get past the USER gate again — the request then
+        // reaches the (test-DI-unavailable) login subsystem, so any status other than the
+        // 401 produced by the gate (and other than a 429 IP-gate trip) proves recovery.
+        now[0] = t0 + lockoutMs + 1_000L;
+        final CapturingResponse after = new CapturingResponse();
+        handler.handle(loginPost(ip, "erin"), after);
+        org.junit.jupiter.api.Assertions.assertNotEquals(429, after.status, after.body());
+        org.junit.jupiter.api.Assertions.assertNotEquals(401, after.status, "the USER lockout must expire " + lockoutSec
+                + "s after it was applied, even though the client retried meanwhile: " + after.body());
+    }
+
     // ── A-1: account-switch audit log must not fire on credential failure ────────
 
     @Test

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -20,13 +20,25 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.codelibs.fess.api.v2.SessionCsrfTokenManager;
+import org.codelibs.fess.app.web.base.login.FessLoginAssist;
+import org.codelibs.fess.entity.FessUser;
+import org.codelibs.fess.helper.ActivityHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
+import org.lastaflute.web.login.credential.LoginCredential;
+import org.lastaflute.web.login.exception.LoginFailureException;
+import org.lastaflute.web.login.option.LoginOpCall;
 
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
@@ -664,6 +676,243 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // Oversized return_to (10001 chars) must be silently dropped.
         addReturnTo.invoke(new LoginHandler(new LoginRateLimiter()), payload, "/".repeat(10001));
         assertNull(payload.get("return_to"), "return_to exceeding 10000 chars must be silently dropped");
+    }
+
+    // ── audit.log: v2 login must leave the same activity records as LoginAction ──
+
+    @Test
+    public void login_successWritesLoginRecordToAuditLog() throws Exception {
+        // Regression: POST /api/v2/auth/login never called ActivityHelper, so a deployment that
+        // authenticates through the static-theme SPA produced NO audit.log line at all — while
+        // the classic JSP flow writes one from LoginAction.login() (activityHelper.login()).
+        // Assert on the rendered LTSV record rather than "some method was called", so the v2
+        // record is byte-identical to the classic one.
+        final List<String> audit = new ArrayList<>();
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        ComponentUtil.register(new StubLoginAssist("alice", false), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.register(new SessionCsrfTokenManager(), SessionCsrfTokenManager.class.getCanonicalName());
+        final CapturingResponse res = new CapturingResponse();
+        new LoginHandler(new LoginRateLimiter()).handle(
+                new StubRequestWithSession("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"alice\",\"password\":\"secret\"}"),
+                res);
+        assertEquals(200, res.status, res.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("action:LOGIN\tuser:alice\tpermissions:-"), audit,
+                "a successful v2 login must write the same LOGIN activity record as LoginAction");
+    }
+
+    @Test
+    public void login_credentialFailureWritesLoginFailureRecordToAuditLog() throws Exception {
+        // Companion regression for the failure path: LoginAction.login() calls
+        // activityHelper.loginFailure(new LocalUserCredential(username, password)) when the
+        // credentials are rejected. Without the same call on the v2 path, brute-force attempts
+        // against the SPA login endpoint are invisible to audit.log.
+        final List<String> audit = new ArrayList<>();
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        ComponentUtil.register(new StubLoginAssist("bob", true), FessLoginAssist.class.getCanonicalName());
+        final CapturingResponse res = new CapturingResponse();
+        new LoginHandler(new LoginRateLimiter())
+                .handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"wrong\"}"), res);
+        assertEquals(401, res.status, res.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("action:LOGIN_FAILURE\tclass:LocalUserCredential\tuser:bob"), audit,
+                "a rejected v2 login must write the same LOGIN_FAILURE activity record as LoginAction");
+    }
+
+    @Test
+    public void login_auditFailureDoesNotBreakAnAlreadySuccessfulLogin() throws Exception {
+        // The credentials have already been verified when the audit record is written, so a
+        // broken audit sink must not turn an authenticated session into a 500 — it is logged
+        // and the success envelope is still returned.
+        ComponentUtil.register(new ActivityHelper() {
+            @Override
+            public void login(final OptionalThing<FessUserBean> user) {
+                throw new IllegalStateException("audit sink is down");
+            }
+        }, "activityHelper");
+        ComponentUtil.register(new StubLoginAssist("alice", false), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.register(new SessionCsrfTokenManager(), SessionCsrfTokenManager.class.getCanonicalName());
+        final CapturingResponse res = new CapturingResponse();
+        new LoginHandler(new LoginRateLimiter()).handle(
+                new StubRequestWithSession("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"alice\",\"password\":\"secret\"}"),
+                res);
+        assertEquals(200, res.status, res.body());
+        assertTrue(res.body().contains("csrf_token"), res.body());
+    }
+
+    /**
+     * Builds an {@link ActivityHelper} that renders real LTSV records into {@code sink} instead
+     * of writing to the audit logger. {@code time}/{@code ip} are stripped so the expectation is
+     * deterministic — same approach as {@code ActivityHelperTest}.
+     */
+    private static ActivityHelper recordingActivityHelper(final List<String> sink) {
+        return new ActivityHelper() {
+            @Override
+            protected void printByLtsv(final Map<String, String> valueMap) {
+                valueMap.remove("time");
+                valueMap.remove("ip");
+                super.printByLtsv(valueMap);
+            }
+
+            @Override
+            protected void printLog(final String message) {
+                sink.add(message);
+            }
+
+            @Override
+            protected String getClientIp() {
+                return "";
+            }
+        };
+    }
+
+    /**
+     * {@link FessLoginAssist} stub registered under its canonical name so
+     * {@code ComponentUtil.getComponent(FessLoginAssist.class)} resolves it (the real component
+     * fails auto-binding in the slim test DI graph, which makes {@code componentMap} the
+     * effective lookup). {@code login()} either binds a user bean or raises the same
+     * {@link LoginFailureException} the production flow raises on a wrong password.
+     */
+    private static class StubLoginAssist extends FessLoginAssist {
+        private final String userId;
+        private final boolean rejectCredential;
+        private FessUserBean bound;
+
+        StubLoginAssist(final String userId, final boolean rejectCredential) {
+            this.userId = userId;
+            this.rejectCredential = rejectCredential;
+        }
+
+        @Override
+        public void login(final LoginCredential credential, final LoginOpCall opLambda) {
+            if (rejectCredential) {
+                throw new LoginFailureException("stubbed credential rejection");
+            }
+            bound = new FessUserBean(new StubFessUser(userId));
+        }
+
+        @Override
+        public OptionalThing<FessUserBean> getSavedUserBean() {
+            return bound == null ? OptionalThing.empty() : OptionalThing.of(bound);
+        }
+
+        @Override
+        public void logout() {
+            bound = null;
+        }
+    }
+
+    /** Minimal {@link FessUser} with no roles, groups or permissions. */
+    private static class StubFessUser implements FessUser {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        StubFessUser(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String[] getRoleNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getGroupNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getPermissions() {
+            return new String[0];
+        }
+    }
+
+    /**
+     * {@link StubRequest} variant backed by an in-memory {@link HttpSession} so the post-success
+     * branch (session rotation plus CSRF issue/rotate) can run to completion.
+     */
+    private static class StubRequestWithSession extends StubRequest {
+        private final HttpSession session = new HttpSession() {
+            private final Map<String, Object> attributes = new HashMap<>();
+
+            @Override
+            public long getCreationTime() {
+                return 0L;
+            }
+
+            @Override
+            public String getId() {
+                return "stub-session-id";
+            }
+
+            @Override
+            public long getLastAccessedTime() {
+                return 0L;
+            }
+
+            @Override
+            public ServletContext getServletContext() {
+                return null;
+            }
+
+            @Override
+            public void setMaxInactiveInterval(final int interval) {
+                // no-op
+            }
+
+            @Override
+            public int getMaxInactiveInterval() {
+                return 1800;
+            }
+
+            @Override
+            public Object getAttribute(final String name) {
+                return attributes.get(name);
+            }
+
+            @Override
+            public Enumeration<String> getAttributeNames() {
+                return Collections.enumeration(attributes.keySet());
+            }
+
+            @Override
+            public void setAttribute(final String name, final Object value) {
+                attributes.put(name, value);
+            }
+
+            @Override
+            public void removeAttribute(final String name) {
+                attributes.remove(name);
+            }
+
+            @Override
+            public void invalidate() {
+                attributes.clear();
+            }
+
+            @Override
+            public boolean isNew() {
+                return false;
+            }
+        };
+
+        StubRequestWithSession(final String method, final String uri) {
+            super(method, uri);
+        }
+
+        @Override
+        public HttpSession getSession(final boolean create) {
+            return session;
+        }
+
+        @Override
+        public HttpSession getSession() {
+            return session;
+        }
     }
 
     /** Minimal HttpServletResponse stub — captures status, content type, headers and body. */

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiterTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiterTest.java
@@ -156,10 +156,10 @@ public class LoginRateLimiterTest extends UnitFessTestCase {
         assertFalse(rl.allow(LoginRateLimiter.Scope.IP, "", 10, 60), "empty key must return false (deny)");
     }
 
-    // ── m-21: lockOut Math.max guard ────────────────────────────────────────────
+    // ── m-21: a second call never moves the deadline of an active lockout ───────
 
     @Test
-    public void test_lockOut_mathMaxGuard_shorterCallDoesNotShrinkLockout() {
+    public void test_lockOut_shorterCallDoesNotShrinkAnActiveLockout() {
         final long[] now = { 1_000_000L };
         final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
         // Apply a 900-second lockout.
@@ -169,7 +169,33 @@ public class LoginRateLimiterTest extends UnitFessTestCase {
         // Advance 61 seconds (past the short window, still inside the long one).
         now[0] += 61_000L;
         assertFalse(rl.allow(LoginRateLimiter.Scope.USER, "carol", 5, 60),
-                "shorter lockOut call must not shrink existing longer lockout (Math.max guard)");
+                "a shorter lockOut call must not shrink the lockout that is already running");
+    }
+
+    @Test
+    public void test_lockOut_longerCallDoesNotExtendAnActiveLockout() {
+        // The guard is "first deadline wins", not "stricter deadline wins": while a lockout is
+        // running the incoming lockoutSeconds is not consulted at all, so a LONGER value is
+        // ignored just like a shorter one. This is the direction the sibling shorter-call test
+        // cannot observe, and it is what keeps a raised theme.api.login.lockout.seconds from
+        // silently pushing out a lockout that is already counting down — callers re-read the
+        // duration from configuration on every refused request.
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+
+        assertTrue(rl.lockOut(LoginRateLimiter.Scope.USER, "frank", 60), "the first call arms a 60-second lockout");
+
+        // Mid-lockout, a caller asks for a much longer one; the call must be a no-op.
+        now[0] = t0 + 30_000L;
+        assertFalse(rl.allow(LoginRateLimiter.Scope.USER, "frank", 5, 60), "still locked 30s into a 60s lockout");
+        assertFalse(rl.lockOut(LoginRateLimiter.Scope.USER, "frank", 3600), "a call during an active lockout must be a no-op");
+
+        // Past the ORIGINAL 60-second deadline the bucket must be released: had the 3600-second
+        // value applied, the key would stay locked for another hour.
+        now[0] = t0 + 61_000L;
+        assertTrue(rl.allow(LoginRateLimiter.Scope.USER, "frank", 5, 60),
+                "a longer lockoutSeconds supplied mid-lockout must not push the original deadline out");
     }
 
     // ── Self-extending lockout: an active lockout must never be pushed forward ──

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiterTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiterTest.java
@@ -135,6 +135,52 @@ public class LoginRateLimiterTest extends UnitFessTestCase {
                 "shorter lockOut call must not shrink existing longer lockout (Math.max guard)");
     }
 
+    // ── Self-extending lockout: an active lockout must never be pushed forward ──
+
+    @Test
+    public void test_lockOut_doesNotExtendAnActiveLockout() {
+        // Regression: every call site (LoginHandler IP gate, LoginHandler USER gate,
+        // PasswordChangeHandler) re-invokes lockOut() on each refused request, and
+        // allow()/peek() keep returning false for the whole lockout. Re-stamping the
+        // deadline from the CURRENT time therefore pushed the release point forward on
+        // every retry, so a client that kept polling was never released — even though the
+        // response advertised "Retry-After: <lockoutSeconds>".
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+
+        rl.lockOut(LoginRateLimiter.Scope.IP, "1.2.3.4", 900);
+
+        // A retry arrives while the lockout is still active; the caller stamps it again.
+        now[0] = t0 + 800_000L;
+        assertFalse(rl.allow(LoginRateLimiter.Scope.IP, "1.2.3.4", 10, 60), "still locked 800s into a 900s lockout");
+        rl.lockOut(LoginRateLimiter.Scope.IP, "1.2.3.4", 900);
+
+        // Past the ORIGINAL deadline (t0 + 900s): the mid-lockout retry must not have moved it.
+        now[0] = t0 + 901_000L;
+        assertTrue(rl.allow(LoginRateLimiter.Scope.IP, "1.2.3.4", 10, 60),
+                "lockOut() during an active lockout must not extend it beyond the advertised Retry-After");
+    }
+
+    @Test
+    public void test_lockOut_reArmsAfterThePreviousLockoutExpired() {
+        // The no-extend guard must not turn lockOut() into a one-shot: once the previous
+        // lockout has elapsed, a fresh lockOut() must arm a new window from "now".
+        final long[] now = { 1_000_000L };
+        final long t0 = now[0];
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+
+        rl.lockOut(LoginRateLimiter.Scope.USER, "dave", 900);
+        now[0] = t0 + 901_000L;
+        assertTrue(rl.allow(LoginRateLimiter.Scope.USER, "dave", 10, 60), "the first lockout must have expired");
+
+        // A new abuse burst locks the key again, armed from the current time.
+        rl.lockOut(LoginRateLimiter.Scope.USER, "dave", 900);
+        assertFalse(rl.allow(LoginRateLimiter.Scope.USER, "dave", 10, 60), "a fresh lockout must arm after the previous one expired");
+        now[0] += 901_000L;
+        assertTrue(rl.allow(LoginRateLimiter.Scope.USER, "dave", 10, 60), "the second lockout must expire on schedule as well");
+    }
+
     // ── Sweep schedule: verify the periodic task wires correctly ────────────────
 
     @Test

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiterTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiterTest.java
@@ -29,6 +29,43 @@ import org.junit.jupiter.api.Test;
 
 public class LoginRateLimiterTest extends UnitFessTestCase {
 
+    // ── lockOut() reports whether it armed a NEW lockout ────────────────────────
+
+    @Test
+    public void test_lockOut_returnsTrueOnlyWhenArmingANewLockout() {
+        // Callers invoke lockOut() on EVERY refused request, so they need a way to tell the
+        // moment a lockout is armed from the stream of refusals that follow it — otherwise a
+        // per-refusal WARN lets a client locked out of the endpoint generate unbounded log
+        // volume. The decision is taken inside the same synchronized block that stamps the
+        // deadline, so it cannot race.
+        final long[] now = { 1_000_000L };
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+
+        assertTrue(rl.lockOut(LoginRateLimiter.Scope.IP, "198.51.100.1", 900), "the first call must arm a new lockout");
+        assertFalse(rl.lockOut(LoginRateLimiter.Scope.IP, "198.51.100.1", 900), "a call during an active lockout must be a no-op");
+
+        // Still inside the window: every retry is a no-op, never a fresh lockout.
+        now[0] += 450_000L;
+        assertFalse(rl.lockOut(LoginRateLimiter.Scope.IP, "198.51.100.1", 900), "a mid-window retry must not arm a lockout");
+
+        // Past the deadline the bucket is free again, so the next call arms a genuinely new one.
+        now[0] += 451_000L;
+        assertTrue(rl.lockOut(LoginRateLimiter.Scope.IP, "198.51.100.1", 900), "a lockout armed after the previous one elapsed is new");
+    }
+
+    @Test
+    public void test_lockOut_returnsFalseWhenTheCallIsIgnored() {
+        // The guard clauses make lockOut() a no-op; they must report "nothing armed" rather
+        // than claiming a lockout the limiter never stamped.
+        final LoginRateLimiter rl = new LoginRateLimiter(() -> 1_000_000L);
+        assertFalse(rl.lockOut(LoginRateLimiter.Scope.USER, "alice", 0), "lockoutSeconds=0 disables the lockout");
+        assertFalse(rl.lockOut(LoginRateLimiter.Scope.USER, "alice", -1), "a negative lockoutSeconds disables the lockout");
+        assertFalse(rl.lockOut(LoginRateLimiter.Scope.USER, null, 900), "a null key cannot be locked out");
+        assertFalse(rl.lockOut(LoginRateLimiter.Scope.USER, "", 900), "an empty key cannot be locked out");
+        // None of the above may have armed anything.
+        assertTrue(rl.allow(LoginRateLimiter.Scope.USER, "alice", 5, 60), "no lockout must have been stamped for alice");
+    }
+
     // ── MJ-4 / M-4: memory cap ──────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LogoutHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LogoutHandlerTest.java
@@ -18,12 +18,20 @@ package org.codelibs.fess.api.v2.handlers;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.codelibs.fess.app.web.base.login.FessLoginAssist;
+import org.codelibs.fess.entity.FessUser;
+import org.codelibs.fess.helper.ActivityHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.AsyncContext;
@@ -85,6 +93,127 @@ public class LogoutHandlerTest extends UnitFessTestCase {
         new LogoutHandler().handle(new StubRequestWithSession("POST", "/api/v2/auth/logout", true), res);
         assertEquals(200, res.status);
         assertTrue(res.body().contains("\"ok\":true"), res.body());
+    }
+
+    // ── audit.log: v2 logout must leave the same activity record as LogoutAction ──
+
+    @Test
+    public void logout_writesLogoutRecordToAuditLog() throws Exception {
+        // Regression: POST /api/v2/auth/logout never called ActivityHelper, so the SPA logout
+        // left no audit.log line while the classic flow writes one from LogoutAction.index()
+        // (activityHelper.logout(userBean)). The record must also be written BEFORE
+        // FessLoginAssist.logout() drops the user bean — otherwise it would degrade to "user:-".
+        final List<String> audit = new ArrayList<>();
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        ComponentUtil.register(new StubLoginAssist("carol"), FessLoginAssist.class.getCanonicalName());
+        final CapturingResponse res = new CapturingResponse();
+        new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
+        assertEquals(200, res.status, res.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("action:LOGOUT\tuser:carol\tpermissions:-"), audit,
+                "a v2 logout must write the same LOGOUT activity record as LogoutAction, with the user still resolved");
+    }
+
+    @Test
+    public void logout_auditFailureStillLogsOutAndReturnsOk() throws Exception {
+        // A broken audit sink must not prevent the actual logout: the endpoint stays idempotent
+        // and FessLoginAssist.logout() must still run.
+        ComponentUtil.register(new ActivityHelper() {
+            @Override
+            public void logout(final OptionalThing<FessUserBean> user) {
+                throw new IllegalStateException("audit sink is down");
+            }
+        }, "activityHelper");
+        final StubLoginAssist assist = new StubLoginAssist("carol");
+        ComponentUtil.register(assist, FessLoginAssist.class.getCanonicalName());
+        final CapturingResponse res = new CapturingResponse();
+        new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
+        assertEquals(200, res.status, res.body());
+        assertTrue(res.body().contains("\"ok\":true"), res.body());
+        assertEquals(1, assist.logoutCount, "logout must still be performed when the audit write fails");
+    }
+
+    /**
+     * Builds an {@link ActivityHelper} that renders real LTSV records into {@code sink} instead
+     * of writing to the audit logger. {@code time}/{@code ip} are stripped so the expectation is
+     * deterministic — same approach as {@code ActivityHelperTest}.
+     */
+    private static ActivityHelper recordingActivityHelper(final List<String> sink) {
+        return new ActivityHelper() {
+            @Override
+            protected void printByLtsv(final Map<String, String> valueMap) {
+                valueMap.remove("time");
+                valueMap.remove("ip");
+                super.printByLtsv(valueMap);
+            }
+
+            @Override
+            protected void printLog(final String message) {
+                sink.add(message);
+            }
+
+            @Override
+            protected String getClientIp() {
+                return "";
+            }
+        };
+    }
+
+    /**
+     * {@link FessLoginAssist} stub registered under its canonical name so
+     * {@code ComponentUtil.getComponent(FessLoginAssist.class)} resolves it (the real component
+     * fails auto-binding in the slim test DI graph, which makes {@code componentMap} the
+     * effective lookup). {@code logout()} clears the bound user bean, mirroring production.
+     */
+    private static class StubLoginAssist extends FessLoginAssist {
+        private FessUserBean bound;
+
+        int logoutCount;
+
+        StubLoginAssist(final String userId) {
+            bound = new FessUserBean(new StubFessUser(userId));
+        }
+
+        @Override
+        public OptionalThing<FessUserBean> getSavedUserBean() {
+            return bound == null ? OptionalThing.empty() : OptionalThing.of(bound);
+        }
+
+        @Override
+        public void logout() {
+            logoutCount++;
+            bound = null;
+        }
+    }
+
+    /** Minimal {@link FessUser} with no roles, groups or permissions. */
+    private static class StubFessUser implements FessUser {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        StubFessUser(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String[] getRoleNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getGroupNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getPermissions() {
+            return new String[0];
+        }
     }
 
     /** Minimal HttpServletResponse stub — captures status, content type, headers and body. */

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
@@ -470,6 +470,59 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
     }
 
     @Test
+    public void passwordChange_lockoutIsNotExtendedByRetriesDuringTheLockout() throws Exception {
+        // Regression, driven through handle(): the C-3 gate calls lockOut() on EVERY refused
+        // request while peek() keeps returning false for the whole lockout, so each retry used
+        // to re-stamp the deadline from "now" — the advertised Retry-After was never honoured
+        // and a client that kept polling stayed locked out forever.
+        registerStubLoginAssist("alice", "secret-current");
+        try {
+            final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+            final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+            final long lockoutMs = lockoutSec * 1_000L;
+            final long[] now = { 1_000_000L };
+            final long t0 = now[0];
+            final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+            final PasswordChangeHandler handler = new PasswordChangeHandler(rl);
+            for (int i = 0; i < userLimit; i++) {
+                rl.allow(LoginRateLimiter.Scope.USER, "alice", userLimit, 60);
+            }
+
+            final CapturingResponse first = new CapturingResponse();
+            handler.handle(passwordPost("secret-current"), first);
+            assertEquals(429, first.status, first.body());
+            org.junit.jupiter.api.Assertions.assertEquals(Integer.toString(lockoutSec), first.getHeader("Retry-After"),
+                    "the 429 promises release after lockoutSeconds");
+
+            for (int i = 1; i <= 3; i++) {
+                now[0] = t0 + lockoutMs / 4 * i;
+                final CapturingResponse retry = new CapturingResponse();
+                handler.handle(passwordPost("secret-current"), retry);
+                assertEquals(429, retry.status, "retry " + i + " inside the lockout must still be refused: " + retry.body());
+            }
+
+            // Past the advertised deadline the gate must open again. We deliberately send the
+            // WRONG current password so the flow stops at the credential check (401) instead of
+            // needing UserService/SystemHelper stubs — a 429 here would mean still locked out.
+            now[0] = t0 + lockoutMs + 1_000L;
+            final CapturingResponse after = new CapturingResponse();
+            handler.handle(passwordPost("WRONG"), after);
+            assertEquals(401, after.status, "the lockout must expire " + lockoutSec
+                    + "s after it was applied, even though the client retried meanwhile: " + after.body());
+            assertTrue(after.body().contains("\"code\":\"auth_required\""), after.body());
+        } finally {
+            ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
+            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+        }
+    }
+
+    /** Builds a well-formed password-change POST carrying {@code currentPw}. */
+    private static StubRequest passwordPost(final String currentPw) {
+        return new StubRequest("POST", "/api/v2/auth/password").withJsonBody("{\"current_password\":\"" + currentPw
+                + "\",\"new_password\":\"NewLongPass123!\",\"confirm_password\":\"NewLongPass123!\"}");
+    }
+
+    @Test
     public void passwordChange_successDoesNotConsumeSlot() throws Exception {
         // C-3: a successful change must NOT leave consumed slots behind — the clear()
         // call resets the bucket. We pre-burn 4 of 5 slots to prove the reset is real:

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
@@ -155,12 +155,14 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
      * Registers a stub {@link FessLoginAssist} that pretends a user named {@code alice} is
      * logged in. {@code findLoginUser} returns a populated entity only when the supplied
      * password equals {@code expectedCurrentPw}; otherwise it returns an empty optional so
-     * the handler must short-circuit to {@code AUTH_REQUIRED}.
+     * the handler must short-circuit to {@code AUTH_REQUIRED}. The registered stub is returned
+     * so a caller can attach a verification-time hook.
      */
-    private static void registerStubLoginAssist(final String userId, final String expectedCurrentPw) {
+    private static StubFessLoginAssist registerStubLoginAssist(final String userId, final String expectedCurrentPw) {
         final StubFessLoginAssist stub = new StubFessLoginAssist(userId, expectedCurrentPw);
         ComponentUtil.register(stub, "fessLoginAssist");
         ComponentUtil.register(stub, FessLoginAssist.class.getCanonicalName());
+        return stub;
     }
 
     @Test
@@ -565,6 +567,97 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
     }
 
     /**
+     * Attaches a hook to the registered stub that plays a concurrent request while the handler
+     * is inside {@code findLoginUser}: it drains the remaining USER slots on {@code rl} and,
+     * when {@code armLockout} is set, stamps the lockout as well.
+     *
+     * <p>This is what makes the post-verification escalation reachable single-threaded. The
+     * handler's {@code peek()} gate evaluates the same predicate over the same deque a few
+     * lines earlier, so {@code allow()} can only refuse on the wrong-password path when another
+     * request consumed the remaining slots in between.</p>
+     */
+    private static void attachConcurrentlyDrainingHook(final StubFessLoginAssist assist, final LoginRateLimiter rl, final String userId,
+            final int userLimit, final int lockoutSec, final boolean armLockout) {
+        assist.withConcurrentRequestDuringVerification(() -> {
+            for (int i = 0; i < userLimit; i++) {
+                rl.allow(LoginRateLimiter.Scope.USER, userId, userLimit, 60);
+            }
+            if (armLockout) {
+                rl.lockOut(LoginRateLimiter.Scope.USER, userId, lockoutSec);
+            }
+        });
+    }
+
+    @Test
+    public void passwordChange_wrongPasswordArmsTheLockoutWhenAConcurrentRequestDrainedTheBucket() throws Throwable {
+        // The escalation on the wrong-password path is what turns a drained bucket into a 429
+        // plus a lockout; nothing else in the handler reports that transition. Without this test
+        // the branch — Retry-After, WARN and the lockOut() that keeps refusing after the sliding
+        // window expires — was never executed by the suite at all.
+        final StubFessLoginAssist assist = registerStubLoginAssist("alice", "secret-current");
+        try {
+            final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+            final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+            final long[] now = { 1_000_000L };
+            final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+            final PasswordChangeHandler handler = new PasswordChangeHandler(rl);
+            attachConcurrentlyDrainingHook(assist, rl, "alice", userLimit, lockoutSec, false);
+
+            final List<LogEvent> events = captureLogEvents(PasswordChangeHandler.class.getName(), () -> {
+                final CapturingResponse res = new CapturingResponse();
+                handler.handle(passwordPost("WRONG"), res);
+                assertEquals(429, res.status, res.body());
+                assertTrue(res.body().contains("\"code\":\"rate_limited\""), res.body());
+                org.junit.jupiter.api.Assertions.assertEquals(Integer.toString(lockoutSec), res.getHeader("Retry-After"), res.body());
+            });
+
+            org.junit.jupiter.api.Assertions.assertEquals(1L, countEvents(events, Level.WARN, "exhausted"),
+                    "the request that armed the lockout on the wrong-password path must log exactly one WARN: " + formatEvents(events));
+            org.junit.jupiter.api.Assertions.assertEquals(0L, countEvents(events, Level.DEBUG, "alice"),
+                    "nothing may be logged at DEBUG when this call armed the lockout: " + formatEvents(events));
+
+            // Past the sliding window the frozen hits no longer count, so a bucket still
+            // refusing here can only be refusing because the escalation stamped a lockout.
+            now[0] += 61_000L;
+            assertFalse(rl.peek(LoginRateLimiter.Scope.USER, "alice", userLimit, 60),
+                    "the escalation must arm a lockout that outlives the sliding window");
+        } finally {
+            ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
+            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+        }
+    }
+
+    @Test
+    public void passwordChange_wrongPasswordDebugsWhenTheConcurrentRequestAlreadyArmedTheLockout() throws Throwable {
+        // Companion of the WARN case: the concurrent request both drained the bucket and armed
+        // the lockout, so this call's lockOut() is a no-op and the refusal has already been
+        // reported. A stolen-session attacker hammering the endpoint must not be able to turn
+        // one lockout into a stream of WARNs.
+        final StubFessLoginAssist assist = registerStubLoginAssist("alice", "secret-current");
+        try {
+            final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+            final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+            final LoginRateLimiter rl = new LoginRateLimiter();
+            final PasswordChangeHandler handler = new PasswordChangeHandler(rl);
+            attachConcurrentlyDrainingHook(assist, rl, "alice", userLimit, lockoutSec, true);
+
+            final List<LogEvent> events = captureLogEvents(PasswordChangeHandler.class.getName(), () -> {
+                final CapturingResponse res = new CapturingResponse();
+                handler.handle(passwordPost("WRONG"), res);
+                assertEquals(429, res.status, res.body());
+            });
+
+            org.junit.jupiter.api.Assertions.assertEquals(0L, countEvents(events, Level.WARN, "alice"),
+                    "a lockout armed by the concurrent request must not be reported a second time: " + formatEvents(events));
+            org.junit.jupiter.api.Assertions.assertEquals(1L, countEvents(events, Level.DEBUG, "alice"),
+                    "the already-locked case must be visible at DEBUG: " + formatEvents(events));
+        } finally {
+            ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
+            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+        }
+    }
+
+    /**
      * Attaches a DEBUG-level capturing appender to {@code loggerName}, runs {@code body}, then
      * restores the original appender set and level. Only events emitted by {@code loggerName}
      * itself are retained, so the surrounding framework chatter is filtered out.
@@ -938,10 +1031,26 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
         private static final long serialVersionUID = 1L;
         private final String userId;
         private final String expectedPw;
+        private transient Runnable concurrentRequest = () -> {};
 
         StubFessLoginAssist(final String userId, final String expectedPw) {
             this.userId = userId;
             this.expectedPw = expectedPw;
+        }
+
+        /**
+         * Runs {@code hook} at the start of {@link #findLoginUser}, i.e. while the handler is
+         * between its {@code peek()} gate and the {@code allow()} call on the wrong-password
+         * path. Tests use it to play the concurrent request that drains the bucket in that
+         * window — the only way the post-verification escalation can be reached, and reachable
+         * here without spawning a thread.
+         *
+         * @param hook action simulating a request that arrives during password verification
+         * @return this stub (fluent)
+         */
+        StubFessLoginAssist withConcurrentRequestDuringVerification(final Runnable hook) {
+            this.concurrentRequest = hook;
+            return this;
         }
 
         @Override
@@ -952,6 +1061,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
 
         @Override
         public OptionalEntity<FessUser> findLoginUser(final LoginCredential credential) {
+            concurrentRequest.run();
             // The handler always passes a LocalUserCredential; defensive-cast and check.
             if (credential instanceof final LocalUserCredential local && expectedPw.equals(local.getPassword())) {
                 return OptionalEntity.of(new StubFessUser(local.getUserId()));

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
@@ -20,12 +20,22 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.app.web.base.login.LocalUserCredential;
 import org.codelibs.fess.entity.FessUser;
@@ -36,6 +46,7 @@ import org.dbflute.optional.OptionalEntity;
 import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.function.Executable;
 import org.lastaflute.web.login.credential.LoginCredential;
 
 import jakarta.servlet.AsyncContext;
@@ -514,6 +525,95 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
             ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
         }
+    }
+
+    @Test
+    public void passwordChange_lockoutWarnsOnceAndDebugsTheRetriesInsideTheWindow() throws Throwable {
+        // Same no-flood contract as the login gates: the C-3 gate reaches its logging statement
+        // on every refused request, so only the request that actually arms the lockout may be a
+        // WARN. A stolen-session attacker who keeps hammering must not be able to pump the log.
+        registerStubLoginAssist("alice", "secret-current");
+        try {
+            final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
+            final int lockoutSec = ComponentUtil.getFessConfig().getThemeApiLoginLockoutSecondsAsInteger();
+            final long lockoutMs = lockoutSec * 1_000L;
+            final long[] now = { 1_000_000L };
+            final long t0 = now[0];
+            final LoginRateLimiter rl = new LoginRateLimiter(() -> now[0]);
+            final PasswordChangeHandler handler = new PasswordChangeHandler(rl);
+            for (int i = 0; i < userLimit; i++) {
+                rl.allow(LoginRateLimiter.Scope.USER, "alice", userLimit, 60);
+            }
+
+            final List<LogEvent> events = captureLogEvents(PasswordChangeHandler.class.getName(), () -> {
+                for (int i = 0; i < 4; i++) {
+                    now[0] = t0 + lockoutMs / 8 * i;
+                    final CapturingResponse res = new CapturingResponse();
+                    handler.handle(passwordPost("secret-current"), res);
+                    assertEquals(429, res.status, res.body());
+                }
+            });
+
+            org.junit.jupiter.api.Assertions.assertEquals(1L, countEvents(events, Level.WARN, "alice"),
+                    "exactly one WARN must be emitted per lockout, not one per refused request: " + formatEvents(events));
+            org.junit.jupiter.api.Assertions.assertEquals(3L, countEvents(events, Level.DEBUG, "alice"),
+                    "the three retries inside the lockout must be logged at DEBUG: " + formatEvents(events));
+        } finally {
+            ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
+            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+        }
+    }
+
+    /**
+     * Attaches a DEBUG-level capturing appender to {@code loggerName}, runs {@code body}, then
+     * restores the original appender set and level. Only events emitted by {@code loggerName}
+     * itself are retained, so the surrounding framework chatter is filtered out.
+     */
+    private static List<LogEvent> captureLogEvents(final String loggerName, final Executable body) throws Throwable {
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        final LoggerConfig loggerCfg = ctx.getConfiguration().getLoggerConfig(loggerName);
+        final Level originalLevel = loggerCfg.getLevel();
+        final List<LogEvent> captured = new ArrayList<>();
+        final String appenderName = "password-handler-capture";
+        final AbstractAppender appender =
+                new AbstractAppender(appenderName, null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
+                    @Override
+                    public void append(final LogEvent event) {
+                        if (loggerName.equals(event.getLoggerName())) {
+                            captured.add(event.toImmutable());
+                        }
+                    }
+                };
+        appender.start();
+        loggerCfg.addAppender(appender, Level.DEBUG, null);
+        loggerCfg.setLevel(Level.DEBUG);
+        ctx.updateLoggers();
+        try {
+            body.execute();
+        } finally {
+            loggerCfg.removeAppender(appenderName);
+            loggerCfg.setLevel(originalLevel);
+            ctx.updateLoggers();
+            appender.stop();
+        }
+        return captured;
+    }
+
+    /**
+     * Counts captured events at {@code level} whose formatted message mentions {@code marker}.
+     * Matching on the bucket key rather than on fixed wording keeps the assertion robust to
+     * message rewording while still excluding unrelated lines from the same logger.
+     */
+    private static long countEvents(final List<LogEvent> events, final Level level, final String marker) {
+        return events.stream()
+                .filter(e -> level.equals(e.getLevel()))
+                .filter(e -> e.getMessage().getFormattedMessage().contains(marker))
+                .count();
+    }
+
+    /** Renders captured events for assertion failure messages. */
+    private static String formatEvents(final List<LogEvent> events) {
+        return events.stream().map(e -> e.getLevel() + " " + e.getMessage().getFormattedMessage()).toList().toString();
     }
 
     /** Builds a well-formed password-change POST carrying {@code currentPw}. */


### PR DESCRIPTION
Three defects on the `/api/v2/auth/*` path, found while investigating a report that
logging in from a static theme stopped working while the classic `/login/` form still
worked. Two follow-up commits correct Javadoc claims the code does not provide and close
the test gaps those first three commits left behind.

## 1. Login lockouts extended themselves on every retry

`LoginHandler` calls `lockOut()` on every refused request, and `allow()`/`peek()` keep
returning `false` for the whole lockout. `lockOut()` re-stamped the deadline from the
current time:

```java
e.lockUntilEpochMs = Math.max(e.lockUntilEpochMs, now + (long) lockoutSeconds * 1_000L);
```

`now` advances between calls, so `now + lockoutSeconds` always won and the release point
moved forward on every retry. `theme.api.login.lockout.seconds` was therefore not a
lockout duration but a required period of silence: a client that kept retrying was never
released, even though the 429 advertised `Retry-After: 900`.

Measured against the unfixed code with a fake clock, driving the real `handle()`:

```
t=+0s    429, Retry-After: 900, lockUntil = T0+900s
t=+800s  429,                   lockUntil = T0+1700s   <-- extended
t=+1000s 429                                            <-- past the advertised deadline
```

`lockOut()` now leaves an active lockout untouched and arms a new window only once the
previous one has elapsed. Re-driving the same scenario against the fix releases the
client at exactly `T0+900s`.

This affected all three gates: the IP gate, both USER gates in `LoginHandler`, and
`PasswordChangeHandler`. The USER gate is the worse of the two for the victim, since it
answers with a generic 401 and no `Retry-After`, so a locked-out user cannot tell a
lockout from a wrong password.

**This is a defect, not a contract change.** `src/main/config/openapi/v2/openapi-user.yaml`
already specifies the behaviour the fix restores — the 429 response documents
`Retry-After` as "seconds the caller should wait before retrying", which a self-extending
lockout does not honour. The spec needs no edit.

**Brute-force resistance is unchanged.** After the fix the budget is 10 attempts per
lockout window per IP and 5 per (IP, user), which is exactly what a client that waited
out the window already got before it. The old tarpit only bit clients that kept
retrying — that is, real users.

The `Math.max` was there for the m-21 review point: a shorter `lockoutSeconds` in a
second call must not shrink a longer active lockout. That direction still holds, but the
guard is *first deadline wins*, not "stricter deadline wins" — while a lockout is running
the incoming value is not consulted at all, so a longer value is ignored too. Since the
duration is re-read from configuration on every refused request, raising
`theme.api.login.lockout.seconds` does not lengthen a lockout that is already counting
down. Commit 4 documents this.

`LoginHandlerTest.test_userLockoutResetsAfterWindowExpires` already stated the invariant
this broke — "clients must regain access once the lockout window elapses, otherwise
transient overload would perma-lock a user" — but it poked the limiter directly instead of
going through the handler, so it never observed the re-stamping. The regression tests
drive `handle()`.

## 2. The v2 endpoints wrote nothing to the audit log

There was no `activityHelper` reference anywhere under `org/codelibs/fess/api/v2/`.
`LoginHandler` wrote neither `LOGIN` nor `LOGIN_FAILURE`, and `LogoutHandler` wrote no
`LOGOUT` — while the classic `LoginAction` and `LogoutAction` write all three. A
deployment whose users sign in through a static theme produced an empty audit trail, so
failed authentication against the SPA login form was undetectable.

The classic **audit** call sites are now mirrored: the same `ActivityHelper` methods, the
same arguments, and the same ordering — `LOGIN` as soon as the credentials are verified,
`LOGOUT` before `assist.logout()` drops the user bean (otherwise the record degrades to
`user:-`). No new activity type is introduced. The non-audit parts of
`LogoutAction.index()` — `ssoManager.logout()` and the user-code cookie — are not mirrored
and remain out of scope.

`ActivityHelper` has no member for a throttled attempt, so the rate-limit branches — which
previously emitted no log line at all — write ordinary log records instead of changing the
audit schema. They deliberately write no `LOGIN_FAILURE`, because no credential was
checked; commit 5 pins that with a negative assertion so it cannot be reversed by
accident.

Audit-sink failures are logged and swallowed: at both call points the authentication or
logout has already been decided, so a broken sink must not turn into a 500 or skip
`assist.logout()`.

`PasswordChangeHandler` writes no activity record, matching `LoginAction.changePassword`.
That is parity — but it is also a gap on both paths, since `ActivityHelper.Action` has no
password-change member at all. Out of scope here.

## 3. The new rate-limit logging would have been a flood vector

Logging every refused request means a client can emit unbounded WARN lines while a
lockout is active. `lockOut()` now returns whether it actually armed a new lockout —
decided inside the same synchronized block that stamps the deadline — and the five call
sites log WARN once per lockout and DEBUG for the refused retries.

Bounds, so the guarantee is not over-read. Suppression is keyed per `(scope, key)`, so
"one WARN per lockout" holds **per bucket, not per client**. A sustained attack that
outlives the window legitimately emits a new WARN each window, and the limiter is
per-JVM, so an N-node cluster emits up to N WARNs per window for the same client. The
return value is likewise a best-effort signal for log volume rather than an exactly-once
guarantee — a concurrent `clear()` (successful login), `sweep()` or eviction can unmap the
entry between the map lookup and the stamp.

## 4. Javadoc claims the code does not provide

Reviewing the three commits above turned up three statements in `lockOut()`'s Javadoc that
are not true of the implementation. Comment-only corrections; no behaviour change.

- "the stricter deadline always wins" — now stated as the narrower m-21 claim it is (see
  section 1).
- "concurrent callers cannot both observe `true` for the same lockout window" — the entry
  is resolved under the `entries` monitor and stamped under the entry monitor, so a
  `clear()`, `sweep()` or eviction in between makes the stamp land on a detached `Entry`.
  Documented as best-effort. The underlying behaviour is unchanged and pre-dates this PR;
  only the claim about it was wrong.
- Release promptness was undocumented. `allow()`/`peek()` return early while locked out,
  *before* the window-pruning step, so the recorded hits are frozen for the duration. When
  `lockoutSeconds <= windowSeconds` those hits are still in-window at expiry and a fresh
  lockout is armed, making effective release about `windowSeconds + lockoutSeconds`. The
  loop is bounded and cannot occur at the shipped defaults (900s lockout, 60s window).

## 5. Tests

```
mvn test -Dtest='org.codelibs.fess.api.v2.**'
  Tests run: 487, Failures: 0, Errors: 0, Skipped: 0
```

Every test was confirmed to fail against a matching mutation of the production code and
to pass once the mutation was reverted. The log-volume tests capture the Log4j2 output
through an appender and assert one WARN plus N-1 DEBUG, following the pattern already used
in `StaticThemeFilterTest`.

The last commit closes five gaps the first three left:

- **The third audit-sink swallow was untested.** `recordLoginActivity` and
  `recordLogoutActivity` each had a test proving a broken sink cannot break the request,
  but deleting the guard from `recordLoginFailureActivity` left the suite green — so
  nothing stopped a throwing sink from turning the generic 401 into a 500.
- **The m-21 test named a construct that no longer exists** and, after the guard change,
  passes even against an implementation that ignores `lockoutSeconds` entirely. Renamed,
  and paired with a new test for the direction it cannot see: a *longer* value supplied
  mid-lockout is ignored too. Restoring `Math.max` reddens the new test while the renamed
  one stays green, which is why both are needed.
- **Two of the five WARN/DEBUG call sites were never executed** — the post-failure
  escalations in `LoginHandler` and `PasswordChangeHandler`. They are unreachable
  single-threaded, because the `peek()` gate evaluates the same predicate over the same
  deque a few lines earlier. The stubs now take a hook that plays the concurrent request,
  draining the remaining slots on the very limiter instance the handler holds, which
  reaches both branches deterministically without threads. Replacing the hook with a no-op
  makes all four tests fail, confirming the branches were otherwise dead to the suite.
- **Nothing drove a lockout through to a successful login.** The expiry tests ended in
  `assertNotEquals(429)`/`assertNotEquals(401)`, which held only because `FessLoginAssist`
  does not resolve in the slim harness and the request landed on 500 — so the headline
  property was asserted by exclusion. Both gates now advance the clock past the deadline
  and complete a real 200 with the success envelope and the `LOGIN` audit record.
- **The "throttle gates write no audit record" decision was unpinned** (see section 2).

## Note on scope

The classic `/login/` form does not consult `LoginRateLimiter` at all. That is why it kept
working while the v2 path was locked — and it also means the throttle can be bypassed.
That is a design question, not a regression, so it is left out of this PR. It does mean
the recovery options before this fix were wider than they looked: besides restarting or
staying silent for the whole window, a locked-out user could sign in through the classic
form (a static theme still serves it) or from a different source address, since both
buckets are keyed by client IP.

Known limitations, not addressed here:

- `Retry-After` carries the configured duration, not the remaining time, so it over-states
  the wait on every retry after the first. Fixing it needs a remaining-time accessor on
  `LoginRateLimiter`, which has none.
- The limiter is per-JVM. In a multi-node deployment each node arms and releases its own
  lockout, so a user who waits exactly the advertised duration can still be refused by a
  node that armed later.
- There is no way to list or release an active lockout — no admin endpoint, no JMX, no
  CLI. The sibling `RateLimitHelper` has `unblockIp()`/`getBlockedIpCount()`; this limiter
  has no equivalent.
