### PR TITLE
fix(sso): let LastaFlute own the SAML SLO redirect

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -409,7 +409,7 @@ public class SamlAuthenticator implements SsoAuthenticator {
                             messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
                             "Failed to log out.", new SsoProcessException(msg));
                 }
-                return new StreamResponse("metadata").contentType("application/xhtml+xml").stream(out -> {
+                return new StreamResponse("metadata.xml").contentType("application/samlmetadata+xml").stream(out -> {
                     try (final Writer writer = new OutputStreamWriter(out.stream(), Constants.UTF_8_CHARSET)) {
                         writer.write(metadata);
                     }
@@ -432,22 +432,34 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * @return The logout response.
      */
     protected ActionResponse getLogoutResponse() {
-        LaRequestUtil.getOptionalRequest().map(request -> {
+        return LaRequestUtil.getOptionalRequest().<ActionResponse> map(request -> {
             if (logger.isDebugEnabled()) {
                 logger.debug("Logging out with SAML Authenticator");
             }
             final HttpServletResponse response = LaResponseUtil.getResponse();
             try {
-                final Auth auth = new Auth(getSettings(), request, response);
-                auth.processSLO();
-                final List<String> errors = auth.getErrors();
-                if (errors.isEmpty()) {
-                    throw new SsoMessageException(messages -> messages.addSuccessSsoLogout(UserMessages.GLOBAL_PROPERTY_KEY), "Logged out");
+                final Saml2Settings settings = getSettings();
+                if (settings.getIdpSingleLogoutServiceResponseUrl() == null) {
+                    final String msg = "IdP single logout service URL is not configured.";
+                    throw new SsoMessageException(
+                            messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
+                            "Failed to log out.", new SsoProcessException(msg));
                 }
-                final String msg = errors.stream().collect(Collectors.joining(", "));
-                throw new SsoMessageException(
-                        messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
-                        "Failed to log out.", new SsoProcessException(msg));
+                final Auth auth = new Auth(settings, request, response);
+                // stay=true keeps java-saml from committing the servlet response itself
+                final String redirectUrl = auth.processSLO(false, null, true);
+                final List<String> errors = auth.getErrors();
+                if (!errors.isEmpty()) {
+                    final String msg = errors.stream().collect(Collectors.joining(", "));
+                    throw new SsoMessageException(
+                            messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
+                            "Failed to log out.", new SsoProcessException(msg));
+                }
+                if (StringUtil.isNotBlank(redirectUrl)) {
+                    // an IdP-initiated LogoutRequest: send our LogoutResponse back to the IdP
+                    return HtmlResponse.fromRedirectPathAsIs(redirectUrl);
+                }
+                throw new SsoMessageException(messages -> messages.addSuccessSsoLogout(UserMessages.GLOBAL_PROPERTY_KEY), "Logged out");
             } catch (final SsoMessageException e) {
                 throw e;
             } catch (final Exception e) {
@@ -459,6 +471,5 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 .orElseThrow(() -> new SsoMessageException(
                         messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, "Invalid state."),
                         "Failed to log out.", new SsoProcessException("Invalid state.")));
-        return null;
     }
 }

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
+import org.codelibs.fess.exception.SsoMessageException;
+import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.saml2.core.settings.Saml2Settings;
@@ -144,6 +146,18 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
 
         assertNotNull(first.getReplayCache());
         assertSame(first.getReplayCache(), second.getReplayCache());
+    }
+
+    @Test
+    public void test_getLogoutResponse_withoutIdpSingleLogoutServiceUrl() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        try {
+            authenticator.getResponse(SsoResponseType.LOGOUT);
+            fail("SsoMessageException should be thrown");
+        } catch (final SsoMessageException e) {
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause().getMessage(), e.getCause().getMessage().contains("single logout service URL"));
+        }
     }
 
     @Test


### PR DESCRIPTION
> Stacked on #3217 (which is stacked on #3214) — this PR targets `saml-sp-url-settings`. Merge #3214, then #3217, then this one.

## 1. The IdP-initiated logout response was written twice

`getLogoutResponse()` called the no-arg `auth.processSLO()`, which delegates to `processSLO(false, null, false)`. When the incoming message is a `SAMLRequest` (IdP-initiated logout), java-saml builds the `LogoutResponse` and, with `stay=false`, sends it itself:

```java
// ServletUtils#sendRedirect
if (!stay) {
    response.sendRedirect(targetUrl);   // commits the servlet response
}
```

Fess then threw `SsoMessageException`, and `SsoAction#logout` caught it, called `saveInfo(...)` and returned `redirect(LoginAction.class)` — a second redirect on an already committed response.

The call is now `processSLO(false, null, true)`, so the URL comes back to Fess and the method returns `HtmlResponse.fromRedirectPathAsIs(redirectUrl)`. LastaFlute stays in charge of the response. A `SAMLResponse` from the IdP produces no URL and still reports success through `SsoMessageException`, exactly as before.

## 2. NPE when SLO is not configured

`Auth#getSLOResponseUrl()` is

```java
return settings.getIdpSingleLogoutServiceResponseUrl().toString();
```

and `getIdpSingleLogoutServiceResponseUrl()` returns `null` when neither the response URL nor the SLO URL is set. A `LogoutRequest` arriving in that state raised a `NullPointerException`, which the catch-all wrapped into a user-facing message built from `e.getMessage()` — literally the string `null`.

`getLogoutResponse()` now checks the URL up front and reports it, matching the guard `logout(FessUserBean)` already had.

## 3. Smaller items

- The trailing `return null;` was unreachable, because the mapped lambda always threw. The method now returns the mapped optional's value.
- SP metadata is served as `application/samlmetadata+xml` with a `metadata.xml` file name rather than `application/xhtml+xml`.

## Test

`test_getLogoutResponse_withoutIdpSingleLogoutServiceUrl` covers the new guard. It is falsifiable: with the guard removed the request instead fails inside the `Auth` constructor with `Invalid settings: idp_entityId_not_found, ...`, and the test catches that difference.

```
Tests run: 130, Failures: 0, Errors: 0, Skipped: 0   (org.codelibs.fess.sso.**)
```

## Not covered here

SP-initiated SLO still calls `processSLO` without a request ID, so the `LogoutResponse` is not bound to the `LogoutRequest` Fess sent — the equivalent of what #3214 fixes for the login flow. `LogoutAction` invalidates the session before the response comes back, so binding it needs a different place to keep the ID. Left for a follow-up.
