### PR TITLE
fix(sso): bind SAML responses to the AuthnRequest and reject replays

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
-import org.codelibs.core.net.UuidUtil;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist.LoginCredentialResolver;
 import org.codelibs.fess.app.web.base.login.SamlCredential;
@@ -42,6 +41,8 @@ import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.saml2.Auth;
 import org.codelibs.saml2.core.authn.AuthnRequestParams;
 import org.codelibs.saml2.core.logout.LogoutRequestParams;
+import org.codelibs.saml2.core.replay.InMemoryReplayCache;
+import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
 import org.dbflute.optional.OptionalEntity;
@@ -150,7 +151,8 @@ public class SamlAuthenticator implements SsoAuthenticator {
     protected static final String SAML_PREFIX = "saml.";
 
     /**
-     * The key for the SAML state in the session.
+     * The session key holding the ID of the AuthnRequest sent to the IdP.
+     * The value is compared with the InResponseTo of the SAML response.
      */
     protected static final String SAML_STATE = "SAML_STATE";
 
@@ -160,6 +162,17 @@ public class SamlAuthenticator implements SsoAuthenticator {
     protected static final String SAML_SP_BASE_URL = "saml.sp.base.url";
 
     private Map<String, Object> defaultSettings;
+
+    /**
+     * Cache of processed assertion IDs, used to reject replayed assertions.
+     *
+     * <p><b>Note:</b> the cache is held in memory by this instance and is not shared in a
+     * multi-instance deployment. That is also why SAML SSO needs sticky sessions: the
+     * assertion has to reach the instance whose session holds the matching AuthnRequest ID.
+     * It is that ID check, not this cache, which rejects an assertion replayed to another
+     * instance; the cache catches a repeated POST within a single session.</p>
+     */
+    private final ReplayCache replayCache = new InMemoryReplayCache();
 
     /**
      * Initializes the SamlAuthenticator.
@@ -249,7 +262,9 @@ public class SamlAuthenticator implements SsoAuthenticator {
             }
             params.put("onelogin.saml2." + key.substring(SAML_PREFIX.length()), e.getValue());
         });
-        return new SettingsBuilder().fromValues(params).build();
+        final Saml2Settings settings = new SettingsBuilder().fromValues(params).build();
+        settings.setReplayCache(replayCache);
+        return settings;
     }
 
     @Override
@@ -263,28 +278,19 @@ public class SamlAuthenticator implements SsoAuthenticator {
 
             final HttpSession session = request.getSession(false);
             if (session != null) {
-                final String sesState = (String) session.getAttribute(SAML_STATE);
-                if (StringUtil.isNotBlank(sesState)) {
+                final String requestId = (String) session.getAttribute(SAML_STATE);
+                if (StringUtil.isNotBlank(requestId)) {
                     session.removeAttribute(SAML_STATE);
                     try {
                         final Auth auth = new Auth(getSettings(), request, response);
-                        auth.processResponse();
+                        auth.processResponse(requestId);
 
                         if (!auth.isAuthenticated()) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Authentication failed.");
-                            }
-                            return null;
-                        }
-
-                        final List<String> errors = auth.getErrors();
-                        if (!errors.isEmpty()) {
-                            logger.warn("{}", errors.stream().collect(Collectors.joining(", ")));
+                            final String errors = auth.getErrors().stream().collect(Collectors.joining(", "));
                             if (auth.isDebugActive() && StringUtil.isNotBlank(auth.getLastErrorReason())) {
-                                logger.warn("Authentication Failure: {} - Reason: {}", errors.stream().collect(Collectors.joining(", ")),
-                                        auth.getLastErrorReason());
+                                logger.warn("Authentication Failure: {} - Reason: {}", errors, auth.getLastErrorReason());
                             } else {
-                                logger.warn("Authentication Failure: {}", errors.stream().collect(Collectors.joining(", ")));
+                                logger.warn("Authentication Failure: {}", errors);
                             }
                             return null;
                         }
@@ -301,7 +307,7 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 final Auth auth = new Auth(getSettings(), request, response);
                 final AuthnRequestParams authnRequestParams = new AuthnRequestParams(false, false, true);
                 final String loginUrl = auth.login(null, authnRequestParams, true);
-                request.getSession().setAttribute(SAML_STATE, UuidUtil.create());
+                request.getSession().setAttribute(SAML_STATE, auth.getLastRequestId());
                 return new ActionResponseCredential(() -> HtmlResponse.fromRedirectPathAsIs(loginUrl));
             } catch (final Exception e) {
                 throw new SsoLoginException("Invalid SAML redirect URL.", e);

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -93,6 +94,18 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
         Field defaultSettingsField = SamlAuthenticator.class.getDeclaredField("defaultSettings");
         defaultSettingsField.setAccessible(true);
         defaultSettingsField.set(authenticator, settings);
+    }
+
+    @Test
+    public void test_getSettings_sharesReplayCacheAcrossRequests() throws Exception {
+        SamlAuthenticator authenticator = new SamlAuthenticator();
+        setDefaultSettings(authenticator, createDefaultSettings());
+
+        Saml2Settings first = authenticator.getSettings();
+        Saml2Settings second = authenticator.getSettings();
+
+        assertNotNull(first.getReplayCache());
+        assertSame(first.getReplayCache(), second.getReplayCache());
     }
 
     @Test


### PR DESCRIPTION
## Summary

The SAML ACS callback (`SamlAuthenticator.getLoginCredential()`) accepted any valid assertion and reported nothing when one was rejected. This PR closes both gaps.

## 1. `SAML_STATE` never bound the response to a request

`SAML_STATE` held a freshly generated UUID. `auth.login(null, ...)` discards `auth.getLastRequestId()` and java-saml puts the *current URL* in `RelayState` when the first argument is `null`, so the UUID was never transmitted to the IdP and never compared with anything — it only signalled "a SAML login is in progress".

The callback then called the no-arg `auth.processResponse()`, which passes `requestId = null`, short-circuiting the `InResponseTo` check in `SamlResponse#isValid`:

```java
if (requestId != null && !Objects.equals(responseInResponseTo, requestId)) { ... }
```

`SAML_STATE` now holds `auth.getLastRequestId()` and is passed to `processResponse(requestId)`, so the response is checked against the AuthnRequest this SP actually issued.

This is also what the other SSO providers already do — `OpenIdConnectAuthenticator` compares `sesState.equals(reqState)`, and the Entra ID authenticator validates state and nonce. SAML was the only one that checked the session attribute for *presence* alone.

## 2. No replay protection

`Saml2Settings#getReplayCache` defaults to `null` and was never set, so java-saml skipped its assertion-ID replay check entirely. A captured, still-valid `SAMLResponse` could be replayed until its `NotOnOrAfter` passed.

A single `InMemoryReplayCache` is now held by the authenticator and attached in `getSettings()`. The cache is thread-safe and evicts expired entries opportunistically, so it needs no lifecycle management.

## 3. Failure reasons were unreachable

```java
if (!auth.isAuthenticated()) { logger.debug("Authentication failed."); return null; }  // always taken on failure
final List<String> errors = auth.getErrors();                                          // never non-empty here
if (!errors.isEmpty()) { ... auth.getLastErrorReason() ... }
```

`Auth#processResponse` sets `authenticated = true` only when `isValid()` returns true and appends to `errors` only in the else branch, so the second block could never run with content. Bad signature, expired assertion, wrong audience and wrong `Destination` all surfaced as a DEBUG-level `"Authentication failed."` with no reason — nothing at all at the default log level.

The errors and `getLastErrorReason()` are now logged at WARN inside the `!isAuthenticated()` branch. This also makes the behaviour documented in `sso-saml.rst` ("`saml.debug=true` を設定すると、SAML認証に失敗した際の詳細な理由がログに出力されます") actually happen; `isDebugActive()` was previously referenced only from the unreachable block.

## Behaviour changes

- Concurrent SAML logins in multiple browser tabs now fail for all but the most recent AuthnRequest, since one session holds one request ID. This matches the existing OIDC behaviour.
- Sessions that still hold the old UUID at upgrade time fail once and succeed on the retry.

## Test

`SamlAuthenticatorTest#test_getSettings_sharesReplayCacheAcrossRequests` asserts the replay cache is attached and is the same instance across calls (this also puts the previously dead `setDefaultSettings` helper to use).

```
Tests run: 15, Failures: 0, Errors: 0, Skipped: 0 -- SamlAuthenticatorTest
```
