### PR TITLE
chore(deps): base on OpenSearch 3.8.0

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -6,7 +6,7 @@
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://maven.codelibs.org" />
-	<property name="opensearch.version" value="3.7.0" />
+	<property name="opensearch.version" value="3.8.0" />
 
 	<target name="install.modules">
 		<mkdir dir="${target.dir}" />

--- a/module.xml
+++ b/module.xml
@@ -5,7 +5,7 @@
 
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
-	<property name="maven.release.repo.url" value="https://maven.codelibs.org" />
+	<property name="maven.release.repo.url" value="https://maven.codelibs.org/release" />
 	<property name="opensearch.version" value="3.8.0" />
 
 	<target name="install.modules">

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,8 +17,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-extension" />
-			<param name="plugin.version" value="3.7.0" />
-			<param name="plugin.zip.version" value="3.7.0" />
+			<param name="plugin.version" value="3.8.0" />
+			<param name="plugin.zip.version" value="3.8.0" />
 		</antcall>
 		<!-- analysis-fess -->
 		<antcall target="install.plugin">
@@ -26,8 +26,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="analysis-fess" />
-			<param name="plugin.version" value="3.7.0" />
-			<param name="plugin.zip.version" value="3.7.0" />
+			<param name="plugin.version" value="3.8.0" />
+			<param name="plugin.zip.version" value="3.8.0" />
 		</antcall>
 		<!-- configsync -->
 		<antcall target="install.plugin">
@@ -35,8 +35,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="configsync" />
-			<param name="plugin.version" value="3.7.0" />
-			<param name="plugin.zip.version" value="3.7.0" />
+			<param name="plugin.version" value="3.8.0" />
+			<param name="plugin.zip.version" value="3.8.0" />
 		</antcall>
 		<!-- minhash -->
 		<antcall target="install.plugin">
@@ -44,8 +44,8 @@
 			<param name="plugin.groupId" value="org/codelibs/opensearch" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="minhash" />
-			<param name="plugin.version" value="3.7.0" />
-			<param name="plugin.zip.version" value="3.7.0" />
+			<param name="plugin.version" value="3.8.0" />
+			<param name="plugin.zip.version" value="3.8.0" />
 		</antcall>
 		<!-- knn -->
 		<antcall target="install.plugin">
@@ -53,8 +53,8 @@
 			<param name="plugin.groupId" value="org/opensearch/plugin" />
 			<param name="plugin.name.prefix" value="opensearch-" />
 			<param name="plugin.name" value="knn" />
-			<param name="plugin.version" value="3.7.0.0" />
-			<param name="plugin.zip.version" value="3.7.0.0" />
+			<param name="plugin.version" value="3.8.0.0" />
+			<param name="plugin.zip.version" value="3.8.0.0" />
 		</antcall>
 
 		<antcall target="remove.jars" />


### PR DESCRIPTION
## Summary

Bump the OpenSearch plugin and module versions that the `antrun` download step
resolves, so a build of this branch provisions an OpenSearch 3.8.0 environment.

- `plugin.xml` — `analysis-extension`, `analysis-fess`, `configsync` and
  `minhash` to 3.8.0; `knn` to 3.8.0.0
- `module.xml` — the `opensearch.version` default to 3.8.0

These are plain literals rather than Maven properties, so they do not follow
fess-parent automatically. Everything else — OpenSearch, the embedded runner,
Lucene, Jackson and fesen-httpclient — is inherited and changes in
codelibs/fess-parent#65.

`plugins/` and `modules/` are gitignored download artifacts regenerated by
`mvn antrun:run`, so the stale versions they contain are not part of this diff.

## Verification

- `mvn antrun:run` downloads all eight modules and five plugins at the new
  versions, and the regenerated descriptors report `opensearch.version=3.8.0`
  (`3.8.0.0` for knn).
- `mvn test` — **6891 tests, 0 failures**.
- fess-suggest (688 tests) and fess-crawler-opensearch (40 tests) pass against
  the same baseline, with the embedded runner starting OpenSearch 3.8.0 on
  Lucene 10.5.0.

## Depends on

codelibs/fess-parent#65 — that needs to merge first, otherwise this branch still
compiles against OpenSearch 3.7.0 while downloading 3.8.0 modules.
