### PR TITLE
fix: mask rag.llm.<provider>.api.key on the admin System Info screen

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoAction.java
@@ -210,7 +210,8 @@ public class AdminSysteminfoAction extends FessAdminAction {
                 || "oic.client.id".equals(key) //
                 || "oic.client.secret".equals(key) //
                 || "content_chunker.embedding.opensearch.password".equals(key) //
-                || isEmbeddingApiKey(key);
+                || isEmbeddingApiKey(key) //
+                || isLlmApiKey(key);
     }
 
     /**
@@ -225,6 +226,26 @@ public class AdminSysteminfoAction extends FessAdminAction {
      */
     protected static boolean isEmbeddingApiKey(final String key) {
         return key != null && key.startsWith("content_chunker.embedding.") && key.endsWith(".api.key");
+    }
+
+    /**
+     * Checks if a key is a RAG LLM provider's API key, e.g. {@code rag.llm.openai.api.key} or
+     * {@code rag.llm.gemini.api.key}. Matching on the {@code rag.llm.<provider>.api.key} shape,
+     * instead of listing every provider by name, means a future LLM provider's API key is masked
+     * by default.
+     *
+     * <p>These live in {@code fess_config.properties} rather than {@code conf/system.properties},
+     * which is why they need their own rule: the embedding-side rule above is anchored on the
+     * {@code content_chunker.embedding.} prefix and never matched them, so every
+     * {@code fess-llm-*} plugin's chat API key was rendered in cleartext under
+     * System Info &gt; Config Info &gt; App Properties while its embedding counterpart one
+     * section away was masked.
+     *
+     * @param key the property key to check
+     * @return true if the key matches the LLM provider API key shape
+     */
+    protected static boolean isLlmApiKey(final String key) {
+        return key != null && key.startsWith("rag.llm.") && key.endsWith(".api.key");
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoActionTest.java
@@ -63,6 +63,19 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_isMaskedValue_masksLlmProviderApiKeys() {
+        // The RAG chat API keys live in fess_config.properties, so the embedding-side rule -
+        // anchored on the content_chunker.embedding. prefix - never matched them and every
+        // fess-llm-* plugin's chat key was rendered in cleartext one section away from its
+        // masked embedding counterpart.
+        assertTrue(AdminSysteminfoAction.isMaskedValue("rag.llm.openai.api.key"));
+        assertTrue(AdminSysteminfoAction.isMaskedValue("rag.llm.gemini.api.key"));
+        // Shape, not a fixed provider list, so a future provider is masked by default.
+        assertTrue(AdminSysteminfoAction.isMaskedValue("rag.llm.ollama.api.key"));
+        assertTrue(AdminSysteminfoAction.isMaskedValue("rag.llm.anthropic.api.key"));
+    }
+
+    @Test
     public void test_isMaskedValue_doesNotMaskOrdinaryKeys() {
         // Other content_chunker.embedding.* keys are plain diagnostic config, not credentials,
         // and must stay visible on the admin screen.
@@ -73,6 +86,13 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         assertFalse(AdminSysteminfoAction.isMaskedValue("content_chunker.embedding.opensearch.model.id"));
         assertFalse(AdminSysteminfoAction.isMaskedValue("content_chunker.enabled"));
         assertFalse(AdminSysteminfoAction.isMaskedValue("some.unrelated.key"));
+        // The rag.llm.* rule is likewise narrow: only the API key is a credential. Endpoint,
+        // model and tuning knobs stay readable, and rag.llm.name selects the provider.
+        assertFalse(AdminSysteminfoAction.isMaskedValue("rag.llm.name"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("rag.llm.openai.api.url"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("rag.llm.openai.model"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("rag.llm.openai.retry.max"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("rag.chat.enabled"));
     }
 
     @Test
@@ -80,6 +100,7 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         ComponentUtil.getSystemProperties().setProperty("content_chunker.embedding.openai.api.key", "sk-super-secret");
         ComponentUtil.getSystemProperties().setProperty("content_chunker.embedding.gemini.api.key", "gm-super-secret");
         ComponentUtil.getSystemProperties().setProperty("content_chunker.embedding.opensearch.password", "hunter2");
+        ComponentUtil.getSystemProperties().setProperty("rag.llm.openai.api.key", "sk-chat-secret");
         ComponentUtil.getSystemProperties().setProperty("content_chunker.embedding.dimension", "768");
 
         final List<Map<String, String>> itemList = AdminSysteminfoAction.getBugReportItems();
@@ -89,6 +110,7 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         assertEquals(MASKED_VALUE, findValue(itemList, "content_chunker.embedding.openai.api.key"));
         assertEquals(MASKED_VALUE, findValue(itemList, "content_chunker.embedding.gemini.api.key"));
         assertEquals(MASKED_VALUE, findValue(itemList, "content_chunker.embedding.opensearch.password"));
+        assertEquals(MASKED_VALUE, findValue(itemList, "rag.llm.openai.api.key"));
 
         // An ordinary diagnostic key is unaffected and keeps its real value.
         assertEquals("768", findValue(itemList, "content_chunker.embedding.dimension"));


### PR DESCRIPTION
## Problem

Every `fess-llm-*` plugin's chat API key is rendered in cleartext under
**System Info > Config Info > App Properties**, one section away from its embedding
counterpart, which is masked:

```
content_chunker.embedding.openai.api.key = XXXXXXXX     (masked)
rag.llm.openai.api.key                   = sk-proj-...  (cleartext)
```

`isMaskedValue()` already covers `content_chunker.embedding.<provider>.api.key` by shape, but
that rule is anchored on the `content_chunker.embedding.` prefix. The RAG chat keys live in
`fess_config.properties` under `rag.llm.<provider>.api.key`, so nothing matched them.
`rag.llm.openai.api.key` and `rag.llm.gemini.api.key` are both affected, and either appears
verbatim in a bug report when set as a system property.

## Change

Adds `isLlmApiKey()`, mirroring the existing `isEmbeddingApiKey()`: `rag.llm.` prefix plus
`.api.key` suffix, so a future provider is masked by default rather than needing a new entry.

The rule is deliberately narrow. `rag.llm.name`, `rag.llm.<provider>.api.url`, `.model` and the
retry knobs are diagnostics and stay readable.

## Verification

- `AdminSysteminfoActionTest`: 5/5 passing. New coverage for the LLM key shape, for the
  diagnostic keys that must *not* be masked, and an extra assertion on the bug-report path.
- Live: replaced this class in a running `ghcr.io/codelibs/fess:snapshot` deployment configured
  with a real OpenAI key.

  | | before | after |
  |---|---|---|
  | `rag.llm.openai.api.key` | live key in cleartext | `XXXXXXXX` |
  | `content_chunker.embedding.openai.api.key` | `XXXXXXXX` | `XXXXXXXX` |
  | `rag.llm.name` / `.model` / `.api.url` | readable | readable |

  Scanning every returned row for the real key string: 1 match before, 0 after.

Found while verifying codelibs/fess-llm-openai#19.
