### PR TITLE
fix(sso): correct SPNEGO logging, config fallback and dead settings

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -67,9 +67,6 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
     /** Logger for this class. */
     private static final Logger logger = LogManager.getLogger(SpnegoAuthenticator.class);
 
-    /** Configuration key for directories to exclude from SPNEGO authentication. */
-    protected static final String SPNEGO_EXCLUDE_DIRS = "spnego.exclude.dirs";
-
     /** Configuration key for enabling delegation in SPNEGO authentication. */
     protected static final String SPNEGO_ALLOW_DELEGATION = "spnego.allow.delegation";
 
@@ -110,7 +107,7 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
     protected static final String SPNEGO_LOGGER_LEVEL = "spnego.logger.level";
 
     /** The underlying SPNEGO authenticator instance. */
-    protected org.codelibs.spnego.SpnegoAuthenticator authenticator = null;
+    protected volatile org.codelibs.spnego.SpnegoAuthenticator authenticator = null;
 
     /**
      * Constructs a new SPNEGO authenticator.
@@ -135,7 +132,7 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
      * Releases the SPNEGO server credentials and login context on shutdown.
      */
     @PreDestroy
-    public void destroy() {
+    public synchronized void destroy() {
         if (authenticator != null) {
             try {
                 authenticator.dispose();
@@ -166,11 +163,34 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             // NOTE: The underlying SpnegoFilterConfig is a JVM-wide singleton, so the SPNEGO
             // configuration is effectively cached for the lifetime of the process. Changes to the
             // spnego.* settings therefore require a Fess restart to take effect.
-            final SpnegoFilterConfig config = SpnegoFilterConfig.getInstance(new SpnegoConfig());
+            final SpnegoConfig spnegoConfig = new SpnegoConfig();
+            warnInsecureSettings(spnegoConfig);
+            final SpnegoFilterConfig config = SpnegoFilterConfig.getInstance(spnegoConfig);
             authenticator = new org.codelibs.spnego.SpnegoAuthenticator(config);
             return authenticator;
         } catch (final Exception e) {
             throw new SsoLoginException("Failed to initialize SPNEGO.", e);
+        }
+    }
+
+    /**
+     * Logs a warning for security-sensitive settings that are effectively enabled.
+     *
+     * The coded defaults for these settings are secure, but they only apply when the key is absent
+     * from the system properties. An instance that stored the old, permissive values before the
+     * defaults were hardened keeps using them silently, so surface them at initialization time.
+     *
+     * @param config the resolved SPNEGO configuration
+     */
+    protected void warnInsecureSettings(final SpnegoConfig config) {
+        if (Boolean.parseBoolean(config.getInitParameter(Constants.ALLOW_LOCALHOST))) {
+            logger.warn("spnego.allow.localhost=true: same-host requests are authenticated as the server OS user "
+                    + "without any Kerberos verification. Set it to false unless you fully understand the risk.");
+        }
+        if (Boolean.parseBoolean(config.getInitParameter(Constants.ALLOW_BASIC))
+                && Boolean.parseBoolean(config.getInitParameter(Constants.ALLOW_UNSEC_BASIC))) {
+            logger.warn(
+                    "spnego.allow.unsecure.basic=true: basic credentials may be sent over plain HTTP. " + "Set it to false and use HTTPS.");
         }
     }
 
@@ -203,16 +223,7 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                     logger.debug("principal={}", principal);
                 }
             } catch (final Exception e) {
-                final String authzHeader = request.getHeader(Constants.AUTHZ_HEADER);
-                final String maskedHeader;
-                if (authzHeader == null) {
-                    maskedHeader = "null";
-                } else if (authzHeader.length() <= 10) {
-                    maskedHeader = "***";
-                } else {
-                    maskedHeader = authzHeader.substring(0, 10) + "***";
-                }
-                final String msg = "Failed to process Authorization Header: " + maskedHeader;
+                final String msg = "Failed to process Authorization Header: " + maskAuthzHeader(request.getHeader(Constants.AUTHZ_HEADER));
                 if (logger.isDebugEnabled()) {
                     logger.debug(msg);
                 }
@@ -225,9 +236,12 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 logger.debug("isStatusSet={}", status);
             }
             if (status) {
+                // The library has already written and flushed the 401 with its WWW-Authenticate header,
+                // so this exception only unwinds the action. Log it at debug level to keep the normal
+                // SPNEGO handshake out of the application log.
                 return new ActionResponseCredential(() -> {
                     throw new RequestLoggingFilter.RequestClientErrorException("Your request is not authorized.", "401 Unauthorized",
-                            HttpServletResponse.SC_UNAUTHORIZED);
+                            HttpServletResponse.SC_UNAUTHORIZED).asLogging(RequestLoggingFilter.DelicateErrorLoggingLevel.DEBUG);
                 });
             }
 
