### PR TITLE
fix(sso): bound Microsoft Graph calls from the Entra ID authenticator

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -42,6 +42,7 @@ import org.codelibs.core.net.UuidUtil;
 import org.codelibs.core.stream.StreamUtil;
 import org.codelibs.core.timer.TimeoutManager;
 import org.codelibs.curl.Curl;
+import org.codelibs.curl.CurlRequest;
 import org.codelibs.curl.CurlResponse;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential;
@@ -239,6 +240,15 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
 
     /** Maximum depth for processing nested groups to prevent infinite loops. */
     protected int maxGroupDepth = 10;
+
+    /**
+     * Connection timeout for Microsoft Graph requests in milliseconds. curl4j leaves this unset,
+     * which means an unbounded wait, and the direct-membership lookup runs on the login thread.
+     */
+    protected int graphConnectTimeout = 10 * 1000;
+
+    /** Read timeout for Microsoft Graph requests in milliseconds. See {@link #graphConnectTimeout}. */
+    protected int graphReadTimeout = 30 * 1000;
 
     /** Use V2 endpoint. */
     protected boolean useV2Endpoint = true;
@@ -603,6 +613,35 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Applies the headers and timeouts every Microsoft Graph request needs.
+     *
+     * @param request The request to configure.
+     * @param accessToken The bearer token to authenticate with.
+     * @return The configured request.
+     */
+    protected CurlRequest createGraphRequest(final CurlRequest request, final String accessToken) {
+        return request.header("Authorization", "Bearer " + accessToken)
+                .header("Accept", "application/json")
+                .timeout(graphConnectTimeout, graphReadTimeout);
+    }
+
+    /**
+     * Sets the connection timeout for Microsoft Graph requests.
+     * @param graphConnectTimeout The timeout in milliseconds.
+     */
+    public void setGraphConnectTimeout(final int graphConnectTimeout) {
+        this.graphConnectTimeout = graphConnectTimeout;
+    }
+
+    /**
+     * Sets the read timeout for Microsoft Graph requests.
+     * @param graphReadTimeout The timeout in milliseconds.
+     */
+    public void setGraphReadTimeout(final int graphReadTimeout) {
+        this.graphReadTimeout = graphReadTimeout;
+    }
+
+    /**
      * Updates the user's group and role membership information with lazy loading for parent groups.
      * Direct groups are retrieved synchronously, while parent groups are fetched asynchronously
      * to avoid login delays when users have many nested group memberships.
@@ -672,10 +711,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         if (logger.isDebugEnabled()) {
             logger.debug("url={}", url);
         }
-        try (CurlResponse response = Curl.get(url)
-                .header("Authorization", "Bearer " + user.getAuthenticationResult().accessToken())
-                .header("Accept", "application/json")
-                .execute()) {
+        try (CurlResponse response = createGraphRequest(Curl.get(url), user.getAuthenticationResult().accessToken()).execute()) {
             final Map<String, Object> contentMap = response.getContent(OpenSearchCurl.jsonParser());
             if (logger.isDebugEnabled()) {
                 logger.debug("response={}", contentMap);
@@ -776,10 +812,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         if (logger.isDebugEnabled()) {
             logger.debug("[processDirectMemberOf] Fetching direct memberships from URL: {}", url);
         }
-        try (CurlResponse response = Curl.get(url)
-                .header("Authorization", "Bearer " + user.getAuthenticationResult().accessToken())
-                .header("Accept", "application/json")
-                .execute()) {
+        try (CurlResponse response = createGraphRequest(Curl.get(url), user.getAuthenticationResult().accessToken()).execute()) {
             final Map<String, Object> contentMap = response.getContent(OpenSearchCurl.jsonParser());
             if (logger.isDebugEnabled()) {
                 logger.debug("response={}", contentMap);
@@ -1009,9 +1042,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 if (logger.isDebugEnabled()) {
                     logger.debug("[getParentGroup] Calling API: {}", url);
                 }
-                try (CurlResponse response = Curl.post(url)
-                        .header("Authorization", "Bearer " + user.getAuthenticationResult().accessToken())
-                        .header("Accept", "application/json")
+                try (CurlResponse response = createGraphRequest(Curl.post(url), user.getAuthenticationResult().accessToken())
                         .header("Content-type", "application/json")
                         .body("{\"securityEnabledOnly\":false}")
                         .execute()) {
@@ -1083,10 +1114,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         if (logger.isDebugEnabled()) {
             logger.debug("[processGroup] Fetching from url: {}", url);
         }
-        try (CurlResponse response = Curl.get(url)
-                .header("Authorization", "Bearer " + user.getAuthenticationResult().accessToken())
-                .header("Accept", "application/json")
-                .execute()) {
+        try (CurlResponse response = createGraphRequest(Curl.get(url), user.getAuthenticationResult().accessToken()).execute()) {
             final Map<String, Object> contentMap = response.getContent(OpenSearchCurl.jsonParser());
             if (logger.isDebugEnabled()) {
                 logger.debug("[processGroup] Response for id {}: {}", id, contentMap);

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -16,6 +16,8 @@
 package org.codelibs.fess.sso.entraid;
 
 import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,6 +28,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.core.misc.Pair;
+import org.codelibs.curl.Curl;
+import org.codelibs.curl.CurlResponse;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
 import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.helper.SystemHelper;
@@ -221,6 +225,36 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         request.setMethod("GET");
 
         assertFalse(authenticator.containsAuthenticationData(request));
+    }
+
+    @Test
+    public void test_graphTimeouts_haveBoundedDefaults() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        // curl4j leaves both timeouts at -1 unless told otherwise, and -1 means "never give up".
+        // Any non-positive default would put an unbounded Graph call back on the login path.
+        assertTrue(authenticator.graphConnectTimeout > 0);
+        assertTrue(authenticator.graphReadTimeout > 0);
+    }
+
+    @Test
+    public void test_createGraphRequest_stopsWaitingOnAnUnresponsiveEndpoint() throws Exception {
+        // A server that accepts the connection and then never answers. Without a read timeout
+        // this call never returns, and on the login path that blocks the request thread.
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+            authenticator.setGraphReadTimeout(300);
+            final String url = "http://" + server.getInetAddress().getHostAddress() + ":" + server.getLocalPort() + "/v1.0/me/memberOf";
+
+            final long start = System.currentTimeMillis();
+            try (CurlResponse response = authenticator.createGraphRequest(Curl.get(url), "access-token").execute()) {
+                fail("expected the request to time out");
+            } catch (final Exception expected) {
+                // curl4j wraps the SocketTimeoutException
+            }
+            final long elapsed = System.currentTimeMillis() - start;
+            // Well under the 30s default, so an ignored setter fails here instead of just being slow.
+            assertTrue("took " + elapsed + "ms", elapsed < 5000L);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

None of the four Microsoft Graph calls in `EntraIdAuthenticator` set a timeout.

curl4j's `CurlRequest` defaults both to `-1`:

```java
protected int connectTimeout = -1;
protected int readTimeout = -1;
...
if (connectTimeout >= 0) { connection.setConnectTimeout(connectTimeout); }
if (readTimeout   >= 0) { connection.setReadTimeout(readTimeout); }
```

so `setConnectTimeout` / `setReadTimeout` are never called, which for
`HttpURLConnection` means wait forever. Fess sets no JVM-wide default
(`sun.net.client.defaultReadTimeout` etc.) either.

Where that hurts:

- `processDirectMemberOf()` runs **synchronously on the login request thread** (called from the
  `EntraIdUser` constructor). An unresponsive Graph endpoint blocks that thread indefinitely.
- The other three run on the `TimeoutManager` pool. That pool is
  `ThreadPoolExecutor(nThreads, nThreads, ..., new LinkedBlockingQueue<>(nThreads), new CallerRunsPolicy())`
  with `nThreads = availableProcessors() / 2` (min 1), so once the queue fills, work runs on the
  caller — the single `CoreLib-TimeoutManager` scheduler thread.

## Fix

- `graphConnectTimeout` (10s) and `graphReadTimeout` (30s), with setters so they can be tuned
  through LastaDi like the other knobs on this component.
- A `createGraphRequest(CurlRequest, String accessToken)` helper that applies the timeouts plus
  the `Authorization` and `Accept` headers, which all four sites repeated verbatim.

Only timeouts and the header de-duplication — no change to what is requested or how responses are
parsed.

## Tests

`EntraIdAuthenticator`'s unit test class, 2 new tests:

- `test_graphTimeouts_haveBoundedDefaults` — guards against a non-positive default silently
  restoring the unbounded behaviour
- `test_createGraphRequest_stopsWaitingOnAnUnresponsiveEndpoint` — binds a loopback `ServerSocket`
  that accepts and never answers, sets the read timeout to 300ms, and asserts the call gives up
  well under the 30s default

Falsification: with `setGraphReadTimeout` stubbed to ignore its argument, the second test fails
with `took 30014ms` instead of passing — so it distinguishes "timeout applied" from "default used"
as well as from "no timeout at all".

```
Tests run: 133, Failures: 0, Errors: 0, Skipped: 0
```

(the whole `org.codelibs.fess.sso` package)
