### PR TITLE
fix(sso): do not cache a failed Entra ID parent group lookup

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -68,6 +68,7 @@ import org.lastaflute.web.util.LaRequestUtil;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.microsoft.aad.msal4j.AuthorizationCodeParameters;
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
 import com.microsoft.aad.msal4j.IAuthenticationResult;
@@ -1101,70 +1102,96 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             logger.debug("[getParentGroup] Cache MISS for id: {}, fetching from API", id);
         }
         try {
-            return groupCache.get(id, () -> {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("[getParentGroup] Loading parent groups for id: {} into cache", id);
-                }
-                final List<String> groupList = new ArrayList<>();
-                final List<String> roleList = new ArrayList<>();
-                final String url = "https://graph.microsoft.com/v1.0/groups/" + id + "/getMemberGroups";
-                if (logger.isDebugEnabled()) {
-                    logger.debug("[getParentGroup] Calling API: {}", url);
-                }
-                try (CurlResponse response = createGraphRequest(Curl.post(url), user.getAuthenticationResult().accessToken())
-                        .header("Content-type", "application/json")
-                        .body("{\"securityEnabledOnly\":false}")
-                        .execute()) {
-                    final Map<String, Object> contentMap = response.getContent(OpenSearchCurl.jsonParser());
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("[getParentGroup] Response for id {}: {}", id, contentMap);
-                    }
-                    if (contentMap.containsKey("value")) {
-                        final String[] values = DocumentUtil.getValue(contentMap, "value", String[].class);
-                        if (values != null) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("[getParentGroup] Found {} parent group IDs for id: {}", values.length, id);
-                            }
-                            for (final String value : values) {
-                                if (logger.isDebugEnabled()) {
-                                    logger.debug("[getParentGroup] Processing parent group id: {} for group: {}", value, id);
-                                }
-                                processGroup(user, groupList, roleList, value);
-                                if (!groupList.contains(value) && !roleList.contains(value)) {
-                                    if (logger.isDebugEnabled()) {
-                                        logger.debug("[getParentGroup] Recursively getting parent groups for: {}", value);
-                                    }
-                                    final Pair<String[], String[]> groupsAndRoles = getParentGroup(user, value, depth + 1);
-                                    StreamUtil.stream(groupsAndRoles.getFirst()).of(stream1 -> stream1.forEach(groupList::add));
-                                    StreamUtil.stream(groupsAndRoles.getSecond()).of(stream2 -> stream2.forEach(roleList::add));
-                                }
-                            }
-                        }
-                    } else if (contentMap.containsKey("error")) {
-                        @SuppressWarnings("unchecked")
-                        final Map<String, Object> errorMap = (Map<String, Object>) contentMap.get("error");
-                        if ("Request_ResourceNotFound".equals(errorMap.get("code"))) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("[getParentGroup] Resource not found for id {}: {}", id, contentMap);
-                            }
-                        } else {
-                            logger.warn("Failed to access parent groups for id {}: {}", id, contentMap);
-                        }
-                    }
-                } catch (final IOException e) {
-                    logger.warn("Failed to access groups/roles in Entra ID for id: {}", id, e);
-                }
-                final Pair<String[], String[]> result = new Pair<>(groupList.stream().distinct().toArray(n1 -> new String[n1]),
-                        roleList.stream().distinct().toArray(n2 -> new String[n2]));
-                if (logger.isDebugEnabled()) {
-                    logger.debug("[getParentGroup] Cached result for id {}: {} groups, {} roles", id, result.getFirst().length,
-                            result.getSecond().length);
-                }
-                return result;
-            });
-        } catch (final ExecutionException e) {
+            return groupCache.get(id, () -> loadParentGroup(user, id, depth));
+        } catch (final ExecutionException | UncheckedExecutionException e) {
+            // A loader that throws leaves nothing in the cache, which is the point: a throttled or
+            // briefly unreachable Graph must not pin an empty result for the whole cache TTL.
+            // UncheckedExecutionException matters because the Graph JSON parser throws
+            // CurlException, a RuntimeException, on a non-JSON error body.
             logger.warn("Failed to process group cache for id: {}", id, e);
             return new Pair<>(StringUtil.EMPTY_STRINGS, StringUtil.EMPTY_STRINGS);
+        }
+    }
+
+    /**
+     * Walks the parent groups of the specified group. Any failure is thrown rather than turned
+     * into an empty result, so a caller that caches this never stores a transient failure.
+     *
+     * @param user The Entra ID user.
+     * @param id The group ID to get parent information for.
+     * @param depth The current recursion depth.
+     * @return A pair containing group names and role names.
+     * @throws IOException If Microsoft Graph could not be reached or returned an error.
+     */
+    protected Pair<String[], String[]> loadParentGroup(final EntraIdUser user, final String id, final int depth) throws IOException {
+        if (logger.isDebugEnabled()) {
+            logger.debug("[getParentGroup] Loading parent groups for id: {}", id);
+        }
+        final List<String> groupList = new ArrayList<>();
+        final List<String> roleList = new ArrayList<>();
+        for (final String value : getMemberGroupIds(user, id)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("[getParentGroup] Processing parent group id: {} for group: {}", value, id);
+            }
+            processGroup(user, groupList, roleList, value);
+            if (!groupList.contains(value) && !roleList.contains(value)) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[getParentGroup] Recursively getting parent groups for: {}", value);
+                }
+                final Pair<String[], String[]> groupsAndRoles = getParentGroup(user, value, depth + 1);
+                StreamUtil.stream(groupsAndRoles.getFirst()).of(stream1 -> stream1.forEach(groupList::add));
+                StreamUtil.stream(groupsAndRoles.getSecond()).of(stream2 -> stream2.forEach(roleList::add));
+            }
+        }
+        final Pair<String[], String[]> result = new Pair<>(groupList.stream().distinct().toArray(n1 -> new String[n1]),
+                roleList.stream().distinct().toArray(n2 -> new String[n2]));
+        if (logger.isDebugEnabled()) {
+            logger.debug("[getParentGroup] Result for id {}: {} groups, {} roles", id, result.getFirst().length, result.getSecond().length);
+        }
+        return result;
+    }
+
+    /**
+     * Asks Microsoft Graph which groups the specified group is a member of.
+     *
+     * <p>A {@code Request_ResourceNotFound} error is a real answer -- the group does not exist --
+     * and comes back as an empty array so it can be cached. Everything else is thrown, so a
+     * transient failure is never mistaken for "this group has no parents".
+     *
+     * @param user The Entra ID user.
+     * @param id The group ID to get parent information for.
+     * @return The parent group IDs, never null.
+     * @throws IOException If Microsoft Graph could not be reached or returned an error.
+     */
+    protected String[] getMemberGroupIds(final EntraIdUser user, final String id) throws IOException {
+        final String url = "https://graph.microsoft.com/v1.0/groups/" + id + "/getMemberGroups";
+        if (logger.isDebugEnabled()) {
+            logger.debug("[getParentGroup] Calling API: {}", url);
+        }
+        try (CurlResponse response =
+                createGraphRequest(Curl.post(url), user.getAuthenticationResult().accessToken()).header("Content-type", "application/json")
+                        .body("{\"securityEnabledOnly\":false}")
+                        .execute()) {
+            final Map<String, Object> contentMap = response.getContent(OpenSearchCurl.jsonParser());
+            if (logger.isDebugEnabled()) {
+                logger.debug("[getParentGroup] Response for id {}: {}", id, contentMap);
+            }
+            if (contentMap.containsKey("value")) {
+                final String[] values = DocumentUtil.getValue(contentMap, "value", String[].class);
+                return values != null ? values : StringUtil.EMPTY_STRINGS;
+            }
+            if (contentMap.containsKey("error")) {
+                @SuppressWarnings("unchecked")
+                final Map<String, Object> errorMap = (Map<String, Object>) contentMap.get("error");
+                if ("Request_ResourceNotFound".equals(errorMap.get("code"))) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[getParentGroup] Resource not found for id {}: {}", id, contentMap);
+                    }
+                    return StringUtil.EMPTY_STRINGS;
+                }
+                throw new IOException("Failed to access parent groups for id " + id + ": " + contentMap);
+            }
+            return StringUtil.EMPTY_STRINGS;
         }
     }
 

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -15,15 +15,18 @@
  */
 package org.codelibs.fess.sso.entraid;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +48,8 @@ import org.lastaflute.web.login.credential.LoginCredential;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+
