### PR TITLE
fix(search): report an unsupported facet field instead of returning no hits

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
@@ -350,6 +350,9 @@ public class FessMessages extends FessLabels {
     /** The key of the message: The specified sort order {0} is unsupported. */
     public static final String ERRORS_invalid_query_unsupported_sort_order = "{errors.invalid_query_unsupported_sort_order}";
 
+    /** The key of the message: The specified facet {0} is unsupported. */
+    public static final String ERRORS_invalid_query_unsupported_facet_field = "{errors.invalid_query_unsupported_facet_field}";
+
     /** The key of the message: Could not process the specified query. */
     public static final String ERRORS_invalid_query_cannot_process = "{errors.invalid_query_cannot_process}";
 
@@ -2205,6 +2208,21 @@ public class FessMessages extends FessLabels {
     public FessMessages addErrorsInvalidQueryUnsupportedSortOrder(String property, String arg0) {
         assertPropertyNotNull(property);
         add(property, new UserMessage(ERRORS_invalid_query_unsupported_sort_order, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.invalid_query_unsupported_facet_field' with parameters.
+     * <pre>
+     * message: The specified facet {0} is unsupported.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsInvalidQueryUnsupportedFacetField(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_invalid_query_unsupported_facet_field, arg0));
         return this;
     }
 

--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -63,7 +63,6 @@ import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.exception.FessSystemException;
 import org.codelibs.fess.exception.InvalidQueryException;
 import org.codelibs.fess.exception.ResultOffsetExceededException;
-import org.codelibs.fess.exception.SearchQueryException;
 import org.codelibs.fess.helper.DocumentHelper;
 import org.codelibs.fess.helper.QueryHelper;
 import org.codelibs.fess.helper.SystemHelper;
@@ -2201,7 +2200,7 @@ public class SearchEngineClient implements Client {
          *
          * @return true if the build was successful, false if the query is blank
          * @throws ResultOffsetExceededException if the offset exceeds the maximum allowed
-         * @throws SearchQueryException if facet fields are invalid
+         * @throws InvalidQueryException if a requested facet field is not allowed
          */
         public boolean build() {
             if (StringUtil.isBlank(query)) {
@@ -2298,12 +2297,19 @@ public class SearchEngineClient implements Client {
          * @param queryHelper the query helper
          * @param queryFieldConfig the query field configuration
          * @param fessConfig the Fess configuration
-         * @throws SearchQueryException if facet fields are invalid
+         * @throws InvalidQueryException if a requested facet field is not allowed by
+         *         {@code query.additional.facet.fields}
          */
         protected void buildFacet(final QueryHelper queryHelper, final QueryFieldConfig queryFieldConfig, final FessConfig fessConfig) {
             stream(facetInfo.field).of(stream -> stream.forEach(f -> {
                 if (!queryFieldConfig.isFacetField(f)) {
-                    throw new SearchQueryException("Invalid facet field: " + f);
+                    // InvalidQueryException (not SearchQueryException) so that the caller sees a
+                    // query error: RankFusionProcessor swallows everything else into an empty
+                    // result list, which turns a misconfigured facet field into a search that
+                    // silently returns no documents at all.
+                    throw new InvalidQueryException(
+                            messages -> messages.addErrorsInvalidQueryUnsupportedFacetField(UserMessages.GLOBAL_PROPERTY_KEY, f),
+                            "Unsupported facet field: " + f);
                 }
                 final String encodedField = BaseEncoding.base64().encode(f.getBytes(StandardCharsets.UTF_8));
                 final TermsAggregationBuilder termsBuilder =

--- a/src/main/resources/fess_message.properties
+++ b/src/main/resources/fess_message.properties
@@ -134,6 +134,7 @@ errors.invalid_query_parse_error = The given query is invalid.
 errors.invalid_query_sort_value = The specified sort {0} is invalid.
 errors.invalid_query_unsupported_sort_field = The specified sort {0} is unsupported.
 errors.invalid_query_unsupported_sort_order = The specified sort order {0} is unsupported.
+errors.invalid_query_unsupported_facet_field = The specified facet {0} is unsupported.
 errors.invalid_query_cannot_process=Could not process the specified query.
 errors.crud_invalid_mode = The mode is incorrect. (not {0}, but {1})
 errors.crud_failed_to_create_instance = Failed to create a new data.

--- a/src/main/resources/fess_message_de.properties
+++ b/src/main/resources/fess_message_de.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = Die angegebene Abfrage ist ungültig.
 errors.invalid_query_sort_value = Die angegebene Sortierung {0} ist ungültig.
 errors.invalid_query_unsupported_sort_field = Die angegebene Sortierung {0} wird nicht unterstützt.
 errors.invalid_query_unsupported_sort_order = Die angegebene Sortierreihenfolge {0} wird nicht unterstützt.
+errors.invalid_query_unsupported_facet_field = Die angegebene Facette {0} wird nicht unterstützt.
 errors.invalid_query_cannot_process=Die angegebene Abfrage konnte nicht verarbeitet werden.
 errors.crud_invalid_mode = Der Modus ist falsch. (nicht {0}, sondern {1})
 errors.crud_failed_to_create_instance = Fehler beim Erstellen neuer Daten.

--- a/src/main/resources/fess_message_en.properties
+++ b/src/main/resources/fess_message_en.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = The given query is invalid.
 errors.invalid_query_sort_value = The specified sort {0} is invalid.
 errors.invalid_query_unsupported_sort_field = The specified sort {0} is unsupported.
 errors.invalid_query_unsupported_sort_order = The specified sort order {0} is unsupported.
+errors.invalid_query_unsupported_facet_field = The specified facet {0} is unsupported.
 errors.invalid_query_cannot_process=Could not process the specified query.
 errors.crud_invalid_mode = The mode is incorrect. (not {0}, but {1})
 errors.crud_failed_to_create_instance = Failed to create a new data.

--- a/src/main/resources/fess_message_es.properties
+++ b/src/main/resources/fess_message_es.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = La consulta proporcionada no es válida.
 errors.invalid_query_sort_value = El orden de clasificación especificado {0} no es válido.
 errors.invalid_query_unsupported_sort_field = El campo de ordenación especificado {0} no es compatible.
 errors.invalid_query_unsupported_sort_order = El orden de clasificación especificado {0} no es compatible.
+errors.invalid_query_unsupported_facet_field = La faceta especificada {0} no es compatible.
 errors.invalid_query_cannot_process=No se pudo procesar la consulta especificada.
 errors.crud_invalid_mode = Modo incorrecto. (Es {1}, no {0})
 errors.crud_failed_to_create_instance = No se pudieron crear nuevos datos.

--- a/src/main/resources/fess_message_fr.properties
+++ b/src/main/resources/fess_message_fr.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = La requête donnée n'est pas valide.
 errors.invalid_query_sort_value = Le tri spécifié {0} n'est pas valide.
 errors.invalid_query_unsupported_sort_field = Le tri spécifié {0} n'est pas pris en charge.
 errors.invalid_query_unsupported_sort_order = L'ordre de tri spécifié {0} n'est pas pris en charge.
+errors.invalid_query_unsupported_facet_field = La facette spécifiée {0} n'est pas prise en charge.
 errors.invalid_query_cannot_process=Impossible de traiter la requête spécifiée.
 errors.crud_invalid_mode = Le mode est incorrect. (pas {0}, mais {1})
 errors.crud_failed_to_create_instance = Échec de la création de nouvelles données.

--- a/src/main/resources/fess_message_hi.properties
+++ b/src/main/resources/fess_message_hi.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = दी गई क्वेरी अमान
 errors.invalid_query_sort_value = निर्दिष्ट सॉर्ट {0} अमान्य है।
 errors.invalid_query_unsupported_sort_field = निर्दिष्ट सॉर्ट {0} असमर्थित है।
 errors.invalid_query_unsupported_sort_order = निर्दिष्ट सॉर्ट क्रम {0} असमर्थित है।
+errors.invalid_query_unsupported_facet_field = निर्दिष्ट पहलू {0} असमर्थित है।
 errors.invalid_query_cannot_process=निर्दिष्ट क्वेरी को संसाधित नहीं किया जा सका।
 errors.crud_invalid_mode = मोड गलत है। ({0} नहीं, बल्कि {1})
 errors.crud_failed_to_create_instance = नया डेटा बनाने में विफल।

--- a/src/main/resources/fess_message_id.properties
+++ b/src/main/resources/fess_message_id.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = Kueri yang diberikan tidak valid.
 errors.invalid_query_sort_value = Sortir yang ditentukan {0} tidak valid.
 errors.invalid_query_unsupported_sort_field = Sortir yang ditentukan {0} tidak didukung.
 errors.invalid_query_unsupported_sort_order = Urutan sortir yang ditentukan {0} tidak didukung.
+errors.invalid_query_unsupported_facet_field = Faset yang ditentukan {0} tidak didukung.
 errors.invalid_query_cannot_process=Tidak dapat memproses kueri yang ditentukan.
 errors.crud_invalid_mode = Mode tidak benar. (bukan {0}, tetapi {1})
 errors.crud_failed_to_create_instance = Gagal membuat data baru.

--- a/src/main/resources/fess_message_it.properties
+++ b/src/main/resources/fess_message_it.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = La query fornita non è valida.
 errors.invalid_query_sort_value = L'ordinamento specificato {0} non è valido.
 errors.invalid_query_unsupported_sort_field = Il campo di ordinamento specificato {0} non è supportato.
 errors.invalid_query_unsupported_sort_order = L'ordinamento specificato {0} non è supportato.
+errors.invalid_query_unsupported_facet_field = La faccetta specificata {0} non è supportata.
 errors.invalid_query_cannot_process=Impossibile elaborare la query specificata.
 errors.crud_invalid_mode = Modalità non valida. (È {1}, non {0})
 errors.crud_failed_to_create_instance = Impossibile creare nuovi dati.

--- a/src/main/resources/fess_message_ja.properties
+++ b/src/main/resources/fess_message_ja.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = 与えられたクエリーは無効です。
 errors.invalid_query_sort_value = 指定されたソート {0} が無効です。
 errors.invalid_query_unsupported_sort_field = 指定されたソート {0} はサポートされていません。
 errors.invalid_query_unsupported_sort_order = 指定されたソート順 {0} はサポートされていません。
+errors.invalid_query_unsupported_facet_field = 指定されたファセット {0} はサポートされていません。
 errors.invalid_query_cannot_process=指定されたクエリーを処理できませんでした。
 errors.crud_invalid_mode = モードが正しくありません。({0} でなく、{1} です)
 errors.crud_failed_to_create_instance = 新しいデータの作成に失敗しました。

--- a/src/main/resources/fess_message_ko.properties
+++ b/src/main/resources/fess_message_ko.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = 주어진 쿼리가 잘못되었습니다.
 errors.invalid_query_sort_value = 지정된 정렬 {0}이(가) 잘못되었습니다.
 errors.invalid_query_unsupported_sort_field = 지정된 정렬 {0}은(는) 지원되지 않습니다.
 errors.invalid_query_unsupported_sort_order = 지정된 정렬 순서 {0}은(는) 지원되지 않습니다.
+errors.invalid_query_unsupported_facet_field = 지정된 패싯 {0}은(는) 지원되지 않습니다.
 errors.invalid_query_cannot_process=지정된 쿼리를 처리할 수 없습니다.
 errors.crud_invalid_mode = 모드가 잘못되었습니다. ({0}이(가) 아니고 {1}입니다)
 errors.crud_failed_to_create_instance = 새 데이터를 만들지 못했습니다.

--- a/src/main/resources/fess_message_nl.properties
+++ b/src/main/resources/fess_message_nl.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = De opgegeven query is ongeldig.
 errors.invalid_query_sort_value = De opgegeven sorteerwaarde {0} is ongeldig.
 errors.invalid_query_unsupported_sort_field = Het opgegeven sorteerveld {0} wordt niet ondersteund.
 errors.invalid_query_unsupported_sort_order = De opgegeven sorteervolgorde {0} wordt niet ondersteund.
+errors.invalid_query_unsupported_facet_field = Het opgegeven facet {0} wordt niet ondersteund.
 errors.invalid_query_cannot_process=Kan de opgegeven query niet verwerken.
 errors.crud_invalid_mode = Ongeldige modus. (Is {1}, niet {0})
 errors.crud_failed_to_create_instance = Kan geen nieuwe gegevens maken.

--- a/src/main/resources/fess_message_pl.properties
+++ b/src/main/resources/fess_message_pl.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = Podane zapytanie jest nieprawidłowe.
 errors.invalid_query_sort_value = Określona wartość sortowania {0} jest nieprawidłowa.
 errors.invalid_query_unsupported_sort_field = Określone pole sortowania {0} nie jest obsługiwane.
 errors.invalid_query_unsupported_sort_order = Określona kolejność sortowania {0} nie jest obsługiwana.
+errors.invalid_query_unsupported_facet_field = Określony aspekt {0} nie jest obsługiwany.
 errors.invalid_query_cannot_process=Nie można przetworzyć określonego zapytania.
 errors.crud_invalid_mode = Nieprawidłowy tryb. (Jest {1}, a nie {0})
 errors.crud_failed_to_create_instance = Nie można utworzyć nowych danych.

--- a/src/main/resources/fess_message_pt_BR.properties
+++ b/src/main/resources/fess_message_pt_BR.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = A consulta fornecida é inválida.
 errors.invalid_query_sort_value = A ordenação especificada {0} é inválida.
 errors.invalid_query_unsupported_sort_field = O campo de ordenação especificado {0} não é suportado.
 errors.invalid_query_unsupported_sort_order = A ordem de ordenação especificada {0} não é suportada.
+errors.invalid_query_unsupported_facet_field = A faceta especificada {0} não é suportada.
 errors.invalid_query_cannot_process=Não foi possível processar a consulta especificada.
 errors.crud_invalid_mode = Modo inválido. (É {1}, não {0})
 errors.crud_failed_to_create_instance = Não foi possível criar novos dados.

--- a/src/main/resources/fess_message_ru.properties
+++ b/src/main/resources/fess_message_ru.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = Данный запрос недействи�
 errors.invalid_query_sort_value = Указанная сортировка {0} недействительна.
 errors.invalid_query_unsupported_sort_field = Указанная сортировка {0} не поддерживается.
 errors.invalid_query_unsupported_sort_order = Указанный порядок сортировки {0} не поддерживается.
+errors.invalid_query_unsupported_facet_field = Указанная фасета {0} не поддерживается.
 errors.invalid_query_cannot_process=Не удалось обработать указанный запрос.
 errors.crud_invalid_mode = Режим неверный. (не {0}, а {1})
 errors.crud_failed_to_create_instance = Не удалось создать новые данные.

--- a/src/main/resources/fess_message_tr.properties
+++ b/src/main/resources/fess_message_tr.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = Verilen sorgu geçersiz.
 errors.invalid_query_sort_value = Belirtilen sıralama {0} geçersiz.
 errors.invalid_query_unsupported_sort_field = Belirtilen sıralama {0} desteklenmiyor.
 errors.invalid_query_unsupported_sort_order = Belirtilen sıralama düzeni {0} desteklenmiyor.
+errors.invalid_query_unsupported_facet_field = Belirtilen facet {0} desteklenmiyor.
 errors.invalid_query_cannot_process=Belirtilen sorgu işlenemedi.
 errors.crud_invalid_mode = Mod yanlış. ({0} değil, {1})
 errors.crud_failed_to_create_instance = Yeni veri oluşturulamadı.

--- a/src/main/resources/fess_message_zh_CN.properties
+++ b/src/main/resources/fess_message_zh_CN.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = 提供的查询无效。
 errors.invalid_query_sort_value = 指定的排序 {0} 无效。
 errors.invalid_query_unsupported_sort_field = 指定的排序字段 {0} 不受支持。
 errors.invalid_query_unsupported_sort_order = 指定的排序顺序 {0} 不受支持。
+errors.invalid_query_unsupported_facet_field = 指定的分类筛选字段 {0} 不受支持。
 errors.invalid_query_cannot_process=无法处理指定的查询。
 errors.crud_invalid_mode = 模式不正确。(是 {1}，而不是 {0})
 errors.crud_failed_to_create_instance = 无法创建新数据。

--- a/src/main/resources/fess_message_zh_TW.properties
+++ b/src/main/resources/fess_message_zh_TW.properties
@@ -130,6 +130,7 @@ errors.invalid_query_parse_error = 提供的查詢無效。
 errors.invalid_query_sort_value = 指定的排序 {0} 無效。
 errors.invalid_query_unsupported_sort_field = 指定的排序欄位 {0} 不支援。
 errors.invalid_query_unsupported_sort_order = 指定的排序順序 {0} 不支援。
+errors.invalid_query_unsupported_facet_field = 指定的分類篩選欄位 {0} 不支援。
 errors.invalid_query_cannot_process=無法處理指定的查詢。
 errors.crud_invalid_mode = 模式不正確。(是 {1}，而不是 {0})
 errors.crud_failed_to_create_instance = 無法建立新資料。

--- a/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientFacetFieldTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientFacetFieldTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.opensearch.client;
+
+import org.codelibs.fess.entity.FacetInfo;
+import org.codelibs.fess.exception.InvalidQueryException;
+import org.codelibs.fess.opensearch.client.SearchEngineClient.SearchConditionBuilder;
+import org.codelibs.fess.query.QueryFieldConfig;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.opensearch.action.search.SearchAction;
+import org.opensearch.action.search.SearchRequestBuilder;
+
+/**
+ * Verifies that a facet field outside the allowlist is reported as an invalid
+ * query rather than being swallowed into an empty result set.
+ *
+ * <p>A facet field is validated against {@code query.additional.facet.fields}
+ * only, never against the index mapping. When a theme or client requests a
+ * field the deployment forgot to allowlist, the failure used to surface as a
+ * {@code SearchQueryException}, which {@code RankFusionProcessor} catches
+ * generically and turns into zero documents plus a WARN - so every search
+ * silently returned nothing. It must be an {@link InvalidQueryException} so
+ * the search action and the API managers report it to the caller, the same way
+ * an unsupported sort field is reported.</p>
+ */
+public class SearchEngineClientFacetFieldTest extends UnitFessTestCase {
+
+    private QueryFieldConfig queryFieldConfig;
+
+    @Override
+    protected void setUp(final TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        queryFieldConfig = new QueryFieldConfig();
+        // setFacetFields() repopulates the lookup set, so init() (and its long
+        // list of index.field.* getters) is not needed here.
+        queryFieldConfig.setFacetFields(new String[] { "label", "filetype" });
+        ComponentUtil.register(queryFieldConfig, "queryFieldConfig");
+    }
+
+    @Test
+    public void test_buildFacet_unsupportedField() {
+        final FacetInfo facetInfo = new FacetInfo();
+        facetInfo.field = new String[] { "repository" };
+
+        try {
+            buildFacet(facetInfo);
+            fail("InvalidQueryException should be thrown for an unsupported facet field.");
+        } catch (final InvalidQueryException e) {
+            assertNotNull(e.getMessageCode());
+            assertTrue(e.getMessage().contains("repository"));
+        }
+    }
+
+    @Test
+    public void test_buildFacet_unsupportedFieldAfterSupportedField() {
+        final FacetInfo facetInfo = new FacetInfo();
+        facetInfo.field = new String[] { "label", "repository" };
+
+        try {
+            buildFacet(facetInfo);
+            fail("InvalidQueryException should be thrown for an unsupported facet field.");
+        } catch (final InvalidQueryException e) {
+            assertTrue(e.getMessage().contains("repository"));
+        }
+    }
+
+    @Test
+    public void test_buildFacet_supportedFields() {
+        final FacetInfo facetInfo = new FacetInfo();
+        facetInfo.field = new String[] { "label", "filetype" };
+
+        final SearchRequestBuilder searchRequestBuilder = newSearchRequestBuilder();
+        SearchConditionBuilder.builder(searchRequestBuilder)
+                .facetInfo(facetInfo)
+                .buildFacet(null, queryFieldConfig, ComponentUtil.getFessConfig());
+
+        assertEquals(2, searchRequestBuilder.request().source().aggregations().count());
+    }
+
+    private void buildFacet(final FacetInfo facetInfo) {
+        SearchConditionBuilder.builder(newSearchRequestBuilder())
+                .facetInfo(facetInfo)
+                .buildFacet(null, queryFieldConfig, ComponentUtil.getFessConfig());
+    }
+
+    private SearchRequestBuilder newSearchRequestBuilder() {
+        return new SearchRequestBuilder(new SearchEngineClient(), SearchAction.INSTANCE);
+    }
+}


### PR DESCRIPTION
## Problem

A facet field is validated against `query.additional.facet.fields` only — never against the index mapping (`QueryFieldConfig.isFacetField`). When a theme or client requests a field the deployment has not allowlisted, `SearchConditionBuilder.buildFacet` threw `SearchQueryException`. That is a sibling of `InvalidQueryException`, not a subtype, so `RankFusionProcessor` caught it in its generic handler and returned an empty result list:

```java
} catch (final InvalidQueryException | ResultOffsetExceededException e) {
    throw e;
} catch (final Exception e) {
    logger.warn("Main searcher failed to execute search for query: {}", query, e);
    return createResponseList(Collections.emptyList(), 0, ...);
}
```

The caller therefore got **HTTP 200 with `record_count: 0` and no error**, and the only trace was one WARN per request whose message did not even name the offending field:

```
WARN Main searcher failed to execute search for query: install
org.codelibs.fess.exception.SearchQueryException: Invalid facet field: repository
```

On a deployment whose facet allowlist is missing a field the theme always requests, *every* search silently returns nothing — indistinguishable from an empty index. It cost a real investigation to trace an empty search page back to one missing property.

The behaviour was also asymmetric: an unsupported **sort** field already produced a proper query error (`errors.invalid_query_unsupported_sort_field` → 400), while an unsupported **facet** field was laundered into a successful empty response.

## Change

Throw `InvalidQueryException` with a new message code, so the failure travels the same path as an unsupported sort field:

- `SearchAction` calls `saveError(e.getMessageCode())` and renders the localized message.
- The API managers answer `400 invalid_request` with the field name (`SearchHandler`).
- Static themes already surface it: the codesearch theme matches `invalid_request` / HTTP 400 and shows `e.message` in `#search-error`.

New key `errors.invalid_query_unsupported_facet_field` ("The specified facet {0} is unsupported."), added to all 17 `fess_message*.properties` files with translations mirroring the existing sort-field message, plus the matching `FessMessages` constant and `addErrorsInvalidQueryUnsupportedFacetField` method.

Behaviour for allowed facet fields is unchanged.

## Compatibility note

A request that previously returned 200 with zero documents now returns 400. That is the intent — the condition was always a client or configuration error — but it is a visible change on the wire, so it is worth calling out in the release notes.

One side effect worth knowing: `SearchHelper.search` catches `InvalidQueryException` and retries once with an escaped query. Escaping does not change the facet params, so the retry fails identically and the exception propagates. The throw happens while building the search condition, before any request reaches OpenSearch, so the retry costs nothing measurable.

## Tests

New `SearchEngineClientFacetFieldTest` drives `buildFacet` directly:

- unsupported field → `InvalidQueryException` carrying a message code and naming the field
- unsupported field after a supported one → same
- supported fields → no exception, both aggregations added

It fails on the base commit with exactly the production exception:

```
SearchQueryException: Invalid facet field: repository
  at SearchEngineClient$SearchConditionBuilder.lambda$buildFacet$0(SearchEngineClient.java:2306)
```

Verification: full suite `Tests run: 6445, Failures: 0, Errors: 0` / `BUILD SUCCESS`; `mvn javadoc:jar` clean (the removed `SearchQueryException` import had two `@throws` references, both retargeted); `formatter:format` and `license:format` applied.

I also tried adding a boot-time warning for `query.facet.fields` entries outside the allowlist and **dropped it**: reading a new property inside `QueryFieldConfig.init()` broke 42 existing tests, because their partial `FessConfig.SimpleImpl` stubs NPE on any newly-called getter — and it would not have caught this case anyway, since the facet fields came from the client request rather than from `query.facet.fields`.

## Related

The deployment-side half of this incident is codelibs/docker-codesearch#3, which fixes the setup that silently produced the misconfiguration. That PR's verification does not depend on this change: it detects the condition on 15.7.0 as well, by comparing a faceted query against the same query without facets.
