### PR TITLE
fix(sso): stop swallowing Entra ID login failures at DEBUG level

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -274,12 +274,15 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 }
                 try {
                     return processAuthenticationData(request);
+                } catch (final SsoLoginException e) {
+                    throw e;
                 } catch (final Exception e) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Failed to process a login request on Entra ID.", e);
-                    }
+                    // Wrapped rather than returned as null so SsoAction logs it at WARN and shows
+                    // the SSO error message, the same as it already does for the other
+                    // authenticators. Swallowing it here left a failed login invisible unless
+                    // DEBUG logging happened to be on.
+                    throw new SsoLoginException("Failed to process a login request on Entra ID.", e);
                 }
-                return null;
             }
 
             return new ActionResponseCredential(() -> HtmlResponse.fromRedirectPathAsIs(getAuthUrl(request)));

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -27,10 +27,14 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.core.misc.Pair;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
+import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
+import org.lastaflute.web.login.credential.LoginCredential;
+
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 
 public class EntraIdAuthenticatorTest extends UnitFessTestCase {
@@ -146,6 +150,52 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         request.setParameter("error", "access_denied");
 
         assertTrue(authenticator.containsAuthenticationData(request));
+    }
+
+    @Test
+    public void test_getLoginCredential_surfacesUnexpectedFailures() {
+        // A swallowed failure leaves the operator with nothing above DEBUG to work from.
+        // SsoAction logs SsoLoginException at WARN and shows the SSO error message, which is
+        // what the OpenID Connect authenticator already relies on.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected LoginCredential processAuthenticationData(final HttpServletRequest request) {
+                throw new IllegalStateException("graph is down");
+            }
+        };
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        request.setParameter("code", "0.AXkAauthorizationcodevalue");
+        request.getSession();
+
+        try {
+            authenticator.getLoginCredential();
+            fail("expected SsoLoginException");
+        } catch (final SsoLoginException e) {
+            assertEquals("graph is down", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_propagatesSsoLoginExceptionUnwrapped() {
+        final SsoLoginException thrown = new SsoLoginException("could not validate state");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected LoginCredential processAuthenticationData(final HttpServletRequest request) {
+                throw thrown;
+            }
+        };
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        request.setParameter("code", "0.AXkAauthorizationcodevalue");
+        request.getSession();
+
+        try {
+            authenticator.getLoginCredential();
+            fail("expected SsoLoginException");
+        } catch (final SsoLoginException e) {
+            assertSame(thrown, e);
+        }
     }
 
     @Test


### PR DESCRIPTION
> Stacked on #3215. Base will retarget to `master` once that merges — review only the last commit.

## Problem

`EntraIdAuthenticator.getLoginCredential()` caught every exception, logged it only at DEBUG,
and returned `null`:

```java
} catch (final Exception e) {
    if (logger.isDebugEnabled()) {
        logger.debug("Failed to process a login request on Entra ID.", e);
    }
}
return null;
```

`SsoAction.index()` already has the right handler one frame up:

```java
} catch (final SsoLoginException e) {
    if (ssoManager.available()) {
        logger.warn("Failed to process SSO login.", e);
        saveError(messages -> messages.addErrorsSsoLoginError(GLOBAL));
    }
    ...
}
```

but the inner catch meant it never ran for Entra ID. `OpenIdConnectAuthenticator` does not
swallow, so it gets the WARN — Entra ID was the outlier.

The practical effect: a state mismatch, a nonce mismatch, a failed token acquisition and a
Microsoft Graph outage all produce the same silent redirect to the login page, with nothing above
DEBUG to tell them apart.

## Fix

Rethrow `SsoLoginException` unchanged, and wrap anything else in one, so both reach `SsoAction`.

The user-visible outcome does not change — the SSO error message, then the login page. Wrapping
rather than letting the raw exception propagate matters because the Graph client throws
`CurlException`, a `RuntimeException`, which `SsoAction` does not catch and which would otherwise
surface as a 500 error page.

## Tests

`EntraIdAuthenticator`'s unit test class, 2 new tests, both failing before the change:

- `test_getLoginCredential_surfacesUnexpectedFailures` — an `IllegalStateException` from
  `processAuthenticationData()` comes back as an `SsoLoginException` wrapping it
- `test_getLoginCredential_propagatesSsoLoginExceptionUnwrapped` — an `SsoLoginException` is
  rethrown as the same instance, not double-wrapped

```
Tests run: 140, Failures: 0, Errors: 0, Skipped: 0
```

(the whole `org.codelibs.fess.sso` package plus `SsoActionTest`)
