### PR TITLE
feat(sso): report insecure SAML settings

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -20,6 +20,7 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -175,6 +176,12 @@ public class SamlAuthenticator implements SsoAuthenticator {
     private final ReplayCache replayCache = new InMemoryReplayCache();
 
     /**
+     * The security warnings reported the last time they were logged, so that the
+     * per-request settings build does not repeat them until the settings change.
+     */
+    private final AtomicReference<List<String>> loggedSecurityWarnings = new AtomicReference<>();
+
+    /**
      * Initializes the SamlAuthenticator.
      */
     @PostConstruct
@@ -276,7 +283,23 @@ public class SamlAuthenticator implements SsoAuthenticator {
         });
         final Saml2Settings settings = new SettingsBuilder().fromValues(params).build();
         settings.setReplayCache(replayCache);
+        logSecurityWarnings(settings);
         return settings;
+    }
+
+    /**
+     * Logs the security warnings reported for the given settings.
+     * The settings are rebuilt on every request, so the warnings are logged
+     * again only when they change.
+     *
+     * @param settings The SAML settings.
+     */
+    protected void logSecurityWarnings(final Saml2Settings settings) {
+        final List<String> warnings = settings.getSecurityWarnings();
+        if (!warnings.equals(loggedSecurityWarnings.getAndSet(warnings)) && !warnings.isEmpty()) {
+            logger.warn("Insecure SAML settings: {}. See the SAML SSO documentation for the recommended values.",
+                    warnings.stream().collect(Collectors.joining(", ")));
+        }
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -16,7 +16,17 @@
 package org.codelibs.fess.sso.saml;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
@@ -138,6 +148,31 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getSettings_logsSecurityWarningsUntilTheyChange() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            authenticator.getSettings();
+            authenticator.getSettings();
+
+            // the permissive defaults are reported, but only once
+            assertEquals(1, appender.warnings().size());
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("assertions_and_messages_not_required_signed"));
+
+            systemProperties.setProperty("saml.security.want_assertions_signed", "true");
+            authenticator.getSettings();
+
+            // the remaining warnings differ, so they are reported again
+            assertEquals(2, appender.warnings().size());
+            assertFalse(appender.warnings().get(1).contains("assertions_and_messages_not_required_signed"));
+        } finally {
+            systemProperties.remove("saml.security.want_assertions_signed");
+            appender.detach();
+        }
+    }
+
+    @Test
     public void test_getSettings_sharesReplayCacheAcrossRequests() throws Exception {
         final SamlAuthenticator authenticator = createAuthenticator();
 
@@ -201,6 +236,42 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertEquals("http://localhost:8080/sso/logout", authenticator.buildDefaultUrl("/sso/logout"));
         } finally {
             systemProperties.remove(BASE_URL_KEY);
+        }
+    }
+
+    /**
+     * Minimal in-memory log4j2 appender for asserting on emitted log messages.
+     * Mirrors {@code LengthChunkerTest.LogCapturingAppender}.
+     */
+    static final class LogCapturingAppender extends AbstractAppender {
+        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+        private final Logger boundLogger;
+
+        private LogCapturingAppender(final Logger logger) {
+            super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
+            this.boundLogger = logger;
+        }
+
+        static LogCapturingAppender attach(final Class<?> targetClass) {
+            final Logger logger = (Logger) LogManager.getLogger(targetClass);
+            final LogCapturingAppender appender = new LogCapturingAppender(logger);
+            appender.start();
+            logger.addAppender(appender);
+            return appender;
+        }
+
+        void detach() {
+            boundLogger.removeAppender(this);
+            stop();
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        List<String> warnings() {
+            return events.stream().filter(e -> e.getLevel() == Level.WARN).map(e -> e.getMessage().getFormattedMessage()).toList();
         }
     }
 }


### PR DESCRIPTION
> Stacked on #3219 (→ #3217 → #3214) — this PR targets `saml-slo-response`. Merge #3214, #3217, #3219, then this one.

## `getSecurityWarnings()` had no caller

java-saml exposes `Saml2Settings#getSecurityWarnings()` for configuration that is weak but not fatal — the things `checkSettings()` deliberately does not reject. Nothing in Fess called it, so an installation running on the permissive defaults had no way to learn about it short of reading `Saml2Settings`.

`getSettings()` now logs them. With the shipped defaults that is:

```
Insecure SAML settings: deprecated_signature_algorithms_not_rejected,
assertions_and_messages_not_required_signed. See the SAML SSO documentation
for the recommended values.
```

Settings are rebuilt on every request (see #3217), so logging unconditionally would put this line in front of every login. The warnings are compared with the previous set and logged only when they change, which also means editing the configuration in the admin UI re-reports the new state rather than going quiet forever after the first request.

To be explicit about what this is and is not: `want_assertions_signed=false` does **not** allow unsigned assertions. `SamlResponse#isValid` rejects a response with no signed element unconditionally, outside the `strict` block. The flag only relaxes *which* element must carry the signature, so this is a hardening prompt, not a vulnerability notice. The defaults are left as they are.

## Dropped: the SameSite note

This PR originally also documented in `src/main/assemblies/files/tomcat_config.properties` why the SAML HTTP-POST binding cannot run on the default `tomcat.sameSiteCookies = lax`. #3215 has since landed equivalent guidance on `master`, and its wording is broader — it covers Entra ID `response_mode=form_post` as well as SAML, and names `session.cookie.secure=true`. The note was dropped on rebase rather than replacing the merged one; the default is still unchanged, since `none` requires HTTPS.

## Test

`test_getSettings_logsSecurityWarningsUntilTheyChange` captures the logger with the `LogCapturingAppender` pattern already used in `LengthChunkerTest`, asserts the defaults produce exactly one warning across two `getSettings()` calls, then flips `saml.security.want_assertions_signed` and asserts the changed set is reported again. Confirmed falsifiable: logging unconditionally makes the first assertion fail with `expected: <1> but was: <2>`.

```
Tests run: 143, Failures: 0, Errors: 0, Skipped: 0   (org.codelibs.fess.sso.**)
```
