### PR TITLE
fix(sso): bound and synchronize the Entra ID state map held in the session

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -23,12 +23,14 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -250,6 +252,13 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /** Read timeout for Microsoft Graph requests in milliseconds. See {@link #graphConnectTimeout}. */
     protected int graphReadTimeout = 30 * 1000;
 
+    /**
+     * Maximum number of unfinished authorization attempts kept per session. Each redirect to the
+     * authorization endpoint stores one; without a cap, a client that keeps starting logins
+     * without finishing one grows the session attribute without bound.
+     */
+    protected int maxStates = 10;
+
     /** Use V2 endpoint. */
     protected boolean useV2Endpoint = true;
 
@@ -337,17 +346,95 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @param nonce The OpenID Connect nonce parameter.
      */
     protected void storeStateInSession(final HttpSession session, final String state, final String nonce) {
-        @SuppressWarnings("unchecked")
-        Map<String, StateData> stateMap = (Map<String, StateData>) session.getAttribute(STATES);
-        if (stateMap == null) {
-            stateMap = new HashMap<>();
-            session.setAttribute(STATES, stateMap);
-        }
+        final Map<String, StateData> stateMap = getStateMap(session);
+        removeExpiredStates(stateMap);
+        removeOldestStates(stateMap, maxStates - 1);
         final StateData stateData = new StateData(nonce, ComponentUtil.getSystemHelper().getCurrentTimeAsLong());
         if (logger.isDebugEnabled()) {
             logger.debug("Storing state in session: {}", stateData);
         }
         stateMap.put(state, stateData);
+    }
+
+    /**
+     * Returns the per-session map of pending authorization attempts, creating it if needed.
+     * The map is concurrent, and the create is synchronized on the session, because a user can
+     * have several login attempts in flight at once -- a plain HashMap created twice loses the
+     * state one of them has to validate later.
+     *
+     * @param session The HTTP session.
+     * @return The state map held by the session.
+     */
+    protected Map<String, StateData> getStateMap(final HttpSession session) {
+        synchronized (session) {
+            @SuppressWarnings("unchecked")
+            final Map<String, StateData> stateMap = (Map<String, StateData>) session.getAttribute(STATES);
+            if (stateMap instanceof ConcurrentHashMap) {
+                return stateMap;
+            }
+            // Either absent, or a plain HashMap left by a session that predates this change.
+            final Map<String, StateData> concurrentMap = new ConcurrentHashMap<>();
+            if (stateMap != null) {
+                concurrentMap.putAll(stateMap);
+            }
+            session.setAttribute(STATES, concurrentMap);
+            return concurrentMap;
+        }
+    }
+
+    /**
+     * Drops states that are older than the configured TTL.
+     *
+     * @param stateMap The state map to prune.
+     */
+    protected void removeExpiredStates(final Map<String, StateData> stateMap) {
+        final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
+        final long stateTtl = getStateTtl();
+        stateMap.entrySet()
+                .stream()
+                .filter(e -> (now - e.getValue().getExpiration()) / 1000L > stateTtl)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList())
+                .forEach(s -> {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Removing old state: {}", s);
+                    }
+                    stateMap.remove(s);
+                });
+    }
+
+    /**
+     * Drops the least recently created states until at most {@code limit} remain. Unfinished
+     * attempts never expire on their own before the TTL, so this is what bounds the map for a
+     * client that keeps starting logins.
+     *
+     * @param stateMap The state map to prune.
+     * @param limit The number of states to keep.
+     */
+    protected void removeOldestStates(final Map<String, StateData> stateMap, final int limit) {
+        if (stateMap.size() <= limit) {
+            return;
+        }
+        stateMap.entrySet()
+                .stream()
+                .sorted(Comparator.comparingLong(e -> e.getValue().getExpiration()))
+                .limit((long) stateMap.size() - limit)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList())
+                .forEach(s -> {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Removing surplus state: {}", s);
+                    }
+                    stateMap.remove(s);
+                });
+    }
+
+    /**
+     * Sets the maximum number of pending authorization attempts kept per session.
+     * @param maxStates The maximum number of states.
+     */
+    public void setMaxStates(final int maxStates) {
+        this.maxStates = maxStates;
     }
 
     /**
@@ -562,31 +649,13 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The removed state data or null if not found.
      */
     protected StateData removeStateFromSession(final HttpSession session, final String state) {
-        @SuppressWarnings("unchecked")
-        final Map<String, StateData> states = (Map<String, StateData>) session.getAttribute(STATES);
-        if (states != null) {
-            final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
-            states.entrySet()
-                    .stream()
-                    .filter(e -> (now - e.getValue().getExpiration()) / 1000L > getStateTtl())
-                    .map(Map.Entry::getKey)
-                    .collect(Collectors.toList())
-                    .forEach(s -> {
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Removing old state: {}", s);
-                        }
-                        states.remove(s);
-                    });
-            final StateData stateData = states.get(state);
-            if (stateData != null) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Restoring state from session: {}", stateData);
-                }
-                states.remove(state);
-                return stateData;
-            }
+        final Map<String, StateData> states = getStateMap(session);
+        removeExpiredStates(states);
+        final StateData stateData = states.remove(state);
+        if (stateData != null && logger.isDebugEnabled()) {
+            logger.debug("Restoring state from session: {}", stateData);
         }