+import com.google.common.cache.CacheBuilder;
 
 public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
@@ -386,6 +391,120 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         assertEquals("nonce-1", stateData.getNonce());
         // A state is single use.
         assertNull(authenticator.removeStateFromSession(session, "state-1"));
+    }
+
+    /**
+     * An authenticator whose Graph access is replaced by a scripted one, so the caching and
+     * recursion around it can be exercised without a tenant.
+     */
+    private static class ScriptedAuthenticator extends EntraIdAuthenticator {
+        private final Map<String, String[]> parents = new HashMap<>();
+        private final List<String> lookups = new ArrayList<>();
+        private final Set<String> failing = new HashSet<>();
+
+        @Override
+        protected String[] getMemberGroupIds(final EntraIdUser user, final String id) throws IOException {
+            lookups.add(id);
+            if (failing.contains(id)) {
+                throw new IOException("simulated Graph failure for " + id);
+            }
+            return parents.getOrDefault(id, new String[0]);
+        }
+
+        @Override
+        protected void processGroup(final EntraIdUser user, final List<String> groupList, final List<String> roleList, final String id) {
+            groupList.add(id);
+        }
+    }
+
+    private ScriptedAuthenticator newScriptedAuthenticator() {
+        final ScriptedAuthenticator authenticator = new ScriptedAuthenticator();
+        authenticator.groupCache = CacheBuilder.newBuilder().build();
+        return authenticator;
+    }
+
+    @Test
+    public void test_getParentGroup_cachesASuccessfulLookup() {
+        final ScriptedAuthenticator authenticator = newScriptedAuthenticator();
+        authenticator.parents.put("group-a", new String[] { "group-b" });
+
+        final Pair<String[], String[]> first = authenticator.getParentGroup(null, "group-a", 0);
+        final Pair<String[], String[]> second = authenticator.getParentGroup(null, "group-a", 0);
+
+        assertEquals(1, first.getFirst().length);
+        assertEquals("group-b", first.getFirst()[0]);
+        assertEquals(1, second.getFirst().length);
+        // "group-a" is looked up once; "group-b" is walked once while loading it.
+        assertEquals(1, authenticator.lookups.stream().filter("group-a"::equals).count());
+    }
+
+    @Test
+    public void test_getParentGroup_doesNotCacheAFailedLookup() {
+        // A throttled or briefly unreachable Graph used to leave an empty result in the cache,
+        // so the user silently lost their parent-group permissions for the whole cache TTL.
+        final ScriptedAuthenticator authenticator = newScriptedAuthenticator();
+        authenticator.failing.add("group-a");
+
+        final Pair<String[], String[]> failed = authenticator.getParentGroup(null, "group-a", 0);
+        assertEquals(0, failed.getFirst().length);
+        assertNull(authenticator.groupCache.getIfPresent("group-a"));
+
+        authenticator.failing.remove("group-a");
+        authenticator.parents.put("group-a", new String[] { "group-b" });
+
+        final Pair<String[], String[]> recovered = authenticator.getParentGroup(null, "group-a", 0);
+        assertEquals(1, recovered.getFirst().length);
+        assertEquals("group-b", recovered.getFirst()[0]);
+    }
+
+    @Test
+    public void test_getParentGroup_cachesAGenuineEmptyResult() {
+        // A group with no parents is a real answer, not a transient failure, so it is cached.
+        // getMemberGroupIds maps Graph's Request_ResourceNotFound onto this same empty result.
+        final ScriptedAuthenticator authenticator = newScriptedAuthenticator();
+
+        final Pair<String[], String[]> result = authenticator.getParentGroup(null, "group-a", 0);
+
+        assertEquals(0, result.getFirst().length);
+        assertNotNull(authenticator.groupCache.getIfPresent("group-a"));
+    }
+
+    @Test
+    public void test_getParentGroup_doesNotRecurseOnceTheParentWasResolved() {
+        // Characterisation: processGroup() unconditionally adds the id it was asked about, so the
+        // `!groupList.contains(value)` guard in loadParentGroup is false on every success path and
+        // the nested-group recursion never runs. maxGroupDepth therefore has no effect here. This
+        // is consistent with Graph's getMemberGroups already being transitive, but it means the
+        // recursion is not what resolves nested groups -- pinning it so a change is deliberate.
+        final ScriptedAuthenticator authenticator = newScriptedAuthenticator();
+        authenticator.parents.put("group-a", new String[] { "group-b" });
+        authenticator.parents.put("group-b", new String[] { "group-c" });
+
+        final Pair<String[], String[]> result = authenticator.getParentGroup(null, "group-a", 0);
+
+        assertEquals(1, result.getFirst().length);
+        assertEquals("group-b", result.getFirst()[0]);
+        assertFalse(authenticator.lookups.contains("group-b"));
+    }
+
+    @Test
+    public void test_getParentGroup_survivesAnUncheckedFailureFromTheLoader() {
+        // Guava wraps an unchecked exception from the loader in UncheckedExecutionException,
+        // which is not an ExecutionException, so it used to escape the catch entirely. The Graph
+        // JSON parser throws CurlException, a RuntimeException, on a non-JSON error body.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected String[] getMemberGroupIds(final EntraIdUser user, final String id) {
+                throw new IllegalStateException("non-JSON error body");
+            }
+        };
+        authenticator.groupCache = CacheBuilder.newBuilder().build();
+
+        final Pair<String[], String[]> result = authenticator.getParentGroup(null, "group-a", 0);
+
+        assertEquals(0, result.getFirst().length);
+        assertEquals(0, result.getSecond().length);
+        assertNull(authenticator.groupCache.getIfPresent("group-a"));
     }
 
     @Test