@@ -250,6 +264,26 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             return new SpnegoCredential(username[0]);
         }).orElse(null);
 
+    }
+
+    /**
+     * Masks an Authorization header so that only its authentication scheme remains.
+     *
+     * The credential part must never reach the log: a Basic token carries the user name and the
+     * password, and even a short prefix of it decodes back to readable characters.
+     *
+     * @param authzHeader the raw Authorization header value (may be null)
+     * @return the scheme followed by a mask, or "null" when the header is absent
+     */
+    protected static String maskAuthzHeader(final String authzHeader) {
+        if (authzHeader == null) {
+            return "null";
+        }
+        final int index = authzHeader.indexOf(' ');
+        if (index <= 0) {
+            return "***";
+        }
+        return authzHeader.substring(0, index) + " ***";
     }
 
     /**
@@ -287,7 +321,7 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
          */
         @Override
         public ServletContext getServletContext() {
-            throw new UnsupportedOperationException("getServletContext() is not supported in SpnegoFilterConfig");
+            throw new UnsupportedOperationException("getServletContext() is not supported in SpnegoConfig");
         }
 
         /**
@@ -319,10 +353,9 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 if (logger.isWarnEnabled()) {
                     return "6";
                 }
-                if (logger.isErrorEnabled()) {
-                    return "7";
-                }
-                return "0";
+                // The library maps every unknown level (including "0") to INFO, so "7" (SEVERE) is
+                // the quietest setting it actually understands.
+                return "7";
             }
             if (SpnegoHttpFilter.Constants.LOGIN_CONF.equals(name)) {
                 return getResourcePath(getProperty(SPNEGO_LOGIN_CONF, "auth_login.conf"));
@@ -368,21 +401,30 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             if (SpnegoHttpFilter.Constants.ALLOW_DELEGATION.equals(name)) {
                 return getProperty(SPNEGO_ALLOW_DELEGATION, "false");
             }
-            if (SpnegoHttpFilter.Constants.EXCLUDE_DIRS.equals(name)) {
-                return getProperty(SPNEGO_EXCLUDE_DIRS, StringUtil.EMPTY);
-            }
+            // NOTE: spnego.exclude.dirs is deliberately not mapped. Only SpnegoHttpFilter consumes it,
+            // and Fess calls SpnegoAuthenticator#authenticate directly instead of installing that
+            // filter, so honoring the key here would advertise an exclusion that never happens.
             return null;
         }
 
         /**
          * Gets a system property value with a default fallback.
          *
+         * A blank value is treated as unset. The admin screen writes every spnego.* key on save, so
+         * clearing an input field stores an empty string rather than removing the key, and passing
+         * that empty string down to the library turns a simple misconfiguration into an opaque
+         * initialization failure.
+         *
          * @param key The property key to look up
-         * @param defaultValue The default value to return if the property is not set
+         * @param defaultValue The default value to return if the property is not set or blank
          * @return The property value or the default value
          */
         protected String getProperty(final String key, final String defaultValue) {
-            return ComponentUtil.getSystemProperties().getProperty(key, defaultValue);
+            final String value = ComponentUtil.getSystemProperties().getProperty(key);
+            if (StringUtil.isBlank(value)) {
+                return defaultValue;
+            }
+            return value;
         }
 
         /**
@@ -408,7 +450,7 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
          */
         @Override
         public Enumeration<String> getInitParameterNames() {
-            throw new UnsupportedOperationException("getInitParameterNames() is not supported in SpnegoFilterConfig");
+            throw new UnsupportedOperationException("getInitParameterNames() is not supported in SpnegoConfig");
         }
 
     }

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
@@ -38,6 +38,8 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
         final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
         systemProperties.remove("spnego.logger.level");
         systemProperties.remove("spnego.allowed.realms");
