### PR TITLE
fix(sso): derive SAML SP URLs per request and ignore blank overrides

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -183,49 +183,52 @@ public class SamlAuthenticator implements SsoAuthenticator {
             logger.debug("Initializing {}", this.getClass().getSimpleName());
         }
         ComponentUtil.getSsoManager().register(this);
+        defaultSettings = createDefaultSettings();
+    }
 
-        // Default SAML settings
-        // NOTE: Many security settings are set to false by default for compatibility.
-        // For production use, it is STRONGLY RECOMMENDED to enable security features:
-        // - onelogin.saml2.security.authnrequest_signed
-        // - onelogin.saml2.security.want_messages_signed
-        // - onelogin.saml2.security.want_assertions_signed
-        // Override these settings in your system properties with the 'saml.' prefix.
-        defaultSettings = new HashMap<>();
-        defaultSettings.put("onelogin.saml2.strict", "true");
-        defaultSettings.put("onelogin.saml2.debug", "false");
-        defaultSettings.put("onelogin.saml2.sp.entityid", buildDefaultUrl("/sso/metadata"));
-        defaultSettings.put("onelogin.saml2.sp.assertion_consumer_service.url", buildDefaultUrl("/sso/"));
-        defaultSettings.put("onelogin.saml2.sp.assertion_consumer_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST");
-        defaultSettings.put("onelogin.saml2.sp.single_logout_service.url", buildDefaultUrl("/sso/logout"));
-        defaultSettings.put("onelogin.saml2.sp.single_logout_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
-        defaultSettings.put("onelogin.saml2.sp.nameidformat", "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
-        defaultSettings.put("onelogin.saml2.sp.x509cert", "");
-        defaultSettings.put("onelogin.saml2.sp.privatekey", "");
-        defaultSettings.put("onelogin.saml2.idp.single_sign_on_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
-        defaultSettings.put("onelogin.saml2.idp.single_logout_service.response.url", "");
-        defaultSettings.put("onelogin.saml2.idp.single_logout_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
-        defaultSettings.put("onelogin.saml2.security.nameid_encrypted", "false");
-        defaultSettings.put("onelogin.saml2.security.authnrequest_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.logoutrequest_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.logoutresponse_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.want_messages_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.want_assertions_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.sign_metadata", "");
-        defaultSettings.put("onelogin.saml2.security.want_assertions_encrypted", "false");
-        defaultSettings.put("onelogin.saml2.security.want_nameid_encrypted", "false");
-        defaultSettings.put("onelogin.saml2.security.requested_authncontext", "urn:oasis:names:tc:SAML:2.0:ac:classes:Password");
-        defaultSettings.put("onelogin.saml2.security.onelogin.saml2.security.requested_authncontextcomparison", "exact");
-        defaultSettings.put("onelogin.saml2.security.want_xml_validation", "true");
-        defaultSettings.put("onelogin.saml2.security.signature_algorithm", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
-        defaultSettings.put("onelogin.saml2.organization.name", "CodeLibs");
-        defaultSettings.put("onelogin.saml2.organization.displayname", "Fess");
-        defaultSettings.put("onelogin.saml2.organization.url", "https://fess.codelibs.org/");
-        defaultSettings.put("onelogin.saml2.organization.lang", "");
-        defaultSettings.put("onelogin.saml2.contacts.technical.given_name", "Technical Guy");
-        defaultSettings.put("onelogin.saml2.contacts.technical.email_address", "technical@example.com");
-        defaultSettings.put("onelogin.saml2.contacts.support.given_name", "Support Guy");
-        defaultSettings.put("onelogin.saml2.contacts.support.email_address", "support@example.com");
+    /**
+     * Creates the settings that are applied before the {@code saml.} system properties.
+     *
+     * <p>NOTE: Many security settings are set to false for compatibility.
+     * For production use, it is STRONGLY RECOMMENDED to enable security features:
+     * {@code saml.security.authnrequest_signed}, {@code saml.security.want_messages_signed}
+     * and {@code saml.security.want_assertions_signed}.</p>
+     *
+     * <p>The SP endpoint URLs are not included here because they are derived from
+     * {@code saml.sp.base.url}, which can be changed at runtime. They are built by
+     * {@link #getSettings()} on every call.</p>
+     *
+     * @return The default settings.
+     */
+    protected Map<String, Object> createDefaultSettings() {
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put("onelogin.saml2.strict", "true");
+        settings.put("onelogin.saml2.debug", "false");
+        settings.put("onelogin.saml2.sp.assertion_consumer_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST");
+        settings.put("onelogin.saml2.sp.single_logout_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
+        settings.put("onelogin.saml2.sp.nameidformat", "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
+        settings.put("onelogin.saml2.idp.single_sign_on_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
+        settings.put("onelogin.saml2.idp.single_logout_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
+        settings.put("onelogin.saml2.security.nameid_encrypted", "false");
+        settings.put("onelogin.saml2.security.authnrequest_signed", "false");
+        settings.put("onelogin.saml2.security.logoutrequest_signed", "false");
+        settings.put("onelogin.saml2.security.logoutresponse_signed", "false");
+        settings.put("onelogin.saml2.security.want_messages_signed", "false");
+        settings.put("onelogin.saml2.security.want_assertions_signed", "false");
+        settings.put("onelogin.saml2.security.want_assertions_encrypted", "false");
+        settings.put("onelogin.saml2.security.want_nameid_encrypted", "false");
+        settings.put("onelogin.saml2.security.requested_authncontext", "urn:oasis:names:tc:SAML:2.0:ac:classes:Password");
+        settings.put("onelogin.saml2.security.requested_authncontextcomparison", "exact");
+        settings.put("onelogin.saml2.security.want_xml_validation", "true");
+        settings.put("onelogin.saml2.security.signature_algorithm", "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
+        settings.put("onelogin.saml2.organization.name", "CodeLibs");
+        settings.put("onelogin.saml2.organization.displayname", "Fess");
+        settings.put("onelogin.saml2.organization.url", "https://fess.codelibs.org/");
+        settings.put("onelogin.saml2.contacts.technical.given_name", "Technical Guy");
+        settings.put("onelogin.saml2.contacts.technical.email_address", "technical@example.com");
+        settings.put("onelogin.saml2.contacts.support.given_name", "Support Guy");
+        settings.put("onelogin.saml2.contacts.support.email_address", "support@example.com");
+        return settings;
     }
 
     /**
@@ -254,13 +257,22 @@ public class SamlAuthenticator implements SsoAuthenticator {
      */
     protected Saml2Settings getSettings() {
         final Map<String, Object> params = new HashMap<>(defaultSettings);
+        // built on every call because saml.sp.base.url can be changed at runtime
+        params.put("onelogin.saml2.sp.entityid", buildDefaultUrl("/sso/metadata"));
+        params.put("onelogin.saml2.sp.assertion_consumer_service.url", buildDefaultUrl("/sso/"));
+        params.put("onelogin.saml2.sp.single_logout_service.url", buildDefaultUrl("/sso/logout"));
         final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
         systemProperties.entrySet().stream().forEach(e -> {
             final String key = e.getKey().toString();
             if (!key.startsWith(SAML_PREFIX)) {
                 return;
             }
-            params.put("onelogin.saml2." + key.substring(SAML_PREFIX.length()), e.getValue());
+            final Object value = e.getValue();
+            if (value instanceof final String s && StringUtil.isBlank(s)) {
+                // a blank property must not wipe out the default above
+                return;
+            }
+            params.put("onelogin.saml2." + key.substring(SAML_PREFIX.length()), value);
         });
         final Saml2Settings settings = new SettingsBuilder().fromValues(params).build();
         settings.setReplayCache(replayCache);

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -16,383 +16,177 @@
 package org.codelibs.fess.sso.saml;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Map;
 
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 public class SamlAuthenticatorTest extends UnitFessTestCase {
 
-    @Override
-    protected void setUp(TestInfo testInfo) throws Exception {
-        super.setUp(testInfo);
-    }
-
-    @Override
-    protected void tearDown(TestInfo testInfo) throws Exception {
-        super.tearDown(testInfo);
-    }
+    private static final String BASE_URL_KEY = "saml.sp.base.url";
 
     /**
-     * Helper method to initialize defaultSettings without calling init()
-     * which requires DI container components
+     * Builds an authenticator whose defaultSettings come from the production code.
+     * init() is not usable here because it registers the instance with the SsoManager.
      */
-    private Map<String, Object> createDefaultSettings() throws Exception {
-        Map<String, Object> defaultSettings = new HashMap<>();
-        defaultSettings.put("onelogin.saml2.strict", "true");
-        defaultSettings.put("onelogin.saml2.debug", "false");
-
-        // Build default URLs using localhost (matching the new implementation)
-        String baseUrl = "http://localhost:8080";
-
-        defaultSettings.put("onelogin.saml2.sp.entityid", baseUrl + "/sso/metadata");
-        defaultSettings.put("onelogin.saml2.sp.assertion_consumer_service.url", baseUrl + "/sso/");
-        defaultSettings.put("onelogin.saml2.sp.assertion_consumer_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST");
-        defaultSettings.put("onelogin.saml2.sp.single_logout_service.url", baseUrl + "/sso/logout");
-        defaultSettings.put("onelogin.saml2.sp.single_logout_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
-        defaultSettings.put("onelogin.saml2.sp.nameidformat", "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
-        defaultSettings.put("onelogin.saml2.sp.x509cert", "");
-        defaultSettings.put("onelogin.saml2.sp.privatekey", "");
-        defaultSettings.put("onelogin.saml2.idp.single_sign_on_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
-        defaultSettings.put("onelogin.saml2.idp.single_logout_service.response.url", "");
-        defaultSettings.put("onelogin.saml2.idp.single_logout_service.binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
-        defaultSettings.put("onelogin.saml2.security.nameid_encrypted", "false");
-        defaultSettings.put("onelogin.saml2.security.authnrequest_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.logoutrequest_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.logoutresponse_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.want_messages_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.want_assertions_signed", "false");
-        defaultSettings.put("onelogin.saml2.security.sign_metadata", "");
-        defaultSettings.put("onelogin.saml2.security.want_assertions_encrypted", "false");
-        defaultSettings.put("onelogin.saml2.security.want_nameid_encrypted", "false");
-        defaultSettings.put("onelogin.saml2.security.requested_authncontext", "urn:oasis:names:tc:SAML:2.0:ac:classes:Password");
-        defaultSettings.put("onelogin.saml2.security.onelogin.saml2.security.requested_authncontextcomparison", "exact");
-        defaultSettings.put("onelogin.saml2.security.want_xml_validation", "true");
-        defaultSettings.put("onelogin.saml2.security.signature_algorithm", "http://www.w3.org/2000/09/xmldsig#rsa-sha1");
-        defaultSettings.put("onelogin.saml2.organization.name", "CodeLibs");
-        defaultSettings.put("onelogin.saml2.organization.displayname", "Fess");
-        defaultSettings.put("onelogin.saml2.organization.url", "https://fess.codelibs.org/");
-        defaultSettings.put("onelogin.saml2.organization.lang", "");
-        defaultSettings.put("onelogin.saml2.contacts.technical.given_name", "Technical Guy");
-        defaultSettings.put("onelogin.saml2.contacts.technical.email_address", "technical@example.com");
-        defaultSettings.put("onelogin.saml2.contacts.support.given_name", "Support Guy");
-        defaultSettings.put("onelogin.saml2.contacts.support.email_address", "support@example.com");
-
-        return defaultSettings;
+    private SamlAuthenticator createAuthenticator() throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        final Field field = SamlAuthenticator.class.getDeclaredField("defaultSettings");
+        field.setAccessible(true);
+        field.set(authenticator, authenticator.createDefaultSettings());
+        return authenticator;
     }
 
-    /**
-     * Helper method to set defaultSettings on an authenticator instance
-     */
-    private void setDefaultSettings(SamlAuthenticator authenticator, Map<String, Object> settings) throws Exception {
-        Field defaultSettingsField = SamlAuthenticator.class.getDeclaredField("defaultSettings");
-        defaultSettingsField.setAccessible(true);
-        defaultSettingsField.set(authenticator, settings);
+    @Test
+    public void test_createDefaultSettings_security() throws Exception {
+        final Map<String, Object> settings = new SamlAuthenticator().createDefaultSettings();
+
+        assertEquals("true", settings.get("onelogin.saml2.strict"));
+        assertEquals("false", settings.get("onelogin.saml2.debug"));
+        assertEquals("true", settings.get("onelogin.saml2.security.want_xml_validation"));
+        assertEquals("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", settings.get("onelogin.saml2.security.signature_algorithm"));
+        // the key must not carry a duplicated prefix, otherwise it is silently ignored
+        assertEquals("exact", settings.get("onelogin.saml2.security.requested_authncontextcomparison"));
+    }
+
+    @Test
+    public void test_createDefaultSettings_hasNoBlankValues() throws Exception {
+        // SettingsBuilder treats blank values as absent, so a blank default is dead weight
+        new SamlAuthenticator().createDefaultSettings().forEach((key, value) -> {
+            assertTrue(key + " must not have a blank default", StringUtil.isNotBlank((String) value));
+        });
+    }
+
+    @Test
+    public void test_createDefaultSettings_omitsSpUrls() throws Exception {
+        // SP URLs depend on saml.sp.base.url and are therefore built per request
+        final Map<String, Object> settings = new SamlAuthenticator().createDefaultSettings();
+
+        assertFalse(settings.containsKey("onelogin.saml2.sp.entityid"));
+        assertFalse(settings.containsKey("onelogin.saml2.sp.assertion_consumer_service.url"));
+        assertFalse(settings.containsKey("onelogin.saml2.sp.single_logout_service.url"));
+    }
+
+    @Test
+    public void test_getSettings_spUrlsUseDefaultBaseUrl() throws Exception {
+        final Saml2Settings settings = createAuthenticator().getSettings();
+
+        assertEquals("http://localhost:8080/sso/metadata", settings.getSpEntityId());
+        assertEquals("http://localhost:8080/sso/", settings.getSpAssertionConsumerServiceUrl().toString());
+        assertEquals("http://localhost:8080/sso/logout", settings.getSpSingleLogoutServiceUrl().toString());
+    }
+
+    @Test
+    public void test_getSettings_spUrlsFollowBaseUrlChangedAfterStartup() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            // the property is changed after the authenticator was built, as the admin UI does
+            systemProperties.setProperty(BASE_URL_KEY, "https://fess.example.com");
+
+            final Saml2Settings settings = authenticator.getSettings();
+
+            assertEquals("https://fess.example.com/sso/metadata", settings.getSpEntityId());
+            assertEquals("https://fess.example.com/sso/", settings.getSpAssertionConsumerServiceUrl().toString());
+            assertEquals("https://fess.example.com/sso/logout", settings.getSpSingleLogoutServiceUrl().toString());
+        } finally {
+            systemProperties.remove(BASE_URL_KEY);
+        }
+    }
+
+    @Test
+    public void test_getSettings_blankPropertyKeepsDefault() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            systemProperties.setProperty("saml.sp.entityid", StringUtil.EMPTY);
+            systemProperties.setProperty("saml.sp.assertion_consumer_service.url", "  ");
+
+            final Saml2Settings settings = authenticator.getSettings();
+
+            assertEquals("http://localhost:8080/sso/metadata", settings.getSpEntityId());
+            assertEquals("http://localhost:8080/sso/", settings.getSpAssertionConsumerServiceUrl().toString());
+            assertTrue(settings.checkSPSettings().isEmpty());
+        } finally {
+            systemProperties.remove("saml.sp.entityid");
+            systemProperties.remove("saml.sp.assertion_consumer_service.url");
+        }
+    }
+
+    @Test
+    public void test_getSettings_propertyOverridesDefault() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            systemProperties.setProperty("saml.sp.entityid", "https://sp.example.com/metadata");
+            systemProperties.setProperty("saml.security.want_assertions_signed", "true");
+
+            final Saml2Settings settings = authenticator.getSettings();
+
+            assertEquals("https://sp.example.com/metadata", settings.getSpEntityId());
+            assertTrue(settings.getWantAssertionsSigned());
+        } finally {
+            systemProperties.remove("saml.sp.entityid");
+            systemProperties.remove("saml.security.want_assertions_signed");
+        }
     }
 
     @Test
     public void test_getSettings_sharesReplayCacheAcrossRequests() throws Exception {
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-        setDefaultSettings(authenticator, createDefaultSettings());
+        final SamlAuthenticator authenticator = createAuthenticator();
 
-        Saml2Settings first = authenticator.getSettings();
-        Saml2Settings second = authenticator.getSettings();
+        final Saml2Settings first = authenticator.getSettings();
+        final Saml2Settings second = authenticator.getSettings();
 
         assertNotNull(first.getReplayCache());
         assertSame(first.getReplayCache(), second.getReplayCache());
     }
 
     @Test
-    public void test_authenticatorInstantiation() {
-        // Verify authenticator can be instantiated without errors
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-        assertNotNull(authenticator);
-    }
-
-    @Test
-    public void test_defaultSettings_emailAddressCorrect() throws Exception {
-        // Test that the email typo fix is correct: support@@example.com -> support@example.com
-        Map<String, Object> defaultSettings = createDefaultSettings();
-
-        // Verify email addresses are correctly formatted (no double @)
-        String technicalEmail = (String) defaultSettings.get("onelogin.saml2.contacts.technical.email_address");
-        String supportEmail = (String) defaultSettings.get("onelogin.saml2.contacts.support.email_address");
-
-        assertNotNull(technicalEmail);
-        assertNotNull(supportEmail);
-
-        // Verify no double @ signs
-        assertFalse("Technical email should not contain @@", technicalEmail.contains("@@"));
-        assertFalse("Support email should not contain @@", supportEmail.contains("@@"));
-
-        // Verify correct email format
-        assertEquals("technical@example.com", technicalEmail);
-        assertEquals("support@example.com", supportEmail);
-
-        // Count @ occurrences - should be exactly 1
-        assertEquals(1, technicalEmail.chars().filter(ch -> ch == '@').count());
-        assertEquals(1, supportEmail.chars().filter(ch -> ch == '@').count());
-    }
-
-    @Test
-    public void test_defaultSettings_securityConfiguration() throws Exception {
-        // Verify security settings are properly configured with appropriate defaults
-        Map<String, Object> defaultSettings = createDefaultSettings();
-
-        // Verify strict mode is enabled by default (good security practice)
-        assertEquals("true", defaultSettings.get("onelogin.saml2.strict"));
-
-        // Verify debug is disabled by default (good security practice)
-        assertEquals("false", defaultSettings.get("onelogin.saml2.debug"));
-
-        // Verify all security-related settings exist (they are set to false for compatibility,
-        // but users should be able to override them via system properties)
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.nameid_encrypted"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.authnrequest_signed"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.logoutrequest_signed"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.logoutresponse_signed"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.want_messages_signed"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.want_assertions_signed"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.want_assertions_encrypted"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.want_nameid_encrypted"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.security.want_xml_validation"));
-    }
-
-    @Test
-    public void test_defaultSettings_organizationInfo() throws Exception {
-        Map<String, Object> defaultSettings = createDefaultSettings();
-
-        // Verify organization information is set
-        assertEquals("CodeLibs", defaultSettings.get("onelogin.saml2.organization.name"));
-        assertEquals("Fess", defaultSettings.get("onelogin.saml2.organization.displayname"));
-        assertEquals("https://fess.codelibs.org/", defaultSettings.get("onelogin.saml2.organization.url"));
-    }
-
-    @Test
-    public void test_defaultSettings_serviceProviderConfig() throws Exception {
-        Map<String, Object> defaultSettings = createDefaultSettings();
-
-        // Verify SP endpoints are configured
-        assertNotNull(defaultSettings.get("onelogin.saml2.sp.entityid"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.sp.assertion_consumer_service.url"));
-        assertNotNull(defaultSettings.get("onelogin.saml2.sp.single_logout_service.url"));
-
-        // Verify bindings are set
-        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                defaultSettings.get("onelogin.saml2.sp.assertion_consumer_service.binding"));
-        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                defaultSettings.get("onelogin.saml2.sp.single_logout_service.binding"));
-
-        // Verify NameID format
-        assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", defaultSettings.get("onelogin.saml2.sp.nameidformat"));
-    }
-
-    @Test
     public void test_buildDefaultUrl_withDefaultBaseUrl() throws Exception {
-        // Test that buildDefaultUrl returns http://localhost:8080 when no property is set
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-
-        // Ensure the property is not set
-        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
-        systemProperties.remove("saml.sp.base.url");
-
-        // Use reflection to access protected method
-        Method buildDefaultUrlMethod = SamlAuthenticator.class.getDeclaredMethod("buildDefaultUrl", String.class);
-        buildDefaultUrlMethod.setAccessible(true);
-
-        String url = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/metadata");
-
-        // Verify URL uses default localhost:8080
-        assertNotNull(url);
-        assertEquals("http://localhost:8080/sso/metadata", url);
+        assertEquals("http://localhost:8080/sso/metadata", new SamlAuthenticator().buildDefaultUrl("/sso/metadata"));
     }
 
     @Test
     public void test_buildDefaultUrl_withCustomBaseUrl() throws Exception {
-        // Test that buildDefaultUrl uses custom base URL from property
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-
-        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
         try {
-            // Set custom base URL
-            systemProperties.setProperty("saml.sp.base.url", "https://fess.example.com");
+            systemProperties.setProperty(BASE_URL_KEY, "https://fess.example.com:8443");
 
-            Method buildDefaultUrlMethod = SamlAuthenticator.class.getDeclaredMethod("buildDefaultUrl", String.class);
-            buildDefaultUrlMethod.setAccessible(true);
-
-            String url = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/metadata");
-
-            // Verify URL uses custom base URL
-            assertNotNull(url);
-            assertEquals("https://fess.example.com/sso/metadata", url);
+            assertEquals("https://fess.example.com:8443/sso/metadata", authenticator.buildDefaultUrl("/sso/metadata"));
         } finally {
-            // Clean up
-            systemProperties.remove("saml.sp.base.url");
+            systemProperties.remove(BASE_URL_KEY);
         }
     }
 
     @Test
     public void test_buildDefaultUrl_withTrailingSlash() throws Exception {
-        // Test that trailing slash is handled correctly
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-
-        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
         try {
-            // Set custom base URL with trailing slash
-            systemProperties.setProperty("saml.sp.base.url", "https://fess.example.com/");
+            systemProperties.setProperty(BASE_URL_KEY, "https://fess.example.com/");
 
-            Method buildDefaultUrlMethod = SamlAuthenticator.class.getDeclaredMethod("buildDefaultUrl", String.class);
-            buildDefaultUrlMethod.setAccessible(true);
-
-            String url = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/metadata");
-
-            // Verify trailing slash is removed and URL is correct
-            assertNotNull(url);
-            assertEquals("https://fess.example.com/sso/metadata", url);
+            assertEquals("https://fess.example.com/sso/", authenticator.buildDefaultUrl("/sso/"));
         } finally {
-            // Clean up
-            systemProperties.remove("saml.sp.base.url");
+            systemProperties.remove(BASE_URL_KEY);
         }
     }
 
     @Test
-    public void test_buildDefaultUrl_withPortInCustomUrl() throws Exception {
-        // Test that custom URL with port is handled correctly
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-
-        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+    public void test_buildDefaultUrl_withBlankProperty() throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
         try {
-            // Set custom base URL with port
-            systemProperties.setProperty("saml.sp.base.url", "http://127.0.0.1:9080");
+            systemProperties.setProperty(BASE_URL_KEY, "   ");
 
-            Method buildDefaultUrlMethod = SamlAuthenticator.class.getDeclaredMethod("buildDefaultUrl", String.class);
-            buildDefaultUrlMethod.setAccessible(true);
-
-            String url = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/metadata");
-
-            // Verify URL uses custom base URL with port
-            assertNotNull(url);
-            assertEquals("http://127.0.0.1:9080/sso/metadata", url);
+            assertEquals("http://localhost:8080/sso/logout", authenticator.buildDefaultUrl("/sso/logout"));
         } finally {
-            // Clean up
-            systemProperties.remove("saml.sp.base.url");
+            systemProperties.remove(BASE_URL_KEY);
         }
-    }
-
-    @Test
-    public void test_buildDefaultUrl_allEndpoints() throws Exception {
-        // Test all SAML endpoints are built correctly
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-
-        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
-        try {
-            systemProperties.setProperty("saml.sp.base.url", "https://fess.example.com");
-
-            Method buildDefaultUrlMethod = SamlAuthenticator.class.getDeclaredMethod("buildDefaultUrl", String.class);
-            buildDefaultUrlMethod.setAccessible(true);
-
-            // Test metadata endpoint
-            String metadataUrl = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/metadata");
-            assertEquals("https://fess.example.com/sso/metadata", metadataUrl);
-
-            // Test ACS endpoint
-            String acsUrl = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/");
-            assertEquals("https://fess.example.com/sso/", acsUrl);
-
-            // Test SLO endpoint
-            String sloUrl = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/logout");
-            assertEquals("https://fess.example.com/sso/logout", sloUrl);
-        } finally {
-            // Clean up
-            systemProperties.remove("saml.sp.base.url");
-        }
-    }
-
-    @Test
-    public void test_buildDefaultUrl_emptyProperty() throws Exception {
-        // Test that empty property falls back to default
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-
-        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
-        try {
-            // Set empty base URL
-            systemProperties.setProperty("saml.sp.base.url", "");
-
-            Method buildDefaultUrlMethod = SamlAuthenticator.class.getDeclaredMethod("buildDefaultUrl", String.class);
-            buildDefaultUrlMethod.setAccessible(true);
-
-            String url = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/metadata");
-
-            // Verify URL uses default localhost:8080 when property is empty
-            assertNotNull(url);
-            assertEquals("http://localhost:8080/sso/metadata", url);
-        } finally {
-            // Clean up
-            systemProperties.remove("saml.sp.base.url");
-        }
-    }
-
-    @Test
-    public void test_buildDefaultUrl_whitespaceProperty() throws Exception {
-        // Test that whitespace-only property falls back to default
-        SamlAuthenticator authenticator = new SamlAuthenticator();
-
-        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
-        try {
-            // Set whitespace-only base URL
-            systemProperties.setProperty("saml.sp.base.url", "   ");
-
-            Method buildDefaultUrlMethod = SamlAuthenticator.class.getDeclaredMethod("buildDefaultUrl", String.class);
-            buildDefaultUrlMethod.setAccessible(true);
-
-            String url = (String) buildDefaultUrlMethod.invoke(authenticator, "/sso/metadata");
-
-            // Verify URL uses default localhost:8080 when property is whitespace
-            assertNotNull(url);
-            assertEquals("http://localhost:8080/sso/metadata", url);
-        } finally {
-            // Clean up
-            systemProperties.remove("saml.sp.base.url");
-        }
-    }
-
-    @Test
-    public void test_contactInformation() throws Exception {
-        Map<String, Object> defaultSettings = createDefaultSettings();
-
-        // Verify contact information is properly set
-        assertEquals("Technical Guy", defaultSettings.get("onelogin.saml2.contacts.technical.given_name"));
-        assertEquals("Support Guy", defaultSettings.get("onelogin.saml2.contacts.support.given_name"));
-
-        // Most importantly, verify the email typo is fixed
-        String techEmail = (String) defaultSettings.get("onelogin.saml2.contacts.technical.email_address");
-        String supportEmail = (String) defaultSettings.get("onelogin.saml2.contacts.support.email_address");
-
-        // Both should have exactly one @ character
-        assertEquals("Email should have exactly one @ character", 1, techEmail.split("@", -1).length - 1);
-        assertEquals("Email should have exactly one @ character", 1, supportEmail.split("@", -1).length - 1);
-
-        // Specific value check
-        assertEquals("support@example.com", supportEmail);
-        assertEquals("technical@example.com", techEmail);
-    }
-
-    @Test
-    public void test_emailTypoFix_supportEmail() throws Exception {
-        // This test specifically verifies the typo fix: support@@example.com -> support@example.com
-        Map<String, Object> defaultSettings = createDefaultSettings();
-        String supportEmail = (String) defaultSettings.get("onelogin.saml2.contacts.support.email_address");
-
-        // The critical assertion: must NOT contain double @
-        assertFalse("Support email must not contain @@", supportEmail.contains("@@"));
-
-        // And must be the correct value
-        assertEquals("support@example.com", supportEmail);
     }
 }


### PR DESCRIPTION
> Stacked on #3214 — this PR targets `saml-response-validation`. Merge #3214 first.

## Summary

Two ways the SP endpoint settings could end up wrong, plus cleanup of dead configuration and a test file that could not detect any of it.

## 1. `saml.sp.base.url` required a restart

`buildDefaultUrl()` was called only from `@PostConstruct init()`, so `sp.entityid`, `sp.assertion_consumer_service.url` and `sp.single_logout_service.url` were computed once at startup and cached in `defaultSettings`.

But `saml.sp.base.url` is writable at runtime: `AdminGeneralAction` writes it via `setSystemProperty` when the "SP Base URL" field on the admin General page is saved. `getSettings()` re-reads every *other* `saml.*` property on every call, so an admin who follows the documented "Option 1: set the base URL" path saw `http://localhost:8080/...` in the SP metadata and in AuthnRequests until Fess was restarted — and with `strict=true` the resulting Destination/Audience mismatches fail the login.

The three URLs are now built inside `getSettings()`.

## 2. A blank `saml.*` property wiped out the default

The overlay loop copied values into the settings map without checking for blanks:

```java
params.put("onelogin.saml2." + key.substring(SAML_PREFIX.length()), e.getValue());
```

`SettingsBuilder#isString` requires `isNotBlank`, so a blank value is not "no override" — it replaces a good default with something the builder then treats as absent. A stray `saml.sp.entityid=` in `system.properties` silently yields:

```
checkSPSettings() = [sp_entityId_not_found, sp_acs_not_found]
```

which surfaces as a `SettingsException` from the `Auth` constructor. Blank values are now skipped.

(The admin UI does *not* produce these: LastaFlute maps empty text parameters to `null` and `setSystemProperty(key, null)` removes the key. This is a guard against hand-edited or migrated `system.properties`.)

## 3. Dead configuration

- `onelogin.saml2.security.onelogin.saml2.security.requested_authncontextcomparison` had a duplicated prefix, so `SettingsBuilder` never read it. Verified against the library: setting that key to `minimum` leaves `getRequestedAuthnContextComparison()` at `exact`. The value it intended to set is also the library default, so fixing the key is behaviour-neutral.
- Five defaults were the empty string — `sp.x509cert`, `sp.privatekey`, `security.sign_metadata`, `idp.single_logout_service.response.url`, `organization.lang`. `isString` rejects blanks, so none of them did anything. Removed.

## 4. The tests could not fail

`SamlAuthenticatorTest` had a private `createDefaultSettings()` that hand-copied the production map, and six tests asserted against that copy without ever touching `SamlAuthenticator`. The copy had already drifted — it still declared

```java
"onelogin.saml2.security.signature_algorithm" -> "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
```

long after the production default moved to `rsa-sha256`, and stayed green. The private `setDefaultSettings()` helper was never called at all.

The map is now extracted into a `protected createDefaultSettings()` on the authenticator, and the tests call the real methods. New coverage:

- `test_getSettings_spUrlsFollowBaseUrlChangedAfterStartup` — fix 1
- `test_getSettings_blankPropertyKeepsDefault` — fix 2
- `test_createDefaultSettings_hasNoBlankValues` — keeps fix 3 from regressing
- `test_createDefaultSettings_security` — pins the signature algorithm and the corrected comparison key

Both regression tests were confirmed to fail when the corresponding fix is reverted.

```
Tests run: 129, Failures: 0, Errors: 0, Skipped: 0   (org.codelibs.fess.sso.**)
```
