### PR TITLE
fix(test): remove environment dependencies from unit tests

### DIFF
--- a/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -29,10 +30,16 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.Pair;
 import org.codelibs.core.misc.Tuple3;
+import org.codelibs.fess.Constants;
 import org.codelibs.fess.exception.FessSystemException;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
@@ -383,9 +390,50 @@ public class SystemHelperTest extends UnitFessTestCase {
         assertEquals(response, systemHelper.getRedirectResponseToRoot(response));
     }
 
+    /**
+     * Captures the JVM-global state that {@link SystemHelper#setLogLevel(String)} rewrites, and returns
+     * a task that puts it back.
+     *
+     * <p>Restoring with {@code setLogLevel(getLogLevel())} does not work: {@code setLogLevel} pushes the
+     * level into the live log4j2 configuration for every package in {@code logging.app.packages}, while
+     * {@code getLogLevel()} only reads the {@code fess.log.level} system property, which is unset under
+     * tests and falls back to WARN. That "restore" pins those packages to WARN for the rest of the
+     * surefire JVM, so any later test asserting on INFO or DEBUG logs sees nothing. Whether it breaks
+     * depends on test class order, which surefire derives from the filesystem, so it reproduces on some
+     * machines only.</p>
+     */
+    private Runnable captureLogLevelState() {
+        final String originalProperty = System.getProperty(Constants.FESS_LOG_LEVEL);
+        final Configuration configuration = ((LoggerContext) LogManager.getContext(false)).getConfiguration();
+        final Map<String, Level> originalLevels = new LinkedHashMap<>();
+        for (final String pkg : appLogPackages()) {
+            originalLevels.put(pkg, configuration.getLoggerConfig(pkg).getLevel());
+        }
+        return () -> {
+            if (originalProperty == null) {
+                System.clearProperty(Constants.FESS_LOG_LEVEL);
+            } else {
+                System.setProperty(Constants.FESS_LOG_LEVEL, originalProperty);
+            }
+            originalLevels.forEach(Configurator::setLevel);
+        };
+    }
+
+    private List<String> appLogPackages() {
+        return Stream.of(ComponentUtil.getFessConfig().getLoggingAppPackages().split(","))
+                .map(String::trim)
+                .filter(StringUtil::isNotEmpty)
+                .collect(Collectors.toList());
+    }
+
+    private Level currentLogLevel(final String pkg) {
+        final Configuration configuration = ((LoggerContext) LogManager.getContext(false)).getConfiguration();
+        return configuration.getLoggerConfig(pkg).getLevel();
+    }
+
     @Test
     public void test_getLogLevel() {
-        final String logLevel = systemHelper.getLogLevel();
+        final Runnable restoreLogLevel = captureLogLevelState();
         try {
             systemHelper.setLogLevel("DEBUG");
             assertEquals("DEBUG", systemHelper.getLogLevel());
@@ -396,8 +444,27 @@ public class SystemHelperTest extends UnitFessTestCase {
             systemHelper.setLogLevel("ERROR");
             assertEquals("ERROR", systemHelper.getLogLevel());
         } finally {
-            systemHelper.setLogLevel(logLevel);
+            restoreLogLevel.run();
         }
+    }
+
+    @Test
+    public void test_setLogLevel_appliesToAppLogPackages() {
+        final Map<String, Level> before = new LinkedHashMap<>();
+        appLogPackages().forEach(pkg -> before.put(pkg, currentLogLevel(pkg)));
+
+        final Runnable restoreLogLevel = captureLogLevelState();
+        try {
+            // two distinct levels, so the assertion cannot pass merely by matching the ambient level
+            systemHelper.setLogLevel("ERROR");
+            before.keySet().forEach(pkg -> assertEquals(pkg + " must follow the requested level", Level.ERROR, currentLogLevel(pkg)));
+            systemHelper.setLogLevel("DEBUG");
+            before.keySet().forEach(pkg -> assertEquals(pkg + " must follow the requested level", Level.DEBUG, currentLogLevel(pkg)));
+        } finally {
+            restoreLogLevel.run();
+        }
+        // the restore has to undo the log4j2 side effect too, otherwise it leaks into every later test
+        before.forEach((pkg, level) -> assertEquals(pkg + " must be restored to its configured level", level, currentLogLevel(pkg)));
     }
 
     @Test
@@ -819,12 +886,12 @@ public class SystemHelperTest extends UnitFessTestCase {
 
     @Test
     public void test_setLogLevel_invalidLevel() {
-        final String originalLevel = systemHelper.getLogLevel();
+        final Runnable restoreLogLevel = captureLogLevelState();
         try {
             systemHelper.setLogLevel("INVALID_LEVEL");
             assertEquals("WARN", systemHelper.getLogLevel());
         } finally {
-            systemHelper.setLogLevel(originalLevel);
+            restoreLogLevel.run();
         }
     }
 

--- a/src/test/java/org/codelibs/fess/util/ResourceUtilTest.java
+++ b/src/test/java/org/codelibs/fess/util/ResourceUtilTest.java
@@ -268,21 +268,27 @@ public class ResourceUtilTest extends UnitFessTestCase {
         assertEquals(0, jarFiles.length);
     }
 
+    // WEB-INF/plugin is the drop-in directory for locally installed plugins, so its contents depend on
+    // the machine: empty on a fresh clone, but populated as soon as a plugin is installed. Asserting a
+    // fixed file count therefore only holds on the former. Assert the prefix/filter contract instead.
+
     @Test
     public void test_getPluginJarFiles_withPrefix() {
-        File[] pluginFiles = ResourceUtil.getPluginJarFiles("plugin");
-        assertNotNull(pluginFiles);
-        // Should return empty array when plugin directory doesn't exist
-        assertEquals(0, pluginFiles.length);
+        assertEquals(0, ResourceUtil.getPluginJarFiles("no-such-plugin-prefix-").length);
+
+        for (final File pluginFile : ResourceUtil.getPluginJarFiles("fess-")) {
+            assertTrue(pluginFile.getName() + " must start with the requested prefix", pluginFile.getName().startsWith("fess-"));
+        }
     }
 
     @Test
     public void test_getPluginJarFiles_withFilter() {
-        FilenameFilter filter = (dir, name) -> name.endsWith(".jar");
-        File[] pluginFiles = ResourceUtil.getPluginJarFiles(filter);
-        assertNotNull(pluginFiles);
-        // Should return empty array when plugin directory doesn't exist
-        assertEquals(0, pluginFiles.length);
+        assertEquals(0, ResourceUtil.getPluginJarFiles((dir, name) -> false).length);
+
+        final FilenameFilter filter = (dir, name) -> name.endsWith(".jar");
+        for (final File pluginFile : ResourceUtil.getPluginJarFiles(filter)) {
+            assertTrue(pluginFile.getName() + " must satisfy the filter", pluginFile.getName().endsWith(".jar"));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

Two unit tests passed or failed depending on the machine rather than on the code under test. The visible symptom was a Jenkins-only failure:

```
[ERROR] SemanticChunkSearcherTest.test_register_logsRestartRequirementWhenDisabled
org.opentest4j.AssertionFailedError: a disabled searcher must state the restart requirement at INFO: []
  ==> expected: <true> but was: <false>
```

The captured log list is empty, and the WARN-level assertions in the same class pass, so the INFO events were never emitted.

## Cause 1 — leaked JVM-global log level (`SystemHelperTest`)

`SystemHelper#setLogLevel` pushes the level into the live log4j2 configuration via `Configurator.setLevel` for every package in `logging.app.packages` (`org.codelibs`, `org.dbflute`, `org.lastaflute`). That is a JVM-global, persistent mutation.

`SystemHelperTest#test_getLogLevel` and `#test_setLogLevel_invalidLevel` restored it with:

```java
final String logLevel = systemHelper.getLogLevel();
try { ... } finally { systemHelper.setLogLevel(logLevel); }
```

`getLogLevel()` only reads the `fess.log.level` system property, which is unset under tests and falls back to `WARN`. The "restore" therefore pinned those packages to `WARN` for the rest of the surefire JVM, instead of returning them to the `DEBUG` level configured in `log4j2.xml`. Every later test asserting on captured INFO or DEBUG logs then saw nothing.

`SemanticChunkSearcherTest#test_register_logsRestartRequirementWhenDisabled` is the only test asserting on captured INFO logs today, which is why exactly one test failed. It broke whenever `SystemHelperTest` happened to run first. Surefire's default `runOrder` is `filesystem`, so class order follows raw directory order and differs between operating systems — hence Jenkins only.

Deterministic reproduction on any machine:

```bash
mvn test -Dtest='SystemHelperTest,SemanticChunkSearcherTest' -Dsurefire.runOrder=alphabetical
```

### Fix

Snapshot the `fess.log.level` system property together with the log4j2 level of each configured package, and restore both. A new test `test_setLogLevel_appliesToAppLogPackages` pins the previously unverified side effect: `setLogLevel` must apply to the configured app packages, and the restore must undo it.

## Cause 2 — assumed-empty plugin directory (`ResourceUtilTest`)

`test_getPluginJarFiles_withPrefix` and `test_getPluginJarFiles_withFilter` asserted an empty result, commented "Should return empty array when plugin directory doesn't exist". `WEB-INF/plugin` is in fact the drop-in directory for locally installed plugins: empty on a fresh clone, but populated as soon as a plugin is installed. On a developer machine with plugins present the filter test fails with `expected: <0> but was: <3>` — the mirror image of the Jenkins failure above.

This one is pre-existing and reproduces on the unmodified tree; it is unrelated to the log level issue but belongs to the same class of defect.

### Fix

Assert the prefix and filter contract rather than a fixed file count.

## Verification

- Full unit test suite (6872 tests) green in `alphabetical`, `reversealphabetical`, `filesystem`, and three `random` class orders.
- `ResourceUtilTest` green with `WEB-INF/plugin` both populated and empty.
- `mvn formatter:format` and `mvn license:format` applied; no other files touched.

Test-only change; no production code is modified.
