### PR TITLE
test(job): pin the child-JVM system-property forwarding contract

### DIFF
--- a/src/test/java/org/codelibs/fess/job/ChunkVectorJobTest.java
+++ b/src/test/java/org/codelibs/fess/job/ChunkVectorJobTest.java
@@ -238,6 +238,39 @@ public class ChunkVectorJobTest extends UnitFessTestCase {
                 cmdList.contains("-D" + Constants.FESS_CONF_PATH + "=" + confPath));
     }
 
+    // The child JVM resolves content_chunker.* through FessProp#getSystemProperty, which falls back
+    // to -Dfess.system.<key> when the key is absent from system.properties (the usual case, since
+    // AdminGeneralAction never writes content_chunker.* into that file). The fallback only reaches
+    // the child if the parent forwards its own -D options, so pin all three families ExecJob hands
+    // over: dropping any addFess*Properties() call must turn this red instead of silently leaving
+    // the indexer disabled while the web JVM sees the setting.
+    @Test
+    public void test_executeChunkVectorIndexer_forwardsPropertiesToChild() {
+        createRequiredDirectories();
+        System.setProperty("fess.system.content_chunker.enabled", "true");
+        System.setProperty("fess.config.chunk.probe.key", "configValue");
+        System.setProperty("custom.chunk.probe.key", "customValue");
+
+        mockProcessHelper.setExitValue(0);
+        mockProcessHelper.setOutput("Success");
+
+        try {
+            chunkVectorJob.executeChunkVectorIndexer();
+        } finally {
+            System.clearProperty("fess.system.content_chunker.enabled");
+            System.clearProperty("fess.config.chunk.probe.key");
+            System.clearProperty("custom.chunk.probe.key");
+        }
+
+        List<String> cmdList = mockProcessHelper.getLastCommandList();
+        assertNotNull(cmdList);
+        assertTrue("fess.system.* must reach the child JVM: " + cmdList, cmdList.contains("-Dfess.system.content_chunker.enabled=true"));
+        assertTrue("fess.config.* must reach the child JVM: " + cmdList, cmdList.contains("-Dfess.config.chunk.probe.key=configValue"));
+        // MockFessConfig#getJobSystemPropertyFilterPattern() returns "custom\\..*"
+        assertTrue("job.system.property.filter.pattern matches must reach the child JVM: " + cmdList,
+                cmdList.contains("-Dcustom.chunk.probe.key=customValue"));
+    }
+
     // Test executeChunkVectorIndexer with local Fesen
     @Test
     public void test_executeChunkVectorIndexer_withLocalFesen() {


### PR DESCRIPTION
## Background

A review comment claimed that `ChunkVectorJob` forwards only `fess.conf.path` to the chunk
indexer child JVM, so that `-Dfess.system.content_chunker.enabled=true` set on the web JVM
would register the semantic searcher while leaving the child process silently disabled.

That is not what the code does. `ChunkVectorJob.executeChunkVectorIndexer()` calls all three
forwarding helpers before the `fess.conf.path` line:

```java
addFessConfigProperties(cmdList);
addFessSystemProperties(cmdList);
addFessCustomSystemProperties(cmdList, fessConfig.getJobSystemPropertyFilterPattern());
addSystemProperty(cmdList, Constants.FESS_CONF_PATH, null, null);
```

The claim was still worth acting on, because **no test made it falsifiable**: removing any of
those three calls kept the whole suite green. `ExecJobTest` covers the `addFess*Properties()`
methods in isolation, but nothing asserted that a concrete job actually invokes them.

## Change

Adds `ChunkVectorJobTest#test_executeChunkVectorIndexer_forwardsPropertiesToChild`, which sets
one property per family on the parent JVM and asserts each one lands on the child command line
captured by the existing `MockProcessHelper`:

| Property set on the parent | Forwarded by |
|---|---|
| `-Dfess.system.content_chunker.enabled=true` | `addFessSystemProperties` |
| `-Dfess.config.chunk.probe.key=configValue` | `addFessConfigProperties` |
| `-Dcustom.chunk.probe.key=customValue` | `addFessCustomSystemProperties` (`MockFessConfig` pattern `custom\..*`) |

This matters for `content_chunker.*` specifically: the child resolves those keys through
`FessProp#getSystemProperty`, which falls back to `-Dfess.system.<key>` when the key is absent
from `system.properties` — and `AdminGeneralAction` never writes `content_chunker.*` into that
file, so the fallback is the normal path. Parent and child keep the same precedence
(`system.properties` wins over `-D`), because the child reloads the copy the parent hands it
via `-p` and then applies the identical expression.

Test only; no production code is touched.

## Verification

- `mvn -o test -Dtest=ChunkVectorJobTest` → `Tests run: 17, Failures: 0, Errors: 0`, BUILD SUCCESS
- Mutation check: commenting out the three `addFess*Properties()` calls in `ChunkVectorJob`
  fails the new test with `fess.system.* must reach the child JVM: [...]`; restoring them
  returns it to green. The assertions are not vacuous.
- `mvn -o formatter:format license:format` produced no further diff.

## Not covered (follow-up candidates)

The same contract holds for `CrawlJob`, `SuggestJob` and `GenerateThumbnailJob`, but their tests
cannot assert it today without a production change:

- `SuggestJob` resolves the servlet context through `ComponentUtil.getComponent(ServletContext.class)`
  rather than an overridable seam, so the UTFlute container mock (whose `getRealPath()` returns
  `null`) wins and `executeSuggestCreator()` throws `NullPointerException` at `SuggestJob.java:135`,
  before the command line is assembled. As a side effect, the five existing
  `getLastCommandList()` assertions in `SuggestJobTest` are all guarded by `if (cmdList != null)`
  and never actually evaluate.
- `CrawlJobTest` and `GenerateThumbnailJobTest` have no command-line-capturing process helper at all.

Closing those gaps needs a `getServletContext()` seam like the one `ChunkVectorJob` already has,
which is out of scope for a test-only change.
