### PR TITLE
refactor(embedding): share provider-agnostic members and credential-URL rules

### DIFF
--- a/src/main/java/org/codelibs/fess/embedding/AbstractEmbeddingClient.java
+++ b/src/main/java/org/codelibs/fess/embedding/AbstractEmbeddingClient.java
@@ -60,6 +60,12 @@ public abstract class AbstractEmbeddingClient implements EmbeddingClient {
      */
     public static final String EMBEDDING_NAME_DEFAULT = "opensearch";
 
+    /** Config key suffix (under {@link #getConfigPrefix()}) for the TCP connect timeout. */
+    protected static final String CONFIG_CONNECT_TIMEOUT = "connect.timeout";
+
+    /** Config key suffix (under {@link #getConfigPrefix()}) for the availability-check interval. */
+    protected static final String CONFIG_AVAILABILITY_CHECK_INTERVAL = "availability.check.interval";
+
     private static final Logger logger = LogManager.getLogger(AbstractEmbeddingClient.class);
 
     /** The HTTP client used for API communication. */
@@ -96,7 +102,13 @@ public abstract class AbstractEmbeddingClient implements EmbeddingClient {
 
     /**
      * Initializes the HTTP client and starts availability checking.
-     * Should be called from subclass init() methods.
+     *
+     * <p>Subclasses should not need to override this. Everything that legitimately varies between
+     * providers is reachable through a narrower seam: {@link #getTimeout()} and
+     * {@link #getConnectTimeout()} for the two timeouts, and
+     * {@link #configureHttpClient(HttpClientBuilder)} for anything else that must be applied to the
+     * builder (default headers, auth). An override that reimplements this method has to keep the
+     * name guard and the availability-check start in sync by hand.</p>
      */
     public void init() {
         if (!getName().equals(getEmbeddingType())) {
@@ -106,24 +118,63 @@ public abstract class AbstractEmbeddingClient implements EmbeddingClient {
             return;
         }
 
-        final int timeout = getTimeout();
+        if (httpClient != null) {
+            try {
+                httpClient.close();
+            } catch (final IOException e) {
+                logger.warn("[Embedding] {} failed to close prior HTTP client during re-init.", getName(), e);
+            }
+        }
+        httpClient = buildHttpClient();
+        if (logger.isDebugEnabled()) {
+            logger.debug("[Embedding] {} initialized. connectTimeout={}ms, timeout={}ms", getName(), getConnectTimeout(), getTimeout());
+        }
+
+        startAvailabilityCheck();
+    }
+
+    /**
+     * Builds the {@link CloseableHttpClient} with two-tier timeouts (connect vs response/read), the
+     * shared proxy configuration, and whatever {@link #configureHttpClient(HttpClientBuilder)}
+     * contributes.
+     *
+     * <p>Connect and response timeouts are kept distinct deliberately. A single value shared by
+     * both means the response budget also bounds the TCP handshake, so a firewalled or black-holed
+     * endpoint blocks for the full response timeout - and this client's first availability probe
+     * runs synchronously from {@link #init()}, which the container invokes as an eager init-method
+     * during startup. A provider with a generous response timeout would therefore stall Tomcat
+     * context startup for that same duration.</p>
+     *
+     * @return a configured {@link CloseableHttpClient}
+     */
+    protected CloseableHttpClient buildHttpClient() {
+        final int connectTimeout = getConnectTimeout();
+        final int responseTimeout = getTimeout();
         final RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectionRequestTimeout(Timeout.ofMilliseconds(timeout))
-                .setResponseTimeout(Timeout.ofMilliseconds(timeout))
+                .setConnectionRequestTimeout(Timeout.ofMilliseconds(connectTimeout))
+                .setResponseTimeout(Timeout.ofMilliseconds(responseTimeout))
                 .build();
         final HttpClientBuilder builder = HttpClients.custom()
                 .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
-                        .setDefaultConnectionConfig(ConnectionConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(timeout)).build())
+                        .setDefaultConnectionConfig(
+                                ConnectionConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(connectTimeout)).build())
                         .build())
                 .setDefaultRequestConfig(requestConfig)
                 .disableAutomaticRetries();
         configureProxy(builder);
-        httpClient = builder.build();
-        if (logger.isDebugEnabled()) {
-            logger.debug("[Embedding] {} initialized. timeout={}ms", getName(), timeout);
-        }
+        configureHttpClient(builder);
+        return builder.build();
+    }
 
-        startAvailabilityCheck();
+    /**
+     * Applies provider-specific configuration to the HTTP client builder, after the timeouts and
+     * the shared proxy settings have been applied and before the client is built. The default
+     * implementation does nothing.
+     *
+     * @param builder the HTTP client builder to configure
+     */
+    protected void configureHttpClient(final HttpClientBuilder builder) {
+        // no provider-specific configuration by default
     }
 
     /**
@@ -305,25 +356,77 @@ public abstract class AbstractEmbeddingClient implements EmbeddingClient {
     protected abstract boolean checkAvailabilityNow();
 
     /**
-     * Gets the request timeout in milliseconds.
+     * Gets the request (response/read) timeout in milliseconds.
      *
      * @return the timeout in milliseconds
      */
     protected abstract int getTimeout();
 
     /**
-     * Gets the availability check interval in seconds.
+     * Gets the TCP connect timeout in milliseconds, separate from {@link #getTimeout()}. Reads
+     * {@code <configPrefix>.connect.timeout}.
      *
-     * @return the interval in seconds
+     * <p>The default is deliberately short and independent of {@link #getTimeout()}: establishing a
+     * connection either succeeds quickly or is not going to succeed, whereas a response budget is
+     * sized for the provider's actual work. See {@link #buildHttpClient()} for why conflating the
+     * two is a startup hazard.</p>
+     *
+     * @return the connect timeout in milliseconds (default 5000)
      */
-    protected abstract int getAvailabilityCheckInterval();
+    protected int getConnectTimeout() {
+        return getConfigInt(CONFIG_CONNECT_TIMEOUT, 5000);
+    }
 
     /**
-     * Checks if content chunking is enabled.
+     * Gets the availability check interval in seconds. Reads
+     * {@code <configPrefix>.availability.check.interval}.
+     *
+     * @return the interval in seconds (default 60)
+     */
+    protected int getAvailabilityCheckInterval() {
+        return getConfigInt(CONFIG_AVAILABILITY_CHECK_INTERVAL, 60);
+    }
+
+    /**
+     * Checks if content chunking is enabled, from the {@value #CONTENT_CHUNKER_ENABLED_PROPERTY}
+     * system property. The property is owned by this class and is not provider-scoped, so this is
+     * the same answer for every provider.
      *
      * @return true if enabled
      */