### PR DESCRIPTION
## Problem

### A transient Graph failure is cached as "no parent groups" for 10 minutes

The `groupCache` loader handled its own failures and returned an empty `Pair`:

```java
} catch (final IOException e) {
    logger.warn("Failed to access groups/roles in Entra ID for id: {}", id, e);
}
final Pair<String[], String[]> result = new Pair<>(groupList..., roleList...);   // empty
return result;                                                                   // ...and cached
```

Guava has no way to tell that apart from a real empty answer, so it stores it for
`groupCacheExpiry` (10 minutes by default). Throttling (429), a 5xx, or a brief network blip
therefore pins "this group has no parents" for every user who logs in during that window. They
lose their parent-group permissions and see it as "some documents are missing"; the only trace is
a WARN line. The error-response branch had the same shape.

### An unchecked exception escapes the handler

```java
} catch (final ExecutionException e) {
```

Guava wraps a **checked** exception from the loader in `ExecutionException`, but an **unchecked**
one in `UncheckedExecutionException`, which is not a subtype. The Graph JSON parser
(`OpenSearchCurl`'s) throws `CurlException`, a `RuntimeException`, whenever an error body is not
JSON — for example an HTML error page from a proxy — so that case escaped this catch entirely.

## Fix

- **`getMemberGroupIds(user, id)`** — the Graph call, extracted. It throws `IOException` for
  transport failures and for error responses, and returns an empty array for
  `Request_ResourceNotFound`, which is a real answer and should stay cached.
- **`loadParentGroup(user, id, depth)`** — the walk, with failures propagating. A loader that
  throws leaves nothing in the cache, so the next login retries.
- The catch is now `ExecutionException | UncheckedExecutionException`.

Behaviour on failure is otherwise unchanged: a WARN plus an empty result for that one caller.

## A note on what this PR does *not* change

While testing this I found that the nested-group recursion never runs on the success path:

```java
processGroup(user, groupList, roleList, value);          // unconditionally does groupList.add(id)
if (!groupList.contains(value) && !roleList.contains(value)) {   // therefore always false
    ... getParentGroup(user, value, depth + 1) ...
}
```

`processGroup()` adds the id it was asked about before returning, so the guard is false for every
group it resolved. The recursion only fires when `processGroup` threw an `IOException` — and
`maxGroupDepth` has no effect on the normal path.

That is consistent with Graph's `getMemberGroups` already being transitive (one call returns every
ancestor), so it may well be correct as-is. I have not changed it here;
`test_getParentGroup_doesNotRecurseOnceTheParentWasResolved` pins the current behaviour so any
change is deliberate.

## Tests

`EntraIdAuthenticator`'s unit test class, 5 new tests, driven through a subclass whose Graph
access is scripted:

- `test_getParentGroup_cachesASuccessfulLookup`
- `test_getParentGroup_doesNotCacheAFailedLookup` — fails, is not cached, and the next call
  succeeds
- `test_getParentGroup_cachesAGenuineEmptyResult`
- `test_getParentGroup_survivesAnUncheckedFailureFromTheLoader`
- `test_getParentGroup_doesNotRecurseOnceTheParentWasResolved` — the characterisation above

Falsification: restoring the swallow-and-cache behaviour fails the second test; narrowing the
catch back to `ExecutionException` errors the fourth.

```
Tests run: 136, Failures: 0, Errors: 0, Skipped: 0
```

(the whole `org.codelibs.fess.sso` package)