+        systemProperties.remove("spnego.login.client.module");
+        systemProperties.remove("spnego.exclude.dirs");
         super.tearDown(testInfo);
     }
 
@@ -158,15 +160,53 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_constantsExist() {
-        // Verify all expected configuration constants are defined
-        SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
+    public void test_getProperty_blankFallsBackToDefault() {
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            // The admin screen stores an empty string when an input is cleared, so a present but
+            // blank key must behave like an absent one instead of reaching the library as "".
+            systemProperties.setProperty("spnego.login.client.module", "");
+            assertEquals("spnego-client", config.getInitParameter(Constants.CLIENT_MODULE));
 
-        // These constants should be accessible (would fail at compile time if not)
-        assertTrue(SpnegoAuthenticator.class.getName().contains("SpnegoAuthenticator"));
+            systemProperties.setProperty("spnego.login.client.module", "   ");
+            assertEquals("spnego-client", config.getInitParameter(Constants.CLIENT_MODULE));
 
-        // Verify authenticator is properly named (no typo)
-        assertEquals("SpnegoAuthenticator", SpnegoAuthenticator.class.getSimpleName());
+            // A real value is still passed through.
+            systemProperties.setProperty("spnego.login.client.module", "custom-client");
+            assertEquals("custom-client", config.getInitParameter(Constants.CLIENT_MODULE));
+        } finally {
+            systemProperties.remove("spnego.login.client.module");
+        }
+    }
+
+    @Test
+    public void test_getInitParameter_excludeDirsIsNotMapped() {
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            // spnego.exclude.dirs is only honored by SpnegoHttpFilter, which Fess does not install,
+            // so the value must not be forwarded as if the exclusion were effective.
+            systemProperties.setProperty("spnego.exclude.dirs", "/api/");
+            assertNull(config.getInitParameter(Constants.EXCLUDE_DIRS));
+        } finally {
+            systemProperties.remove("spnego.exclude.dirs");
+        }
+    }
+
+    @Test
+    public void test_maskAuthzHeader() {
+        // Absent header.
+        assertEquals("null", SpnegoAuthenticator.maskAuthzHeader(null));
+        // Negotiate token must be reduced to its scheme.
+        assertEquals("Negotiate ***", SpnegoAuthenticator.maskAuthzHeader("Negotiate YIIFxQYGKwYBBQUCoIIFuTCCBbW"));
+        // Basic credentials must not leak: even four base64 characters decode to three plain bytes
+        // of "user:password".
+        assertEquals("Basic ***", SpnegoAuthenticator.maskAuthzHeader("Basic dXNlcjpwYXNzd29yZA=="));
+        // A header without a scheme separator is fully masked.
+        assertEquals("***", SpnegoAuthenticator.maskAuthzHeader("dXNlcjpwYXNzd29yZA=="));
+        assertEquals("***", SpnegoAuthenticator.maskAuthzHeader(""));
+        assertEquals("***", SpnegoAuthenticator.maskAuthzHeader(" leading-space"));
     }
 
     @Test
@@ -191,18 +231,13 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_innerClassNaming() {
-        // Verify the inner SpnegoConfig class exists and is properly named
-        // This test ensures the typo fix (SpengoConfig -> SpnegoConfig) is correct
-        try {
-            Class<?> configClass = Class.forName("org.codelibs.fess.sso.spnego.SpnegoAuthenticator$SpnegoConfig");
-            assertNotNull(configClass);
-            assertEquals("SpnegoConfig", configClass.getSimpleName());
-
-            // Verify it's a static inner class
-            assertTrue(java.lang.reflect.Modifier.isStatic(configClass.getModifiers()));
-        } catch (ClassNotFoundException e) {
-            fail("SpnegoConfig inner class should exist");
-        }
+    public void test_unsupportedOperations() {
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        // These two FilterConfig methods are never called by the library; make sure they fail loudly
+        // and name the class that actually threw.
+        UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, () -> config.getServletContext());
+        assertTrue(e.getMessage().contains("SpnegoConfig"));
+        e = assertThrows(UnsupportedOperationException.class, () -> config.getInitParameterNames());
+        assertTrue(e.getMessage().contains("SpnegoConfig"));
     }
 }


### PR DESCRIPTION
## Summary