-        return null;
+        return stateData;
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -19,12 +19,16 @@ import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.core.misc.Pair;
@@ -36,12 +40,26 @@ import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
+import org.junit.jupiter.api.Test;
 import org.lastaflute.web.login.credential.LoginCredential;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.Test;
+import jakarta.servlet.http.HttpSession;
 
 public class EntraIdAuthenticatorTest extends UnitFessTestCase {
+
+    /** Lets a test move the clock that state expiry is measured against. */
+    private final AtomicLong clock = new AtomicLong(1_000_000L);
+
+    private EntraIdAuthenticator newAuthenticatorWithControlledClock() {
+        ComponentUtil.register(new SystemHelper() {
+            @Override
+            public long getCurrentTimeAsLong() {
+                return clock.get();
+            }
+        }, "systemHelper");
+        return new EntraIdAuthenticator();
+    }
 
     @Test
     public void test_maskSecret() {
@@ -255,6 +273,119 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
             // Well under the 30s default, so an ignored setter fails here instead of just being slow.
             assertTrue("took " + elapsed + "ms", elapsed < 5000L);
         }
+    }
+
+    @Test
+    public void test_storeStateInSession_dropsExpiredStatesOnWrite() {
+        // Expired states used to be cleared only when a callback arrived. A user who keeps
+        // starting logins without finishing one grew the session map without bound.
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final HttpSession session = getMockRequest().getSession();
+
+        authenticator.storeStateInSession(session, "state-1", "nonce-1");
+        assertEquals(1, authenticator.getStateMap(session).size());
+
+        // getStateTtl() defaults to 3600 and is compared in seconds.
+        clock.addAndGet(3601L * 1000L);
+        authenticator.storeStateInSession(session, "state-2", "nonce-2");
+
+        final Map<String, EntraIdAuthenticator.StateData> stateMap = authenticator.getStateMap(session);
+        assertEquals(1, stateMap.size());
+        assertTrue(stateMap.containsKey("state-2"));
+    }
+
+    @Test
+    public void test_storeStateInSession_capsTheNumberOfLiveStates() {
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        authenticator.setMaxStates(3);
+        final HttpSession session = getMockRequest().getSession();
+
+        for (int i = 0; i < 20; i++) {
+            clock.addAndGet(1000L);
+            authenticator.storeStateInSession(session, "state-" + i, "nonce-" + i);
+        }
+
+        final Map<String, EntraIdAuthenticator.StateData> stateMap = authenticator.getStateMap(session);
+        assertEquals(3, stateMap.size());
+        // The most recent attempts are the ones a user can still complete.
+        assertTrue(stateMap.containsKey("state-19"));
+        assertTrue(stateMap.containsKey("state-18"));
+        assertTrue(stateMap.containsKey("state-17"));
+    }
+
+    @Test
+    public void test_getStateMap_migratesALegacyHashMap() {
+        // A session created before this change holds a plain HashMap under the same key.
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final HttpSession session = getMockRequest().getSession();
+        final Map<String, EntraIdAuthenticator.StateData> legacy = new HashMap<>();
+        legacy.put("legacy-state", new EntraIdAuthenticator.StateData("legacy-nonce", clock.get()));
+        session.setAttribute("entraidStates", legacy);
+
+        final Map<String, EntraIdAuthenticator.StateData> stateMap = authenticator.getStateMap(session);
+
+        assertTrue(stateMap instanceof ConcurrentHashMap);
+        assertEquals("legacy-nonce", stateMap.get("legacy-state").getNonce());
+        // The migrated map is the one stored back on the session, so later writes are not lost.
+        assertSame(stateMap, session.getAttribute("entraidStates"));
+    }
+
+    @Test
+    public void test_getStateMap_isCreatedOnceUnderConcurrentAccess() throws Exception {
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final HttpSession session = getMockRequest().getSession();
+        final int threads = 8;
+        final CountDownLatch start = new CountDownLatch(1);
+        final List<Map<String, EntraIdAuthenticator.StateData>> seen = Collections.synchronizedList(new ArrayList<>());
+        final List<Thread> workers = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            final Thread t = new Thread(() -> {
+                try {
+                    start.await();
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                seen.add(authenticator.getStateMap(session));
+            });
+            workers.add(t);
+            t.start();
+        }
+        start.countDown();
+        for (final Thread t : workers) {
+            t.join(10000L);
+        }
+
+        assertEquals(threads, seen.size());
+        // Every caller must share one map, otherwise a state stored by one request is invisible
+        // to the request that has to validate it.
+        seen.forEach(m -> assertSame(seen.get(0), m));
+    }
+
+    @Test
+    public void test_removeStateFromSession_stillDropsExpiredStates() {
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final HttpSession session = getMockRequest().getSession();
+        authenticator.storeStateInSession(session, "state-1", "nonce-1");
+
+        clock.addAndGet(3601L * 1000L);
+
+        assertNull(authenticator.removeStateFromSession(session, "state-1"));
+        assertEquals(0, authenticator.getStateMap(session).size());
+    }
+
+    @Test
+    public void test_removeStateFromSession_returnsAndConsumesALiveState() {
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final HttpSession session = getMockRequest().getSession();
+        authenticator.storeStateInSession(session, "state-1", "nonce-1");
+
+        final EntraIdAuthenticator.StateData stateData = authenticator.removeStateFromSession(session, "state-1");
+
+        assertNotNull(stateData);
+        assertEquals("nonce-1", stateData.getNonce());
+        // A state is single use.
+        assertNull(authenticator.removeStateFromSession(session, "state-1"));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`storeStateInSession()` kept pending authorization attempts in a plain `HashMap` under the
session's `entraidStates` attribute:

```java
Map<String, StateData> stateMap = (Map<String, StateData>) session.getAttribute(STATES);
if (stateMap == null) {
    stateMap = new HashMap<>();
    session.setAttribute(STATES, stateMap);
}
...
stateMap.put(state, stateData);
```

**Unbounded growth.** Every redirect to the authorization endpoint adds one entry, and expired
entries were cleared only inside `removeStateFromSession()` — that is, only when a callback
actually arrived. A client that keeps starting logins without finishing one grows the map without
bound for the whole session lifetime, and nothing caps it.

**Not synchronized.** Two concurrent login attempts in the same session (two tabs, or a page that
triggers the SSO endpoint more than once) can each read a `null` attribute and create their own
map. The loser's state is then unreachable when its callback returns, so that login fails with
`could not validate state`. Concurrent `put` on a shared `HashMap` has the usual resize hazards on
top.

## Fix

- **`getStateMap(HttpSession)`** — creates the map once, synchronized on the session, and returns
  a `ConcurrentHashMap`. A plain `HashMap` left behind by a session that predates this change is
  migrated in place, so an in-flight login survives the upgrade.
- **`removeExpiredStates(Map)`** — the TTL pruning, now shared by the write path and the read
  path. A session that never completes a login gets pruned on every new attempt.
- **`removeOldestStates(Map, int)`** — caps the map at `maxStates` (default 10, settable via
  LastaDi like the other knobs on this component), keeping the most recent attempts, which are the
  ones a user can still complete.

`removeStateFromSession()` keeps its behaviour and gets shorter: expired states are dropped, a
live state is returned and consumed exactly once.

## Tests

`EntraIdAuthenticator`'s unit test class, 6 new tests, using a `SystemHelper` with a controllable
clock so expiry is deterministic:

- `test_storeStateInSession_dropsExpiredStatesOnWrite`
- `test_storeStateInSession_capsTheNumberOfLiveStates` — 20 writes with `maxStates=3` leave the 3
  newest
- `test_getStateMap_migratesALegacyHashMap` — the migrated map is the one stored back on the
  session, so later writes are not lost
- `test_getStateMap_isCreatedOnceUnderConcurrentAccess` — 8 threads must all get the same instance
- `test_removeStateFromSession_stillDropsExpiredStates`
- `test_removeStateFromSession_returnsAndConsumesALiveState`

Falsification: with the two pruning calls removed from `storeStateInSession`, the first two tests
fail.

```
Tests run: 137, Failures: 0, Errors: 0, Skipped: 0
```

(the whole `org.codelibs.fess.sso` package)
