### PR TITLE
feat: point the plugin installer at maven.codelibs.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,14 @@
 		</filters>
 
 		<plugins>
+			<!-- This project publishes to Maven Central. fess-parent only manages this
+			     plugin in pluginManagement, because the Fess plugins deploy to
+			     maven.codelibs.org instead. -->
+			<plugin>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -1990,7 +1990,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. homeDirectory */
     String LDAP_ATTR_HOME_DIRECTORY = "ldap.attr.homeDirectory";
 
-    /** The key of the configuration. e.g. https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml */
+    /** The key of the configuration. e.g. https://maven.codelibs.org/release/org/codelibs/fess/,https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml */
     String PLUGIN_REPOSITORIES = "plugin.repositories";
 
     /** The key of the configuration. e.g.  */
@@ -9450,7 +9450,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /**
      * Get the value for the key 'plugin.repositories'. <br>
-     * The value is, e.g. https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml <br>
+     * The value is, e.g. https://maven.codelibs.org/release/org/codelibs/fess/,https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml <br>
      * comment: Plugin repository URLs.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
@@ -14586,7 +14586,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.LDAP_ATTR_GID_NUMBER, "gidNumber");
             defaultMap.put(FessConfig.LDAP_ATTR_HOME_DIRECTORY, "homeDirectory");
             defaultMap.put(FessConfig.PLUGIN_REPOSITORIES,
-                    "https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml");
+                    "https://maven.codelibs.org/release/org/codelibs/fess/,https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml");
             defaultMap.put(FessConfig.PLUGIN_VERSION_FILTER, "");
             defaultMap.put(FessConfig.STORAGE_MAX_ITEMS_IN_PAGE, "1000");
             defaultMap.put(FessConfig.PASSWORD_INVALID_ADMIN_PASSWORDS, "admin");

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1691,10 +1691,10 @@ ldap.attr.homeDirectory=homeDirectory
 #                                                  Scheduler
 #                                                     ------
 
-#plugin.repositories=https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml
+#plugin.repositories=https://maven.codelibs.org/release/org/codelibs/fess/,https://maven.codelibs.org/snapshot/org/codelibs/fess/,https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml
 
 # Plugin repository URLs.
-plugin.repositories=https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml
+plugin.repositories=https://maven.codelibs.org/release/org/codelibs/fess/,https://repo.maven.apache.org/maven2/org/codelibs/fess/,https://fess.codelibs.org/plugin/artifacts.yaml
 # Version filter for plugins.
 plugin.version.filter=
 


### PR DESCRIPTION
## Summary

Maven Central introduced an upload limit that makes it impractical to keep releasing the Fess
plugin artifacts there, so the plugins now deploy to `maven.codelibs.org`
(codelibs/fess-parent#61). Two changes follow from that.

### 1. Declare central-publishing-maven-plugin explicitly

`fess-parent` moved `central-publishing-maven-plugin` from `build/plugins` to
`pluginManagement` so that the plugin repositories stop inheriting it. `fess` stays on Maven
Central and therefore declares it itself. The `version` and `publishingServerId` are still
inherited from `fess-parent`.

### 2. Add maven.codelibs.org to plugin.repositories

Plugins released after the migration will not appear on Maven Central, so without this the
admin plugin installer can no longer find them. The CodeLibs release repository is added at
the front of the list. Maven Central is kept for plugins released before the migration.

```
plugin.repositories=https://maven.codelibs.org/release/org/codelibs/fess/,\
                    https://repo.maven.apache.org/maven2/org/codelibs/fess/,\
                    https://fess.codelibs.org/plugin/artifacts.yaml
```

The value is updated consistently in `fess_config.properties` (the active setting and the
commented example) and in `FessConfig` (the key Javadoc, the getter Javadoc and the
`defaultMap` default).

## Verification

- Before the change: `mvn validate` no longer logged `Installing Central Publishing features`
  (i.e. the Maven Central path had been lost)
- After the change: `Installing Central Publishing features` is logged again
- A script confirms the `plugin.repositories` value is byte-identical across all four
  locations (`fess_config.properties`, `defaultMap`, key Javadoc, getter Javadoc)
- `mvn formatter:format license:format` applied (no diff)
- `mvn package -DskipTests` succeeds

## Depends on

codelibs/fess-parent#61 (must be merged first)