Defects found while auditing `org.codelibs.fess.sso.spnego` against the underlying `org.codelibs:spnego` library. All of them are self-contained fixes in `SpnegoAuthenticator`; no behavior that a working SPNEGO deployment depends on is changed.

## Changes

### Credential prefix leaks through the Authorization-header mask

The mask kept the first 10 characters of the header. `"Negotiate "` is exactly 10 characters, so a Negotiate token was masked correctly — but `"Basic dXNl"` retains four base64 characters, which decode to the first three plain bytes of `user:password`, i.e. the first three characters of the user name. `SsoAction#index` logs this message at **WARN**.

Now masked to the scheme token only: `Basic ***`, `Negotiate ***`.

### A blank spnego.* property is no longer passed through as ""

`Properties#getProperty(key, default)` returns `""` for a key that is present but empty, not the default. `AdminGeneralAction#doUpdate` writes every `spnego.*` key on save, so clearing an input field in **System → General** persists an empty string. That empty string then reached the library, and for the file-path keys it surfaced as `EmptyArgumentException` swallowed into the generic `"Failed to initialize SPNEGO."` — losing the specific "configuration file not found" message.

`SpnegoConfig#getProperty` now treats blank as unset.

### spnego.exclude.dirs is no longer advertised

`excludeDirs` is consumed only by `SpnegoHttpFilter`. Fess does not install that filter — it calls `SpnegoAuthenticator#authenticate` directly from `getLoginCredential` — so an operator listing `/api/` got no exclusion and no warning. The constant and the mapping are removed; the docs are updated separately in codelibs/fess-docs.

### spnego.logger.level "0" raised the level instead of silencing it

The library's `setLogLevel` switch has cases for 1/2/3/4/6/7 and `default: Level.INFO` — no case for `0`. `getInitParameter` returned `"0"` when none of the Log4j levels were enabled, so the branch intended to silence the library set it to INFO. It now returns `"7"` (SEVERE), the quietest level the switch actually understands.

### The 401 challenge no longer logs on the normal path

The library's `SpnegoHttpServletResponse#setStatus(401, true)` sets content-length 0 and **flushes**, so the response is already committed when `RequestClientErrorException` is thrown. LastaFlute's `handleClientError` sees `beforeHandlingCommitted == true` and logs `*Cannot send error as '401 ...' because of already committed` at INFO — on **every** SPNEGO handshake, i.e. on the normal login path.

Functionally harmless (LastaFlute guards `isCommitted()`), so this keeps the existing control flow and just marks the exception `.asLogging(DelicateErrorLoggingLevel.DEBUG)`. Returning `ActionResponse.undefined()` instead would be cleaner still, but that changes the response path and is left as a follow-up.

### Warn when the permissive settings are actually in effect

`spnego.allow.localhost` and `spnego.allow.unsecure.basic` were hardened to `false`, but a coded default only applies when the key is **absent**. `FessProp#setSystemProperty` removes a key only on `null`, and the admin screen always writes a concrete `"true"`/`"false"`. An instance where an admin saved **System → General** before the hardening therefore has `spnego.allow.localhost=true` persisted in `system.properties`, and the new default never fires.

`warnInsecureSettings` now logs a WARN at initialization for both, so the condition is visible in the log instead of silent.

### Lifecycle and message fixes

- `authenticator` is `volatile` and `destroy()` is `synchronized`. `getAuthenticator()` holds the monitor, but `@PreDestroy destroy()` read and cleared the same field without it.
- The two `UnsupportedOperationException` messages said "not supported in **SpnegoFilterConfig**"; the class that throws them is `SpnegoConfig`.

## Tests

`SpnegoAuthenticatorTest`: **Tests run: 17, Failures: 0, Errors: 0**.

Two tautological tests are replaced (`test_constantsExist` and `test_innerClassNaming` asserted that `SpnegoAuthenticator.class.getSimpleName()` equals `"SpnegoAuthenticator"`). New coverage: the header mask across null / Negotiate / Basic / no-separator inputs, the blank-property fallback, the `exclude.dirs` mapping, and the exception messages.

## Not included

- Documentation corrections (default-value table, `krb5.conf` encryption types, `spnego.allowed.realms`) — codelibs/fess-docs.
- Admin-screen validation and the `spnego.allowed.realms` field — separate PR.
