### PR TITLE
fix(sso): use query response mode so the Entra ID callback keeps its session

### DIFF
--- a/src/main/assemblies/files/tomcat_config.properties
+++ b/src/main/assemblies/files/tomcat_config.properties
@@ -11,5 +11,8 @@ tomcat.useBodyEncodingForURI = true
 #tomcat.bindAddress=127.0.0.1
 #tomcat.proxyPort=
 #tomcat.maxHttpHeaderSize=4096
-# SameSite attribute for cookies (lax|strict|none). Lax keeps OAuth/OIDC redirects working.
+# SameSite attribute for cookies (lax|strict|none). Lax keeps redirect-based (GET) SSO
+# callbacks working. A callback delivered as a cross-site POST -- SAML's HTTP-POST binding,
+# or Entra ID with response_mode=form_post -- does not carry a Lax cookie, so those setups
+# need `none`, which in turn requires HTTPS and session.cookie.secure=true.
 tomcat.sameSiteCookies = lax

--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -263,7 +263,15 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 logger.debug("Logging in with Entra ID Authenticator");
             }
             final HttpSession session = request.getSession(false);
-            if (session != null && containsAuthenticationData(request)) {
+            if (containsAuthenticationData(request)) {
+                if (session == null) {
+                    // Redirecting again would send the user straight back here without a session,
+                    // looping forever. The usual cause is the session cookie not being sent on the
+                    // callback; see tomcat.sameSiteCookies in tomcat_config.properties.
+                    logger.warn("Received an Entra ID authentication response without a session."
+                            + " The session cookie was not sent back with the callback request.");
+                    return null;
+                }
                 try {
                     return processAuthenticationData(request);
                 } catch (final Exception e) {
@@ -292,13 +300,13 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         if (useV2Endpoint) {
             // v2.0 endpoint with MSAL4J (recommended)
             authUrl = getAuthority() + getTenant()
-                    + "/oauth2/v2.0/authorize?response_type=code&scope=https://graph.microsoft.com/.default&response_mode=form_post&redirect_uri="
+                    + "/oauth2/v2.0/authorize?response_type=code&scope=https://graph.microsoft.com/.default&response_mode=query&redirect_uri="
                     + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id=" + getClientId() + "&state=" + state
                     + "&nonce=" + nonce;
         } else {
             // v1.0 endpoint for backward compatibility
             authUrl = getAuthority() + getTenant()
-                    + "/oauth2/authorize?response_type=code&scope=directory.read.all&response_mode=form_post&redirect_uri="
+                    + "/oauth2/authorize?response_type=code&scope=directory.read.all&response_mode=query&redirect_uri="
                     + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id=" + getClientId()
                     + "&resource=https%3a%2f%2fgraph.microsoft.com" + "&state=" + state + "&nonce=" + nonce;
         }
@@ -577,7 +585,11 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         if (logger.isDebugEnabled()) {
             logger.debug("HTTP Method: {}", request.getMethod());
         }
-        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+        // The authorization response arrives as a GET in query mode, which is what getAuthUrl now
+        // asks for. POST is still accepted so that a deployment already configured for form_post
+        // (tomcat.sameSiteCookies=none) keeps working.
+        final String method = request.getMethod();
+        if (!"GET".equalsIgnoreCase(method) && !"POST".equalsIgnoreCase(method)) {
             return false;
         }
         final Map<String, String[]> params = request.getParameterMap();

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -27,7 +27,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.core.misc.Pair;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
+import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
 import org.junit.jupiter.api.Test;
 
 public class EntraIdAuthenticatorTest extends UnitFessTestCase {
@@ -80,6 +83,80 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
         assertEquals(List.of("0.AXkAau***"), masked.get("Code"));
         assertEquals(List.of("accessto***"), masked.get("ACCESS_TOKEN"));
+    }
+
+    @Test
+    public void test_getAuthUrl_requestsQueryResponseMode() {
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+
+        final String authUrl = authenticator.getAuthUrl(getMockRequest());
+
+        // form_post makes Entra ID reply with a cross-site POST, which does not carry a
+        // SameSite=Lax session cookie -- and Fess sets SameSite=Lax on JSESSIONID by default
+        // (tomcat.sameSiteCookies). Without the session there is no stored state, so the
+        // callback can never be validated. query mode replies with a top-level GET instead.
+        assertTrue(authUrl.contains("response_mode=query"));
+        assertFalse(authUrl.contains("response_mode=form_post"));
+        // The rest of the authorization request is unchanged.
+        assertTrue(authUrl.contains("response_type=code"));
+        assertTrue(authUrl.contains("&state="));
+        assertTrue(authUrl.contains("&nonce="));
+    }
+
+    @Test
+    public void test_getAuthUrl_requestsQueryResponseModeOnV1Endpoint() {
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        authenticator.setUseV2Endpoint(false);
+
+        final String authUrl = authenticator.getAuthUrl(getMockRequest());
+
+        assertTrue(authUrl.contains("response_mode=query"));
+        assertFalse(authUrl.contains("response_mode=form_post"));
+    }
+
+    @Test
+    public void test_containsAuthenticationData_acceptsQueryModeCallback() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        request.setParameter("code", "0.AXkAauthorizationcodevalue");
+        request.setParameter("state", "2b1f5c3e-0000-0000-0000-000000000000");
+
+        assertTrue(authenticator.containsAuthenticationData(request));
+    }
+
+    @Test
+    public void test_containsAuthenticationData_acceptsFormPostCallback() {
+        // An existing deployment that already set tomcat.sameSiteCookies=none keeps working.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("POST");
+        request.setParameter("code", "0.AXkAauthorizationcodevalue");
+
+        assertTrue(authenticator.containsAuthenticationData(request));
+    }
+
+    @Test
+    public void test_containsAuthenticationData_acceptsErrorCallback() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        request.setParameter("error", "access_denied");
+
+        assertTrue(authenticator.containsAuthenticationData(request));
+    }
+
+    @Test
+    public void test_containsAuthenticationData_ignoresRequestWithoutArtifacts() {
+        // A plain visit to /sso must still start a fresh login instead of being treated
+        // as a callback.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+
+        assertFalse(authenticator.containsAuthenticationData(request));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -149,6 +149,20 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getLoginCredential_doesNotRedirectACallbackThatLostItsSession() {
+        // Redirecting a callback that arrived without a session sends the user straight back
+        // here without a session again, which is the infinite loop this change is about.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        request.setParameter("code", "0.AXkAauthorizationcodevalue");
+        request.setParameter("state", "2b1f5c3e-0000-0000-0000-000000000000");
+        assertNull(request.getSession(false));
+
+        assertNull(authenticator.getLoginCredential());
+    }
+
+    @Test
     public void test_containsAuthenticationData_ignoresRequestWithoutArtifacts() {
         // A plain visit to /sso must still start a fresh login instead of being treated
         // as a callback.


### PR DESCRIPTION
## Problem

`getAuthUrl()` asked Entra ID for `response_mode=form_post`:

```java
+ "/oauth2/v2.0/authorize?response_type=code&scope=...&response_mode=form_post&redirect_uri="
```

so the authorization response comes back as a **cross-site POST** from
`login.microsoftonline.com`.

Fess sets `SameSite=Lax` on the session cookie — `tomcat.sameSiteCookies = lax` in
`tomcat_config.properties`, applied to the Tomcat `CookieProcessor` in `FessBoot`. A `Lax`
cookie is not sent on a cross-site POST. And because the attribute is set **explicitly**,
Chrome's two-minute "Lax + POST" grace period does not apply either — that grace period only
covers cookies with no `SameSite` attribute at all.

So on the callback:

1. `request.getSession(false)` returns `null`
2. the stored `state` / `nonce` are unreachable, so the response can never be validated
3. `getLoginCredential()` falls through to `ActionResponseCredential` → redirect to the
   authorization endpoint → **the loop repeats forever**

The default value of `tomcat.sameSiteCookies` was only added recently (#3136). Before that the
attribute was unset, so the grace period kept `form_post` working — this is a regression rather
than a long-standing bug.

## Fix

**Ask for `response_mode=query`.** With `response_type=code` the response is then a top-level
GET navigation, which *does* carry a `Lax` cookie. `query` is also the default response mode for
the authorization code flow, so nothing about the app registration changes — `response_mode` is
chosen by us in the authorization request, not configured on the Entra ID side.

`containsAuthenticationData()` now accepts `GET` as well as `POST`, so a deployment that already
set `tomcat.sameSiteCookies=none` and relies on `form_post` keeps working.

**Stop bouncing a session-less callback back to the IdP.** That is what turned a missing cookie
into an infinite redirect. It now logs a warning naming the likely cause and returns `null`, so
`SsoAction` shows the SSO login error and goes to the login page once.

The comment on `tomcat.sameSiteCookies` said "Lax keeps OAuth/OIDC redirects working", which is
true for redirect-based callbacks but not for POST ones. Reworded to say which setups need
`none` — SAML's HTTP-POST binding has the same constraint.

### On putting the code in the query string

The authorization code is single-use, short-lived, and cannot be redeemed without the client
secret, which is why `query` is the standard mode for a confidential client. #3213 stops the code
being written to the debug log.

## Tests

`EntraIdAuthenticator`'s unit test class, 6 new tests:

- `test_getAuthUrl_requestsQueryResponseMode` / `...OnV1Endpoint` — asserts `response_mode=query`,
  no `form_post`, and that `response_type`, `state` and `nonce` are unchanged
- `test_containsAuthenticationData_acceptsQueryModeCallback` — GET with `code`
- `test_containsAuthenticationData_acceptsFormPostCallback` — POST still accepted
- `test_containsAuthenticationData_acceptsErrorCallback` — GET with `error`
- `test_containsAuthenticationData_ignoresRequestWithoutArtifacts` — a plain visit to `/sso` still
  starts a fresh login

All 4 behavioural ones failed before the change.

```
Tests run: 108, Failures: 0, Errors: 0, Skipped: 0
```

(the whole `org.codelibs.fess.sso` package, including the OIDC and SAML authenticator tests)
