### PR TITLE
fix(theme): compare the v2 API error codes the server actually sends

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/auth.js
+++ b/src/main/webapp/themes/bootstrap/assets/auth.js
@@ -25,8 +25,10 @@ export async function probeMe() {
     setLoggedOut();
     return null;
   } catch (e) {
-    // 401 / AUTH_REQUIRED → not logged in; expected and silent.
-    if (e.code === "AUTH_REQUIRED" || e.httpStatus === 401) {
+    // 401 / auth_required → not logged in; expected and silent.
+    // V2ErrorCode emits lowercase snake_case wire codes ("auth_required"); the
+    // uppercase spelling is kept alongside it so the branch survives either form.
+    if (e.code === "auth_required" || e.code === "AUTH_REQUIRED" || e.httpStatus === 401) {
       setLoggedOut();
       return null;
     }
@@ -288,7 +290,8 @@ export function attach() {
         }
         document.dispatchEvent(new CustomEvent("fess:auth:login", { detail: env.user }));
       } catch (e) {
-        if (e.code === "RATE_LIMITED" || e.httpStatus === 429) err.textContent = t("auth.error_rate_limited");
+        // V2ErrorCode emits lowercase snake_case wire codes ("rate_limited").
+        if (e.code === "rate_limited" || e.code === "RATE_LIMITED" || e.httpStatus === 429) err.textContent = t("auth.error_rate_limited");
         else err.textContent = t("auth.error_invalid_credentials");
         err.classList.remove("d-none");
       }

--- a/src/main/webapp/themes/bootstrap/assets/cache.js
+++ b/src/main/webapp/themes/bootstrap/assets/cache.js
@@ -243,7 +243,7 @@ export function attach() {
       host.appendChild(iframe);
     })
     .catch(err => {
-      const isNotFound = err && (err.code === "NOT_FOUND" || err.httpStatus === 404);
+      const isNotFound = err && (err.code === "not_found" || err.code === "NOT_FOUND" || err.httpStatus === 404);
       const msg = isNotFound
         ? t("labels.cache_not_found")
         : t("error.server");

--- a/src/main/webapp/themes/bootstrap/assets/profile.js
+++ b/src/main/webapp/themes/bootstrap/assets/profile.js
@@ -77,7 +77,9 @@ export function localizePasswordError(err) {
   if (err && err.name === "NetworkError") return t("error.network");
   const code = err && err.code;
   const httpStatus = err && err.httpStatus;
-  if (code === "RATE_LIMITED" || httpStatus === 429) return t("auth.error_rate_limited");
+  // V2ErrorCode emits lowercase snake_case wire codes ("rate_limited"); the
+  // uppercase spelling is kept alongside it so the branch survives either form.
+  if (code === "rate_limited" || code === "RATE_LIMITED" || httpStatus === 429) return t("auth.error_rate_limited");
   const details = (err && err.details) || {};
   const reason = details.reason;
   if (reason === "invalid_current_password") return t("profile.error_wrong_current");
@@ -104,7 +106,7 @@ export function localizePasswordError(err) {
       break;
   }
   // Fallbacks by HTTP/code when no specific reason is present.
-  if (code === "AUTH_REQUIRED" || httpStatus === 401) return t("profile.error_wrong_current");
+  if (code === "auth_required" || code === "AUTH_REQUIRED" || httpStatus === 401) return t("profile.error_wrong_current");
   return t("error.server");
 }
 

--- a/src/main/webapp/themes/bootstrap/assets/search.js
+++ b/src/main/webapp/themes/bootstrap/assets/search.js
@@ -736,7 +736,7 @@ async function runSearch() {
     // search failed with a 500 or a dropped connection. Fall back to #results-meta when a
     // theme has no visible banner.
     const msg = (e && e.name === "NetworkError") ? t("error.network")
-              : (e && e.code === "AUTH_REQUIRED") ? t("error.auth_required")
+              : (e && (e.code === "auth_required" || e.code === "AUTH_REQUIRED")) ? t("error.auth_required")
               : t("error.server");
     if (errBox) { errBox.textContent = msg; errBox.classList.remove("d-none"); }
     else { const meta = document.getElementById("results-meta"); if (meta) meta.textContent = msg; }
@@ -1840,7 +1840,7 @@ async function syncFavorites(queryId) {
       setFavoriteUi(btn, favoriteSet.has(docId), Number(btn.dataset.count) || 0);
     });
   } catch (e) {
-    if (e && (e.code === "AUTH_REQUIRED" || e.httpStatus === 401)) return; // unauthenticated — silent
+    if (e && (e.code === "auth_required" || e.code === "AUTH_REQUIRED" || e.httpStatus === 401)) return; // unauthenticated — silent
     // other errors: ignore, favorites are best-effort
   }
 }
