### PR TITLE
build: deploy to maven.codelibs.org instead of Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,14 +96,6 @@
 		</filters>
 
 		<plugins>
-			<!-- This project publishes to Maven Central. fess-parent only manages this
-			     plugin in pluginManagement, because the Fess plugins deploy to
-			     maven.codelibs.org instead. -->
-			<plugin>
-				<groupId>org.sonatype.central</groupId>
-				<artifactId>central-publishing-maven-plugin</artifactId>
-				<extensions>true</extensions>
-			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
@@ -954,6 +946,25 @@
 			</plugin>
 		</plugins>
 	</build>
+	<!-- Distributed through maven.codelibs.org instead of Maven Central. This cannot be
+	     inherited from fess-parent: distributionManagement is inherited unconditionally
+	     and a POM cannot exempt itself from what it declares, so declaring it there
+	     would also redirect the deployments of fess-parent itself, which stays on Maven
+	     Central so that every project inheriting from it can resolve the parent POM
+	     without extra repository configuration. The scpexe transport comes from the
+	     wagon-ssh-external build extension inherited from fess-parent. -->
+	<distributionManagement>
+		<repository>
+			<id>codelibs-repo</id>
+			<name>CodeLibs Repository</name>
+			<url>scpexe://maven.codelibs.org/var/www/maven/release</url>
+		</repository>
+		<snapshotRepository>
+			<id>codelibs-snapshots</id>
+			<name>CodeLibs Snapshot Repository</name>
+			<url>scpexe://maven.codelibs.org/var/www/maven/snapshot</url>
+		</snapshotRepository>
+	</distributionManagement>
 	<repositories>
 		<repository>
 			<id>snapshots.central.sonatype.com</id>


### PR DESCRIPTION
## Summary

Publish this project to `maven.codelibs.org` instead of Maven Central, matching the Fess plugins.

## Changes

- Remove the `central-publishing-maven-plugin` declaration from `build/plugins`
- Declare the CodeLibs release and snapshot repositories in `distributionManagement`

## Why it is done this way

Removing the plugin declaration is the part that actually switches the destination. `central-publishing-maven-plugin` registers a `DeployLifecycleParticipant` that clears `maven-deploy-plugin`'s executions whenever the plugin is present in `build/plugins`, so adding `distributionManagement` on its own would have had no effect at all.

`distributionManagement` cannot be inherited from `fess-parent`: it is inherited unconditionally and a POM cannot exempt itself from what it declares, so declaring it there would also redirect `fess-parent`'s own deployments. `fess-parent` has to stay on Maven Central, because a parent POM is only resolvable from repositories the consuming project already knows about — see codelibs/fess-parent#66.

The `scpexe` transport comes from the `wagon-ssh-external` build extension inherited from `fess-parent`.

## Verification

- `mvn -B validate` no longer reports `Installing Central Publishing features`, so the lifecycle participant is inactive
- The effective `distributionManagement` snapshot URL resolves to the CodeLibs snapshot repository
- `mvn deploy` to a local file repository writes the POM, jar, sources jar and metadata — the participant would have suppressed this had it still been active
