### PR TITLE
feat(chunk): split content at sensible text boundaries instead of a fixed character count

### DIFF
--- a/src/main/java/org/codelibs/fess/chunk/ChunkBoundaryFinder.java
+++ b/src/main/java/org/codelibs/fess/chunk/ChunkBoundaryFinder.java
@@ -1,0 +1,766 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.chunk;
+
+/**
+ * Finds a "good" place to cut a chunk near an ideal character offset, instead of cutting
+ * blindly at a fixed length.
+ *
+ * <p>A boundary is only ever <em>moved</em>: no character is dropped, so concatenating the
+ * chunks still reproduces the original text exactly. This matters because
+ * {@link org.codelibs.fess.helper.ChunkVectorHelper} stores the chunks as the searchable
+ * {@code content} array.</p>
+ *
+ * <p>Registered as the LastaDi component {@code chunkBoundaryFinder} in {@code fess_chunk.xml}.
+ * The class is deliberately non-final and its character predicates are {@code protected} so a
+ * deployment can register a subclass that only swaps the character sets. Instances are shared
+ * singletons used concurrently by {@code content_chunker.job.concurrency} job threads, so this
+ * class must never hold mutable state.</p>
+ */
+public class ChunkBoundaryFinder {
+
+    /** Zero-width joiner; splitting next to it breaks an emoji/grapheme sequence. */
+    protected static final int ZWJ = 0x200D;
+
+    /** Returned in place of an offset when a tier has no candidate. */
+    private static final int NO_CANDIDATE = -1;
+
+    /**
+     * How far the hard-cut fallback may walk back (then forward) to leave a grapheme cluster
+     * intact, in code points.
+     *
+     * <p>{@code protected} suggests a subclass can retune this budget by redeclaring the
+     * constant, but it cannot: the sole reader, {@link #adjustToClusterStart}, is {@code private}
+     * and binds this class's own constant at compile time -- {@code static} fields have no
+     * virtual dispatch, so a subclass's redeclaration is simply never read. This budget is not
+     * currently part of the swappable seam that {@link #isClusterContinuation} and the other
+     * {@code protected} predicates form; kept {@code protected} rather than narrowed to
+     * {@code private} to avoid an unrelated visibility change.</p>
+     */
+    protected static final int MAX_CLUSTER_ADJUST = 16;
+
+    /**
+     * Default constructor.
+     */
+    public ChunkBoundaryFinder() {
+        // Default constructor
+    }
+
+    /**
+     * Returns the offset at which the current chunk should end.
+     *
+     * <p>Walks backward from {@code ideal} looking for a STRONG boundary first, then a WEAK or
+     * SCRIPT one. When no STRONG boundary is found behind {@code ideal}, a forward search looks
+     * for a sentence end or line break just ahead; that candidate beats a backward WEAK or
+     * SCRIPT one. Failing all of that, the offset is hard-cut at {@code ideal} and adjusted --
+     * backward first, then forward if backward finds nothing -- to avoid splitting a grapheme
+     * cluster; see {@link #adjustToClusterStart}.</p>
+     *
+     * <p>No path returns an offset that splits a grapheme cluster: a tier candidate that would
+     * strand a combining mark or a joiner half is rejected during the scan and the search
+     * continues, so the protection is not limited to the hard-cut path.</p>
+     *
+     * <p>The returned offset may exceed {@code ideal} by at most
+     * {@code max(lookahead, 2 * MAX_CLUSTER_ADJUST) + 1} UTF-16 units. The forward sentence
+     * search and the grapheme-cluster escape are <em>mutually exclusive</em>, not additive: this
+     * method returns as soon as the forward search succeeds, so the escape only ever runs when
+     * the forward search found nothing, and their two overshoot budgets never stack. The
+     * trailing {@code + 1} comes from {@link #alignToCodePoint}, which can move the aligned
+     * offset one UTF-16 unit past {@code ideal} before either search runs, to step off the
+     * inside of a surrogate pair. The cluster escape is <em>not</em> governed by
+     * {@code lookahead} and fires even when {@code lookahead} is {@code 0}: returning an offset
+     * that splits a grapheme cluster -- an emoji sequence rendering as mismatched halves across
+     * two chunks -- defeats the purpose of this search, so the escape is allowed to overshoot
+     * where the other tiers are not; a UTF-16 surrogate pair itself is never split regardless of
+     * how far either search has to move.</p>
+     *
+     * <p>The {@code start < result <= limitEnd} guarantee below holds for in-contract arguments
+     * ({@code 0 <= start < ideal <= limitEnd == text.length()}). Out-of-contract arguments --
+     * e.g. {@code ideal} at or below {@code start}, or {@code limitEnd} past the text -- are not
+     * rejected or normalized back onto the contract; the result is only clamped as far as the
+     * internal {@code bound}/{@code origin} defensive clamps reach, and can land at or below
+     * {@code start} or past {@code limitEnd} in those cases. This is unlike the sibling
+     * {@link #snapOverlapStart}, which degrades any out-of-contract shape to {@code end}.</p>
+     *
+     * @param text the full content being split
+     * @param start the offset at which the current chunk starts
+     * @param ideal the offset the fixed-length rule would cut at
+     * @param limitEnd the highest offset any chunk may end at (the content length)
+     * @param lookback how many characters before {@code ideal} may be searched; 0 disables it
+     * @param lookahead how many characters after {@code ideal} may be searched; 0 disables it
+     * @return the chunk end offset; always {@code start < result <= limitEnd} for in-contract
+     *         arguments
+     */
+    public int findChunkEnd(final CharSequence text, final int start, final int ideal, final int limitEnd, final int lookback,
+            final int lookahead) {
+        // Clamp defensively: limitEnd is contractually the content length, but this is a public
+        // component method and an oversized bound must not turn into an index-out-of-bounds.
+        final int bound = Math.min(limitEnd, text.length());
+        // Mirror of the bound clamp: start is contractually non-negative, but a public component
+        // method must not turn an out-of-contract argument into an index-out-of-bounds.
+        final int origin = Math.max(start, 0);
+        final int base = alignToCodePoint(text, origin, ideal, bound);
+        if (base >= bound || base <= origin) {
+            return base;
+        }
+        int fallback = NO_CANDIDATE;
+        if (lookback > 0) {
+            final long packed = searchBackward(text, origin, base, bound, lookback);
+            final int strong = unpackStrong(packed);
+            if (strong != NO_CANDIDATE) {
+                return strong;
+            }
+            fallback = unpackWeakOrScript(packed);
+        }
+        if (lookahead > 0) {
+            final int forward = searchForward(text, base, bound, lookahead);
+            if (forward != NO_CANDIDATE) {
+                return forward;
+            }
+        }
+        if (fallback != NO_CANDIDATE) {
+            return fallback;
+        }
+        return adjustToClusterStart(text, base, origin, bound);
+    }
+
+    /**
+     * Returns the offset at which the next chunk should start when an overlap is configured.
+     *
+     * <p>Walks backward from {@code ideal} looking for a STRONG boundary first, then a WEAK or
+     * SCRIPT one, exactly like the backward half of {@link #findChunkEnd}. There is no forward
+     * search: moving the overlap start forward would skip text that the previous chunk already
+     * ended before, so a candidate is only ever accepted if it stays within {@code (start, end]}.
+     * When no candidate qualifies, the aligned {@code ideal} offset is returned unchanged.</p>
+     *
+     * <p>The caller must pass {@code start < end}; given that, the result satisfies
+     * {@code start < result <= end}. Any other argument shape -- {@code ideal <= start}, or
+     * {@code ideal} past {@code end} or the text -- is out of contract and degrades to
+     * {@code end} (equivalently: the overlap is dropped for that step) rather than throwing or
+     * handing back an offset the caller would have to repair itself.</p>
+     *
+     * @param text the full content being split
+     * @param start the offset at which the current chunk starts
+     * @param ideal the offset the fixed overlap rule would restart at
+     * @param end the offset at which the current chunk ends
+     * @param lookback how many characters before {@code ideal} may be searched; 0 disables it
+     * @return the next start offset; always {@code start < result <= end}
+     */
+    public int snapOverlapStart(final CharSequence text, final int start, final int ideal, final int end, final int lookback) {
+        // The same pair of defensive clamps findChunkEnd applies, with `end` in place of the
+        // content length: the overlap start may never move past the chunk it overlaps.
+        final int bound = Math.min(end, text.length());
+        final int origin = Math.max(start, 0);
+        final int base = alignToCodePoint(text, origin, ideal, bound);
+        if (base <= origin || base > bound) {
+            // Out of contract: the ideal offset makes no forward progress, or lies past the chunk
+            // it overlaps. No valid overlap start exists, so restart at the chunk end -- i.e. drop
+            // the overlap for this step rather than returning an offset the caller must repair.
+            return bound;
+        }
+        if (lookback <= 0 || base == origin + 1) {
+            return base;
+        }
+        // The scan's limitEnd is `bound`, and there is no forward search here: moving the overlap
+        // start forward would skip text.
+        final long packed = searchBackward(text, origin, base, bound, lookback);
+        final int strong = unpackStrong(packed);
+        if (strong != NO_CANDIDATE && strong > origin && strong <= bound) {
+            return strong;
+        }
+        final int weakOrScript = unpackWeakOrScript(packed);
+        if (weakOrScript != NO_CANDIDATE && weakOrScript > origin && weakOrScript <= bound) {
+            return weakOrScript;
+        }
+        return base;
+    }
+
+    /**
+     * Pulls an offset off the inside of a UTF-16 surrogate pair so the whole scan can step by
+     * code points.
+     *
+     * <p>The offset normally moves back to the start of the pair. When moving back would reach
+     * {@code start} — leaving the caller no forward progress — it moves forward past the pair
+     * instead, provided that stays within {@code upperBound}.</p>
+     *
+     * @param text the full content being split
+     * @param start the offset at which the current chunk starts
+     * @param index the offset to align
+     * @param upperBound the highest offset the result may take
+     * @return the aligned offset
+     */
+    private int alignToCodePoint(final CharSequence text, final int start, final int index, final int upperBound) {
+        if (index <= start || index >= text.length() || !Character.isLowSurrogate(text.charAt(index))
+                || !Character.isHighSurrogate(text.charAt(index - 1))) {
+            return index;
+        }
+        if (index > start + 1) {
+            return index - 1;
+        }
+        return index + 1 <= upperBound ? index + 1 : index;
+    }
+
+    /**
+     * Single reverse pass over the lookback window.
+     *
+     * <p>Walking backward one code point at a time, a run of skippable code points (spaces and
+     * closing marks) is accumulated; when the run ends, the character in front of it decides
+     * which tier the run's end position belongs to. Doing it in one pass keeps the cost O(W)
+     * instead of the O(W^2) that re-scanning the run at every candidate would cost.</p>
+     *
+     * <p>Both tiers are returned because the caller must be able to tell "a strong boundary was
+     * found" from "only a weak one was": the forward search only runs when there is no strong
+     * boundary behind the ideal offset.</p>
+     *
+     * @param text the full content being split
+     * @param start the offset at which the current chunk starts
+     * @param ideal the offset the fixed-length rule would cut at
+     * @param limitEnd the highest offset any chunk may end at
+     * @param lookback how many characters before {@code ideal} may be searched
+     * @return the strong candidate in the high 32 bits and the weak-or-script candidate in the
+     *         low 32 bits; either is {@code NO_CANDIDATE} when that tier found nothing
+     */
+    private long searchBackward(final CharSequence text, final int start, final int ideal, final int limitEnd, final int lookback) {
+        final int floor = Math.max(start + 1, ideal - lookback);
+        int weak = NO_CANDIDATE;
+        int script = NO_CANDIDATE;
+        int runEnd = NO_CANDIDATE;
+        // The two code points bracketing runEnd, carried so the cluster guard below costs no
+        // extra decoding: both are already in hand at the moment the run starts.
+        int runEndCp = -1;
+        int runEndBeforeCp = -1;
+        boolean runHasNewline = false;
+        boolean runHasSpace = false;
+        boolean runHasClosing = false;
+        int b = ideal;
+        // codePointAt(text, b) is always the code point that codePointBefore() decoded as
+        // "before" on the previous iteration (the cursor moved back by exactly its charCount()),
+        // so it is carried forward here instead of being decoded again every iteration.
+        int after = b < limitEnd ? Character.codePointAt(text, b) : -1;
+        while (b >= floor) {
+            final int before = Character.codePointBefore(text, b);
+            final int beforeLen = Character.charCount(before);
+            if (isSkippableAfterBoundary(before)) {
+                if (runEnd == NO_CANDIDATE) {
+                    runEnd = b;
+                    runEndCp = after;
+                    runEndBeforeCp = before;
+                }
+                runHasNewline |= isNewline(before);
+                runHasSpace |= isBreakableSpace(before);
+                runHasClosing |= isClosingBracket(before);
+                b -= beforeLen;
+                after = before;
+                continue;
+            }
+            final int candidate = runEnd == NO_CANDIDATE ? b : runEnd;
+            final boolean spaceSatisfied = runHasSpace || candidate >= limitEnd;
+            // A tier candidate is no more allowed to split a grapheme cluster than the hard cut
+            // is; an offset that strands a combining mark or a joiner half is rejected and the
+            // scan simply keeps looking. Without this the boundary search could split a cluster
+            // the fixed-length cut it replaces had left intact.
+            final boolean candidateSafe = candidate >= limitEnd
+                    || !splitsCluster(runEnd == NO_CANDIDATE ? after : runEndCp, runEnd == NO_CANDIDATE ? before : runEndBeforeCp);
+            final boolean bSafe = b >= limitEnd || !splitsCluster(after, before);
+            // `after` is the code point immediately following `before`, so this is exactly the
+            // "punctuation sits between digits" test -- a run of spaces in between means the
+            // punctuation is not a decimal or thousands separator.
+            final boolean blockedByDigit = isPunctuationRequiringNonDigit(before) && after >= 0 && Character.isDigit(after);
+            if (candidateSafe && !blockedByDigit
+                    && (runHasNewline || isSentenceTerminator(before) && (!isAsciiPunctuationRequiringSpace(before) || spaceSatisfied))) {
+                return pack(candidate, weak != NO_CANDIDATE ? weak : script);
+            }
+            if (weak == NO_CANDIDATE) {
+                if (candidateSafe && (runHasSpace || runHasClosing
+                        || isClauseSeparator(before) && (!isAsciiPunctuationRequiringSpace(before) || spaceSatisfied) && !blockedByDigit)) {
+                    weak = candidate;
+                } else if (b < limitEnd && bSafe && isOpeningBracket(after)) {
+                    weak = b;
+                }
+            }
+            // Once a WEAK candidate exists this tier can never win (WEAK beats SCRIPT), so
+            // isScriptBoundary() -- a binary search over the Unicode block table -- must not run.
+            if (script == NO_CANDIDATE && weak == NO_CANDIDATE && b < limitEnd && bSafe && isScriptBoundary(before, after)) {
+                script = b;
+            }
+            runEnd = NO_CANDIDATE;
+            runHasNewline = false;
+            runHasSpace = false;
+            runHasClosing = false;
+            b -= beforeLen;
+            after = before;
+        }
+        if (runEnd != NO_CANDIDATE) {
+            // The window ran out inside a skippable run. The run-based rules (a newline in the
+            // run makes it STRONG; any space or closing mark makes it WEAK) do not depend on the
+            // character in front of the run, and runEnd is >= floor, so this candidate is valid
+            // and must not be discarded just because the window ended mid-run.
+            final boolean runEndSafe = runEnd >= limitEnd || !splitsCluster(runEndCp, runEndBeforeCp);
+            if (runEndSafe) {
+                if (runHasNewline) {
+                    return pack(runEnd, weak != NO_CANDIDATE ? weak : script);
+                }
+                if (weak == NO_CANDIDATE && (runHasSpace || runHasClosing)) {
+                    weak = runEnd;
+                }
+            }
+        }
+        return pack(NO_CANDIDATE, weak != NO_CANDIDATE ? weak : script);
+    }
+
+    /**
+     * Returns true if placing a boundary between the two given adjacent code points would split a
+     * grapheme cluster.
+     *
+     * @param at the code point at the candidate offset, or a negative value when there is none
+     * @param before the code point immediately before the candidate offset
+     * @return true if the boundary must not be placed there
+     */
+    private boolean splitsCluster(final int at, final int before) {
+        return at >= 0 && (isClusterContinuation(at) || isClusterJoiner(before));
+    }
+
+    /**
+     * {@link #splitsCluster} for an offset whose bracketing code points are not already in hand.
+     *
+     * @param text the full content being split
+     * @param index the candidate offset
+     * @param limitEnd the highest offset any chunk may end at
+     * @return true if the boundary must not be placed there
+     */
+    private boolean splitsClusterAt(final CharSequence text, final int index, final int limitEnd) {
+        if (index <= 0 || index >= limitEnd) {
+            return false;
+        }
+        return splitsCluster(Character.codePointAt(text, index), Character.codePointBefore(text, index));
+    }
+
+    private long pack(final int strong, final int weakOrScript) {
+        return (long) strong << 32 | weakOrScript & 0xFFFFFFFFL;
+    }
+
+    private int unpackStrong(final long packed) {
+        return (int) (packed >> 32);
+    }
+
+    private int unpackWeakOrScript(final long packed) {
+        return (int) packed;
+    }
+
+    /**
+     * Scans forward from the ideal offset for a sentence end or a line break.
+     *
+     * <p>Only STRONG boundaries are looked for ahead: overshooting the configured chunk size is
+     * acceptable to keep a sentence whole, but not to land on a comma or a space.</p>
+     *
+     * @param text the full content being split
+     * @param ideal the offset the fixed-length rule would cut at
+     * @param limitEnd the highest offset any chunk may end at
+     * @param lookahead how many characters after {@code ideal} may be searched
+     * @return the forward candidate, or {@code -1} if there is none
+     */
+    private int searchForward(final CharSequence text, final int ideal, final int limitEnd, final int lookahead) {
+        final int ceiling = Math.min(limitEnd, ideal + lookahead);
+        int i = ideal;
+        while (i < ceiling) {
+            final int cp = Character.codePointAt(text, i);
+            final int cpLen = Character.charCount(cp);
+            if (isNewline(cp) || isSentenceTerminator(cp)) {
+                int p = i + cpLen;
+                boolean sawSpace = false;
+                while (p < ceiling) {
+                    final int next = Character.codePointAt(text, p);
+                    if (!isSkippableAfterBoundary(next)) {
+                        break;
+                    }
+                    sawSpace |= isBreakableSpace(next);
+                    p += Character.charCount(next);
+                }
+                final boolean spaceSatisfied = sawSpace || p >= limitEnd;
+                final int afterCp = i + cpLen < limitEnd ? Character.codePointAt(text, i + cpLen) : -1;
+                final boolean blockedByDigit = isPunctuationRequiringNonDigit(cp) && afterCp >= 0 && Character.isDigit(afterCp);
+                if ((isNewline(cp) || !isAsciiPunctuationRequiringSpace(cp) || spaceSatisfied) && !blockedByDigit && p <= ceiling
+                        && !splitsClusterAt(text, p, limitEnd)) {
+                    return p;
+                }
+            }
+            i += cpLen;
+        }
+        return NO_CANDIDATE;
+    }
+
+    /**
+     * Walks the hard-cut offset off a grapheme cluster so the boundary does not split it.
+     *
+     * <p>Three phases, tried in order:</p>
+     * <ol>
+     * <li>Walk backward from {@code index}, at most {@link #MAX_CLUSTER_ADJUST} code points and
+     * never below {@code start + 1}, and return the first position that is safe -- one where
+     * {@link Character#codePointAt} is not a cluster continuation and
+     * {@link Character#codePointBefore} is not {@link #ZWJ}.</li>
+     * <li>If backward found nothing (it exhausted its budget or ran into {@code start} -- for
+     * example a ZWJ-joined emoji sequence that begins exactly at {@code start}, which backward
+     * can never clear no matter how far the window extends), walk forward from {@code index}
+     * instead, at most {@link #MAX_CLUSTER_ADJUST} code points, stepping by
+     * {@link Character#charCount} so the cursor is always code-point aligned. This is what
+     * guarantees a UTF-16 surrogate pair is never split, even when {@code upperBound} itself
+     * falls inside one: the walk only ever stops exactly on {@code upperBound} or on the start
+     * of a code point, never in between.</li>
+     * <li>If neither walk found a safe position, return {@code index} unchanged -- still
+     * code-point aligned, just not guaranteed cluster-safe.</li>
+     * </ol>
+     *
+     * @param text the full content being split
+     * @param index the hard-cut offset
+     * @param start the offset at which the current chunk starts; the result stays above it
+     * @param upperBound the highest offset the result may take
+     * @return the adjusted offset, or {@code index} if no safe adjustment exists in either
+     *         direction
+     */
+    private int adjustToClusterStart(final CharSequence text, final int index, final int start, final int upperBound) {
+        // `start` is guaranteed non-negative here: findChunkEnd is this method's only caller and
+        // already clamps it (see `origin` there), so codePointBefore(text, b) below can never be
+        // reached with a non-positive `b`.
+        int b = index;
+        for (int i = 0; i < MAX_CLUSTER_ADJUST && b > start; i++) {
+            final int at = Character.codePointAt(text, b);
+            final int before = Character.codePointBefore(text, b);
+            if (!isClusterContinuation(at) && !isClusterJoiner(before)) {
+                return b;
+            }
+            b -= Character.charCount(before);
+        }
+        // Backward found nothing safe without going through `start`. Walk forward from the
+        // original hard-cut offset instead, stepping by charCount() so the cursor is always
+        // code-point aligned -- a surrogate pair can then never be split, even when
+        // `upperBound` itself falls inside one.
+        int f = index;
+        int cp = Character.codePointAt(text, f);
+        for (int i = 0; i < MAX_CLUSTER_ADJUST && f < upperBound; i++) {
+            final int cpLen = Character.charCount(cp);
+            if (f + cpLen > upperBound) {
+                // The next aligned step would overshoot upperBound; nothing more can be tried.
+                break;
+            }
+            f += cpLen;
+            if (f >= upperBound) {
+                // Landed exactly on upperBound: always code-point aligned by construction, and
+                // there is no character at-or-after it in this chunk left to split.
+                return f;
+            }
+            final int next = Character.codePointAt(text, f);
+            if (!isClusterContinuation(next) && !isClusterJoiner(cp)) {
+                return f;
+            }
+            cp = next;
+        }
+        return index;
+    }
+
+    /**
+     * Returns true if the code point is a break opportunity that behaves like a space.
+     *
+     * <p>Includes the code points {@link Character#isWhitespace(int)} reports as
+     * <em>non</em>-whitespace but that Fess's extracted text treats as separators
+     * (see {@code crawler.document.space.chars}).</p>
+     *
+     * @param cp the code point
+     * @return true if the code point is a breakable space
+     */
+    protected boolean isBreakableSpace(final int cp) {
+        if (cp == ' ') {
+            // By far the most common code point in extracted text: check it before anything else.
+            return true;
+        }
+        if (Character.isWhitespace(cp)) {
+            return true;
+        }
+        switch (cp) {
+        case 0x0085: // NEXT LINE (NEL) -- Character.isWhitespace() rejects it
+        case 0x00A0: // NO-BREAK SPACE
+        case 0x2007: // FIGURE SPACE
+        case 0x202F: // NARROW NO-BREAK SPACE
+        case 0x200B: // ZERO WIDTH SPACE
+        case 0x200C: // ZERO WIDTH NON-JOINER
+        case 0x2060: // WORD JOINER
+        case 0xFEFF: // ZERO WIDTH NO-BREAK SPACE / BOM
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if the code point ends a line.
+     *
+     * @param cp the code point
+     * @return true if the code point is a line separator
+     */
+    protected boolean isNewline(final int cp) {
+        return cp == '\n' || cp == '\r' || cp == 0x0085 || cp == 0x2028 || cp == 0x2029;
+    }
+
+    /**
+     * Returns true if the code point ends a sentence.
+     *
+     * @param cp the code point
+     * @return true if the code point is a sentence terminator
+     */
+    protected boolean isSentenceTerminator(final int cp) {
+        switch (cp) {
+        case '.':
+        case '!':
+        case '?':
+        case 0x3002: // 。
+        case 0xFF0E: // ．
+        case 0xFF61: // ｡
+        case 0xFF01: // ！
+        case 0xFF1F: // ？
+        case 0x2025: // ‥
+        case 0x2026: // …
+        case 0x203C: // ‼
+        case 0x2047: // ⁇
+        case 0x2048: // ⁈
+        case 0x2049: // ⁉
+        case 0x06D4: // Arabic full stop
+        case 0x1362: // Ethiopic full stop
+        case 0x2E3C: // stenographic full stop
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if the code point separates clauses within a sentence.
+     *
+     * @param cp the code point
+     * @return true if the code point is a clause separator
+     */
+    protected boolean isClauseSeparator(final int cp) {
+        switch (cp) {
+        case ',':
+        case ';':
+        case ':':
+        case '-':
+        case 0x3001: // 、
+        case 0xFF0C: // ，
+        case 0xFF1B: // ；
+        case 0xFF1A: // ：
+        case 0xFF64: // ､
+        case 0xFF65: // ･
+        case 0x30FB: // ・
+        case 0x2010: // ‐
+        case 0x2013: // –
+        case 0x2014: // —
+        case 0x2015: // ―
+        case 0x301C: // 〜
+        case 0xFF5E: // ～
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if the code point only counts as a boundary when whitespace follows it.
+     *
+     * <p>ASCII {@code . , ; :} are ambiguous inside numbers and abbreviations
+     * ({@code 3.14}, {@code 1,234}); requiring a following space rejects those without needing a
+     * separate digit test. The fullwidth forms cannot use this rule -- CJK sentences carry no
+     * trailing space -- and are handled by {@link #isPunctuationRequiringNonDigit} instead.</p>
+     *
+     * @param cp the code point
+     * @return true if a following space is required
+     */
+    protected boolean isAsciiPunctuationRequiringSpace(final int cp) {
+        return cp == '.' || cp == ',' || cp == ';' || cp == ':';
+    }
+
+    /**
+     * Returns true if the code point only counts as a boundary when the code point immediately
+     * following it is not a digit.
+     *
+     * <p>This is the counterpart of {@link #isAsciiPunctuationRequiringSpace} for the forms that
+     * rule cannot cover. The fullwidth stop, comma and colon are decimal points, thousands
+     * separators and time separators in ordinary Japanese typography ({@code １．５倍},
+     * {@code １，２３４}, {@code １０：３０}), so they cannot simply be trusted -- but they cannot be
+     * made to require a following space either, because CJK sentences are not written with one
+     * (the JIS {@code ，．} convention would stop working). Hyphens get the same treatment so
+     * that ISO dates and version strings ({@code 2026-08-09}, {@code UTF-8}) survive; a hyphen
+     * inside a word ({@code well-known}) remains a boundary, which is the ordinary line-break
+     * behaviour for hyphenated compounds.</p>
+     *
+     * @param cp the code point
+     * @return true if a following digit disqualifies this code point as a boundary
+     */
+    protected boolean isPunctuationRequiringNonDigit(final int cp) {
+        switch (cp) {
+        case '-':
+        case 0x2010: // ‐
+        case 0xFF0E: // ．
+        case 0xFF0C: // ，
+        case 0xFF1A: // ：
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if the code point closes a bracket or a quotation.
+     *
+     * @param cp the code point
+     * @return true if the code point is a closing mark
+     */
+    protected boolean isClosingBracket(final int cp) {
+        switch (cp) {
+        case ')':
+        case ']':
+        case '}':
+        case '"':
+        case '\'':
+        case 0xFF09: // ）
+        case 0xFF3D: // ］
+        case 0xFF5D: // ｝
+        case 0x300D: // 」
+        case 0x300F: // 』
+        case 0x3011: // 】
+        case 0x3015: // 〕
+        case 0x300B: // 》
+        case 0x3009: // 〉
+        case 0x2019: // ’
+        case 0x201D: // ”
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if the code point opens a bracket or a quotation.
+     *
+     * @param cp the code point
+     * @return true if the code point is an opening mark
+     */
+    protected boolean isOpeningBracket(final int cp) {
+        switch (cp) {
+        case '(':
+        case '[':
+        case '{':
+        case 0xFF08: // （
+        case 0xFF3B: // ［
+        case 0xFF5B: // ｛
+        case 0x300C: // 「
+        case 0x300E: // 『
+        case 0x3010: // 【
+        case 0x3014: // 〔
+        case 0x300A: // 《
+        case 0x3008: // 〈
+        case 0x2018: // ‘
+        case 0x201C: // “
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if the code point may be swallowed into the preceding chunk when it trails a
+     * separator (spaces and closing marks).
+     *
+     * @param cp the code point
+     * @return true if the code point belongs to a trailing run
+     */
+    protected boolean isSkippableAfterBoundary(final int cp) {
+        return isBreakableSpace(cp) || isClosingBracket(cp);
+    }
+
+    /**
+     * Returns true if two adjacent code points belong to different writing systems.
+     *
+     * <p>{@code COMMON} / {@code INHERITED} / {@code UNKNOWN} are excluded so that digits,
+     * punctuation and emoji do not register as script changes — those are handled by the
+     * other tiers.</p>
+     *
+     * @param before the code point before the candidate boundary
+     * @param after the code point at the candidate boundary
+     * @return true if the boundary sits on a script change
+     */
+    protected boolean isScriptBoundary(final int before, final int after) {
+        if (before < 0x80 && after < 0x80) {
+            // Fast path: ASCII never changes script in a way this tier cares about, and
+            // UnicodeScript.of() is a binary search over the Unicode block table -- an order of
+            // magnitude more expensive than the switch-based predicates around it.
+            return false;
+        }
+        final Character.UnicodeScript b = Character.UnicodeScript.of(before);
+        if (isNeutralScript(b)) {
+            return false;
+        }
+        final Character.UnicodeScript a = Character.UnicodeScript.of(after);
+        if (isNeutralScript(a)) {
+            return false;
+        }
+        return b != a;
+    }
+
+    private boolean isNeutralScript(final Character.UnicodeScript script) {
+        return script == Character.UnicodeScript.COMMON || script == Character.UnicodeScript.INHERITED
+                || script == Character.UnicodeScript.UNKNOWN;
+    }
+
+    /**
+     * Returns true if the code point continues the grapheme cluster started by the preceding
+     * code point, so a boundary must not be placed in front of it.
+     *
+     * <p>Covers combining marks, variation selectors and the zero-width joiner. Regional
+     * indicator pairs (flag emoji) are deliberately <em>not</em> covered: splitting is lossless,
+     * so a flag merely renders as two letters across the chunk boundary.</p>
+     *
+     * @param cp the code point
+     * @return true if a boundary must not be placed before this code point
+     */
+    protected boolean isClusterContinuation(final int cp) {
+        if (cp == ZWJ) {
+            return true;
+        }
+        if (cp >= 0xFE00 && cp <= 0xFE0F || cp >= 0xE0100 && cp <= 0xE01EF) {
+            return true;
+        }
+        final int type = Character.getType(cp);
+        return type == Character.NON_SPACING_MARK || type == Character.COMBINING_SPACING_MARK || type == Character.ENCLOSING_MARK;
+    }
+
+    /**
+     * Returns true if the code point, when it appears immediately before a candidate boundary,
+     * joins that boundary's code point into the same grapheme cluster -- so a boundary must not
+     * be placed right after it either.
+     *
+     * <p>This is the backward-looking counterpart of {@link #isClusterContinuation}, which asks
+     * the same question about the code point <em>at</em> the candidate boundary. {@link
+     * #adjustToClusterStart} tests both directions, so both must be overridable for a subclass
+     * that redefines cluster joining to take full effect: overriding only
+     * {@link #isClusterContinuation} would leave this direction on the built-in zero-width-joiner
+     * rule.</p>
+     *
+     * @param cp the code point immediately before the candidate boundary
+     * @return true if a boundary must not be placed right after this code point
+     */
+    protected boolean isClusterJoiner(final int cp) {
+        return cp == ZWJ;
+    }
+}

--- a/src/main/java/org/codelibs/fess/chunk/LengthChunker.java
+++ b/src/main/java/org/codelibs/fess/chunk/LengthChunker.java
@@ -22,14 +22,51 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.Constants;
 import org.codelibs.fess.util.ComponentUtil;
 
 /**
- * Default {@link Chunker} implementation: fixed-length character windows,
- * with optional overlap between consecutive windows. Never splits a chunk
- * boundary in the middle of a UTF-16 surrogate pair (Java {@link String} is
- * UTF-16 internally; splitting between a high and low surrogate produces two
- * chunks each containing an unpaired, semantically invalid surrogate).
+ * Default {@link Chunker} implementation: character windows of roughly
+ * {@code content_chunker.length.chunk_size} characters, with optional overlap between
+ * consecutive windows.
+ *
+ * <p>By default each cut moves to a suitable break found by {@link ChunkBoundaryFinder} within
+ * the search window: the <em>nearest candidate of the highest tier present</em>, not simply the
+ * nearest candidate. A line break or sentence end wins over any clause separator or space no
+ * matter how much farther back it is, and those win over a script change. Only the boundary
+ * moves; no character is dropped, so with the default {@code content_chunker.length.overlap=0}
+ * concatenating the chunks still reproduces the content exactly. Set
+ * {@code content_chunker.length.boundary.enabled=false} for the legacy fixed-length
+ * behaviour.</p>
+ *
+ * <p>Because the forward search may overshoot, {@code chunk_size} is a target rather than a hard
+ * ceiling: a chunk can reach {@code chunk_size + lookahead}. There is a second, independent
+ * source of overshoot: {@link ChunkBoundaryFinder}'s grapheme-cluster escape is <em>not</em>
+ * governed by {@code lookahead} and can fire even when {@code lookahead_percent=0}, so the worst
+ * case reachable through this class is
+ * {@code chunk_size + max(lookahead, 2 * ChunkBoundaryFinder.MAX_CLUSTER_ADJUST)} characters --
+ * 840 at the shipped defaults ({@code chunk_size=800}, {@code lookahead_percent=5}). Setting
+ * {@code lookahead_percent=0} alone does not lower this ceiling below
+ * {@code chunk_size + 2 * ChunkBoundaryFinder.MAX_CLUSTER_ADJUST} (832 at the shipped defaults):
+ * the cluster escape still runs whenever boundary search runs at all, which only requires
+ * {@code lookback_percent > 0}. Boundary search runs at all only when {@code lookback} or
+ * {@code lookahead} is positive (see {@link #split(String, int)}), so setting <em>both</em>
+ * percentages to {@code 0} makes {@code chunk_size} an exact ceiling with no overshoot.
+ * ({@link ChunkBoundaryFinder#findChunkEnd} documents one further {@code + 1}; that branch needs
+ * {@code ideal == start + 1}, which {@link #MIN_CHUNK_SIZE} makes unreachable from here.)</p>
+ *
+ * <p>The backward search can undershoot symmetrically: because a cut may move earlier to reach a
+ * boundary, a chunk can end up to {@code lookback} characters <em>shorter</em> than
+ * {@code chunk_size} -- 160 characters at the shipped defaults ({@code chunk_size=800}, {@code
+ * lookback_percent=20}). A document therefore yields more chunks than before: measured at +9% on
+ * English prose and up to +25% in the worst case, which matters against
+ * {@code content_chunker.max_chunks_per_document}. Never splits a chunk boundary in the middle of
+ * a UTF-16 surrogate pair.</p>
+ *
+ * <p>When an overlap is configured, the restart point is snapped to a boundary too, which can
+ * only move it <em>earlier</em> and so makes the effective overlap larger than the configured
+ * value. The snap window is capped at the configured overlap (see {@link #split(String, int)}),
+ * so the effective overlap never exceeds {@code 2 * overlap}.</p>
  */
 public class LengthChunker implements Chunker {
 
@@ -48,11 +85,11 @@ public class LengthChunker implements Chunker {
     protected static final int DEFAULT_CHUNK_SIZE = 800;
 
     /**
-     * Minimum allowed chunk size. A chunk size of 1 can force the surrogate-pair
-     * boundary adjustment (see {@link #split(String)}) to collide with the
-     * defensive forward-progress fallback, re-landing the boundary on the split
-     * it was meant to avoid and silently dropping the low surrogate. A chunk
-     * size of 2 or more makes that collision mathematically unreachable.
+     * Minimum allowed chunk size: a sanity floor, not a correctness requirement. A chunk size of
+     * 1 is nonsensical in practice, but it is no longer a correctness hazard -- the defensive
+     * forward-progress fallback in {@link #split(String, int)} steps a whole code point
+     * ({@code start + Character.charCount(content.codePointAt(start))}), so it can no longer
+     * collide with the surrogate-pair boundary adjustment and silently drop a low surrogate.
      */
     protected static final int MIN_CHUNK_SIZE = 2;
 
@@ -66,6 +103,46 @@ public class LengthChunker implements Chunker {
      * affects a reasonable real configuration.
      */
     protected static final int MAX_CHUNK_SIZE = 100_000;
+
+    /** System property key toggling boundary-aware splitting. */
+    protected static final String BOUNDARY_ENABLED_PROPERTY = "content_chunker.length.boundary.enabled";
+
+    /** System property key for how far before the ideal cut a boundary may be searched, in percent of the chunk size. */
+    protected static final String LOOKBACK_PERCENT_PROPERTY = "content_chunker.length.boundary.lookback_percent";
+
+    /** System property key for how far after the ideal cut a sentence end may be searched, in percent of the chunk size. */
+    protected static final String LOOKAHEAD_PERCENT_PROPERTY = "content_chunker.length.boundary.lookahead_percent";
+
+    /** Boundary-aware splitting ships enabled; set the property to false for the legacy fixed-length behaviour. */
+    protected static final boolean DEFAULT_BOUNDARY_ENABLED = true;
+
+    /** Default backward search window, in percent of the chunk size. */
+    protected static final int DEFAULT_LOOKBACK_PERCENT = 20;
+
+    /** Default forward search window, in percent of the chunk size. */
+    protected static final int DEFAULT_LOOKAHEAD_PERCENT = 5;
+
+    /** Upper bound for the backward window: beyond half a chunk the chunks get pointlessly short. */
+    protected static final int MAX_LOOKBACK_PERCENT = 50;
+
+    /**
+     * Upper bound for the forward window. The forward search is the only overshoot path this
+     * setting governs -- {@link ChunkBoundaryFinder}'s grapheme-cluster escape can also push a
+     * chunk past {@code chunk_size}, but it ignores {@code lookahead} entirely and fires even at
+     * {@code lookahead_percent=0}, so it is not bounded by this cap. Within the range this setting
+     * does govern, it caps how far past an embedding model's token budget a chunk can grow.
+     */
+    protected static final int MAX_LOOKAHEAD_PERCENT = 25;
+
+    /** LastaDi component name of the boundary finder, defined in {@code fess_chunk.xml}. */
+    protected static final String BOUNDARY_FINDER_COMPONENT = "chunkBoundaryFinder";
+
+    /**
+     * Used when {@link #BOUNDARY_FINDER_COMPONENT} is not registered (unit tests constructing a
+     * chunker directly, or a container without {@code fess_chunk.xml}). Safe to share: the finder
+     * holds no state.
+     */
+    private static final ChunkBoundaryFinder DEFAULT_BOUNDARY_FINDER = new ChunkBoundaryFinder();
 
     /**
      * Default constructor.
@@ -85,6 +162,39 @@ public class LengthChunker implements Chunker {
             ComponentUtil.getComponent(ChunkerManager.class).register(this);
         }
         warnOnOverlapSideEffect();
+        logBoundaryMode();
+    }
+
+    /**
+     * Logs the effective boundary-search configuration once, at registration time, so that an
+     * upgrade which silently turns {@code chunk_size} from a hard ceiling into a target leaves a
+     * trace an operator can correlate an embedding-provider rejection against.
+     */
+    protected void logBoundaryMode() {
+        try {
+            if (!isBoundaryEnabled()) {
+                logger.info("[Chunk] {}=false: chunks are cut at exactly {} characters.", BOUNDARY_ENABLED_PROPERTY,
+                        normalizeChunkSize(getChunkSize()));
+                return;
+            }
+            final int chunkSize = normalizeChunkSize(getChunkSize());
+            final int lookback =
+                    windowSize(chunkSize, normalizeBoundaryPercent(getLookbackPercent(), MAX_LOOKBACK_PERCENT, LOOKBACK_PERCENT_PROPERTY));
+            final int lookahead = windowSize(chunkSize,
+                    normalizeBoundaryPercent(getLookaheadPercent(), MAX_LOOKAHEAD_PERCENT, LOOKAHEAD_PERCENT_PROPERTY));
+            logger.info(
+                    "[Chunk] Boundary-aware splitting is enabled: {}={} is a target, not a ceiling. "
+                            + "Chunks range from {} to {} characters (lookback={}, lookahead={}); "
+                            + "expect more chunks per document than a fixed-length split, which counts against {}.",
+                    CHUNK_SIZE_PROPERTY, chunkSize, chunkSize - lookback,
+                    chunkSize + Math.max(lookahead, 2 * ChunkBoundaryFinder.MAX_CLUSTER_ADJUST), lookback, lookahead,
+                    "content_chunker.max_chunks_per_document");
+        } catch (final Exception e) {
+            // Diagnostics only; never let a config-read failure break component registration.
+            if (logger.isDebugEnabled()) {
+                logger.debug("[Chunk] Skipping boundary-mode diagnostic.", e);
+            }
+        }
     }
 
     /**
@@ -133,8 +243,20 @@ public class LengthChunker implements Chunker {
         }
         final int chunkSize = normalizeChunkSize(getChunkSize());
         final int overlap = normalizeOverlap(getOverlap(), chunkSize);
+        final boolean boundaryEnabled = isBoundaryEnabled();
+        final int lookback = boundaryEnabled
+                ? windowSize(chunkSize, normalizeBoundaryPercent(getLookbackPercent(), MAX_LOOKBACK_PERCENT, LOOKBACK_PERCENT_PROPERTY))
+                : 0;
+        final int lookahead = boundaryEnabled
+                ? windowSize(chunkSize, normalizeBoundaryPercent(getLookaheadPercent(), MAX_LOOKAHEAD_PERCENT, LOOKAHEAD_PERCENT_PROPERTY))
+                : 0;
+        // Resolved once per document, never cached on this singleton: see getBoundaryFinder().
+        final ChunkBoundaryFinder finder = lookback > 0 || lookahead > 0 ? getBoundaryFinder() : null;
         final int length = content.length();
-        final List<String> chunks = new ArrayList<>();
+        // Pre-size to avoid repeated growth on large documents. limit may be Integer.MAX_VALUE,
+        // so cap with long arithmetic before narrowing.
+        final int stride = Math.max(1, chunkSize - overlap);
+        final List<String> chunks = new ArrayList<>((int) Math.min(limit, (long) length / stride + 2L));
         int start = 0;
         while (start < length) {
             if (isMidSurrogatePair(content, start)) {
@@ -147,9 +269,19 @@ public class LengthChunker implements Chunker {
             if (isMidSurrogatePair(content, end)) {
                 end--;
             }
+            if (finder != null) {
+                end = finder.findChunkEnd(content, start, end, length, lookback, lookahead);
+                if (isMidSurrogatePair(content, end)) {
+                    // Defensive: a custom finder is not required to be code-point aligned.
+                    end--;
+                }
+            }
             if (end <= start) {
-                // Defensive: guarantee forward progress even in pathological edge cases.
-                end = start + 1;
+                // Defensive: guarantee forward progress even in pathological edge cases. Step a
+                // whole code point so a custom finder returning a mid-pair offset cannot make the
+                // fallback strand a lone surrogate -- the loop-top adjustment would then skip its
+                // low half, losing a character.
+                end = start + Character.charCount(content.codePointAt(start));
             }
             chunks.add(content.substring(start, end));
             if (chunks.size() >= limit) {
@@ -161,6 +293,18 @@ public class LengthChunker implements Chunker {
                 break;
             }
             int nextStart = end - overlap;
+            if (finder != null && overlap > 0) {
+                // Cap the snap window at the configured overlap. snapOverlapStart only ever moves
+                // the restart point earlier, so an uncapped `lookback` window (derived from
+                // chunk_size, not from overlap) would let the effective overlap reach
+                // overlap + lookback -- 165 for a configured 10 at the shipped defaults, silently
+                // multiplying the index duplication warnOnOverlapSideEffect() exists to warn
+                // about. Capped, the effective overlap can at most double.
+                nextStart = finder.snapOverlapStart(content, start, nextStart, end, Math.min(lookback, overlap));
+                if (isMidSurrogatePair(content, nextStart)) {
+                    nextStart--;
+                }
+            }
             if (nextStart <= start) {
                 // The surrogate-pair adjustment consumed the overlap slack; fall back to
                 // the actual chunk end so we never re-process the same position forever.
@@ -210,6 +354,87 @@ public class LengthChunker implements Chunker {
         return getConfigInt(OVERLAP_PROPERTY, 0);
     }
 
+    /**
+     * Returns whether each chunk boundary is moved to the nearest candidate of the highest tier
+     * present in the search window -- a line break or sentence end beats any clause separator or
+     * space however much farther back it is, and those beat a script change -- instead of being
+     * cut at exactly {@code chunk_size} characters.
+     *
+     * @return the value of {@code content_chunker.length.boundary.enabled} (default true)
+     */
+    protected boolean isBoundaryEnabled() {
+        return getConfigBoolean(BOUNDARY_ENABLED_PROPERTY, DEFAULT_BOUNDARY_ENABLED);
+    }
+
+    /**
+     * Returns how far before the ideal cut a boundary may be searched, in percent of the chunk size.
+     *
+     * @return the value of {@code content_chunker.length.boundary.lookback_percent} (default 20)
+     */
+    protected int getLookbackPercent() {
+        return getConfigInt(LOOKBACK_PERCENT_PROPERTY, DEFAULT_LOOKBACK_PERCENT);
+    }
+
+    /**
+     * Returns how far after the ideal cut a sentence end may be searched, in percent of the chunk size.
+     *
+     * @return the value of {@code content_chunker.length.boundary.lookahead_percent} (default 5)
+     */
+    protected int getLookaheadPercent() {
+        return getConfigInt(LOOKAHEAD_PERCENT_PROPERTY, DEFAULT_LOOKAHEAD_PERCENT);
+    }
+
+    /**
+     * Resolves the boundary finder.
+     *
+     * <p>Deliberately not an {@code @Resource} field: unit tests construct this chunker with
+     * {@code new}, where field injection never runs. Deliberately not cached either: a cached
+     * reference would go stale across container re-creation. Callers resolve it once per
+     * {@code split} call.</p>
+     *
+     * @return the registered {@code chunkBoundaryFinder} component, or a built-in fallback
+     */
+    protected ChunkBoundaryFinder getBoundaryFinder() {
+        if (ComponentUtil.hasComponent(BOUNDARY_FINDER_COMPONENT)) {
+            return ComponentUtil.getComponent(BOUNDARY_FINDER_COMPONENT);
+        }
+        return DEFAULT_BOUNDARY_FINDER;
+    }
+
+    private boolean getConfigBoolean(final String key, final boolean defaultValue) {
+        final String value = ComponentUtil.getFessConfig().getSystemProperty(key, null);
+        if (value != null) {
+            final String trimmed = value.trim();
+            if (Constants.TRUE.equalsIgnoreCase(trimmed)) {
+                return true;
+            }
+            if (Constants.FALSE.equalsIgnoreCase(trimmed)) {
+                return false;
+            }
+            logger.warn("[Chunk] Invalid boolean for {}: {}. Using default {}.", key, value, defaultValue);
+        }
+        return defaultValue;
+    }
+
+    private int normalizeBoundaryPercent(final int value, final int max, final String key) {
+        if (value < 0) {
+            logger.warn("[Chunk] {}={} is negative, treating it as 0 (that direction is not searched)", key, value);
+            return 0;
+        }
+        if (value > max) {
+            logger.warn("[Chunk] {}={} exceeds the maximum of {}, clamping to {}", key, value, max, max);
+            return max;
+        }
+        return value;
+    }
+
+    private int windowSize(final int chunkSize, final int percent) {
+        if (percent <= 0) {
+            return 0;
+        }
+        return Math.max(1, (int) ((long) chunkSize * percent / 100L));
+    }
+
     private int getConfigInt(final String key, final int defaultValue) {
         final String value = ComponentUtil.getFessConfig().getSystemProperty(key, null);
         if (value != null) {
@@ -228,8 +453,8 @@ public class LengthChunker implements Chunker {
             return DEFAULT_CHUNK_SIZE;
         }
         if (chunkSize < MIN_CHUNK_SIZE) {
-            logger.warn("[Chunk] chunk_size={} is below the minimum of {} (required to avoid splitting UTF-16 surrogate pairs), "
-                    + "clamping to {}", chunkSize, MIN_CHUNK_SIZE, MIN_CHUNK_SIZE);
+            logger.warn("[Chunk] chunk_size={} is below the minimum of {} (a sanity floor), clamping to {}", chunkSize, MIN_CHUNK_SIZE,
+                    MIN_CHUNK_SIZE);
             return MIN_CHUNK_SIZE;
         }
         if (chunkSize > MAX_CHUNK_SIZE) {

--- a/src/main/resources/fess_chunk.xml
+++ b/src/main/resources/fess_chunk.xml
@@ -10,4 +10,8 @@
 	<component name="lengthChunker" class="org.codelibs.fess.chunk.LengthChunker">
 		<postConstruct name="register"/>
 	</component>
+
+	<!-- Boundary finder used by the length chunker -->
+	<component name="chunkBoundaryFinder" class="org.codelibs.fess.chunk.ChunkBoundaryFinder">
+	</component>
 </components>

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -136,6 +136,9 @@ jvm.suggest.options=\
 #   content_chunker.chunker.name                   (default length)
 #   content_chunker.length.chunk_size              (default 800)
 #   content_chunker.length.overlap                 (default 0)
+#   content_chunker.length.boundary.enabled        (default true)
+#   content_chunker.length.boundary.lookback_percent   (default 20; 0-50)
+#   content_chunker.length.boundary.lookahead_percent  (default 5; 0-25)
 #   content_chunker.max_chunks_per_document        (default 1000)
 #   content_chunker.embedding.name                 (default opensearch)
 #   content_chunker.embedding.dimension            (default 768)
@@ -151,6 +154,40 @@ jvm.suggest.options=\
 #   content_chunker.search.knn.param.ef_search     (unset = not sent)
 #   content_chunker.search.min_score               (unset = no cutoff)
 #   content_chunker.chat.top_k                     (default 3)
+#
+# With content_chunker.length.boundary.enabled=true (the default) the chunker moves each cut to
+# a suitable break within the search window instead of cutting at exactly chunk_size characters.
+# Candidates are grouped into three tiers and the NEAREST CANDIDATE OF THE HIGHEST TIER PRESENT
+# wins -- not simply the nearest candidate:
+#   STRONG  line break; sentence end (. 。 ! ? and similar)
+#   WEAK    clause separator (, 、 ; : - and similar); space; bracket
+#   SCRIPT  writing-system change (any Unicode script pair)
+# A sentence end 100 characters back therefore beats a space 2 characters back. With the default
+# content_chunker.length.overlap=0 no character is dropped: concatenating a document's chunks
+# reproduces its content exactly.
+#
+# This makes content_chunker.length.chunk_size a TARGET rather than a hard ceiling: when nothing
+# was found behind the cut, a forward search may overshoot it by up to lookahead_percent (default
+# 5%, so 840 characters at the default chunk_size of 800) to keep a sentence or a line whole.
+# Leave that margin against the embedding model's token limit, or set lookahead_percent=0 to
+# forbid it.
+#
+# A second overshoot is possible and is NOT governed by lookahead_percent: when the cut would land
+# inside a grapheme cluster (a combining mark, a variation selector or a zero-width-joined emoji
+# sequence), the boundary moves past the cluster rather than splitting it, by at most 32 UTF-16
+# units. The two overshoots are mutually exclusive -- the cluster escape runs only when the
+# forward search found nothing -- so the worst-case chunk length is
+# chunk_size + max(lookahead, 32) characters: 840 at the shipped defaults.
+#
+# Chunks may also end up to lookback_percent OF chunk_size shorter (160 characters at the
+# defaults), so a document produces MORE chunks than a fixed-length split: measured at +9% on
+# English prose and up to +25% in the worst case. If that pushes a document past
+# content_chunker.max_chunks_per_document (default 1000) it is marked skipped and gets no
+# embeddings at all -- raise that cap, or lower lookback_percent, for very large documents.
+#
+# With content_chunker.length.overlap > 0 the restart point is snapped to a boundary as well.
+# Snapping can only move it earlier, so the EFFECTIVE overlap is larger than the configured
+# value; it is capped at twice the configured overlap.
 #
 # content_chunker.embedding.opensearch.* -- the built-in OpenSearch ML Commons provider
 # (same system.properties channel as every key above):

--- a/src/test/java/org/codelibs/fess/chunk/ChunkBoundaryFinderTest.java
+++ b/src/test/java/org/codelibs/fess/chunk/ChunkBoundaryFinderTest.java
@@ -1,0 +1,890 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.chunk;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class ChunkBoundaryFinderTest extends UnitFessTestCase {
+
+    private ExposedFinder finder;
+
+    @Override
+    public void setUp(final TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        finder = new ExposedFinder();
+    }
+
+    @Test
+    public void test_isBreakableSpace_coversUnicodeSpacesJavaMisses() {
+        // Character.isWhitespace() returns false for these, but they are legitimate
+        // break opportunities in extracted text.
+        assertTrue(finder.breakableSpace(' '));
+        assertTrue(finder.breakableSpace('\t'));
+        assertTrue(finder.breakableSpace('\n'));
+        assertTrue(finder.breakableSpace(0x3000)); // IDEOGRAPHIC SPACE
+        assertTrue(finder.breakableSpace(0x00A0)); // NBSP
+        assertTrue(finder.breakableSpace(0x2007)); // FIGURE SPACE
+        assertTrue(finder.breakableSpace(0x202F)); // NNBSP
+        assertTrue(finder.breakableSpace(0x200B)); // ZWSP
+        assertTrue(finder.breakableSpace(0x200C)); // ZWNJ
+        assertTrue(finder.breakableSpace(0x2060)); // WORD JOINER
+        assertTrue(finder.breakableSpace(0xFEFF)); // ZWNBSP / BOM
+        assertTrue(finder.breakableSpace(0x0085)); // NEL
+        assertFalse(finder.breakableSpace('a'));
+        assertFalse(finder.breakableSpace(0x3042)); // HIRAGANA A
+        assertFalse(finder.breakableSpace(0x200D)); // ZWJ is a joiner, not a break
+    }
+
+    @Test
+    public void test_isNewline_coversUnicodeLineSeparators() {
+        assertTrue(finder.newline('\n'));
+        assertTrue(finder.newline('\r'));
+        assertTrue(finder.newline(0x0085)); // NEL
+        assertTrue(finder.newline(0x2028)); // LINE SEPARATOR
+        assertTrue(finder.newline(0x2029)); // PARAGRAPH SEPARATOR
+        assertFalse(finder.newline(' '));
+        assertFalse(finder.newline('\t'));
+    }
+
+    @Test
+    public void test_isSentenceTerminator_japaneseAndAscii() {
+        assertTrue(finder.sentenceTerminator(0x3002)); // 。
+        assertTrue(finder.sentenceTerminator(0xFF0E)); // ．
+        assertTrue(finder.sentenceTerminator(0xFF61)); // ｡
+        assertTrue(finder.sentenceTerminator(0xFF01)); // ！
+        assertTrue(finder.sentenceTerminator(0xFF1F)); // ？
+        assertTrue(finder.sentenceTerminator('!'));
+        assertTrue(finder.sentenceTerminator('?'));
+        assertTrue(finder.sentenceTerminator('.'));
+        assertTrue(finder.sentenceTerminator(0x2026)); // …
+        assertTrue(finder.sentenceTerminator(0x06D4)); // Arabic full stop
+        assertTrue(finder.sentenceTerminator(0x2E3C)); // stenographic full stop
+        assertFalse(finder.sentenceTerminator(0x3001)); // 、 is a clause separator
+        assertFalse(finder.sentenceTerminator('a'));
+    }
+
+    @Test
+    public void test_isClauseSeparator_japaneseAndAsciiAndDashes() {
+        assertTrue(finder.clauseSeparator(0x3001)); // 、
+        assertTrue(finder.clauseSeparator(0xFF0C)); // ，
+        assertTrue(finder.clauseSeparator(0xFF1B)); // ；
+        assertTrue(finder.clauseSeparator(0xFF1A)); // ：
+        assertTrue(finder.clauseSeparator(0x30FB)); // ・
+        assertTrue(finder.clauseSeparator(','));
+        assertTrue(finder.clauseSeparator(';'));
+        assertTrue(finder.clauseSeparator(':'));
+        assertTrue(finder.clauseSeparator('-'));
+        assertTrue(finder.clauseSeparator(0x2014)); // em dash
+        assertTrue(finder.clauseSeparator(0x301C)); // 〜
+        assertFalse(finder.clauseSeparator(0x3002)); // 。 is a sentence terminator
+        assertFalse(finder.clauseSeparator('a'));
+    }
+
+    @Test
+    public void test_isAsciiPunctuationRequiringSpace_onlyAmbiguousAsciiMarks() {
+        // These are ambiguous inside numbers/abbreviations (3.14, 1,234), so they only
+        // count as boundaries when whitespace follows.
+        assertTrue(finder.asciiRequiringSpace('.'));
+        assertTrue(finder.asciiRequiringSpace(','));
+        assertTrue(finder.asciiRequiringSpace(';'));
+        assertTrue(finder.asciiRequiringSpace(':'));
+        assertFalse(finder.asciiRequiringSpace('!'));
+        assertFalse(finder.asciiRequiringSpace('-'));
+        assertFalse(finder.asciiRequiringSpace(0x3002)); // 。 never needs a following space
+        assertFalse(finder.asciiRequiringSpace(0x3001)); // 、 never needs a following space
+    }
+
+    @Test
+    public void test_brackets() {
+        assertTrue(finder.closingBracket(0xFF09)); // ）
+        assertTrue(finder.closingBracket(0x300D)); // 」
+        assertTrue(finder.closingBracket(')'));
+        assertTrue(finder.closingBracket('"'));
+        assertTrue(finder.openingBracket(0xFF08)); // （
+        assertTrue(finder.openingBracket(0x300C)); // 「
+        assertTrue(finder.openingBracket('('));
+        assertFalse(finder.closingBracket('('));
+        assertFalse(finder.openingBracket(')'));
+    }
+
+    @Test
+    public void test_isSkippableAfterBoundary_spacesAndClosingMarks() {
+        // The run that gets swallowed into the preceding chunk.
+        assertTrue(finder.skippable(' '));
+        assertTrue(finder.skippable(0x0085)); // NEL
+        assertTrue(finder.skippable(0x300D)); // 」
+        assertTrue(finder.skippable(')'));
+        assertFalse(finder.skippable('a'));
+        assertFalse(finder.skippable(0x3002)); // the terminator itself is not skippable
+        assertFalse(finder.skippable(0x300C)); // an opening bracket is not skippable
+    }
+
+    @Test
+    public void test_isScriptBoundary_ignoresCommonAndInherited() {
+        assertTrue(finder.scriptBoundary(0x90FD, 'T')); // 都 (HAN) -> T (LATIN)
+        assertTrue(finder.scriptBoundary(0x6F22, 0x3042)); // 漢 (HAN) -> あ (HIRAGANA)
+        assertTrue(finder.scriptBoundary(0x3042, 0x30A2)); // あ (HIRAGANA) -> ア (KATAKANA)
+        assertFalse(finder.scriptBoundary('a', 'b'));
+        assertFalse(finder.scriptBoundary('a', '1')); // digits are COMMON
+        assertFalse(finder.scriptBoundary('1', 'a'));
+        assertFalse(finder.scriptBoundary(0x3042, 0x1F600)); // emoji are COMMON
+    }
+
+    @Test
+    public void test_isClusterContinuation_marksAndJoiners() {
+        assertTrue(finder.clusterContinuation(0x3099)); // COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK
+        assertTrue(finder.clusterContinuation(0x0301)); // COMBINING ACUTE ACCENT
+        assertTrue(finder.clusterContinuation(0xFE0F)); // VARIATION SELECTOR-16
+        assertTrue(finder.clusterContinuation(0xE0101)); // VARIATION SELECTOR-18
+        assertTrue(finder.clusterContinuation(0x200D)); // ZWJ
+        assertFalse(finder.clusterContinuation('a'));
+        assertFalse(finder.clusterContinuation(0x3042));
+    }
+
+    // Literal pin: the component name is the seam a deployment overrides to swap the boundary
+    // rules. Losing the definition would silently fall back to the built-in finder.
+    @Test
+    public void test_fessChunkXml_definesChunkBoundaryFinderComponent() throws Exception {
+        final String xml;
+        try (var in = getClass().getClassLoader().getResourceAsStream("fess_chunk.xml")) {
+            assertTrue(in != null, "fess_chunk.xml must be on the classpath");
+            xml = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        }
+        assertTrue(xml.contains("name=\"chunkBoundaryFinder\""), "fess_chunk.xml must define the chunkBoundaryFinder component");
+        assertTrue(xml.contains("class=\"org.codelibs.fess.chunk.ChunkBoundaryFinder\""),
+                "chunkBoundaryFinder must point at ChunkBoundaryFinder");
+    }
+
+    // ===================================================================================
+    //                                                                     backward search
+    //                                                                     ===============
+
+    @Test
+    public void test_findChunkEnd_zeroWindows_returnsIdealUnchanged() {
+        final String text = "abc def ghi";
+        assertEquals(5, finder.findChunkEnd(text, 0, 5, text.length(), 0, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_idealAtEnd_returnsEndWithoutSearching() {
+        // The final chunk must not be cut short just because a boundary sits nearby.
+        final String text = "abc def";
+        assertEquals(text.length(), finder.findChunkEnd(text, 0, text.length(), text.length(), 4, 4));
+    }
+
+    @Test
+    public void test_findChunkEnd_strong_afterAsciiPeriodFollowedBySpace() {
+        //            0123456789012345
+        final String text = "one two. three four";
+        // ideal=12 is inside "three"; the nearest strong boundary is just after "two. ".
+        assertEquals(9, finder.findChunkEnd(text, 0, 12, text.length(), 6, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_strong_afterJapaneseFullStop() {
+        final String text = "これは本文です。次の文がここから始まります";
+        final int ideal = 12; // inside "次の文が"
+        assertEquals(8, finder.findChunkEnd(text, 0, ideal, text.length(), 6, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_strong_swallowsClosingBracketAndSpaceRun() {
+        final String text = "彼は「そうだ。」 と答えた。";
+        // The boundary after 。」 plus the trailing space is index 9.
+        assertEquals(9, finder.findChunkEnd(text, 0, 12, text.length(), 8, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_strong_afterNewlineRun() {
+        final String text = "first line\n\nsecond paragraph";
+        assertEquals(12, finder.findChunkEnd(text, 0, 16, text.length(), 8, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_asciiPeriodWithoutFollowingSpace_isNotStrong() {
+        // "3.14" must not be treated as a sentence end; the space boundary wins instead.
+        final String text = "value 3.14159 rest";
+        assertEquals(6, finder.findChunkEnd(text, 0, 10, text.length(), 6, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_asciiCommaInsideNumber_isNotWeak() {
+        // "1,234" must not break at the comma; the preceding space boundary is used.
+        final String text = "total 1,234567 yen";
+        assertEquals(6, finder.findChunkEnd(text, 0, 11, text.length(), 6, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_weak_afterJapaneseComma() {
+        final String text = "まず準備をして、それから実行します";
+        assertEquals(8, finder.findChunkEnd(text, 0, 11, text.length(), 6, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_weak_beforeOpeningBracket() {
+        final String text = "説明文はここまで（補足はこちら）";
+        assertEquals(8, finder.findChunkEnd(text, 0, 11, text.length(), 6, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_weak_atSpaceRun() {
+        final String text = "alpha beta gamma delta";
+        // ideal=13 is inside "gamma"; the nearest space boundary is right after "beta ".
+        assertEquals(11, finder.findChunkEnd(text, 0, 13, text.length(), 6, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_strongBeatsNearerWeak() {
+        // A weak boundary sits closer to ideal, but the strong one must win.
+        final String text = "文の終わり。ここは、途中です";
+        // 。 boundary = 6, 、 boundary = 10, ideal = 12
+        assertEquals(6, finder.findChunkEnd(text, 0, 12, text.length(), 8, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_weakBeatsScript() {
+        // Both a comma boundary and a script change are in the window; weak wins.
+        final String text = "データを集計、abcdefgh";
+        assertEquals(7, finder.findChunkEnd(text, 0, 11, text.length(), 8, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_script_whenNothingElseAvailable() {
+        final String text = "東京都Tokyoにあります";
+        // ideal=6 is inside "Tokyo"; the HAN->LATIN change at index 3 is the only candidate.
+        assertEquals(3, finder.findChunkEnd(text, 0, 6, text.length(), 4, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_noCandidate_returnsIdeal() {
+        final String text = "あ".repeat(50);
+        assertEquals(20, finder.findChunkEnd(text, 0, 20, text.length(), 5, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_candidateOutsideWindow_isIgnored() {
+        // The 。 is 10 chars before ideal but the window only reaches 3 back.
+        final String text = "終わり。あいうえおかきくけこさしすせそ";
+        assertEquals(14, finder.findChunkEnd(text, 0, 14, text.length(), 3, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_neverReturnsAtOrBeforeStart() {
+        // The only boundary in the text is a space sitting immediately before `start`; a window
+        // wide enough to otherwise reach back to it must still be clamped so the search never
+        // returns `start` itself (no forward progress) or before it.
+        final String text = " bbbbbbbbbb";
+        final int start = 1;
+        final int result = finder.findChunkEnd(text, start, 8, text.length(), 20, 0);
+        assertTrue(result > start, "must make forward progress, got " + result);
+        assertTrue(result <= text.length(), "must not exceed limitEnd, got " + result);
+    }
+
+    @Test
+    public void test_findChunkEnd_neverLandsInsideSurrogatePair() {
+        final String text = "あ😀".repeat(20);
+        for (int ideal = 2; ideal < text.length(); ideal++) {
+            final int result = finder.findChunkEnd(text, 0, ideal, text.length(), 4, 0);
+            assertFalse(result > 0 && result < text.length() && Character.isHighSurrogate(text.charAt(result - 1))
+                    && Character.isLowSurrogate(text.charAt(result)), "boundary split a surrogate pair at " + result);
+        }
+    }
+
+    @Test
+    public void test_findChunkEnd_runReachingWindowFloor_isStillACandidate() {
+        // Regression: the window ending in the middle of a skippable run used to discard the
+        // run's boundary entirely, cutting mid-word even though the boundary was inside the window.
+        final String text = "first\n\nsecond";
+        assertEquals(7, finder.findChunkEnd(text, 0, 9, text.length(), 3, 0));
+        assertEquals(7, finder.findChunkEnd(text, 0, 9, text.length(), 4, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_weakRunReachingWindowFloor_isStillACandidate() {
+        final String text = "alpha beta gamma";
+        assertEquals(11, finder.findChunkEnd(text, 0, 13, text.length(), 2, 0));
+        assertEquals(11, finder.findChunkEnd(text, 0, 13, text.length(), 3, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_lookbackIsMonotonic() {
+        // Growing the window must never turn a good boundary back into a worse one.
+        final String text = "alpha beta gamma delta epsilon";
+        int previous = -1;
+        for (int lookback = 1; lookback <= 12; lookback++) {
+            final int result = finder.findChunkEnd(text, 0, 20, text.length(), lookback, 0);
+            assertTrue(result > 0 && result <= text.length(), "lookback=" + lookback + " result=" + result);
+            if (previous != -1) {
+                assertTrue(result <= previous, "widening lookback must not move the boundary later: lookback=" + lookback);
+            }
+            previous = result;
+        }
+    }
+
+    @Test
+    public void test_findChunkEnd_idealJustPastStartInsideSurrogatePair_escapesForward() {
+        // Pulling back would land on start and leave no forward progress, so the offset must
+        // move past the pair instead of splitting it.
+        final String text = "😀ab";
+        final int result = finder.findChunkEnd(text, 0, 1, text.length(), 4, 0);
+        assertEquals(2, result);
+        assertFalse(Character.isLowSurrogate(text.charAt(result)) && Character.isHighSurrogate(text.charAt(result - 1)),
+                "boundary must not split a surrogate pair");
+    }
+
+    @Test
+    public void test_findChunkEnd_nearestWeakWinsWithinTheTier() {
+        // Two weak candidates in the window (11 and 6); the one nearest the ideal offset wins.
+        final String text = "alpha beta gamma delta";
+        assertEquals(11, finder.findChunkEnd(text, 0, 13, text.length(), 10, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_nearestScriptChangeWinsWithinTheTier() {
+        // Two script changes in the window (HAN->LATIN at 3, LATIN->HAN at 8) and no weak or
+        // strong candidate anywhere; the one nearest the ideal offset must win.
+        final String text = "東京都Tokyo日本語です";
+        assertEquals(8, finder.findChunkEnd(text, 0, 10, text.length(), 8, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_oversizedLimitEnd_doesNotThrow() {
+        // limitEnd is contractually the content length, but an oversized bound must degrade to a
+        // clamped answer rather than an IndexOutOfBounds from a public component method.
+        final String text = "ab ";
+        final int result = finder.findChunkEnd(text, 0, 3, 10, 2, 0);
+        assertTrue(result > 0 && result <= text.length(), "result must stay within the text, got " + result);
+    }
+
+    // ===================================================================================
+    //                                                     forward search & cluster adjust
+    //                                                     ===============================
+
+    @Test
+    public void test_findChunkEnd_forward_takesSentenceEndJustAhead() {
+        // No strong boundary behind ideal, but "。" sits 2 chars ahead: overshoot to keep the
+        // sentence whole.
+        final String text = "あいうえおかきくけこ。さしすせそ";
+        assertEquals(11, finder.findChunkEnd(text, 0, 9, text.length(), 3, 4));
+    }
+
+    @Test
+    public void test_findChunkEnd_forward_swallowsTrailingRunWithinCeiling() {
+        final String text = "abcdefgh. ijklmnop";
+        // ideal=7, terminator at 8, trailing space at 9 -> boundary 10.
+        assertEquals(10, finder.findChunkEnd(text, 0, 7, text.length(), 0, 5));
+    }
+
+    @Test
+    public void test_findChunkEnd_forward_notTakenWhenBackwardStrongExists() {
+        // A "。" exists both behind and ahead; the backward one must win (never overshoot
+        // when the chunk size can be honoured).
+        final String text = "まず終わり。あいうえお。つづき";
+        assertEquals(6, finder.findChunkEnd(text, 0, 9, text.length(), 6, 6));
+    }
+
+    @Test
+    public void test_findChunkEnd_forward_beyondLookahead_isIgnored() {
+        final String text = "あいうえおかきくけこさしすせそ。つづき";
+        // The 。 is 6 chars past ideal but lookahead only reaches 2; fall back to hard cut.
+        assertEquals(9, finder.findChunkEnd(text, 0, 9, text.length(), 0, 2));
+    }
+
+    @Test
+    public void test_findChunkEnd_forward_asciiPeriodWithoutSpace_isIgnored() {
+        final String text = "abcdefg3.14159xyz";
+        assertEquals(7, finder.findChunkEnd(text, 0, 7, text.length(), 0, 4));
+    }
+
+    @Test
+    public void test_findChunkEnd_forward_preferredOverBackwardWeak() {
+        // Backward has only a weak boundary; a strong one is just ahead and wins.
+        final String text = "リスト、あいう。つづき";
+        assertEquals(8, finder.findChunkEnd(text, 0, 6, text.length(), 6, 3));
+    }
+
+    @Test
+    public void test_findChunkEnd_hardCut_doesNotSplitCombiningMark() {
+        // KA + COMBINING VOICED SOUND MARK ("ga"). A cut in front of U+3099 orphans the mark.
+        final String text = "\u304B\u3099".repeat(20);
+        final int result = finder.findChunkEnd(text, 0, 5, text.length(), 0, 0);
+        assertFalse(finder.clusterContinuation(text.codePointAt(result)), "boundary must not sit in front of a combining mark");
+    }
+
+    @Test
+    public void test_findChunkEnd_hardCut_doesNotSplitZwjEmojiSequence() {
+        // Family emoji: person ZWJ person ZWJ person. Written with Unicode escapes on purpose --
+        // a literal zero-width joiner in source is invisible and unreviewable.
+        final String person = new String(Character.toChars(0x1F468));
+        final String seq = person + "\u200D" + person + "\u200D" + person;
+        final String text = seq.repeat(4);
+        for (int ideal = 1; ideal < text.length(); ideal++) {
+            if (Character.isLowSurrogate(text.charAt(ideal))) {
+                continue;
+            }
+            final int result = finder.findChunkEnd(text, 0, ideal, text.length(), 0, 0);
+            assertFalse(result < text.length() && text.codePointAt(result) == 0x200D,
+                    "boundary must not sit in front of a ZWJ, ideal=" + ideal);
+            assertFalse(result > 0 && text.codePointBefore(result) == 0x200D, "boundary must not sit right after a ZWJ, ideal=" + ideal);
+        }
+    }
+
+    @Test
+    public void test_findChunkEnd_hardCut_doesNotSplitVariationSelector() {
+        final String text = "\u2764\uFE0F".repeat(20); // HEAVY BLACK HEART + VARIATION SELECTOR-16
+        final int result = finder.findChunkEnd(text, 0, 5, text.length(), 0, 0);
+        assertFalse(result < text.length() && text.codePointAt(result) == 0xFE0F, "boundary must not sit in front of a variation selector");
+    }
+
+    @Test
+    public void test_findChunkEnd_clusterAdjust_neverGoesAtOrBeforeStart() {
+        // A base character trailed by more combining marks than MAX_CLUSTER_ADJUST can walk back
+        // OR forward (30 marks exceeds the 16-code-point budget in both directions), so this
+        // hits the aligned give-up path: the result stays at the unmoved ideal offset instead of
+        // landing on an unsafe position.
+        final String text = "\u304B" + "\u3099".repeat(30);
+        final int ideal = 3;
+        final int result = finder.findChunkEnd(text, 0, ideal, text.length(), 0, 0);
+        assertTrue(result > 0, "must make forward progress, got " + result);
+        assertTrue(result <= text.length(), "must not exceed limitEnd, got " + result);
+        assertTrue(!finder.clusterContinuation(text.codePointAt(result)) || result == ideal,
+                "must be cluster-safe or the unmoved give-up offset, got " + result);
+    }
+
+    @Test
+    public void test_findChunkEnd_clusterEscape_neverSplitsASurrogatePair() {
+        // Regression: the cluster escape used to clamp to upperBound without checking alignment,
+        // landing between the two halves of an emoji.
+        final String person = new String(Character.toChars(0x1F468));
+        final String text = person + "\u200D" + person + "\u200D" + person + person;
+        for (final int upperBound : new int[] { 4, 7, text.length() }) {
+            final int result = finder.findChunkEnd(text, 0, 2, upperBound, 0, 0);
+            assertTrue(result > 0 && result <= upperBound, "upperBound=" + upperBound + " result=" + result);
+            assertFalse(
+                    result < text.length() && Character.isLowSurrogate(text.charAt(result))
+                            && Character.isHighSurrogate(text.charAt(result - 1)),
+                    "boundary split a surrogate pair at " + result + " for upperBound=" + upperBound);
+        }
+    }
+
+    @Test
+    public void test_findChunkEnd_clusterEscape_firesWhenBackwardWalkIsBlockedNearStart() {
+        // Regression: the escape used to fire only when the backward walk landed exactly on
+        // start, so a cluster one offset away still got split.
+        final String text = "\u304B" + "\u3099".repeat(3) + "\u304D";
+        final int result = finder.findChunkEnd(text, 0, 2, text.length(), 0, 0);
+        assertEquals(4, result);
+        assertFalse(finder.clusterContinuation(text.codePointAt(result)), "boundary must not sit in front of a combining mark");
+    }
+
+    @Test
+    public void test_findChunkEnd_negativeStart_doesNotThrow() {
+        // start < 0 is out of contract, but a public component method must degrade to an answer
+        // rather than an IndexOutOfBounds -- on the cluster-escape path and on the backward-scan
+        // path alike.
+        final String marks = "\u3099".repeat(3);
+        final int viaClusterEscape = finder.findChunkEnd(marks, -1, 1, marks.length(), 0, 0);
+        assertTrue(viaClusterEscape >= 0 && viaClusterEscape <= marks.length(), "cluster escape path, got " + viaClusterEscape);
+        final String plain = "ab";
+        final int viaBackwardScan = finder.findChunkEnd(plain, -1, 1, plain.length(), 1, 0);
+        assertTrue(viaBackwardScan >= 0 && viaBackwardScan <= plain.length(), "backward scan path, got " + viaBackwardScan);
+    }
+
+    @Test
+    public void test_findChunkEnd_alwaysWithinBounds_fuzz() {
+        final String text = "Hello world. これはテストです、ok? 東京Tokyo\n\n次の段落。😀👨‍👩 end.";
+        for (int start = 0; start < text.length(); start++) {
+            for (int size = 2; size <= 12; size++) {
+                final int ideal = Math.min(start + size, text.length());
+                if (ideal <= start) {
+                    continue;
+                }
+                final int result = finder.findChunkEnd(text, start, ideal, text.length(), 4, 2);
+                assertTrue(result > start, "start=" + start + " size=" + size + " result=" + result);
+                assertTrue(result <= text.length(), "start=" + start + " size=" + size + " result=" + result);
+            }
+        }
+    }
+
+    // ===================================================================================
+    //                                                                      overlap snapping
+    //                                                                      ================
+
+    @Test
+    public void test_snapOverlapStart_zeroLookback_returnsIdeal() {
+        final String text = "alpha beta gamma";
+        assertEquals(8, finder.snapOverlapStart(text, 0, 8, 16, 0));
+    }
+
+    @Test
+    public void test_snapOverlapStart_snapsBackToSpaceBoundary() {
+        final String text = "alpha beta gamma";
+        // ideal=8 is inside "beta"; the space boundary at 6 is the nearest candidate.
+        assertEquals(6, finder.snapOverlapStart(text, 0, 8, 16, 4));
+    }
+
+    @Test
+    public void test_snapOverlapStart_snapsToJapaneseSentenceBoundary() {
+        final String text = "前の文です。次の文です。";
+        assertEquals(6, finder.snapOverlapStart(text, 0, 8, 12, 4));
+    }
+
+    @Test
+    public void test_snapOverlapStart_neverReturnsAtOrBeforeStart() {
+        final String text = "a. bbbbbbbbbbbb";
+        final int result = finder.snapOverlapStart(text, 3, 6, 12, 10);
+        assertTrue(result > 3, "must stay ahead of start, got " + result);
+        assertTrue(result <= 12, "must not pass the chunk end, got " + result);
+    }
+
+    @Test
+    public void test_snapOverlapStart_neverPassesChunkEnd() {
+        // No candidate exists; the ideal is returned unchanged and stays within (start, end].
+        final String text = "あ".repeat(30);
+        final int result = finder.snapOverlapStart(text, 0, 10, 15, 5);
+        assertEquals(10, result);
+    }
+
+    @Test
+    public void test_snapOverlapStart_doesNotSearchForward() {
+        // A "。" sits right after ideal; overlap must never move forward (that would drop text).
+        final String text = "あいうえお。かきくけこ";
+        assertEquals(5, finder.snapOverlapStart(text, 0, 5, 11, 3));
+    }
+
+    @Test
+    public void test_snapOverlapStart_alwaysWithinBounds_fuzz() {
+        final String text = "Hello world. これはテストです、ok? 東京Tokyo\n\n次の段落。😀 end.";
+        for (int start = 0; start < text.length() - 2; start++) {
+            for (int end = start + 2; end <= Math.min(start + 14, text.length()); end++) {
+                for (int ideal = start + 1; ideal <= end; ideal++) {
+                    final int result = finder.snapOverlapStart(text, start, ideal, end, 5);
+                    assertTrue(result > start, "start=" + start + " ideal=" + ideal + " end=" + end + " result=" + result);
+                    assertTrue(result <= end, "start=" + start + " ideal=" + ideal + " end=" + end + " result=" + result);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void test_snapOverlapStart_outOfContractArguments_degradeToTheChunkEnd() {
+        // The method advertises start < result <= end; out-of-contract arguments must degrade to
+        // the chunk end rather than handing back an offset the caller has to repair.
+        final String text = "alpha beta gamma";
+        assertEquals(10, finder.snapOverlapStart(text, 5, 5, 10, 4), "ideal == start");
+        assertEquals(10, finder.snapOverlapStart(text, 5, 3, 10, 4), "ideal < start");
+        assertEquals(text.length(), finder.snapOverlapStart(text, 0, 999, 999, 4), "ideal past the text");
+        assertEquals(5, finder.snapOverlapStart(text, 0, 12, 5, 4), "ideal past the chunk end");
+    }
+
+    // ===================================================================================
+    //                                                                       subclass seam
+    //                                                                       =============
+
+    @Test
+    public void test_findChunkEnd_subclassOverridingIsSentenceTerminator_changesBoundarySelection() {
+        // Design requirement: subclassing ChunkBoundaryFinder and swapping a protected character
+        // predicate must change the boundary the real search picks -- not just change what the
+        // predicate itself reports when called directly (that much is already covered by
+        // ExposedFinder's delegating accessors below). This pins that findChunkEnd/searchBackward
+        // actually dispatch through the protected predicate rather than, say, inlining the switch
+        // on '。' into searchBackward -- a refactor that would keep every other test in this class
+        // green while silently closing the extension point that makes this class a swappable
+        // chunkBoundaryFinder DI component.
+        //
+        //   text:  あ  い  う  え  お  。  か  き  く  け  こ
+        //  index:  0   1   2   3   4   5   6   7   8   9  10
+        //
+        // ideal=8 (inside "く"), lookback=6 (floor=2), lookahead=0 (no forward search).
+        //
+        // Base class, by hand: walking back from 8, き(7) and か(6) hit no tier (same HIRAGANA
+        // script on both sides, no punctuation). '。'(5) is a sentence terminator -> STRONG,
+        // and the candidate for a non-skippable character is the offset right after it, so
+        // searchBackward returns candidate=6 immediately (STRONG wins as soon as it is found).
+        // findChunkEnd returns that strong candidate unchanged: 6.
+        final String text = "あいうえお。かきくけこ";
+        final ChunkBoundaryFinder base = new ChunkBoundaryFinder();
+        assertEquals(6, base.findChunkEnd(text, 0, 8, text.length(), 6, 0), "base class must treat 。 as a STRONG boundary");
+
+        // Subclass, by hand: with '。' no longer a sentence terminator, it is not a clause
+        // separator either (isClauseSeparator does not cover 0x3002) and both neighbours are
+        // hiragana (no script change), so it registers in NO tier -- it becomes exactly as
+        // boundary-inert as any other hiragana character in this string. Every other character in
+        // the window is plain hiragana, so searchBackward finds no candidate at all in either
+        // tier. lookahead=0 skips the forward search, and findChunkEnd falls through to the
+        // hard-cut path: index 8 sits between two ordinary hiragana code points (not a cluster
+        // continuation, no ZWJ before it), so adjustToClusterStart returns it unchanged. Result: 8
+        // (the ideal offset, unmoved) -- a different offset than the base class picked for the
+        // identical input.
+        final ChunkBoundaryFinder noTerminator = new ChunkBoundaryFinder() {
+            @Override
+            protected boolean isSentenceTerminator(final int cp) {
+                return cp != 0x3002 && super.isSentenceTerminator(cp);
+            }
+        };
+        assertEquals(8, noTerminator.findChunkEnd(text, 0, 8, text.length(), 6, 0),
+                "a subclass that overrides isSentenceTerminator must see that override honoured inside "
+                        + "the real backward search, not just when the predicate is called directly");
+    }
+
+    // ===================================================================================
+    //                                                    Cluster safety on every tier path
+    //                                                    ---------------------------------
+    // The escape used to be wired to the hard-cut fallback only, so a STRONG/WEAK/SCRIPT or
+    // forward candidate could hand back an offset that split a grapheme cluster -- something the
+    // fixed-length cut this search replaces would have left intact. Every test below fails if the
+    // guard is removed from its tier.
+
+    @Test
+    public void test_findChunkEnd_weakCandidateNeverStrandsACombiningMark() {
+        // The space at 2 is a WEAK candidate, but cutting after it strands the combining acute on
+        // the far side of the boundary. The cut must fall back to 2 (before the space), never 3.
+        final String text = "ab \u0301cd";
+        assertEquals(2, finder.findChunkEnd(text, 0, 3, text.length(), 1, 0));
+        assertEquals(2, finder.findChunkEnd(text, 0, 3, text.length(), 2, 0));
+        assertEquals(2, finder.findChunkEnd(text, 0, 3, text.length(), 8, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_weakCandidateNeverStrandsAVariationSelector() {
+        final String text = "ab \uFE0Fcd";
+        assertEquals(2, finder.findChunkEnd(text, 0, 3, text.length(), 3, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_strongCandidateNeverStrandsACombiningMark() {
+        // "ab." is a sentence end with a following space, i.e. a STRONG candidate at 4 -- but 4 is
+        // in front of a combining mark, so the STRONG tier must decline it too.
+        final String text = "ab. \u0301cd";
+        final int result = finder.findChunkEnd(text, 0, 5, text.length(), 5, 0);
+        assertTrue(result != 4, "the STRONG tier must not return an offset that strands a combining mark");
+        assertFalse(finder.clusterContinuation(Character.codePointAt(text, result)));
+    }
+
+    @Test
+    public void test_findChunkEnd_forwardSearchNeverStrandsACombiningMark() {
+        // The forward search would land on 4, immediately in front of the combining mark.
+        final String text = "ab. \u0301cd";
+        final int result = finder.findChunkEnd(text, 0, 2, text.length(), 0, 5);
+        assertTrue(result != 4, "the forward search must not return an offset that strands a combining mark");
+    }
+
+    @Test
+    public void test_findChunkEnd_clusterGuardMatchesTheFixedLengthCutItReplaces() {
+        // Regression pin: boundary search must never split a cluster the blind cut kept whole.
+        final String text = "aaaa bbbb cccc \u0301dddd eeee ffff";
+        for (int ideal = 1; ideal < text.length(); ideal++) {
+            for (final int lookback : new int[] { 0, 1, 2, 4, 8, 16 }) {
+                final int result = finder.findChunkEnd(text, 0, ideal, text.length(), lookback, 0);
+                if (result > 0 && result < text.length()) {
+                    assertFalse(finder.clusterContinuation(Character.codePointAt(text, result)),
+                            "ideal=" + ideal + " lookback=" + lookback + " returned " + result);
+                    assertFalse(finder.clusterJoiner(Character.codePointBefore(text, result)),
+                            "ideal=" + ideal + " lookback=" + lookback + " returned " + result);
+                }
+            }
+        }
+    }
+
+    // ===================================================================================
+    //                                                     Punctuation between digits
+    //                                                     --------------------------
+    // The following-space rule covers ASCII "." "," ";" ":" but cannot cover the fullwidth forms
+    // (CJK sentences carry no trailing space) or hyphens. Those require a following non-digit.
+
+    @Test
+    public void test_isPunctuationRequiringNonDigit_coversFullwidthFormsAndHyphens() {
+        assertTrue(finder.requiringNonDigit('-'));
+        assertTrue(finder.requiringNonDigit(0x2010)); // HYPHEN
+        assertTrue(finder.requiringNonDigit(0xFF0E)); // FULLWIDTH FULL STOP
+        assertTrue(finder.requiringNonDigit(0xFF0C)); // FULLWIDTH COMMA
+        assertTrue(finder.requiringNonDigit(0xFF1A)); // FULLWIDTH COLON
+        assertFalse(finder.requiringNonDigit('.'));
+        assertFalse(finder.requiringNonDigit(0x3002)); // 。
+        assertFalse(finder.requiringNonDigit(0x3001)); // 、
+        assertFalse(finder.requiringNonDigit(0x2014)); // EM DASH is a real clause separator
+    }
+
+    @Test
+    public void test_isClauseSeparator_excludesTheNonBreakingHyphen() {
+        // U+2011 exists precisely to forbid a break; it must not be a break opportunity.
+        assertFalse(finder.clauseSeparator(0x2011));
+        assertTrue(finder.clauseSeparator(0x2010));
+    }
+
+    @Test
+    public void test_findChunkEnd_fullwidthStopBetweenDigitsIsNotABoundary() {
+        // 処理速度は従来比で１．５倍に向上しました -- the fullwidth stop is a decimal point here.
+        final String text = "\u51E6\u7406\u901F\u5EA6\u306F\u5F93\u6765\u6BD4\u3067\uFF11\uFF0E\uFF15\u500D"
+                + "\u306B\u5411\u4E0A\u3057\u307E\u3057\u305F";
+        final int result = finder.findChunkEnd(text, 0, 12, text.length(), 12, 0);
+        assertTrue(result != 11, "a fullwidth stop between fullwidth digits must not end a chunk");
+    }
+
+    @Test
+    public void test_findChunkEnd_fullwidthCommaAndColonBetweenDigitsAreNotBoundaries() {
+        // 売上高は１，２３４，５６７円です
+        final String comma = "\u58F2\u4E0A\u9AD8\u306F\uFF11\uFF0C\uFF12\uFF13\uFF14\uFF0C\uFF15\uFF16\uFF17" + "\u5186\u3067\u3059";
+        assertTrue(finder.findChunkEnd(comma, 0, 10, comma.length(), 10, 0) != 6,
+                "a fullwidth comma between fullwidth digits must not end a chunk");
+        // 開始は１０：３０からです
+        final String colon = "\u958B\u59CB\u306F\uFF11\uFF10\uFF1A\uFF13\uFF10\u304B\u3089\u3067\u3059";
+        assertTrue(finder.findChunkEnd(colon, 0, 7, colon.length(), 7, 0) != 6,
+                "a fullwidth colon between fullwidth digits must not end a chunk");
+    }
+
+    @Test
+    public void test_findChunkEnd_fullwidthStopIsStillASentenceEndBeforeANonDigit() {
+        // The JIS 、。-替わりの ，． convention must keep working: これで終わり．次は導入手順です
+        final String text = "\u3053\u308C\u3067\u7D42\u308F\u308A\uFF0E\u6B21\u306F\u5C0E\u5165\u624B\u9806" + "\u3067\u3059";
+        assertEquals(7, finder.findChunkEnd(text, 0, 10, text.length(), 10, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_hyphenBetweenDigitsIsNotABoundary() {
+        // Both hyphens sit between digits, so the cut falls back to the space in front of the date
+        // (12) instead of landing at 17 or 20.
+        final String date = "released on 2026-08-09 in tokyo";
+        assertEquals(12, finder.findChunkEnd(date, 0, 19, date.length(), 20, 0));
+        final String version = "charset is UTF-8 today please";
+        assertEquals(11, finder.findChunkEnd(version, 0, 15, version.length(), 8, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_hyphenBeforeALetterStillBreaks() {
+        // Breaking after the hyphen of a hyphenated compound is ordinary line-break behaviour and
+        // is deliberately kept.
+        final String text = "send an e-mail today please";
+        assertEquals(10, finder.findChunkEnd(text, 0, 14, text.length(), 6, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_asciiDecimalsAreStillProtectedByTheSpaceRule() {
+        // Guard that the new digit rule did not displace the pre-existing following-space rule.
+        assertEquals(5, finder.findChunkEnd("aaaa 3.1415926 bbbb", 0, 8, 19, 8, 0));
+        assertEquals(5, finder.findChunkEnd("aaaa 1,234,567 bbbb", 0, 8, 19, 8, 0));
+    }
+
+    @Test
+    public void test_isPunctuationRequiringNonDigit_isDispatchedThroughTheSearch() {
+        // The predicate is part of the documented subclass seam, so the search must call it
+        // virtually rather than inlining its character set.
+        final ChunkBoundaryFinder allowsDigits = new ChunkBoundaryFinder() {
+            @Override
+            protected boolean isPunctuationRequiringNonDigit(final int cp) {
+                return false;
+            }
+        };
+        final String version = "charset is UTF-8 today please";
+        assertEquals(11, finder.findChunkEnd(version, 0, 15, version.length(), 8, 0));
+        assertEquals(15, allowsDigits.findChunkEnd(version, 0, 15, version.length(), 8, 0),
+                "a subclass that opts out of the digit rule must see the hyphen accepted again");
+    }
+
+    @Test
+    public void test_findChunkEnd_propertySweep_clusterSafeAlignedAndMonotonic() {
+        // Randomised sweep over a pool built to hit every tier plus the shapes that used to break
+        // the invariants: combining marks, ZWJ, variation selectors, astral code points, fullwidth
+        // punctuation and digits. Fixed seed, so a failure is reproducible.
+        final int[] pool = { 'a', 'b', ' ', '.', ',', '-', '\'', 0x0301, 0x200D, 0xFE0F, 0x3042, 0x65E5, 'A', 0x2029, 0x300C, 0xFF0E,
+                0xFF0C, 0xFF10, 0x1F600 };
+        final java.util.Random random = new java.util.Random(20260809L);
+        for (int iteration = 0; iteration < 20000; iteration++) {
+            final StringBuilder builder = new StringBuilder();
+            final int codePoints = 4 + random.nextInt(12);
+            for (int i = 0; i < codePoints; i++) {
+                builder.appendCodePoint(pool[random.nextInt(pool.length)]);
+            }
+            final String text = builder.toString();
+            final int ideal = 1 + random.nextInt(Math.max(1, text.length() - 1));
+            final int lookahead = random.nextInt(4);
+            int previous = Integer.MAX_VALUE;
+            for (int lookback = 0; lookback <= 8; lookback++) {
+                final int result = finder.findChunkEnd(text, 0, ideal, text.length(), lookback, lookahead);
+                final String where = "text="
+                        + text.codePoints().mapToObj(cp -> String.format("U+%04X", cp)).collect(java.util.stream.Collectors.joining(" "))
+                        + " ideal=" + ideal + " lookback=" + lookback + " lookahead=" + lookahead + " result=" + result;
+                assertTrue(result > 0 && result <= text.length(), where);
+                assertFalse(Character.isLowSurrogate(text.charAt(Math.min(result, text.length() - 1))) && result > 0
+                        && result < text.length() && Character.isHighSurrogate(text.charAt(result - 1)),
+                        "a surrogate pair must never be split: " + where);
+                if (result < text.length()) {
+                    assertFalse(finder.clusterContinuation(Character.codePointAt(text, result)),
+                            "no tier may strand a cluster continuation: " + where);
+                    assertFalse(finder.clusterJoiner(Character.codePointBefore(text, result)),
+                            "no tier may cut right after a joiner: " + where);
+                }
+                if (lookback > 0) {
+                    assertTrue(result <= previous, "widening lookback must not move the boundary later: " + where);
+                }
+                previous = result;
+            }
+        }
+    }
+
+    /** Exposes the protected character predicates for assertion. */
+    private static final class ExposedFinder extends ChunkBoundaryFinder {
+        boolean breakableSpace(final int cp) {
+            return isBreakableSpace(cp);
+        }
+
+        boolean newline(final int cp) {
+            return isNewline(cp);
+        }
+
+        boolean sentenceTerminator(final int cp) {
+            return isSentenceTerminator(cp);
+        }
+
+        boolean clauseSeparator(final int cp) {
+            return isClauseSeparator(cp);
+        }
+
+        boolean asciiRequiringSpace(final int cp) {
+            return isAsciiPunctuationRequiringSpace(cp);
+        }
+
+        boolean closingBracket(final int cp) {
+            return isClosingBracket(cp);
+        }
+
+        boolean openingBracket(final int cp) {
+            return isOpeningBracket(cp);
+        }
+
+        boolean skippable(final int cp) {
+            return isSkippableAfterBoundary(cp);
+        }
+
+        boolean scriptBoundary(final int before, final int after) {
+            return isScriptBoundary(before, after);
+        }
+
+        boolean clusterContinuation(final int cp) {
+            return isClusterContinuation(cp);
+        }
+
+        boolean clusterJoiner(final int cp) {
+            return isClusterJoiner(cp);
+        }
+
+        boolean requiringNonDigit(final int cp) {
+            return isPunctuationRequiringNonDigit(cp);
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/chunk/LengthChunkerTest.java
+++ b/src/test/java/org/codelibs/fess/chunk/LengthChunkerTest.java
@@ -15,7 +15,9 @@
  */
 package org.codelibs.fess.chunk;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -25,7 +27,9 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Property;
+import org.codelibs.fess.Constants;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -50,6 +54,50 @@ public class LengthChunkerTest extends UnitFessTestCase {
     public void test_externalContractLiterals() {
         assertEquals("content_chunker.length.chunk_size", LengthChunker.CHUNK_SIZE_PROPERTY);
         assertEquals("content_chunker.length.overlap", LengthChunker.OVERLAP_PROPERTY);
+        assertEquals("content_chunker.length.boundary.enabled", LengthChunker.BOUNDARY_ENABLED_PROPERTY);
+        assertEquals("content_chunker.length.boundary.lookback_percent", LengthChunker.LOOKBACK_PERCENT_PROPERTY);
+        assertEquals("content_chunker.length.boundary.lookahead_percent", LengthChunker.LOOKAHEAD_PERCENT_PROPERTY);
+        assertEquals("chunkBoundaryFinder", LengthChunker.BOUNDARY_FINDER_COMPONENT);
+    }
+
+    // ===================================================================================
+    //                                                                boundary configuration
+    //                                                                ======================
+
+    @Test
+    public void test_boundaryDefaults() {
+        assertTrue(LengthChunker.DEFAULT_BOUNDARY_ENABLED, "boundary adjustment ships enabled");
+        assertEquals(20, LengthChunker.DEFAULT_LOOKBACK_PERCENT);
+        assertEquals(5, LengthChunker.DEFAULT_LOOKAHEAD_PERCENT);
+        assertEquals(50, LengthChunker.MAX_LOOKBACK_PERCENT);
+        assertEquals(25, LengthChunker.MAX_LOOKAHEAD_PERCENT);
+    }
+
+    @Test
+    public void test_getBoundaryFinder_fallsBackWhenComponentMissing() {
+        // test_app.xml does not include fess_chunk.xml, so the component is absent by default.
+        assertFalse(ComponentUtil.hasComponent(LengthChunker.BOUNDARY_FINDER_COMPONENT),
+                "precondition: chunkBoundaryFinder must not be registered");
+        final ChunkBoundaryFinder fallback = chunker.exposedBoundaryFinder();
+        assertNotNull(fallback, "must fall back to a default finder");
+        // The documented contract is a SHARED stateless singleton, not merely "non-null": the
+        // finder is resolved once per split() call, so handing back a fresh instance every time
+        // would allocate one per document for no reason.
+        assertSame(fallback, chunker.exposedBoundaryFinder(), "the fallback finder must be a shared singleton");
+    }
+
+    @Test
+    public void test_getBoundaryFinder_usesRegisteredComponent() {
+        // The DI seam: a deployment swaps the boundary rules by registering its own finder.
+        final ChunkBoundaryFinder stub = new ChunkBoundaryFinder();
+        try {
+            ComponentUtil.register(stub, LengthChunker.BOUNDARY_FINDER_COMPONENT);
+            assertSame(stub, chunker.exposedBoundaryFinder());
+        } finally {
+            // The UTFlute container is shared across test classes in the same JVM (CI runs
+            // -Dparallel=classes -DreuseForks=true), so the stub must not leak.
+            ComponentUtil.register(new ChunkBoundaryFinder(), LengthChunker.BOUNDARY_FINDER_COMPONENT);
+        }
     }
 
     @Test
@@ -288,9 +336,680 @@ public class LengthChunkerTest extends UnitFessTestCase {
         }
     }
 
+    // ===================================================================================
+    //                                                             boundary-aware splitting
+    //                                                             ========================
+
+    @Test
+    public void test_split_japaneseTextBreaksAtFullStop() {
+        chunker.setTestChunkSize(20);
+        chunker.setTestOverlap(0);
+        final String content = "これは最初の文です。これは二番目の文です。これは三番目の文です。";
+        final List<String> chunks = chunker.split(content);
+        assertEquals(content, String.join("", chunks));
+        for (int i = 0; i < chunks.size() - 1; i++) {
+            assertTrue(chunks.get(i).endsWith("。"), "chunk " + i + " should end at a sentence: " + chunks.get(i));
+        }
+    }
+
+    @Test
+    public void test_split_englishTextDoesNotCutWordsInHalf() {
+        chunker.setTestChunkSize(30);
+        chunker.setTestOverlap(0);
+        final String content = "The quick brown fox jumps over the lazy dog while the elephant watches quietly nearby";
+        final List<String> chunks = chunker.split(content);
+        assertEquals(content, String.join("", chunks));
+        for (int i = 0; i < chunks.size() - 1; i++) {
+            final String chunk = chunks.get(i);
+            assertTrue(chunk.endsWith(" "), "chunk " + i + " must end on a space boundary: [" + chunk + "]");
+        }
+    }
+
+    @Test
+    public void test_split_boundaryEnabled_reconstructsOriginalExactly() {
+        chunker.setTestChunkSize(24);
+        chunker.setTestOverlap(0);
+        final String content = "Hello world. これはテストです、大丈夫ですか？ 東京Tokyo 2026\n\n次の段落。😀 The end.";
+        assertEquals(content, String.join("", chunker.split(content)));
+    }
+
+    @Test
+    public void test_split_boundaryEnabled_boundedMatchesUnboundedPrefix() {
+        chunker.setTestChunkSize(16);
+        chunker.setTestOverlap(0);
+        final String content = "これは最初の文です。これは二番目の文です。alpha beta gamma delta epsilon。おわり。";
+        final List<String> unbounded = chunker.split(content);
+        assertTrue(unbounded.size() > 2, "precondition: more chunks than the limit");
+        for (int limit = 1; limit <= unbounded.size(); limit++) {
+            assertEquals("limit=" + limit, unbounded.subList(0, limit), chunker.split(content, limit));
+        }
+    }
+
+    @Test
+    public void test_split_boundaryDisabled_matchesLegacyFixedLength() {
+        chunker.setTestBoundaryEnabled(false);
+        chunker.setTestChunkSize(10);
+        chunker.setTestOverlap(0);
+        final String content = "これは最初の文です。これは二番目の文です。";
+        final List<String> chunks = chunker.split(content);
+        assertEquals(3, chunks.size());
+        assertEquals("これは最初の文です。", chunks.get(0));
+        // A pure chunk_size=10 fixed-length cut on this 21-char string lands at 10/20, not 10/19:
+        // "これは二番目の文です" (10 chars) + "。" (1 char).
+        assertEquals("これは二番目の文です", chunks.get(1));
+        assertEquals("。", chunks.get(2));
+    }
+
+    @Test
+    public void test_split_zeroPercents_matchLegacyFixedLength() {
+        chunker.setTestLookbackPercent(0);
+        chunker.setTestLookaheadPercent(0);
+        chunker.setTestChunkSize(10);
+        chunker.setTestOverlap(0);
+        final String content = "これは最初の文です。これは二番目の文です。";
+        // Same fixed-length cut as test_split_boundaryDisabled_matchesLegacyFixedLength: 10/20, not 10/19.
+        assertEquals(List.of("これは最初の文です。", "これは二番目の文です", "。"), chunker.split(content));
+    }
+
+    @Test
+    public void test_split_forwardSearchTakesSentenceEndBeyondChunkSize() {
+        // Note: the per-chunk bound below (chunk_size + lookahead = 25) never actually binds on
+        // this content -- the largest chunk produced is well under it -- so this test does not
+        // exercise that ceiling being reached. What it does pin: the forward search overshoots
+        // chunk_size to keep the "。" sentence end whole (chunks.get(0) below), round-trips
+        // losslessly, and stays under the ceiling with margin to spare.
+        chunker.setTestChunkSize(20);
+        chunker.setTestOverlap(0);
+        chunker.setTestLookbackPercent(10); // 2 chars back: not enough to reach the previous 。
+        chunker.setTestLookaheadPercent(25); // 5 chars ahead
+        final String content = "あいうえおかきくけこさしすせそたちつてとなに。つづきの文章がここにあります。";
+        final List<String> chunks = chunker.split(content);
+        assertEquals(content, String.join("", chunks));
+        assertEquals("あいうえおかきくけこさしすせそたちつてとなに。", chunks.get(0));
+        for (final String chunk : chunks) {
+            // chunk_size + lookahead is not a universal ceiling (the grapheme-cluster escape is
+            // ungoverned by lookahead and can push a chunk further, see LengthChunker's class
+            // Javadoc), but this content has no grapheme clusters for that escape to act on, so
+            // chunk_size + lookahead is the applicable bound for this specific input.
+            assertTrue(chunk.length() <= 25,
+                    "a chunk must not exceed chunk_size + lookahead for this grapheme-cluster-free content: " + chunk.length());
+        }
+    }
+
+    @Test
+    public void test_split_withOverlap_boundaryEnabled_isContiguousAndTerminates() {
+        chunker.setTestChunkSize(20);
+        chunker.setTestOverlap(6);
+        final String content = "これは最初の文です。これは二番目の文です。これは三番目の文です。おしまい。";
+        final List<String> chunks = chunker.split(content);
+        assertTrue(chunks.size() >= 2, "precondition: multiple chunks");
+        // Every chunk must start at the offset the previous chunk's own contract guarantees it
+        // can (snapOverlapStart: start < result <= end) -- not merely "wherever content.indexOf
+        // happens to match". This content repeats "これは...の文です。" three times, so a search
+        // with a loosely-computed lower bound (e.g. cursor - chunk.length()) could silently accept
+        // a stale earlier occurrence of the same text and still look contiguous. Track each
+        // chunk's real, verified start and only search strictly after it (never at or before it,
+        // per the "start < result" half of the contract) for the next one, so an earlier
+        // occurrence of the same substring can never be mistaken for the real next chunk.
+        int expectedStart = 0;
+        for (int i = 0; i < chunks.size(); i++) {
+            final String chunk = chunks.get(i);
+            assertTrue(content.startsWith(chunk, expectedStart),
+                    "chunk " + i + " does not start at the expected offset " + expectedStart + ": " + chunk);
+            final int end = expectedStart + chunk.length();
+            if (i + 1 < chunks.size()) {
+                final int nextAt = content.indexOf(chunks.get(i + 1), expectedStart + 1);
+                assertTrue(nextAt >= 0, "chunk " + (i + 1) + " not found strictly after offset " + expectedStart);
+                assertTrue(nextAt <= end, "text was skipped between chunk " + i + " and chunk " + (i + 1));
+                expectedStart = nextAt;
+            } else {
+                assertEquals(content.length(), end, "the chunks must cover the whole content");
+            }
+        }
+    }
+
+    @Test
+    public void test_split_allSpaces_terminates() {
+        chunker.setTestChunkSize(4);
+        chunker.setTestOverlap(0);
+        // Blank content short-circuits, so mix in one non-space character.
+        final String content = "x" + "　".repeat(30);
+        final List<String> chunks = chunker.split(content);
+        assertEquals(content, String.join("", chunks));
+        assertTrue(chunks.size() <= content.length(), "must not produce more chunks than characters");
+    }
+
+    @Test
+    public void test_split_allNewlines_terminates() {
+        chunker.setTestChunkSize(4);
+        chunker.setTestOverlap(0);
+        final String content = "x" + "\n".repeat(30);
+        final String joined = String.join("", chunker.split(content));
+        assertEquals(content, joined);
+    }
+
+    @Test
+    public void test_split_largeDocument_staysLinear() {
+        // A guard against an accidental O(N^2): re-scanning the skippable run at every candidate,
+        // or losing the `ideal - lookback` floor so every cut rescans the whole prefix, would turn
+        // this into minutes. An ABSOLUTE threshold cannot see that -- the real time here is a few
+        // milliseconds, so a 1000x regression still fits inside any bound loose enough not to be
+        // flaky. The ratio between 4N and N is the only assertion that actually measures the
+        // growth curve; the absolute bound below is kept only as a coarse "nothing hung" cap.
+        chunker.setTestChunkSize(800);
+        chunker.setTestOverlap(0);
+        // Han text with no space, no punctuation and no script change: every cut must walk the
+        // whole lookback window and the whole lookahead window before giving up, so the scan is
+        // never cut short by an early hit.
+        final String unit = "本日快晴無風";
+        final String small = unit.repeat(SMALL_DOCUMENT_UNITS);
+        final String large = unit.repeat(4 * SMALL_DOCUMENT_UNITS);
+        // Warm up first: the first passes measure the JIT, not the algorithm.
+        for (int i = 0; i < 2; i++) {
+            chunker.split(small);
+            chunker.split(large);
+        }
+        final long smallNanos = fastestSplitNanos(small, 7);
+        final long largeNanos = fastestSplitNanos(large, 7);
+        assertEquals(large, String.join("", chunker.split(large)));
+        final double ratio = (double) largeNanos / Math.max(1L, smallNanos);
+        assertTrue(ratio < 6.0, "quadrupling the document multiplied the time by " + ratio + " (small=" + smallNanos / 1_000_000L
+                + "ms, large=" + largeNanos / 1_000_000L + "ms); the scan is not linear");
+        assertTrue(largeNanos < 10_000_000_000L, "splitting " + large.length() + " characters took " + largeNanos / 1_000_000L + "ms");
+    }
+
+    /** 250,002 characters; the ratio assertion above compares this against four times as many. */
+    private static final int SMALL_DOCUMENT_UNITS = 41_667;
+
+    @Test
+    public void test_split_minimumChunkSize_boundaryEnabled_isLossless() {
+        chunker.setTestChunkSize(1); // floored to MIN_CHUNK_SIZE
+        chunker.setTestOverlap(0);
+        final String content = "あ。い、う えTokyo😀";
+        assertEquals(content, String.join("", chunker.split(content)));
+    }
+
+    @Test
+    public void test_boundaryPercent_clampedAboveMaximum() {
+        final LogCapturingAppender appender = LogCapturingAppender.attach(LengthChunker.class);
+        try {
+            chunker.setTestLookbackPercent(999);
+            chunker.setTestChunkSize(100);
+            chunker.setTestOverlap(0);
+            chunker.split("a".repeat(300));
+            assertTrue(appender.warnings().stream().anyMatch(w -> w.contains("lookback_percent")),
+                    "an out-of-range percent must warn, got " + appender.warnings());
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_boundaryPercent_negativeTreatedAsDisabled() {
+        final LogCapturingAppender appender = LogCapturingAppender.attach(LengthChunker.class);
+        try {
+            chunker.setTestLookbackPercent(-1);
+            chunker.setTestChunkSize(10);
+            chunker.setTestOverlap(0);
+            assertEquals(2, chunker.split("a".repeat(20)).size());
+            assertTrue(appender.warnings().stream().anyMatch(w -> w.contains("lookback_percent")),
+                    "a negative percent must warn, got " + appender.warnings());
+        } finally {
+            appender.detach();
+        }
+    }
+
+    // ===================================================================================
+    //                                                   the boundary search is not a no-op
+    //                                                   =================================
+    // "concatenating the chunks reproduces the content" is a TAUTOLOGY at overlap=0: the loop
+    // sets start = end every iteration, so any partition round-trips. Deleting the whole boundary
+    // search (ChunkBoundaryFinder#findChunkEnd => return base) leaves every round-trip test green.
+    // The tests below assert WHERE the cuts land, so a no-op search reddens them.
+
+    @Test
+    public void test_split_prose_everyCutLandsOnASentenceEndOrASpace() {
+        chunker.setTestChunkSize(60);
+        chunker.setTestOverlap(0);
+        final List<String> chunks = chunker.split(PROSE_CORPUS);
+        assertTrue(chunks.size() >= 10, "precondition: the corpus must produce at least ten chunks, got " + chunks.size());
+        assertEquals(PROSE_CORPUS, String.join("", chunks));
+        for (int i = 0; i < chunks.size() - 1; i++) {
+            final String chunk = chunks.get(i);
+            final char last = chunk.charAt(chunk.length() - 1);
+            assertTrue(last == ' ' || last == '。' || last == '.' || last == '!' || last == '?',
+                    "chunk " + i + " was cut mid-word at [" + last + "] (U+" + Integer.toHexString(last) + "): " + chunk);
+        }
+    }
+
+    @Test
+    public void test_split_randomizedProse_boundarySearchMovesEveryCutAndLosesNothing() {
+        // A differential property test: the boundary-enabled output must differ from the
+        // boundary-disabled one on content that HAS boundaries. A no-op search makes the two
+        // identical, because the disabled path is exactly "cut at `base`".
+        final int[] chunkSizes = { 17, 40, 96, 250 };
+        int cases = 0;
+        int differing = 0;
+        for (long seed = 1L; seed <= 8L; seed++) {
+            final String content = randomBoundaryRichContent(seed, 4000);
+            for (final int chunkSize : chunkSizes) {
+                chunker.setTestChunkSize(chunkSize);
+                chunker.setTestOverlap(0);
+                chunker.setTestBoundaryEnabled(true);
+                final List<String> enabled = chunker.split(content);
+                chunker.setTestBoundaryEnabled(false);
+                final List<String> disabled = chunker.split(content);
+                assertEquals(content, String.join("", enabled));
+                assertEquals(content, String.join("", disabled));
+                cases++;
+                if (!enabled.equals(disabled)) {
+                    differing++;
+                }
+            }
+        }
+        assertEquals(cases, differing, "boundary-aware splitting produced the same cuts as the fixed-length one; the search is a no-op");
+    }
+
+    @Test
+    public void test_split_graphemeRichContent_neverCutsInsideACluster() {
+        // The existing round-trip corpora contain no combining marks, no ZWJ sequences and (apart
+        // from one lone emoji) no astral characters, so the "a candidate that would strand a
+        // combining mark is rejected" contract was never exercised end to end.
+        chunker.setTestOverlap(0);
+        for (long seed = 1L; seed <= 4L; seed++) {
+            final String content = randomClusterRichContent(seed, 2000);
+            for (final int chunkSize : new int[] { 16, 40, 100 }) {
+                chunker.setTestChunkSize(chunkSize);
+                final List<String> chunks = chunker.split(content);
+                assertEquals(content, String.join("", chunks));
+                for (int i = 0; i < chunks.size(); i++) {
+                    final String chunk = chunks.get(i);
+                    final int firstCp = chunk.codePointAt(0);
+                    final int lastCp = chunk.codePointBefore(chunk.length());
+                    assertFalse(Character.isLowSurrogate(chunk.charAt(0)), "chunk " + i + " starts with a lone low surrogate");
+                    assertFalse(Character.isHighSurrogate(chunk.charAt(chunk.length() - 1)),
+                            "chunk " + i + " ends with a lone high surrogate");
+                    if (i > 0) {
+                        assertFalse(isClusterContinuationCodePoint(firstCp),
+                                "chunk " + i + " starts with a combining mark/joiner stranded from its base: U+"
+                                        + Integer.toHexString(firstCp) + " seed=" + seed + " chunkSize=" + chunkSize);
+                    }
+                    if (i < chunks.size() - 1) {
+                        assertFalse(lastCp == 0x200D,
+                                "chunk " + i + " ends on a zero-width joiner, splitting the sequence it joins. seed=" + seed);
+                    }
+                }
+            }
+        }
+    }
+
+    // ===================================================================================
+    //                                                          overlap restart point (snap)
+    //                                                          ==========================
+    // The existing overlap tests use all-'a' content, where snapping the restart point is a
+    // no-op: replacing the snapOverlapStart() call with the raw `end - overlap` left them green.
+
+    @Test
+    public void test_split_withOverlap_restartSnapsEarlierThanTheRawOffset() {
+        final int overlap = 10;
+        chunker.setTestChunkSize(100);
+        chunker.setTestOverlap(overlap);
+        final List<String> chunks = chunker.split(PROSE_CORPUS);
+        assertTrue(chunks.size() >= 5, "precondition: the corpus must produce several overlapping chunks, got " + chunks.size());
+        final int[] starts = chunkStartOffsets(PROSE_CORPUS, chunks);
+        for (int i = 1; i < chunks.size(); i++) {
+            final int previousEnd = starts[i - 1] + chunks.get(i - 1).length();
+            assertTrue(starts[i] < previousEnd - overlap, "chunk " + i + " restarted at the raw end-overlap offset "
+                    + (previousEnd - overlap) + " instead of snapping back to a boundary (actual " + starts[i] + ")");
+        }
+    }
+
+    @Test
+    public void test_split_withOverlap_effectiveOverlapStaysWithinTwiceTheConfiguredValue() {
+        // Snapping only ever moves the restart point EARLIER, so the effective overlap can only
+        // grow. split() caps the snap window at the configured overlap (Math.min(lookback,
+        // overlap)); without that cap the window is derived from chunk_size and the effective
+        // overlap reaches overlap + lookback, silently multiplying the index duplication that
+        // warnOnOverlapSideEffect() exists to warn about.
+        for (final int overlap : new int[] { 5, 10, 20 }) {
+            chunker.setTestChunkSize(100);
+            chunker.setTestOverlap(overlap);
+            final List<String> chunks = chunker.split(PROSE_CORPUS);
+            assertTrue(chunks.size() >= 5, "precondition: several chunks for overlap=" + overlap);
+            final int[] starts = chunkStartOffsets(PROSE_CORPUS, chunks);
+            for (int i = 1; i < chunks.size(); i++) {
+                final int previousEnd = starts[i - 1] + chunks.get(i - 1).length();
+                final int actualOverlap = previousEnd - starts[i];
+                assertTrue(actualOverlap >= overlap,
+                        "configured overlap=" + overlap + " but chunk " + i + " only overlapped " + actualOverlap + " characters");
+                assertTrue(actualOverlap <= 2 * overlap, "configured overlap=" + overlap + " but chunk " + i + " overlapped "
+                        + actualOverlap + " characters; the snap window is not capped at the configured overlap");
+            }
+        }
+    }
+
+    // ===================================================================================
+    //                                                            the real configuration channel
+    //                                                            ==============================
+    // TestableLengthChunker overrides all five getters, so the whole getConfigBoolean/getConfigInt
+    // channel was dead in tests: making both throw on entry left every test green. These tests use
+    // a plain LengthChunker and drive FessProp#getSystemProperty's documented -D fallback
+    // (`fess.system.<key>`), which the shared conf/system.properties store does not define for any
+    // content_chunker.length.* key -- so nothing is written to that JVM-lifetime singleton.
+
+    @Test
+    public void test_realConfigChannel_boundaryDisabledProducesFixedLengthOutput() {
+        final String content = "これは最初の文です。これは二番目の文です。";
+        try {
+            setChunkerProperty(LengthChunker.CHUNK_SIZE_PROPERTY, "10");
+            setChunkerProperty(LengthChunker.OVERLAP_PROPERTY, "0");
+            final LengthChunker real = new LengthChunker();
+            // Control: with the kill switch unset the very same instance splits at boundaries,
+            // so the difference below can only come from reading the property.
+            assertEquals(List.of("これは最初の文です。", "これは二番目の文です。"), real.split(content));
+            setChunkerProperty(LengthChunker.BOUNDARY_ENABLED_PROPERTY, "false");
+            assertEquals(List.of("これは最初の文です。", "これは二番目の文です", "。"), real.split(content));
+            assertEquals(referenceFixedLengthSplit(content, 10, 0), real.split(content));
+        } finally {
+            clearChunkerProperties();
+        }
+    }
+
+    @Test
+    public void test_realConfigChannel_invalidBooleanFallsBackToTheDefaultAndWarns() {
+        final String content = "これは最初の文です。これは二番目の文です。";
+        final LogCapturingAppender capture = LogCapturingAppender.attach(LengthChunker.class);
+        try {
+            setChunkerProperty(LengthChunker.CHUNK_SIZE_PROPERTY, "10");
+            setChunkerProperty(LengthChunker.BOUNDARY_ENABLED_PROPERTY, "yes-please");
+            final List<String> chunks = new LengthChunker().split(content);
+            assertEquals(List.of("これは最初の文です。", "これは二番目の文です。"), chunks);
+            assertTrue(
+                    capture.warnings()
+                            .stream()
+                            .anyMatch(w -> w.contains(LengthChunker.BOUNDARY_ENABLED_PROPERTY) && w.contains("yes-please")),
+                    "an unparseable boolean must WARN and fall back to the default: " + capture.warnings());
+        } finally {
+            capture.detach();
+            clearChunkerProperties();
+        }
+    }
+
+    @Test
+    public void test_realConfigChannel_percentsAreReadFromTheChannel() {
+        try {
+            setChunkerProperty(LengthChunker.CHUNK_SIZE_PROPERTY, "100");
+            setChunkerProperty(LengthChunker.OVERLAP_PROPERTY, "0");
+            final LengthChunker real = new LengthChunker();
+            final List<String> fixedLength = referenceFixedLengthSplit(PROSE_CORPUS, 100, 0);
+
+            setChunkerProperty(LengthChunker.LOOKBACK_PERCENT_PROPERTY, "0");
+            setChunkerProperty(LengthChunker.LOOKAHEAD_PERCENT_PROPERTY, "0");
+            assertEquals(fixedLength, real.split(PROSE_CORPUS));
+
+            setChunkerProperty(LengthChunker.LOOKBACK_PERCENT_PROPERTY, "20");
+            assertFalse(fixedLength.equals(real.split(PROSE_CORPUS)), "lookback_percent=20 must be read and change the cuts");
+
+            setChunkerProperty(LengthChunker.LOOKBACK_PERCENT_PROPERTY, "0");
+            setChunkerProperty(LengthChunker.LOOKAHEAD_PERCENT_PROPERTY, "25");
+            assertFalse(fixedLength.equals(real.split(PROSE_CORPUS)), "lookahead_percent=25 must be read and change the cuts");
+        } finally {
+            clearChunkerProperties();
+        }
+    }
+
+    @Test
+    public void test_realConfigChannel_invalidPercentFallsBackToTheDefaultAndWarns() {
+        final LogCapturingAppender capture = LogCapturingAppender.attach(LengthChunker.class);
+        try {
+            setChunkerProperty(LengthChunker.CHUNK_SIZE_PROPERTY, "100");
+            setChunkerProperty(LengthChunker.OVERLAP_PROPERTY, "0");
+            setChunkerProperty(LengthChunker.LOOKAHEAD_PERCENT_PROPERTY, "0");
+            final LengthChunker real = new LengthChunker();
+            setChunkerProperty(LengthChunker.LOOKBACK_PERCENT_PROPERTY, String.valueOf(LengthChunker.DEFAULT_LOOKBACK_PERCENT));
+            final List<String> withExplicitDefault = real.split(PROSE_CORPUS);
+            setChunkerProperty(LengthChunker.LOOKBACK_PERCENT_PROPERTY, "twenty");
+            final List<String> withInvalidValue = real.split(PROSE_CORPUS);
+            // Pins the fallback VALUE, not merely "something sensible happened".
+            assertEquals(withExplicitDefault, withInvalidValue);
+            assertFalse(referenceFixedLengthSplit(PROSE_CORPUS, 100, 0).equals(withInvalidValue),
+                    "the default lookback must still drive a real backward search");
+            assertTrue(
+                    capture.warnings().stream().anyMatch(w -> w.contains(LengthChunker.LOOKBACK_PERCENT_PROPERTY) && w.contains("twenty")),
+                    "an unparseable integer must WARN and fall back to the default: " + capture.warnings());
+        } finally {
+            capture.detach();
+            clearChunkerProperties();
+        }
+    }
+
+    // ===================================================================================
+    //                                       legacy fixed-length equivalence (differential)
+    //                                       =====================================================
+    // The two existing legacy-equivalence tests use content with no grapheme clusters, so removing
+    // the `lookback > 0 || lookahead > 0` gate in split() -- which is what keeps the cluster escape
+    // from firing at lookback=lookahead=0 -- left them green. referenceFixedLengthSplit below is an
+    // independent substring loop; it never calls split(), so the expectation cannot drift with it.
+
+    @Test
+    public void test_split_boundaryDisabled_matchesIndependentFixedLengthReference() {
+        chunker.setTestBoundaryEnabled(false);
+        assertFixedLengthReferenceEquivalence();
+    }
+
+    @Test
+    public void test_split_zeroPercents_matchIndependentFixedLengthReference() {
+        chunker.setTestLookbackPercent(0);
+        chunker.setTestLookaheadPercent(0);
+        assertFixedLengthReferenceEquivalence();
+    }
+
+    private void assertFixedLengthReferenceEquivalence() {
+        for (long seed = 1L; seed <= 4L; seed++) {
+            final String content = randomClusterRichContent(seed, 1500);
+            for (final int chunkSize : new int[] { 5, 13, 64, 200 }) {
+                for (final int overlap : new int[] { 0, 3 }) {
+                    chunker.setTestChunkSize(chunkSize);
+                    chunker.setTestOverlap(overlap);
+                    final String where = "seed=" + seed + " chunkSize=" + chunkSize + " overlap=" + overlap;
+                    final List<String> expected = referenceFixedLengthSplit(content, chunkSize, overlap);
+                    final List<String> actual = chunker.split(content);
+                    // Compared chunk by chunk rather than list to list: these corpora run to
+                    // hundreds of chunks, and a whole-list mismatch message is unreadable.
+                    for (int i = 0; i < Math.min(expected.size(), actual.size()); i++) {
+                        // Qualified: UnitFessTestCase deliberately omits assertEquals(Object,
+                        // Object, String), so this is the only way to keep the JUnit 5 argument
+                        // order when all three arguments are Strings.
+                        org.junit.jupiter.api.Assertions.assertEquals(expected.get(i), actual.get(i), where + " chunk=" + i);
+                    }
+                    assertEquals(expected.size(), actual.size(), where + " produced a different number of chunks");
+                }
+            }
+        }
+    }
+
+    // ===================================================================================
+    //                                                          clamp values, not just WARNs
+    //                                                          ============================
+
+    @Test
+    public void test_boundaryPercent_aboveMaximum_searchesExactlyTheMaximumWindow() {
+        // MAX_LOOKBACK_PERCENT=50 of chunk_size=100 is a 50-character backward window. Both halves
+        // are needed: the first fails if the clamp yields 0 (no search at all), the second fails if
+        // the out-of-range value is used unclamped (a 999-character window).
+        chunker.setTestChunkSize(100);
+        chunker.setTestOverlap(0);
+        chunker.setTestLookbackPercent(999);
+        chunker.setTestLookaheadPercent(0);
+        // A sentence end 45 characters before the ideal cut: inside a 50-character window.
+        final String inWindow = "a".repeat(53) + ". " + "b".repeat(120);
+        assertEquals(55, chunker.split(inWindow).get(0).length(), "a boundary 45 characters back must be found within the clamped window");
+        // A sentence end 70 characters before the ideal cut: outside a 50-character window.
+        final String outOfWindow = "a".repeat(28) + ". " + "b".repeat(150);
+        assertEquals(100, chunker.split(outOfWindow).get(0).length(),
+                "a boundary 70 characters back is outside the clamped window and must not be reached");
+    }
+
+    @Test
+    public void test_boundaryPercent_negative_disablesThatDirectionEntirely() {
+        // Pins the VALUE the negative percent normalizes to: 0, not the maximum. With lookahead
+        // also 0 the finder is never resolved at all, so the output is the legacy fixed-length one.
+        chunker.setTestChunkSize(10);
+        chunker.setTestOverlap(0);
+        chunker.setTestLookbackPercent(-1);
+        chunker.setTestLookaheadPercent(0);
+        final String content = "これは最初の文です。これは二番目の文です。";
+        assertEquals(List.of("これは最初の文です。", "これは二番目の文です", "。"), chunker.split(content));
+        assertEquals(referenceFixedLengthSplit(content, 10, 0), chunker.split(content));
+    }
+
+    // ===================================================================================
+    //                                                                     test helpers
+    //                                                                     ============
+
+    private static final String PROSE_CORPUS = "Fess is an open source enterprise search server. "
+            + "It crawls web sites, file systems and data stores, then indexes the extracted text. " + "これは日本語の文章です。全文検索エンジンとして動作します。"
+            + "The administration UI lets an operator schedule crawls, review logs and tune relevance. " + "クローラは HTTP と SMB の両方に対応しています。"
+            + "Documents in Office, PDF and plain text formats are all supported out of the box. " + "検索結果はスコア順に並び替えられ、ハイライトが付与されます。"
+            + "A plugin can replace the tokenizer, the ranking model or the storage backend entirely. " + "設定ファイルを編集すると、動作を細かく調整できます。"
+            + "Finally, the REST API exposes every feature the browser UI offers, and a little more. ";
+
+    /** Prose-like fragments: plenty of spaces, sentence ends and script changes to snap onto. */
+    private static final String[] BOUNDARY_RICH_TOKENS = { "search", "index", "crawler", "document", "relevance", " ", " ", " ", ". ", ", ",
+            "。", "、", "検索", "文書", "クローラ", "全文検索", "設定", "\n", "Fess", "OpenSearch", "1234", "😀" };
+
+    /** Deliberately hostile to a fixed-length cut: combining marks, ZWJ sequences and astral chars. */
+    private static final String[] CLUSTER_RICH_TOKENS =
+            { "é", "à́", "ñ", "👩‍💻", "👨‍👩‍👦", "😀", "❤️", "🇯🇵", "が", "abc", " ", "。", "नि" };
+
+    private static String randomBoundaryRichContent(final long seed, final int approximateLength) {
+        return randomContent(seed, approximateLength, BOUNDARY_RICH_TOKENS);
+    }
+
+    private static String randomClusterRichContent(final long seed, final int approximateLength) {
+        return randomContent(seed, approximateLength, CLUSTER_RICH_TOKENS);
+    }
+
+    private static String randomContent(final long seed, final int approximateLength, final String[] tokens) {
+        final Random random = new Random(seed);
+        final StringBuilder buf = new StringBuilder(approximateLength + 32);
+        while (buf.length() < approximateLength) {
+            buf.append(tokens[random.nextInt(tokens.length)]);
+        }
+        return buf.toString();
+    }
+
+    /**
+     * An independent fixed-length splitter: a plain substring loop with the surrogate-pair
+     * adjustment, deliberately NOT derived from {@link LengthChunker#split(String, int)} so that
+     * comparing against it is a real differential test rather than a restatement.
+     *
+     * @param content the text to split
+     * @param chunkSize the (already normalized) chunk size
+     * @param overlap the (already normalized) overlap
+     * @return the fixed-length chunks
+     */
+    private static List<String> referenceFixedLengthSplit(final String content, final int chunkSize, final int overlap) {
+        final List<String> chunks = new ArrayList<>();
+        final int length = content.length();
+        int start = 0;
+        while (start < length) {
+            if (splitsSurrogatePair(content, start)) {
+                start++;
+            }
+            if (start >= length) {
+                break;
+            }
+            int end = Math.min(start + chunkSize, length);
+            if (splitsSurrogatePair(content, end)) {
+                end--;
+            }
+            if (end <= start) {
+                end = start + Character.charCount(content.codePointAt(start));
+            }
+            chunks.add(content.substring(start, end));
+            if (end >= length) {
+                break;
+            }
+            int nextStart = end - overlap;
+            if (nextStart <= start) {
+                nextStart = end;
+            }
+            start = nextStart;
+        }
+        return chunks;
+    }
+
+    private static boolean splitsSurrogatePair(final String content, final int index) {
+        return index > 0 && index < content.length() && Character.isLowSurrogate(content.charAt(index))
+                && Character.isHighSurrogate(content.charAt(index - 1));
+    }
+
+    private static boolean isClusterContinuationCodePoint(final int cp) {
+        if (cp == 0x200D || cp >= 0xFE00 && cp <= 0xFE0F || cp >= 0xE0100 && cp <= 0xE01EF) {
+            return true;
+        }
+        final int type = Character.getType(cp);
+        return type == Character.NON_SPACING_MARK || type == Character.COMBINING_SPACING_MARK || type == Character.ENCLOSING_MARK;
+    }
+
+    /**
+     * Recovers the offset each chunk really started at. The chunks are only strings, so the
+     * restart points an overlap produces are otherwise unobservable.
+     *
+     * @param content the text that was split
+     * @param chunks the produced chunks
+     * @return the start offset of each chunk
+     */
+    private int[] chunkStartOffsets(final String content, final List<String> chunks) {
+        final int[] starts = new int[chunks.size()];
+        for (int i = 1; i < chunks.size(); i++) {
+            final String chunk = chunks.get(i);
+            final int at = content.indexOf(chunk, starts[i - 1] + 1);
+            assertTrue(at >= 0, "chunk " + i + " was not found after offset " + starts[i - 1]);
+            if (chunk.length() >= 16) {
+                // Guards the search above: a repeated fragment could otherwise resolve to a stale
+                // earlier occurrence and make the offsets fiction.
+                assertEquals(at, content.lastIndexOf(chunk), "chunk " + i + " is not unique in the corpus; the offsets are unreliable");
+            }
+            final int previousEnd = starts[i - 1] + chunks.get(i - 1).length();
+            assertTrue(at <= previousEnd, "text was skipped between chunk " + (i - 1) + " and chunk " + i);
+            starts[i] = at;
+        }
+        final int lastIndex = chunks.size() - 1;
+        assertEquals(content.length(), starts[lastIndex] + chunks.get(lastIndex).length(), "the chunks must cover the whole content");
+        return starts;
+    }
+
+    private long fastestSplitNanos(final String content, final int runs) {
+        long best = Long.MAX_VALUE;
+        for (int i = 0; i < runs; i++) {
+            final long startedAt = System.nanoTime();
+            final List<String> chunks = chunker.split(content);
+            best = Math.min(best, System.nanoTime() - startedAt);
+            assertFalse(chunks.isEmpty(), "the split must produce chunks");
+        }
+        return best;
+    }
+
+    private static void setChunkerProperty(final String key, final String value) {
+        System.setProperty(Constants.SYSTEM_PROP_PREFIX + key, value);
+    }
+
+    private static void clearChunkerProperties() {
+        for (final String key : new String[] { LengthChunker.CHUNK_SIZE_PROPERTY, LengthChunker.OVERLAP_PROPERTY,
+                LengthChunker.BOUNDARY_ENABLED_PROPERTY, LengthChunker.LOOKBACK_PERCENT_PROPERTY,
+                LengthChunker.LOOKAHEAD_PERCENT_PROPERTY }) {
+            System.clearProperty(Constants.SYSTEM_PROP_PREFIX + key);
+        }
+    }
+
     private static final class TestableLengthChunker extends LengthChunker {
         private int testChunkSize = 800;
         private int testOverlap = 0;
+        private boolean testBoundaryEnabled = DEFAULT_BOUNDARY_ENABLED;
+        private int testLookbackPercent = DEFAULT_LOOKBACK_PERCENT;
+        private int testLookaheadPercent = DEFAULT_LOOKAHEAD_PERCENT;
 
         void setTestChunkSize(final int chunkSize) {
             this.testChunkSize = chunkSize;
@@ -298,6 +1017,22 @@ public class LengthChunkerTest extends UnitFessTestCase {
 
         void setTestOverlap(final int overlap) {
             this.testOverlap = overlap;
+        }
+
+        void setTestBoundaryEnabled(final boolean enabled) {
+            this.testBoundaryEnabled = enabled;
+        }
+
+        void setTestLookbackPercent(final int percent) {
+            this.testLookbackPercent = percent;
+        }
+
+        void setTestLookaheadPercent(final int percent) {
+            this.testLookaheadPercent = percent;
+        }
+
+        ChunkBoundaryFinder exposedBoundaryFinder() {
+            return getBoundaryFinder();
         }
 
         @Override
@@ -308,6 +1043,21 @@ public class LengthChunkerTest extends UnitFessTestCase {
         @Override
         protected int getOverlap() {
             return testOverlap;
+        }
+
+        @Override
+        protected boolean isBoundaryEnabled() {
+            return testBoundaryEnabled;
+        }
+
+        @Override
+        protected int getLookbackPercent() {
+            return testLookbackPercent;
+        }
+
+        @Override
+        protected int getLookaheadPercent() {
+            return testLookaheadPercent;
         }
     }
 


### PR DESCRIPTION
## Summary

`LengthChunker` cut every `content_chunker.length.chunk_size` characters regardless of what was at that offset, so words and sentences were routinely split in half. Because the chunks become both the searchable `content` array and the embedding input, a cut landing mid-word degrades both.

Each cut now moves to a suitable break near the ideal offset. No character is dropped -- only the cut point moves -- so with the default `content_chunker.length.overlap=0`, concatenating a document's chunks still reproduces its content exactly.

## How boundaries are chosen

Candidates inside the search window are grouped into three tiers, and **the nearest candidate of the highest tier present wins** -- not simply the nearest candidate. A sentence end 100 characters back beats a space 2 characters back.

| tier | breaks |
|---|---|
| STRONG | line break; sentence end (`.` `。` `｡` `！` `？` `!` `?` `…` `‥` and similar) |
| WEAK | clause separator (`,` `、` `，` `;` `:` `・` `-` and similar); space; bracket |
| SCRIPT | writing-system change (any Unicode script pair; `COMMON`/`INHERITED`/`UNKNOWN` are excluded, so digits, punctuation, emoji and `ー` never register) |

Punctuation that is ambiguous inside numbers is rejected two ways:

- ASCII `.` `,` `;` `:` only count when whitespace (or the end of the content) follows, so `3.14` and `1,234` are never split at them.
- The fullwidth forms `．` `，` `：` and hyphens (`-`, `‐`) only count when the code point immediately after them is **not a digit**. CJK sentences carry no trailing space, so the whitespace rule cannot be used for them -- but `１．５倍`, `１，２３４`, `１０：３０`, `2026-08-09` and `UTF-8` must not be cut apart, while the JIS `，．` sentence convention (`終わり．次は`) must keep working. `‑` U+2011 NON-BREAKING HYPHEN is not a break opportunity at all.

The SCRIPT tier is what keeps Japanese text without spaces or punctuation from falling back to a blind cut.

The search runs backward from the ideal offset. Only when no STRONG candidate exists behind it does it look ahead, and only for a STRONG break -- a sentence end **or a line break** -- so overshooting the chunk size is reserved for keeping a sentence or a line whole.

Unicode whitespace that `Character.isWhitespace` rejects (NBSP, FIGURE SPACE, NNBSP, ZWSP, ZWNJ, WORD JOINER, BOM, NEL) is treated as breakable. Scanning is code-point-based, so a boundary can never split a UTF-16 surrogate pair, and **no tier returns an offset that splits a grapheme cluster**: a candidate that would strand a combining mark, a variation selector or a zero-width-joined emoji half is rejected during the scan and the search continues. The hard-cut fallback additionally steps off a cluster rather than splitting it.

## New settings

All three use the same `conf/system.properties` channel as the existing chunker keys (`-Dfess.system.<key>` also works).

| key | default | range |
|---|---|---|
| `content_chunker.length.boundary.enabled` | `true` | -- |
| `content_chunker.length.boundary.lookback_percent` | `20` | 0-50 |
| `content_chunker.length.boundary.lookahead_percent` | `5` | 0-25 |

Setting `boundary.enabled=false`, or both percentages to `0`, reproduces the previous fixed-length output exactly. The effective configuration is logged once at registration time.

## Behaviour changes to be aware of

**`chunk_size` becomes a target rather than a hard ceiling.** The forward sentence search may overshoot it by up to `lookahead_percent`, and -- independently, and not governed by `lookahead_percent` -- the grapheme-cluster escape may overshoot by up to 32 UTF-16 units. The two are mutually exclusive, so the worst case reachable through `LengthChunker` is `chunk_size + max(lookahead, 32)`: **840** characters at the shipped defaults. Leave that margin against the embedding model's token limit. (`ChunkBoundaryFinder#findChunkEnd` documents one further `+ 1` for direct API callers; that branch needs `ideal == start + 1`, which `MIN_CHUNK_SIZE` makes unreachable from the chunker.)

**A document produces more chunks than before.** Chunks can end up to `lookback_percent` *of `chunk_size`* shorter -- 160 characters at the defaults. Measured: **+9%** on English prose, **+2.7%** on Japanese prose, up to **+25%** in the worst case. If that pushes a document past `content_chunker.max_chunks_per_document` (default 1000) it is marked `skipped` and gets no embeddings at all, so raise that cap or lower `lookback_percent` for very large corpora of long documents.

**With `overlap > 0` the effective overlap grows.** The restart point is snapped to a boundary too, and snapping can only move it earlier. The snap window is capped at the configured overlap, so the effective overlap never exceeds `2 * overlap`.

Existing indexed documents keep their stored chunk arrays; re-chunking requires a recrawl, as it already did for `chunk_size`.

## Structure

Boundary search lives in a new `ChunkBoundaryFinder`, registered as the LastaDi component `chunkBoundaryFinder` in `fess_chunk.xml`. It holds no state (the chunk job runs it concurrently), and its character predicates are `protected` so a deployment can register a subclass that swaps only the character sets. The two `protected` constants (`ZWJ`, `MAX_CLUSTER_ADJUST`) are *not* part of that seam -- `static` fields have no virtual dispatch. `LengthChunker` resolves the component once per `split` call, falling back to a built-in instance when it is not registered.

The backward scan is a single reverse pass that carries its run state and its decoded code point across iterations, so it costs O(W) per chunk and decodes each code point once. Character classification is `int` switches only -- no collections, boxing, regex or streams on the scan path.

## Testing

- `ChunkBoundaryFinderTest`: each tier, tier precedence, the ASCII-punctuation and non-digit rules, script changes, surrogate pairs, grapheme clusters on **every** tier path, the search windows, overlap snapping, the subclass seam, out-of-contract arguments, and a randomised property sweep asserting cluster safety, code-point alignment and lookback monotonicity.
- `LengthChunkerTest`: where the cuts actually land (not just that nothing was lost), boundary-aware splitting for Japanese and English, lossless reconstruction over a corpus including combining marks and ZWJ sequences, the overlap snap wired end to end, the effective-overlap cap, the real `getSystemProperty` config channel including the `boundary.enabled=false` kill switch, a differential check against an independent fixed-length reference splitter, and a relative linearity guard.

## Known limitations (follow-ups, not addressed here)

Each is tracked separately: #3228 (non-Latin sentence marks and scriptio-continua scripts), #3229 (character-classification refinements), #3230 (startup observability and config validation) and #3231 (user documentation in fess-docs).

- Sentence terminators are Latin + CJK only: the Devanagari danda `।`, Arabic `؟` `،`, Myanmar `။`, Khmer `។` and others are not recognised, so those languages never reach the STRONG tier.
- Scriptio-continua scripts without phrase spaces (Thai, Khmer, Lao) produce no candidate in any tier and fall back to the blind cut.
- ASCII `'` and `"` are classified as closing marks only, so English contractions can be cut at the apostrophe (`don'` / `t`).
- Halfwidth corner brackets `｢` `｣`, `・` and `〜` inside words, and bidi isolate/embedding controls are not special-cased.

