### PR TITLE
fix(security): mask SSO client credentials in system info and bug reports

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoAction.java
@@ -207,11 +207,29 @@ public class AdminSysteminfoAction extends FessAdminAction {
                 || "ldap.admin.security.credentials".equals(key) //
                 || "spnego.preauth.password".equals(key) //
                 || "app.cipher.key".equals(key) //
-                || "oic.client.id".equals(key) //
-                || "oic.client.secret".equals(key) //
                 || "content_chunker.embedding.opensearch.password".equals(key) //
+                || isSsoClientCredential(key) //
                 || isEmbeddingApiKey(key) //
                 || isLlmApiKey(key);
+    }
+
+    /**
+     * Checks if a key is an SSO provider's client credential, e.g. {@code oic.client.secret} or
+     * {@code entraid.client.secret}. Matching on the {@code <provider>.client.id} /
+     * {@code <provider>.client.secret} shape, instead of listing every provider by name, means a
+     * future SSO provider's credential is masked by default.
+     *
+     * <p>Only OpenID Connect was listed by name before, so the Entra ID client secret was rendered
+     * in cleartext under System Info &gt; Config Info, and was also copied verbatim into the bug
+     * report that users paste into public issues. The legacy {@code aad.*} keys are covered by the
+     * same shape because {@link org.codelibs.fess.sso.entraid.EntraIdAuthenticator} still reads
+     * them as a fallback.
+     *
+     * @param key the property key to check
+     * @return true if the key matches the SSO client credential shape
+     */
+    protected static boolean isSsoClientCredential(final String key) {
+        return key != null && (key.endsWith(".client.id") || key.endsWith(".client.secret"));
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoActionTest.java
@@ -76,6 +76,20 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_isMaskedValue_masksSsoClientCredentials() {
+        // Entra ID stores its client secret in conf/system.properties just like OpenID
+        // Connect does, so it has to be masked on the same screens.
+        assertTrue(AdminSysteminfoAction.isMaskedValue("entraid.client.id"));
+        assertTrue(AdminSysteminfoAction.isMaskedValue("entraid.client.secret"));
+        // The legacy Azure AD keys are still read as a fallback by EntraIdAuthenticator,
+        // so an upgraded installation can still hold values under these names.
+        assertTrue(AdminSysteminfoAction.isMaskedValue("aad.client.id"));
+        assertTrue(AdminSysteminfoAction.isMaskedValue("aad.client.secret"));
+        // The rule matches on shape, so an SSO provider added later is masked by default.
+        assertTrue(AdminSysteminfoAction.isMaskedValue("okta.client.secret"));
+    }
+
+    @Test
     public void test_isMaskedValue_doesNotMaskOrdinaryKeys() {
         // Other content_chunker.embedding.* keys are plain diagnostic config, not credentials,
         // and must stay visible on the admin screen.
@@ -93,6 +107,12 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         assertFalse(AdminSysteminfoAction.isMaskedValue("rag.llm.openai.model"));
         assertFalse(AdminSysteminfoAction.isMaskedValue("rag.llm.openai.retry.max"));
         assertFalse(AdminSysteminfoAction.isMaskedValue("rag.chat.enabled"));
+
+        // The rest of the Entra ID settings are plain configuration, not credentials.
+        assertFalse(AdminSysteminfoAction.isMaskedValue("entraid.tenant"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("entraid.authority"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("entraid.reply.url"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("entraid.permission.fields"));
     }
 
     @Test
@@ -101,6 +121,8 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         ComponentUtil.getSystemProperties().setProperty("content_chunker.embedding.gemini.api.key", "gm-super-secret");
         ComponentUtil.getSystemProperties().setProperty("content_chunker.embedding.opensearch.password", "hunter2");
         ComponentUtil.getSystemProperties().setProperty("rag.llm.openai.api.key", "sk-chat-secret");
+        ComponentUtil.getSystemProperties().setProperty("entraid.client.secret", "entraid-super-secret");
+        ComponentUtil.getSystemProperties().setProperty("entraid.tenant", "contoso.onmicrosoft.com");
         ComponentUtil.getSystemProperties().setProperty("content_chunker.embedding.dimension", "768");
 
         final List<Map<String, String>> itemList = AdminSysteminfoAction.getBugReportItems();
@@ -111,9 +133,11 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         assertEquals(MASKED_VALUE, findValue(itemList, "content_chunker.embedding.gemini.api.key"));
         assertEquals(MASKED_VALUE, findValue(itemList, "content_chunker.embedding.opensearch.password"));
         assertEquals(MASKED_VALUE, findValue(itemList, "rag.llm.openai.api.key"));
+        assertEquals(MASKED_VALUE, findValue(itemList, "entraid.client.secret"));
 
         // An ordinary diagnostic key is unaffected and keeps its real value.
         assertEquals("768", findValue(itemList, "content_chunker.embedding.dimension"));
+        assertEquals("contoso.onmicrosoft.com", findValue(itemList, "entraid.tenant"));
     }
 
     private String findValue(final List<Map<String, String>> itemList, final String label) {


### PR DESCRIPTION
## Problem

`AdminSysteminfoAction.isMaskedValue()` listed the OpenID Connect client credentials by name:

```java
|| "oic.client.id".equals(key)
|| "oic.client.secret".equals(key)
```

The Entra ID equivalents were never added. `AdminGeneralAction` stores them with
`setSystemProperty("entraid.client.secret", ...)`, and `getFessPropItems()` enumerates
*every* system property, so the Entra ID client secret was rendered in cleartext under
**System Info > Config Info**.

`getBugReportItems()` takes the same path, so the secret was also copied verbatim into
the bug report that users paste into public issues.

The legacy `aad.client.secret` key has the same problem, and `EntraIdAuthenticator` still
reads it as a fallback, so an upgraded installation can hold a value under that name.

The general settings screen already masks these fields with `DUMMY_PASSWORD`, so this was
a gap on the System Info side only.

## Fix

Replace the two by-name entries with `isSsoClientCredential()`, matching on the
`<provider>.client.id` / `<provider>.client.secret` shape:

- keeps `oic.client.id` / `oic.client.secret` masked (regression-guarded by the existing test)
- adds `entraid.client.id` / `entraid.client.secret` and the legacy `aad.*` names
- masks a future SSO provider's credential by default

This follows the same reasoning already documented in this file for `isEmbeddingApiKey()`
and `isLlmApiKey()`. `oic`, `entraid` and `aad` are the only keys in the tree matching this
shape, so nothing else changes.

## Tests

`AdminSysteminfoActionTest`:

- `test_isMaskedValue_masksSsoClientCredentials` (new) - entraid / aad / a hypothetical future provider
- `test_isMaskedValue_doesNotMaskOrdinaryKeys` - extended with `entraid.tenant`, `entraid.authority`, `entraid.reply.url`, `entraid.permission.fields`
- `test_getBugReportItems_masksSensitiveKeysInsteadOfLeakingCleartext` - extended with `entraid.client.secret`; also asserts `entraid.tenant` keeps its real value

Both new assertions failed before the change (the bug report one reported
`expected: <XXXXXXXX> but was: <entraid-super-secret>`) and pass after it.

```
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```