@@ -1952,7 +1952,7 @@ async function toggleFavorite(docId, btn, queryId) {
     // expired between page load and the click) *before* the auth check runs, so a
     // guest click can surface as 403 instead of 401. Logging in through the modal
     // issues a fresh session + token, so treat both the same.
-    if (e.code === "AUTH_REQUIRED" || e.httpStatus === 401 || e.httpStatus === 403) {
+    if (e.code === "auth_required" || e.code === "AUTH_REQUIRED" || e.httpStatus === 401 || e.httpStatus === 403) {
       if (!window.bootstrap || !bootstrap.Modal) {
         console.warn("[fess] bootstrap not loaded; skipping modal show");
       } else {

--- a/src/test/js/themes/bootstrap/auth.test.js
+++ b/src/test/js/themes/bootstrap/auth.test.js
@@ -188,6 +188,28 @@ describe("probeMe", () => {
     expect(document.getElementById("user-dropdown")).toBeNull();
   });
 
+  // V2ErrorCode.AUTH_REQUIRED puts the wire code "auth_required" (lowercase
+  // snake_case) on the envelope, and api.js copies err.code through verbatim —
+  // nothing in the SPA normalises the case. No httpStatus is supplied here, so
+  // the `|| e.httpStatus === 401` fallback cannot mask a failure to recognise
+  // the code itself. Both the AUTH_REQUIRED branch and the generic fallback log
+  // the user out, so the distinguishing observable is that the expected-and-silent
+  // branch emits no console warning.
+  it("treats the server's lowercase auth_required wire code as logged out, silently", async () => {
+    document.body.innerHTML = '<ul id="auth-controls"></ul>';
+    api.getConfig.mockReturnValue({});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    api.get.mockRejectedValue({ code: "auth_required" });
+
+    const result = await probeMe();
+
+    expect(result).toBeNull();
+    expect(api.setAuthenticated).toHaveBeenCalledWith(false);
+    expect(document.getElementById("login-btn")).not.toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("surfaces a network/server (5xx) error without flipping auth state", async () => {
     document.body.innerHTML = '<div id="results-meta"></div><ul id="auth-controls"></ul>';
     let networkEvent = null;
@@ -244,6 +266,22 @@ describe("attach — login form submit", () => {
     document.body.innerHTML = LOGIN_FIXTURE;
     await attach();
     api.post.mockRejectedValue({ httpStatus: 429 });
+
+    document.getElementById("login-form").dispatchEvent(new Event("submit"));
+    await flush();
+
+    const err = document.getElementById("login-error");
+    expect(err.textContent).toBe("auth.error_rate_limited");
+    expect(err.classList.contains("d-none")).toBe(false);
+  });
+
+  // The 429 case above is carried by the httpStatus fallback alone. This one pins
+  // the code arm against the string the server actually sends
+  // (V2ErrorCode.RATE_LIMITED → "rate_limited"), with no httpStatus to fall back on.
+  it("shows the rate-limited message for the server's lowercase rate_limited wire code", async () => {
+    document.body.innerHTML = LOGIN_FIXTURE;
+    await attach();
+    api.post.mockRejectedValue({ code: "rate_limited" });
 
     document.getElementById("login-form").dispatchEvent(new Event("submit"));
     await flush();

--- a/src/test/js/themes/bootstrap/profile.test.js
+++ b/src/test/js/themes/bootstrap/profile.test.js
@@ -40,6 +40,10 @@ describe("localizePasswordError", () => {
   it.each([
     [{ name: "NetworkError" }, "error.network"],
     [{ code: "RATE_LIMITED" }, "auth.error_rate_limited"],
+    // The server's actual wire code is lowercase snake_case (V2ErrorCode
+    // .RATE_LIMITED → "rate_limited"); api.js copies err.code through unchanged.
+    // No httpStatus here, so the 429 fallback cannot cover for the code arm.
+    [{ code: "rate_limited" }, "auth.error_rate_limited"],
     [{ httpStatus: 429 }, "auth.error_rate_limited"],
     [{ details: { reason: "invalid_current_password" } }, "profile.error_wrong_current"],
     [{ details: { reason: "errors.password_length", min_length: 8 } }, "profile.error_password_length"],
@@ -53,6 +57,8 @@ describe("localizePasswordError", () => {
     [{ details: { reason: "current_password_required" } }, "profile.error_blank_password"],
     [{ details: { reason: "password_mismatch" } }, "profile.error_mismatch"],
     [{ code: "AUTH_REQUIRED" }, "profile.error_wrong_current"],
+    // Same wire-code contract for V2ErrorCode.AUTH_REQUIRED → "auth_required".
+    [{ code: "auth_required" }, "profile.error_wrong_current"],
     [{ httpStatus: 401 }, "profile.error_wrong_current"],
     [{ code: "SOMETHING_UNMAPPED" }, "error.server"],
     [null, "error.server"],

--- a/src/test/js/themes/bootstrap/search.test.js
+++ b/src/test/js/themes/bootstrap/search.test.js
@@ -789,6 +789,16 @@ describe("runSearch — error handling", () => {
     expect(errBox().textContent).toBe("error.auth_required");
   });
 
+  // This arm has NO httpStatus fallback in search.js, so the code string is the
+  // only thing standing between an authentication failure and a generic
+  // "error.server". The server sends V2ErrorCode.AUTH_REQUIRED's wire code
+  // "auth_required" (lowercase snake_case) and api.js passes it through verbatim.
+  it("shows error.auth_required for the server's lowercase auth_required wire code", async () => {
+    api.get.mockRejectedValueOnce(Object.assign(new Error("auth"), { code: "auth_required" }));
+    await runSearch();
+    expect(errBox().textContent).toBe("error.auth_required");
+  });
+
   it("shows error.server for a generic failure and clears the spinner", async () => {
     api.get.mockRejectedValueOnce(new Error("boom"));
     await runSearch();

--- a/src/test/js/themes/bootstrap/wire-error-codes.contract.test.js
+++ b/src/test/js/themes/bootstrap/wire-error-codes.contract.test.js
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Source contract: a comparison against a v2 API error code must accept the
+// LOWERCASE wire code the server actually sends.
+//
+// V2ErrorCode pairs a SCREAMING_SNAKE_CASE Java constant with a lowercase
+// snake_case wire code (AUTH_REQUIRED -> "auth_required"). V2EnvelopeWriter puts
+// code.code() — the wire code — onto the error envelope, api.js copies it onto the
+// thrown ApiError verbatim, and nothing in the SPA normalises the case. So a branch
+// that compares err.code only to the Java CONSTANT NAME is dead: it can never match
+// a real server response, and the user silently gets the wrong message (or, where a
+// `|| e.httpStatus === 4xx` fallback exists, the right message for the wrong reason
+// — which is why the defect survived so long).
+//
+// Writing a behavioural test for each of the ~40 comparison sites is not practical,
+// and behavioural tests only cover the sites someone remembered to write one for.
+// This suite instead reads the shipped source and fails on ANY uppercase-only
+// comparison, so a newly added branch cannot reintroduce the defect. The companion
+// behavioural suites (auth.test.js / profile.test.js / search.test.js) stay: this
+// contract proves a comparison is not misspelled, only they prove it produces the
+// right message.
+//
+// The enum table is derived from V2ErrorCode.java rather than hardcoded, so adding a
+// constant there automatically extends the contract instead of quietly escaping it.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// fileURLToPath is given the URL as a STRING: the suite runs under the jsdom
+// environment, whose global URL is whatwg-url rather than node's, and node's
+// fileURLToPath rejects a foreign URL instance ("The URL must be of scheme file").
+// src/test/js/themes/bootstrap/ -> repo root is five levels up.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const ASSETS = join(repoRoot, "src/main/webapp/themes/bootstrap/assets");
+const V2_ERROR_CODE_JAVA = join(repoRoot, "src/main/java/org/codelibs/fess/api/v2/V2ErrorCode.java");
+
+/**
+ * Uppercase string literals api.js mints CLIENT-SIDE that are deliberately NOT
+ * subject to this contract:
+ *
+ *   NETWORK / PROTOCOL  — transport and envelope-shape failures detected before any
+ *                         server error code exists (invalid JSON, missing envelope).
+ *   UNKNOWN             — the fallback when the server omits error.code entirely
+ *                         (`new ApiError(err.code || "UNKNOWN", ...)`).
+ *   HTTP_ERROR          — a non-JSON HTTP failure with no v2 envelope at all.
+ *   BUFFER_OVERFLOW     — a streaming-reader guard, purely local.
+ *
+ * These never travel over the wire, so there is no lowercase counterpart to compare
+ * against and no server spelling they could disagree with. They are listed here (a)
+ * to document why they are exempt and (b) so the disjointness assertion below fails
+ * loudly if a future V2ErrorCode constant ever collides with one of these names —
+ * at which point the same literal would mean two different things.
+ */
+const CLIENT_SENTINELS = ["NETWORK", "PROTOCOL", "UNKNOWN", "HTTP_ERROR", "BUFFER_OVERFLOW"];
+
+/** Parse `CONSTANT_NAME("wire_code", 400),` out of the V2ErrorCode enum body. */
+function readWireCodes() {
+  const src = readFileSync(V2_ERROR_CODE_JAVA, "utf8");
+  const map = new Map();
+  for (const m of src.matchAll(/^\s{4}([A-Z][A-Z0-9_]*)\("([a-z0-9_]+)",\s*\d+\)/gm)) {
+    map.set(m[1], m[2]);
+  }
+  return map;
+}
+
+/**
+ * Every `<something>.code === "LITERAL"` / `code === "LITERAL"` comparison in a file.
+ * `===` binds tighter than `||`/`&&`, so each match is one complete operand of the
+ * surrounding condition.
+ */
+const COMPARISON = /([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*===\s*"([A-Z][A-Z0-9_]*)"/g;
+
+const assetFiles = readdirSync(ASSETS).filter((f) => f.endsWith(".js")).sort();
+
+describe("V2ErrorCode wire-code table", () => {
+  const wireCodes = readWireCodes();
+
+  it("parses every constant out of V2ErrorCode.java", () => {
+    // A parse failure would make every assertion below vacuously green.
+    expect(wireCodes.size).toBeGreaterThanOrEqual(12);
+    expect(wireCodes.get("AUTH_REQUIRED")).toBe("auth_required");
+    expect(wireCodes.get("RATE_LIMITED")).toBe("rate_limited");
+    expect(wireCodes.get("INVALID_REQUEST")).toBe("invalid_request");
+  });
+
+  it("emits only lowercase snake_case wire codes", () => {
+    for (const [name, code] of wireCodes) {
+      expect(code, `${name} wire code`).toMatch(/^[a-z][a-z0-9_]*$/);
+      expect(code, `${name} wire code must differ from the constant name`).not.toBe(name);
+    }
+  });
+
+  it("keeps the client-side sentinels disjoint from the wire codes", () => {
+    for (const sentinel of CLIENT_SENTINELS) {
+      expect(wireCodes.has(sentinel), `${sentinel} is both a client sentinel and a V2ErrorCode`).toBe(false);
+    }
+  });
+});
+
+describe("theme JS compares the lowercase wire codes", () => {
+  const wireCodes = readWireCodes();
+
+  /**
+   * Collect every uppercase wire-code comparison that does NOT also test the
+   * lowercase spelling within the same condition. The convention every fixed site
+   * follows is `x.code === "lower" || x.code === "UPPER"` on ONE line, so a
+   * same-line check is both sufficient and deliberately strict: it keeps the two
+   * spellings adjacent and reviewable instead of scattered across a condition.
+   */
+  function violations(file) {
+    const lines = readFileSync(join(ASSETS, file), "utf8").split("\n");
+    const found = [];
+    let checked = 0;
+    lines.forEach((line, i) => {
+      for (const m of line.matchAll(COMPARISON)) {
+        const [, lhs, upper] = m;
+        if (!wireCodes.has(upper)) continue; // client sentinel or unrelated literal
+        checked++;
+        const lower = wireCodes.get(upper);
+        if (!new RegExp(`===\\s*"${lower}"`).test(line)) {
+          found.push(`${file}:${i + 1}  ${lhs} === "${upper}" without "${lower}"\n    ${line.trim()}`);
+        }
+      }
+    });
+    return { found, checked };
+  }
+
+  it("scans the real shipped assets (guards against a vacuous pass)", () => {
+    expect(assetFiles.length).toBeGreaterThan(5);
+    const total = assetFiles.reduce((n, f) => n + violations(f).checked, 0);
+    expect(total, "no wire-code comparisons found at all — the scan is broken").toBeGreaterThan(5);
+  });
+
+  it.each(assetFiles)("%s pairs every uppercase wire code with its lowercase form", (file) => {
+    const { found } = violations(file);
+    expect(found, `uppercase-only v2 error-code comparison(s):\n${found.join("\n")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
`V2ErrorCode` sends lowercase snake_case wire codes (`auth_required`, `rate_limited`,
`not_found`, ...):

```java
RATE_LIMITED("rate_limited", 429),
```

`V2EnvelopeWriter` puts the value on the envelope unchanged (`err.put("code", code.code())`)
and `api.js` passes it into `ApiError` unchanged (`new ApiError(err.code || "UNKNOWN", ...)`).
Nothing in the theme JS normalizes it — the only `toUpperCase`/`toLowerCase` calls in the
bundle are for tag names, locale matching and text search.

So every comparison against the uppercase spelling was dead code:

```js
if (e.code === "RATE_LIMITED" || e.httpStatus === 429) ...
```

Most sites were masked by the `httpStatus` fallback in the same expression, but not all:
the `AUTH_REQUIRED` arm of the `runSearch` error ternary has no fallback and fell through
to the generic "server error" message, and `profile.js` reported `error.server` instead of
the rate-limit and wrong-password messages.

The fix follows the `invalid_request` comparison already present in this file, which checks
both spellings:

```js
if (e && (e.code === "invalid_request" || e.code === "INVALID_REQUEST" || e.httpStatus === 400)) {
```

Sites corrected in `auth.js`, `profile.js`, `search.js` and `cache.js`. The client-side
sentinels in `api.js` (`NETWORK`, `PROTOCOL`, `UNKNOWN`, `HTTP_ERROR`, `BUFFER_OVERFLOW`)
are left alone — they never travel over the wire.

## Tests

The behavioural cases supply each wire code with **no** `httpStatus`, so the code arm is the
only thing under test and the assertions cannot be rescued by the fallback.

`src/test/js/themes/bootstrap/wire-error-codes.contract.test.js` parses the wire-code table
straight out of `V2ErrorCode.java` and fails if an uppercase comparison in the shipped JS is
not accompanied by the lowercase spelling on the same line, so a new enum constant extends the
contract automatically. The `api.js` sentinels are an explicit, commented exclusion list, and
an assertion keeps that set disjoint from the wire codes.

```
src/test/js: Test Files 17 passed (17) / Tests 437 passed (437)
```

Both were confirmed to fail before the change, and the contract test was confirmed to fail —
naming the exact `file:line` — when a single site is reverted.

## Related

`bootstrap` is the reference copy of these shared modules; the matching change for the ten
shipped themes is in the `fess-themes` repository. The two should land together so the copies
stay in sync.

Paired with codelibs/fess-themes#40, which carries the same change for the ten shipped themes.