-    protected abstract boolean isContentChunkerEnabled();
+    protected boolean isContentChunkerEnabled() {
+        return Boolean.parseBoolean(ComponentUtil.getFessConfig().getSystemProperty(CONTENT_CHUNKER_ENABLED_PROPERTY, "false"));
+    }
+
+    /**
+     * Returns the vector dimension every vector this client produces must have, from the required
+     * {@value #EMBEDDING_DIMENSION_PROPERTY} system property.
+     *
+     * <p>The dimension is a property of the index, not of the provider: fess core creates the
+     * {@code knn_vector} mapping from this one value, so a provider that reported a different
+     * number would only be describing vectors the index cannot store. It is therefore resolved
+     * here rather than per provider.</p>
+     *
+     * @return the configured vector dimension
+     * @throws EmbeddingException if the dimension is unset, non-numeric, or not positive
+     */
+    @Override
+    public int getDimension() {
+        final String value = ComponentUtil.getFessConfig().getSystemProperty(EMBEDDING_DIMENSION_PROPERTY, null);
+        if (StringUtil.isBlank(value)) {
+            throw new EmbeddingException(EMBEDDING_DIMENSION_PROPERTY + " is not configured");
+        }
+        final int dimension;
+        try {
+            dimension = Integer.parseInt(value.trim());
+        } catch (final NumberFormatException e) {
+            throw new EmbeddingException("Invalid " + EMBEDDING_DIMENSION_PROPERTY + " value: " + value, e);
+        }
+        if (dimension <= 0) {
+            throw new EmbeddingException(EMBEDDING_DIMENSION_PROPERTY + " must be positive: " + value);
+        }
+        return dimension;
+    }
 
     /**
      * Gets the configured embedding provider type from the
@@ -381,7 +484,39 @@ public abstract class AbstractEmbeddingClient implements EmbeddingClient {
                     return value;
                 }
             } catch (final NumberFormatException e) {
-                logger.warn("Invalid config value for key={}. Using default: {}", key, defaultValue);
+                // Reported under the concrete provider's logger, and naming the offending value:
+                // "which key" alone does not tell an operator what they actually typed.
+                LogManager.getLogger(getClass())
+                        .warn("Invalid config value for key={}: '{}'. Using default: {}", key, configValue, defaultValue);
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Gets a long configuration value using the config prefix and key suffix.
+     *
+     * <p>Unlike {@link #getConfigInt(String, int)} this does <em>not</em> reject non-positive
+     * values. The {@code int} variant serves timeouts, intervals and counts, where {@code 0} is
+     * never a meaningful setting and is better read as "unset"; the {@code long} variant serves
+     * millisecond delays, where {@code 0} is a legitimate value meaning "do not wait". Only an
+     * unparseable value falls back to {@code defaultValue}, and it is reported.</p>
+     *
+     * @param keySuffix the key suffix (appended to getConfigPrefix() + ".")
+     * @param defaultValue the default value
+     * @return the configured or default value
+     */
+    protected long getConfigLong(final String keySuffix, final long defaultValue) {
+        final String key = getConfigPrefix() + "." + keySuffix;
+        final String configValue = ComponentUtil.getFessConfig().getSystemProperty(key, null);
+        if (configValue != null) {
+            try {
+                return Long.parseLong(configValue.trim());
+            } catch (final NumberFormatException e) {
+                // Reported under the concrete provider's logger, and naming the offending value:
+                // "which key" alone does not tell an operator what they actually typed.
+                LogManager.getLogger(getClass())
+                        .warn("Invalid config value for key={}: '{}'. Using default: {}", key, configValue, defaultValue);
             }
         }
         return defaultValue;

--- a/src/main/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClient.java
+++ b/src/main/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClient.java
@@ -31,18 +31,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.config.ConnectionConfig;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
-import org.apache.hc.core5.util.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
@@ -50,6 +44,7 @@ import org.codelibs.fess.Constants;
 import org.codelibs.fess.embedding.AbstractEmbeddingClient;
 import org.codelibs.fess.embedding.EmbeddingException;
 import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.fess.util.CredentialUrlUtil;
 import org.codelibs.fess.util.SystemUtil;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -112,7 +107,6 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
     private static final String CONFIG_MODEL_ID = "model.id";
     private static final String CONFIG_RETRY_MAX = "retry.max";
     private static final String CONFIG_RETRY_BASE_DELAY_MS = "retry.base.delay.ms";
-    private static final String CONFIG_CONNECT_TIMEOUT = "connect.timeout";
     private static final String CONFIG_DOCUMENT_PREFIX = "document.prefix";
     private static final String CONFIG_QUERY_PREFIX = "query.prefix";
     private static final String CONFIG_USERNAME = "username";
@@ -163,24 +157,6 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
     @Override
     public String getName() {
         return NAME;
-    }
-
-    @Override
-    public int getDimension() {
-        final String value = ComponentUtil.getFessConfig().getSystemProperty(EMBEDDING_DIMENSION_PROPERTY, null);
-        if (StringUtil.isBlank(value)) {
-            throw new EmbeddingException(EMBEDDING_DIMENSION_PROPERTY + " is not configured");
-        }
-        final int dimension;
-        try {
-            dimension = Integer.parseInt(value.trim());
-        } catch (final NumberFormatException e) {
-            throw new EmbeddingException("Invalid " + EMBEDDING_DIMENSION_PROPERTY + " value: " + value, e);
-        }
-        if (dimension <= 0) {
-            throw new EmbeddingException(EMBEDDING_DIMENSION_PROPERTY + " must be positive: " + value);
-        }
-        return dimension;
     }
 
     @Override
@@ -575,7 +551,7 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
             source = "the built-in default";
         }
         final String normalized = normalizeApiUrl(url);
