### PR TITLE
chore(build): drop the unused snapshot repository property

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -4,7 +4,6 @@
 	<property name="target.dir" value="${basedir}/target/modules" />
 
 	<!-- Maven Repository -->
-	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://maven.codelibs.org/release" />
 	<property name="opensearch.version" value="3.8.0" />
 


### PR DESCRIPTION
## Summary

`module.xml` declares `maven.snapshot.repo.url` but nothing references it —
every `antcall` passes `${maven.release.repo.url}`, and `pom.xml` passes only
`with.fess` and `opensearch.version` to this Ant file.

#3207 moved the OpenSearch module downloads to the CodeLibs release
repository, which leaves the snapshot property naming a host that no longer
serves those artifacts. Rather than repoint it at a path that currently has
nothing published, drop the dead declaration.

`plugin.xml` and `deps.xml` are unchanged: the OpenSearch plugins
(`opensearch-analysis-fess`, `opensearch-analysis-extension`,
`opensearch-minhash`, `opensearch-configsync`, `opensearch-knn`) and
`jakarta.annotation-api` are published to Maven Central, so their
declarations are correct.

## Verification

No behaviour change — the property had no readers. Every URL the build
actually downloads was probed and returns 200: the 8 module archives from
the CodeLibs release repository and the 5 plugin archives from Maven Central.