-        if (hasUserInfo(normalized)) {
+        if (CredentialUrlUtil.hasUserInfo(normalized)) {
             if (userInfoRejectionLogged.compareAndSet(false, true)) {
                 // Names the source and the remedy, never the value: the whole point is that the
                 // value holds a credential.
@@ -645,38 +621,6 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
     }
 
     /**
-     * Returns whether the authority of {@code url} carries a userinfo subcomponent, i.e. whether
-     * the URL embeds credentials as {@code scheme://user:password@host}.
-     *
-     * <p>Deliberately a textual scan rather than a parse. The values worth catching include the
-     * ones {@code java.net.URI} cannot parse at all (a raw space in the password, say), and those
-     * are exactly the ones a parse-based check would turn into a
-     * {@link URISyntaxException} whose message quotes the credential back. The authority is the
-     * span after {@code "://"} - or from the start when no scheme is present - up to the first
-     * {@code /}, {@code ?} or {@code #}, so an {@code @} in a path, query or fragment is not
-     * mistaken for userinfo, and a plain {@code host:port} never matches.</p>
-     *
-     * @param url the raw configured URL, possibly null or blank
-     * @return true when the authority contains an {@code @}
-     */
-    static boolean hasUserInfo(final String url) {
-        if (StringUtil.isBlank(url)) {
-            return false;
-        }
-        final int schemeEnd = url.indexOf("://");
-        final int authorityStart = schemeEnd >= 0 ? schemeEnd + 3 : 0;
-        int authorityEnd = url.length();
-        for (int i = authorityStart; i < url.length(); i++) {
-            final char c = url.charAt(i);
-            if (c == '/' || c == '?' || c == '#') {
-                authorityEnd = i;
-                break;
-            }
-        }
-        return authorityStart < authorityEnd && url.lastIndexOf('@', authorityEnd - 1) >= authorityStart;
-    }
-
-    /**
      * Gets the configured ML Commons model id. Required: a blank value makes
      * {@link #checkAvailabilityNow()} return false and embed calls throw
      * {@link EmbeddingException}.
@@ -707,59 +651,15 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
     }
 
     /**
-     * Gets the TCP connect timeout in milliseconds, separate from
-     * {@link #getTimeout()} (response/read timeout).
+     * Adds a preemptive {@code Authorization: Basic ...} default header when both a username and a
+     * password resolve to non-blank values, matching how fess core authenticates against the same
+     * cluster. The timeouts and the shared proxy configuration come from
+     * {@link AbstractEmbeddingClient#buildHttpClient()}.
      *
-     * @return the connect timeout in milliseconds
-     */
-    protected int getConnectTimeout() {
-        return getConfigInt(CONFIG_CONNECT_TIMEOUT, 5000);
-    }
-
-    /**
-     * Overrides {@link AbstractEmbeddingClient#init()} to apply distinct
-     * connect and response timeouts and the preemptive basic-auth header,
-     * mirroring {@code OllamaEmbeddingClient.init()}.
+     * @param builder the HTTP client builder to configure
      */
     @Override
-    public void init() {
-        if (!getName().equals(getEmbeddingType())) {
-            return;
-        }
-        if (httpClient != null) {
-            try {
-                httpClient.close();
-            } catch (final IOException e) {
-                logger.warn("[Embedding:OPENSEARCH] Failed to close prior HTTP client during re-init", e);
-            }
-        }
-        httpClient = buildHttpClient();
-        startAvailabilityCheck();
-    }
-
-    /**
-     * Builds the {@link CloseableHttpClient} with two-tier timeouts (connect vs
-     * response/read), the shared proxy configuration, and - when both a
-     * username and a password resolve to non-blank values - a preemptive
-     * {@code Authorization: Basic ...} default header, matching how fess core
-     * authenticates against the same cluster.
-     *
-     * @return a configured {@link CloseableHttpClient}
-     */
-    protected CloseableHttpClient buildHttpClient() {
-        final int connectTimeout = getConnectTimeout();
-        final int responseTimeout = getTimeout();
-        final RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectionRequestTimeout(Timeout.ofMilliseconds(connectTimeout))
-                .setResponseTimeout(Timeout.ofMilliseconds(responseTimeout))
-                .build();
-        final HttpClientBuilder builder = HttpClients.custom()
-                .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
-                        .setDefaultConnectionConfig(
-                                ConnectionConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(connectTimeout)).build())
-                        .build())
-                .setDefaultRequestConfig(requestConfig)
-                .disableAutomaticRetries();
+    protected void configureHttpClient(final HttpClientBuilder builder) {
         final String username = getUsername();
         final String password = getPassword();
         if (StringUtil.isNotBlank(username) && StringUtil.isNotBlank(password)) {
@@ -770,8 +670,6 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
                 logger.debug("[Embedding:OPENSEARCH] Basic authentication enabled. username={}", username);
             }
         }
-        configureProxy(builder);
-        return builder.build();
     }
 
     /**
@@ -858,16 +756,6 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
         return getConfigString(CONFIG_QUERY_PREFIX, DEFAULT_QUERY_PREFIX);
     }
 
-    @Override
-    protected int getAvailabilityCheckInterval() {
-        return getConfigInt("availability.check.interval", 60);
-    }
-
-    @Override
-    protected boolean isContentChunkerEnabled() {
-        return Boolean.parseBoolean(ComponentUtil.getFessConfig().getSystemProperty(CONTENT_CHUNKER_ENABLED_PROPERTY, "false"));
-    }
-
     /**
      * Functional interface for the retryable HTTP call body executed by
      * {@link #executeWithRetry(String, HttpCall)}.
@@ -945,14 +833,7 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
      * @return the value of {@code content_chunker.embedding.opensearch.retry.base.delay.ms} (default 2000)
      */
     protected long getRetryBaseDelayMs() {
-        final String raw = getConfigString(CONFIG_RETRY_BASE_DELAY_MS, "2000");
-        try {
-            return Long.parseLong(raw);
-        } catch (final NumberFormatException e) {
-            logger.warn("[Embedding:OPENSEARCH] Invalid {}.{}='{}', using default 2000ms", getConfigPrefix(), CONFIG_RETRY_BASE_DELAY_MS,
-                    raw);
-            return 2000L;
-        }
+        return getConfigLong(CONFIG_RETRY_BASE_DELAY_MS, 2000L);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/util/CredentialUrlUtil.java
+++ b/src/main/java/org/codelibs/fess/util/CredentialUrlUtil.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.util;
+
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+
+/**
+ * Credential handling for operator-configured endpoint URLs: whether one embeds a credential, how
+ * to keep one out of a log, and how to report a URL that will not parse without quoting it back.
+ *
+ * <p>Every provider integration - the built-in OpenSearch embedding client and each external
+ * {@code fess-llm-*} / embedding plugin - accepts a user-configured {@code api.url} that may point
+ * at a proxy or gateway, and each logs it. This class is the single definition of those rules, so
+ * a masking rule added for one provider reaches all of them.</p>
+ *
+ * <p>What stays with the caller is the <em>remedy</em>: which configuration key to fix and which
+ * authentication mechanism to use instead are provider-specific, so the rejection message is built
+ * by the provider, not here.</p>
+ */
+public final class CredentialUrlUtil {
+
+    /**
+     * Matches a credential-bearing query parameter. Names cover the spellings the supported
+     * providers document ({@code api_key}, {@code apikey}, {@code api-key}, {@code key},
+     * {@code token}, {@code access_token}, {@code access-token}), case-insensitively.
+     */
+    private static final Pattern CREDENTIAL_QUERY_PARAM_PATTERN =
+            Pattern.compile("(?i)([?&](?:api[-_]?key|key|token|access[-_]?token)=)[^&]*");
+
+    /**
+     * Matches RFC 3986 userinfo in a URL authority ({@code scheme://user:pass@host}). Neither
+     * userinfo component may contain {@code /}, {@code @}, or whitespace, so the pattern cannot run
+     * past the authority into the path and cannot mistake a {@code host:port} authority (no
+     * {@code @}) or a later {@code @} in the path for a credential.
+     *
+     * <p>Excluding whitespace also means this pattern does <em>not</em> match a credential
+     * containing a space, which is exactly the shape a mistyped one tends to have. That is why
+     * masking must never be the thing a URL's safety rests on - use {@link #hasUserInfo(String)} to
+     * refuse the value up front, and treat masking as a backstop.</p>
+     */
+    private static final Pattern CREDENTIAL_USER_INFO_PATTERN = Pattern.compile("(?i)(://)[^/@\\s]*:[^/@\\s]*@");
+
+    /** Separator between the scheme and the authority of an absolute URL. */
+    private static final String SCHEME_SEPARATOR = "://";
+
+    private CredentialUrlUtil() {
+        // utility class
+    }
+
+    /**
+     * Masks credentials embedded in a URL, in both forms one can appear: a credential-bearing query
+     * parameter (value replaced with {@code ***}) and RFC 3986 userinfo (replaced with
+     * {@code ***:***}).
+     *
+     * <p>The query-parameter rule covers a credential a <em>working</em> configuration can genuinely
+     * carry - several providers document passing the API key as {@code ?key=...} - while the
+     * userinfo rule is a backstop for a value that should have been refused by
+     * {@link #hasUserInfo(String)} before any log statement rendered it. See
+     * {@link #CREDENTIAL_USER_INFO_PATTERN} for why the backstop is not something to rely on.</p>
+     *
+     * @param url the URL to mask (may be {@code null})
+     * @return the URL with credential values replaced by {@code ***}, or {@code null} when the
+     *         input is {@code null}
+     */
+    public static String maskCredentialInUrl(final String url) {
+        if (url == null) {
+            return null;
+        }
+        final String withoutUserInfo = CREDENTIAL_USER_INFO_PATTERN.matcher(url).replaceAll("$1***:***@");
+        return CREDENTIAL_QUERY_PARAM_PATTERN.matcher(withoutUserInfo).replaceAll("$1***");
+    }
+
+    /**
+     * Determines whether {@code url}'s authority carries an RFC 3986 userinfo component, i.e.
+     * whether the URL embeds a credential as {@code scheme://user:password@host}.
+     *
+     * <p>Detection is structural rather than pattern-based, and deliberately not a
+     * {@link java.net.URI} parse. The values most worth catching are the ones a parser rejects
+     * outright - a raw space in the password, say - and rejecting them yields a
+     * {@link URISyntaxException} whose message quotes the credential straight back. A textual scan
+     * answers the question for any input at all.</p>
+     *
+     * <p>The authority is located by delimiter position: it begins after {@code "://"} when what
+     * precedes that could be a scheme, after a leading {@code "//"} for a protocol-relative
+     * reference, and otherwise at the start of the string; it ends at the first {@code /},
+     * {@code ?} or {@code #}. Userinfo is present exactly when that span contains an {@code @}.</p>
+     *
+     * <p>Each clause exists because a narrower rule missed a real case:</p>
+     * <ul>
+     * <li>The <em>scheme guard</em> keeps a {@code "://"} that appears after a path character from
+     * being read as a scheme delimiter, which would make the text after it look like an
+     * authority.</li>
+     * <li>The <em>protocol-relative</em> clause catches {@code //user:pw@host}, which a rule
+     * requiring {@code "://"} misses entirely.</li>
+     * <li>The <em>scheme-less</em> fallback catches a bare {@code user:pw@host}. That is not a
+     * valid absolute URI, but it is a credential an operator typed into a URL setting, and the
+     * useful answer is to refuse it rather than hand it to the HTTP client - which fails anyway,
+     * with the credential in the message.</li>
+     * </ul>
+     *
+     * <p>A plain {@code host:port} carries no {@code @}, and an {@code @} in a path, query or
+     * fragment falls outside the authority, so neither is a false positive.</p>
+     *
+     * @param url the configured URL (may be {@code null})
+     * @return {@code true} when the URL has an authority containing a userinfo component
+     */
+    public static boolean hasUserInfo(final String url) {
+        if (url == null) {
+            return false;
+        }
+        final String trimmed = url.trim();
+        final int authorityStart;
+        final int schemeEnd = trimmed.indexOf(SCHEME_SEPARATOR);
+        if (schemeEnd >= 0 && couldBeScheme(trimmed, schemeEnd)) {
+            authorityStart = schemeEnd + SCHEME_SEPARATOR.length();
+        } else if (trimmed.startsWith("//")) {
+            authorityStart = 2;
+        } else {
+            authorityStart = 0;
+        }
+        int authorityEnd = trimmed.length();
+        for (int i = authorityStart; i < trimmed.length(); i++) {
+            final char c = trimmed.charAt(i);
+            if (c == '/' || c == '?' || c == '#') {
+                authorityEnd = i;
+                break;
+            }
+        }
+        return authorityStart < authorityEnd && trimmed.lastIndexOf('@', authorityEnd - 1) >= authorityStart;
+    }
+
+    /**
+     * Returns whether {@code [0, end)} of {@code url} could be a URI scheme, i.e. holds no
+     * character that would place it in a path, query or fragment instead.
+     *
+     * <p>Deliberately permissive rather than the exact RFC 3986 scheme grammar: a value that only
+     * <em>nearly</em> looks like a scheme should still have the text after {@code "://"} treated as
+     * an authority and scanned for a credential. Being wrong in that direction costs a refused
+     * configuration that could never have worked; being wrong the other way leaks one.</p>
+     *
+     * @param url the URL being inspected
+     * @param end exclusive end index of the candidate scheme
+     * @return true when nothing in the span rules out a scheme
+     */
+    private static boolean couldBeScheme(final String url, final int end) {
+        for (int i = 0; i < end; i++) {
+            final char c = url.charAt(i);
+            if (c == '/' || c == '?' || c == '#' || c == '@') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Builds the replacement for an {@link IllegalArgumentException} raised while a request URI is
+     * being constructed from a configured URL.
+     *
+     * <p>That exception quotes the offending URI verbatim and carries a {@link URISyntaxException}
+     * that quotes it again, so it leaks a configured credential through every channel at once: the
+     * message, the throwable attached to a log statement, and the cause chain every upstream handler
+     * renders.</p>
+     *
+     * <p>The replacement carries no part of the URL, not even a masked one:
+     * {@link #maskCredentialInUrl(String)} is at its least reliable here, because a URL reaches this
+     * path only by containing a character the patterns exclude. What is left is the name of the
+     * setting to look at plus the parser's own reason and index, which {@link URISyntaxException}
+     * keeps separate from the offending input. There is no cause, so nothing downstream can recover
+     * the raw URI.</p>
+     *
+     * @param configKey the configuration property the URL was read from, named so an operator knows
+     *            what to inspect
+     * @param e the exception raised while constructing the request URI (may be {@code null})
+     * @return the replacement exception to throw in place of {@code e}
+     */
+    public static IllegalArgumentException invalidUrlException(final String configKey, final IllegalArgumentException e) {
+        final StringBuilder buf = new StringBuilder("Invalid URL configured in ").append(configKey);
+        if (e != null && e.getCause() instanceof final URISyntaxException syntaxException) {
+            if (syntaxException.getReason() != null) {
+                buf.append(": ").append(syntaxException.getReason());
+            }
+            if (syntaxException.getIndex() >= 0) {
+                buf.append(" at index ").append(syntaxException.getIndex());
+            }
+        }
+        return new IllegalArgumentException(buf.toString());
+    }
+}

--- a/src/test/java/org/codelibs/fess/embedding/AbstractEmbeddingClientTest.java
+++ b/src/test/java/org/codelibs/fess/embedding/AbstractEmbeddingClientTest.java
@@ -116,6 +116,137 @@ public class AbstractEmbeddingClientTest extends UnitFessTestCase {
         }
     }
 
+    // ========== Shared member tests ==========
+    //
+    // getDimension(), isContentChunkerEnabled() and getAvailabilityCheckInterval() are resolved
+    // here rather than per provider: each reads a property this class owns, so every provider that
+    // implemented them separately produced the same answer by construction. These tests pin the one
+    // shared contract; a provider is free to override, but no longer has to.
+
+    @Test
+    public void test_getDimension_readsConfiguredValue() {
+        ComponentUtil.getSystemProperties().setProperty(AbstractEmbeddingClient.EMBEDDING_DIMENSION_PROPERTY, " 768 ");
+        try {
+            assertEquals(768, new TestEmbeddingClient().testBaseGetDimension(), "a surrounding-whitespace value must still parse");
+        } finally {
+            ComponentUtil.getSystemProperties().remove(AbstractEmbeddingClient.EMBEDDING_DIMENSION_PROPERTY);
+        }
+    }
+
+    @Test
+    public void test_getDimension_rejectsUnsetBlankNonNumericAndNonPositive() {
+        final TestEmbeddingClient client = new TestEmbeddingClient();
+        final String key = AbstractEmbeddingClient.EMBEDDING_DIMENSION_PROPERTY;
+        assertNull(ComponentUtil.getSystemProperties().getProperty(key), "precondition: dimension must be unset");
+        assertThrowsEmbeddingException(client::testBaseGetDimension, "is not configured", "unset");
+        try {
+            for (final String bad : new String[] { "", "   ", "abc", "12.5", "0", "-1" }) {
+                ComponentUtil.getSystemProperties().setProperty(key, bad);
+                assertThrowsEmbeddingException(client::testBaseGetDimension, key, "value '" + bad + "'");
+            }
+        } finally {
+            ComponentUtil.getSystemProperties().remove(key);
+        }
+    }
+
+    private void assertThrowsEmbeddingException(final Runnable action, final String expectedFragment, final String label) {
+        try {
+            action.run();
+            fail("expected EmbeddingException for " + label);
+        } catch (final EmbeddingException e) {
+            assertTrue(e.getMessage().contains(expectedFragment),
+                    "message for " + label + " should mention '" + expectedFragment + "': " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_isContentChunkerEnabled_readsSharedSystemProperty() {
+        final String key = AbstractEmbeddingClient.CONTENT_CHUNKER_ENABLED_PROPERTY;
+        final TestEmbeddingClient client = new TestEmbeddingClient();
+        assertFalse(client.testBaseIsContentChunkerEnabled(), "must default to false when unset");
+        ComponentUtil.getSystemProperties().setProperty(key, "true");
+        try {
+            assertTrue(client.testBaseIsContentChunkerEnabled());
+        } finally {
+            ComponentUtil.getSystemProperties().remove(key);
+        }
+    }
+
+    @Test
+    public void test_getAvailabilityCheckInterval_defaultsTo60AndHonorsConfig() {
+        final String key = "test.embedding.availability.check.interval";
+        final TestEmbeddingClient client = new TestEmbeddingClient();
+        assertEquals(60, client.testBaseGetAvailabilityCheckInterval());
+        ComponentUtil.getSystemProperties().setProperty(key, "5");
+        try {
+            assertEquals(5, client.testBaseGetAvailabilityCheckInterval());
+        } finally {
+            ComponentUtil.getSystemProperties().remove(key);
+        }
+    }
+
+    @Test
+    public void test_getConnectTimeout_defaultsTo5000AndHonorsConfig() {
+        final String key = "test.embedding.connect.timeout";
+        final TestEmbeddingClient client = new TestEmbeddingClient();
+        // Deliberately independent of getTimeout() (1000 for this client): a shared value would let
+        // a generous response budget bound the TCP handshake, and the first probe runs from init().
+        assertEquals(5000, client.getConnectTimeout());
+        ComponentUtil.getSystemProperties().setProperty(key, "250");
+        try {
+            assertEquals(250, client.getConnectTimeout());
+        } finally {
+            ComponentUtil.getSystemProperties().remove(key);
+        }
+    }
+
+    // getConfigLong deliberately does NOT inherit getConfigInt's positive-only rule: it serves
+    // millisecond delays, where 0 means "do not wait" and must survive the round trip.
+    @Test
+    public void test_getConfigLong_parsesAnyNumericIncludingZeroAndNegative() {
+        final String key = "test.embedding.delay.ms";
+        final TestEmbeddingClient client = new TestEmbeddingClient();
+        // An absent key must fall back to the default.
+        assertEquals(2000L, client.testGetConfigLong("delay.ms", 2000L));
+        try {
+            ComponentUtil.getSystemProperties().setProperty(key, "5000");
+            assertEquals(5000L, client.testGetConfigLong("delay.ms", 2000L));
+            ComponentUtil.getSystemProperties().setProperty(key, " 7000 ");
+            // A surrounding-whitespace value must still parse.
+            assertEquals(7000L, client.testGetConfigLong("delay.ms", 2000L));
+            ComponentUtil.getSystemProperties().setProperty(key, "0");
+            // 0 is a legitimate delay, not 'unset'.
+            assertEquals(0L, client.testGetConfigLong("delay.ms", 2000L));
+            ComponentUtil.getSystemProperties().setProperty(key, "-1");
+            assertEquals(-1L, client.testGetConfigLong("delay.ms", 2000L));
+        } finally {
+            ComponentUtil.getSystemProperties().remove(key);
+        }
+    }
+
+    @Test
+    public void test_getConfigLong_invalidValueFallsBackToDefault() {
+        final String key = "test.embedding.delay.ms";
+        ComponentUtil.getSystemProperties().setProperty(key, "not-a-number");
+        try {
+            assertEquals(2000L, new TestEmbeddingClient().testGetConfigLong("delay.ms", 2000L));
+        } finally {
+            ComponentUtil.getSystemProperties().remove(key);
+        }
+    }
+
+    // The hook exists so a provider needing default headers (OpenSearch's preemptive basic auth)
+    // does not have to reimplement init() and buildHttpClient() to get them.
+    @Test
+    public void test_buildHttpClient_invokesConfigureHttpClientHook() throws Exception {
+        final TestEmbeddingClient client = new TestEmbeddingClient();
+        assertEquals(0, client.configureHttpClientCallCount());
+        try (CloseableHttpClient built = client.testBuildHttpClient()) {
+            assertNotNull(built);
+        }
+        assertEquals(1, client.configureHttpClientCallCount(), "buildHttpClient must give subclasses a shot at the builder");
+    }
+
     // ========== Proxy configuration tests ==========
 
     @Test
@@ -346,6 +477,7 @@ public class AbstractEmbeddingClientTest extends UnitFessTestCase {
         private int testAvailabilityCheckInterval = 0;
         private RuntimeException testAvailabilityFailure;
         private final AtomicInteger availabilityProbes = new AtomicInteger();
+        private final AtomicInteger configureHttpClientCalls = new AtomicInteger();
 
         void setTestContentChunkerEnabled(final boolean enabled) {
             this.testContentChunkerEnabled = enabled;
@@ -397,6 +529,35 @@ public class AbstractEmbeddingClientTest extends UnitFessTestCase {
 
         String testBaseGetEmbeddingType() {
             return super.getEmbeddingType();
+        }
+
+        int testBaseGetDimension() {
+            return super.getDimension();
+        }
+
+        boolean testBaseIsContentChunkerEnabled() {
+            return super.isContentChunkerEnabled();
+        }
+
+        int testBaseGetAvailabilityCheckInterval() {
+            return super.getAvailabilityCheckInterval();
+        }
+
+        long testGetConfigLong(final String keySuffix, final long defaultValue) {
+            return getConfigLong(keySuffix, defaultValue);
+        }
+
+        CloseableHttpClient testBuildHttpClient() {
+            return buildHttpClient();
+        }
+
+        @Override
+        protected void configureHttpClient(final HttpClientBuilder builder) {
+            configureHttpClientCalls.incrementAndGet();
+        }
+
+        int configureHttpClientCallCount() {
+            return configureHttpClientCalls.get();
         }
 
         @Override

--- a/src/test/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClientTest.java
+++ b/src/test/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClientTest.java
@@ -1474,26 +1474,6 @@ public class OpenSearchEmbeddingClientTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_hasUserInfo_detectsCredentialsWithoutParsing() {
-        assertTrue(OpenSearchEmbeddingClient.hasUserInfo("http://user:pass@host:9200"));
-        assertTrue(OpenSearchEmbeddingClient.hasUserInfo("http://user@host:9200"));
-        // Unparseable *and* credential-bearing. The scan is textual, so the userinfo is
-        // still seen; a parse-based check would throw here and leak the value instead.
-        assertTrue(OpenSearchEmbeddingClient.hasUserInfo("http://user:pa ss@host:9200"));
-        // No scheme: the whole leading segment is the authority candidate.
-        assertTrue(OpenSearchEmbeddingClient.hasUserInfo("user:pass@host:9200"));
-        assertFalse(OpenSearchEmbeddingClient.hasUserInfo("https://search.example.com:9200"));
-        assertFalse(OpenSearchEmbeddingClient.hasUserInfo("http://localhost:9200"));
-        assertFalse(OpenSearchEmbeddingClient.hasUserInfo("http://[::1]:9200"));
-        // '@' outside the authority is not userinfo.
-        assertFalse(OpenSearchEmbeddingClient.hasUserInfo("http://host:9200/a@b"));
-        assertFalse(OpenSearchEmbeddingClient.hasUserInfo("http://host:9200?q=a@b"));
-        assertFalse(OpenSearchEmbeddingClient.hasUserInfo("http://host:9200#a@b"));
-        assertFalse(OpenSearchEmbeddingClient.hasUserInfo(""));
-        assertFalse(OpenSearchEmbeddingClient.hasUserInfo(null));
-    }
-
-    @Test
     public void test_getApiUrl_real_userInfoIsRefused() {
         final FessConfig original = installFessConfigStub(USERINFO_API_URL);
         final LogCapturingAppender capture = LogCapturingAppender.attach(OpenSearchEmbeddingClient.class);

--- a/src/test/java/org/codelibs/fess/util/CredentialUrlUtilTest.java
+++ b/src/test/java/org/codelibs/fess/util/CredentialUrlUtilTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.util;
+
+import java.net.URISyntaxException;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+public class CredentialUrlUtilTest extends UnitFessTestCase {
+
+    // ========== hasUserInfo() ==========
+
+    @Test
+    public void test_hasUserInfo_detectsUserinfoAuthority() {
+        assertTrue(CredentialUrlUtil.hasUserInfo("https://user:pass@gw.example.com/v1"));
+        assertTrue(CredentialUrlUtil.hasUserInfo("http://user:pass@gw.example.com:8080/v1"));
+        assertTrue(CredentialUrlUtil.hasUserInfo("https://user@gw.example.com/v1"), "userinfo without a password still counts");
+        assertTrue(CredentialUrlUtil.hasUserInfo("https://user:pass@gw.example.com"), "no path after the authority");
+        assertTrue(CredentialUrlUtil.hasUserInfo("https://user:pass@gw.example.com?key=K"), "authority ends at '?'");
+        assertTrue(CredentialUrlUtil.hasUserInfo("https://user:pass@gw.example.com#frag"), "authority ends at '#'");
+    }
+
+    // The masking pattern excludes whitespace from both userinfo segments, so it cannot see this
+    // value at all - which is exactly why refusal, not masking, is what a URL's safety rests on.
+    @Test
+    public void test_hasUserInfo_detectsCredentialContainingWhitespace() {
+        assertTrue(CredentialUrlUtil.hasUserInfo("https://user:pw x@gw.example.com/v1"));
+        // Precondition: masking genuinely cannot handle this value, so hasUserInfo must.
+        assertEquals("https://user:pw x@gw.example.com/v1", CredentialUrlUtil.maskCredentialInUrl("https://user:pw x@gw.example.com/v1"));
+    }
+
+    // Each of these was missed by at least one of the four implementations this class replaces.
+    @Test
+    public void test_hasUserInfo_casesTheSeparateImplementationsDisagreedOn() {
+        // Protocol-relative: missed by any rule requiring "://".
+        assertTrue(CredentialUrlUtil.hasUserInfo("//user:pass@gw.example.com/v1"));
+        // Scheme-less: not a valid absolute URI, but it is a credential typed into a URL setting.
+        assertTrue(CredentialUrlUtil.hasUserInfo("user:pass@gw.example.com"));
+        assertTrue(CredentialUrlUtil.hasUserInfo("user:pass@gw.example.com:9200"));
+        // A scheme whose name is not strictly RFC 3986 must still have its authority scanned.
+        assertTrue(CredentialUrlUtil.hasUserInfo("ht tp://user:pass@gw.example.com/v1"));
+        // An empty userinfo still carries the forbidden delimiter, and an '@' inside the credential
+        // must not hide the one that delimits it.
+        assertTrue(CredentialUrlUtil.hasUserInfo("http://@host"));
+        assertTrue(CredentialUrlUtil.hasUserInfo("http://user:p@ss@host/api/chat"));
+        // A "://" appearing after a path character is not a scheme delimiter, so what follows it
+        // is not an authority.
+        assertFalse(CredentialUrlUtil.hasUserInfo("foo/bar://user:pass@gw.example.com"));
+    }
+
+    @Test
+    public void test_hasUserInfo_rejectsNonCredentialUrls() {
+        assertFalse(CredentialUrlUtil.hasUserInfo(null));
+        assertFalse(CredentialUrlUtil.hasUserInfo(""));
+        assertFalse(CredentialUrlUtil.hasUserInfo("   "));
+        assertFalse(CredentialUrlUtil.hasUserInfo("http://localhost:9200"), "host:port is not userinfo");
+        assertFalse(CredentialUrlUtil.hasUserInfo("https://gw.example.com/v1beta"));
+        assertFalse(CredentialUrlUtil.hasUserInfo("https://gw.example.com/v1beta/a:b@c"), "'@' in the path is not userinfo");
+        assertFalse(CredentialUrlUtil.hasUserInfo("https://gw.example.com/v1?to=a@b"), "'@' in the query is not userinfo");
+        assertFalse(CredentialUrlUtil.hasUserInfo("https://gw.example.com/v1#a@b"), "'@' in the fragment is not userinfo");
+        assertFalse(CredentialUrlUtil.hasUserInfo("localhost:9200"), "scheme-less host:port carries no credential");
+        assertFalse(CredentialUrlUtil.hasUserInfo("/v1/models"), "a bare path has no authority");
+        assertFalse(CredentialUrlUtil.hasUserInfo("http://[::1]:9200"), "an IPv6 literal authority carries no userinfo");
+        assertFalse(CredentialUrlUtil.hasUserInfo("https://gw.example.com/v1?next=https://u:p@other.example"),
+                "a second '://' inside the query is not this URL's authority");
+    }
+
+    // A whitespace-padded configuration value must not defeat the check.
+    @Test
+    public void test_hasUserInfo_trimsInput() {
+        assertTrue(CredentialUrlUtil.hasUserInfo("  https://user:pass@gw.example.com/v1  "));
+        assertTrue(CredentialUrlUtil.hasUserInfo("\t//user:pass@gw.example.com\n"));
+    }
+
+    // ========== maskCredentialInUrl() ==========
+
+    @Test
+    public void test_maskCredentialInUrl_masksQueryParameters() {
+        assertEquals("https://host/v1?key=***", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?key=AIzaSecret"));
+        assertEquals("https://host/v1?key=***&alt=json", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?key=AIzaSecret&alt=json"));
+        assertEquals("https://host/v1?alt=json&key=***", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?alt=json&key=AIzaSecret"));
+        // Parameter names are matched case-insensitively.
+        assertEquals("https://host/v1?KEY=***", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?KEY=AIzaSecret"));
+        assertEquals("https://host/v1?api_key=***&token=***&access_token=***",
+                CredentialUrlUtil.maskCredentialInUrl("https://host/v1?api_key=s1&token=s2&access_token=s3"));
+        assertEquals("https://host/v1?api-key=***&access-token=***",
+                CredentialUrlUtil.maskCredentialInUrl("https://host/v1?api-key=s1&access-token=s2"));
+        assertEquals("https://host/v1?apikey=***", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?apikey=s1"));
+        assertEquals("https://host/v1?a=1&API_KEY=***&b=2", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?a=1&API_KEY=zzz&b=2"));
+    }
+
+    @Test
+    public void test_maskCredentialInUrl_masksUserinfo() {
+        assertEquals("https://***:***@gw.example.com/v1beta",
+                CredentialUrlUtil.maskCredentialInUrl("https://user:pass@gw.example.com/v1beta"));
+        assertEquals("http://***:***@gw.example.com:8080/v1beta",
+                CredentialUrlUtil.maskCredentialInUrl("http://user:pass@gw.example.com:8080/v1beta"));
+        // Both rules apply to the same URL.
+        assertEquals("https://***:***@gw.example.com/v1beta?key=***",
+                CredentialUrlUtil.maskCredentialInUrl("https://user:pass@gw.example.com/v1beta?key=AIzaSecret"));
+    }
+
+    @Test
+    public void test_maskCredentialInUrl_leavesInnocuousUrlsAlone() {
+        assertNull(CredentialUrlUtil.maskCredentialInUrl(null));
+        assertEquals("", CredentialUrlUtil.maskCredentialInUrl(""));
+        assertEquals("https://host/v1?alt=json", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?alt=json"));
+        assertEquals("https://host/v1beta", CredentialUrlUtil.maskCredentialInUrl("https://host/v1beta"));
+        // host:port must not be mistaken for userinfo, and '@' in the path must not be masked.
+        assertEquals("http://localhost:8080/v1beta/models", CredentialUrlUtil.maskCredentialInUrl("http://localhost:8080/v1beta/models"));
+        assertEquals("https://gw.example.com/v1beta/a:b@c", CredentialUrlUtil.maskCredentialInUrl("https://gw.example.com/v1beta/a:b@c"));
+        // A parameter name that merely contains a secret-ish substring must not be masked: the
+        // pattern anchors on '?' or '&', so "monkey" and "keyword" are left alone.
+        assertEquals("https://host/v1?monkey=1", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?monkey=1"));
+        assertEquals("https://host/v1?keyword=1", CredentialUrlUtil.maskCredentialInUrl("https://host/v1?keyword=1"));
+    }
+
+    // ========== invalidUrlException() ==========
+
+    @Test
+    public void test_invalidUrlException_carriesNeitherUrlNorCause() {
+        final String secret = "s3cr3t";
+        final URISyntaxException syntax =
+                new URISyntaxException("https://user:" + secret + "@host/v1", "Illegal character in authority", 13);
+        final IllegalArgumentException original = new IllegalArgumentException(syntax.getMessage(), syntax);
+
+        final IllegalArgumentException replacement = CredentialUrlUtil.invalidUrlException("rag.llm.example.api.url", original);
+
+        assertFalse(replacement.getMessage().contains(secret), "the replacement must not quote the URL back: " + replacement.getMessage());
+        assertNull(replacement.getCause(), "no cause, so nothing downstream can recover the raw URI");
+        assertTrue(replacement.getMessage().contains("rag.llm.example.api.url"), "the setting to inspect must be named");
+        assertTrue(replacement.getMessage().contains("Illegal character in authority"));
+        assertTrue(replacement.getMessage().contains("13"), "the parser's index is safe to carry");
+    }
+
+    @Test
+    public void test_invalidUrlException_toleratesMissingDetail() {
+        assertEquals("Invalid URL configured in a.b.url", CredentialUrlUtil.invalidUrlException("a.b.url", null).getMessage());
+        // A non-URISyntaxException cause contributes nothing, since its message may hold the URL.
+        assertEquals("Invalid URL configured in a.b.url",
+                CredentialUrlUtil.invalidUrlException("a.b.url", new IllegalArgumentException("boom")).getMessage());
+        // A negative index is omitted rather than printed.
+        final URISyntaxException noIndex = new URISyntaxException("input", "Expected scheme name");
+        assertEquals("Invalid URL configured in a.b.url: Expected scheme name",
+                CredentialUrlUtil.invalidUrlException("a.b.url", new IllegalArgumentException("m", noIndex)).getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

Three external plugins are adding an `EmbeddingClient` implementation right now — [fess-llm-ollama#22](https://github.com/codelibs/fess-llm-ollama/pull/22), [fess-llm-openai#19](https://github.com/codelibs/fess-llm-openai/pull/19), [fess-llm-gemini#21](https://github.com/codelibs/fess-llm-gemini/pull/21) — and each independently arrived at a byte-identical copy of the same members, because core either did not provide them or declared them `abstract`. This PR resolves them in core, in two parts:

1. **`AbstractEmbeddingClient`** — the config readers and lifecycle members that are provider-agnostic become concrete, and `init()` gains a narrower extension seam.
2. **`CredentialUrlUtil`** — "does this configured URL embed a credential" becomes a single definition instead of four disagreeing copies.

---

## 1. `AbstractEmbeddingClient`

### What moved

| Member | Why it belongs here |
|---|---|
| `getDimension()` | Reads `content_chunker.embedding.dimension`, a property this class owns. The dimension belongs to the **index**, not the provider: core builds the `knn_vector` mapping from this one value, so a provider reporting a different number would only be describing vectors the index cannot store. Verified byte-identical in all four implementations. |
| `isContentChunkerEnabled()` | Was `abstract`, yet reads `CONTENT_CHUNKER_ENABLED_PROPERTY` — owned by this class, not provider-scoped. Exactly one correct body, and the compiler was *forcing* every provider to retype it. |
| `getAvailabilityCheckInterval()` | Same: was `abstract`, but is just `getConfigInt("availability.check.interval", 60)`. |
| `getConfigLong()` | The missing sibling of `getConfigInt()`. Every provider hand-rolled parse / catch / warn / default. |

`getConfigLong` deliberately does **not** inherit `getConfigInt`'s positive-only rule. That rule suits timeouts, intervals and counts, where `0` is better read as "unset"; this variant serves millisecond delays, where `0` legitimately means "do not wait". The difference is documented on the method.

### The `init()` seam

`init()` applied a single `getTimeout()` value to the connect timeout as well as the response timeout. A provider wanting the two separated had to reimplement `init()` *and* hand-build its own `CloseableHttpClient` — which `OpenSearchEmbeddingClient` did, and which left every provider that did not with a connect timeout as long as its response budget.

That matters at startup, not just in steady state: `startAvailabilityCheck()` runs a **synchronous** probe from `init()`, and the container invokes `init()` as an eager init-method. A firewalled or black-holed endpoint therefore stalls Tomcat context startup for the provider's full response timeout (120s for the OpenAI plugin as written, 60s for Gemini).

`init()` now delegates to `buildHttpClient()`, which honors a new `getConnectTimeout()` (default 5000ms, matching what `OpenSearchEmbeddingClient` already used) and calls a `configureHttpClient(HttpClientBuilder)` hook for anything else a provider must contribute. `OpenSearchEmbeddingClient` drops both overrides and keeps only the hook, for its preemptive basic-auth header.

**No behavior change for the built-in provider**: it already defaulted `connect.timeout` to 5000ms and already closed a prior client on re-init.

### Config warning

While moving the readers, the invalid-value WARN now names the offending value and is emitted under the *concrete provider's* logger instead of the base class's — an operator can see what was actually typed, and can raise the log level for one provider. `OpenSearchEmbeddingClientTest.test_getRetryBaseDelayMs_real_invalidValue_warnsAndReturnsDefault` already asserted both properties, and caught the regression when the first version of this change did not.

---

## 2. `CredentialUrlUtil`

"Does this configured URL embed a credential" was answered in four places — `OpenSearchEmbeddingClient`'s private `hasUserInfo` plus one utility in each of the three `fess-llm-*` plugins — and the four already disagreed:

- protocol-relative `//user:pw@host` was detected by two of the four;
- scheme-less `user:pw@host` by one;
- a `://` appearing *after* a path character was correctly refused as a scheme delimiter by one, and misread as one by the other three.

The masking regexes were byte-identical across all three plugins, so a rule added for one provider reached none of the others — with no compiler or test signal that anything was missed. That is a poor property for a security rule.

`CredentialUrlUtil` takes the union of the strongest behavior of each:

- input is trimmed, so a whitespace-padded value cannot defeat the check;
- the authority begins after `://` only when what precedes it could be a scheme, else after a leading `//`, else at the start of the string;
- the scheme test is deliberately permissive rather than the exact RFC 3986 grammar, because a value that only *nearly* looks like a scheme should still have its authority scanned — being wrong in that direction costs a refused configuration that could never have worked, being wrong the other way leaks a credential.

Detection stays a textual scan rather than a `java.net.URI` parse: the values most worth catching are the ones a parser rejects outright (a raw space in the password), and rejecting them produces a `URISyntaxException` that quotes the credential straight back.

It also carries `maskCredentialInUrl` and `invalidUrlException`, the latter being the rewriter that replaces the URI-construction failure whose message *and* cause chain both quote the offending URL verbatim.

What deliberately does **not** move here is the rejection message: which config key to fix, and which authentication mechanism to use instead, are provider-specific, so each caller still builds its own.

`OpenSearchEmbeddingClient` now delegates, and its `hasUserInfo` cases moved into `CredentialUrlUtilTest` — which also carries the cases the plugin suites covered and this one did not: an empty userinfo (`http://@host`) still carries the forbidden delimiter; an `@` inside the credential must not hide the one that delimits it; a second `://` inside a query string is not this URL's authority; an IPv6 literal authority carries no userinfo; and the bare `apikey` parameter spelling is masked, while a parameter whose name merely *contains* a secret-ish substring (`monkey`, `keyword`) is not.

---

## Testing

- **8 new tests** in `AbstractEmbeddingClientTest` (18 → 26) covering each moved member, including the `getConfigLong` zero/negative contract and that `buildHttpClient()` actually invokes the hook.
- **10 tests** in the new `CredentialUrlUtilTest`, pinning each of the disagreement cases above.
- Full suite: **6890 tests, 0 failures**.
- `mvn formatter:format license:format javadoc:jar` clean.

## Follow-ups (not in this PR)

- The retry engine (`executeWithRetry` / `sleepBackoff` / `RetryableHttpException` / `HttpCall`) is byte-identical between `OpenSearchEmbeddingClient` and the Ollama plugin, and lightly varied in the other two. Worth pulling up, but the four differ in real policy (Retry-After handling, which statuses are retryable), so it needs its own design pass.
