### PR TITLE
refactor(sso): drop unreachable code from the Entra ID authenticator

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -105,6 +105,9 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /** Configuration key for Entra ID state time-to-live. */
     protected static final String ENTRAID_STATE_TTL = "entraid.state.ttl";
 
+    /** Default state time-to-live in seconds. */
+    protected static final String DEFAULT_STATE_TTL = "3600";
+
     /** Configuration key for Entra ID authority URL. */
     protected static final String ENTRAID_AUTHORITY = "entraid.authority";
 
@@ -771,87 +774,6 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     }
 
     /**
-     * Processes member-of information from Microsoft Graph API.
-     * @param user The Entra ID user.
-     * @param groupList The list to add group names to.
-     * @param roleList The list to add role names to.
-     * @param url The Microsoft Graph API URL.
-     */
-    protected void processMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList, final String url) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("url={}", url);
-        }
-        try (CurlResponse response = createGraphRequest(Curl.get(url), user.getAuthenticationResult().accessToken()).execute()) {
-            final Map<String, Object> contentMap = response.getContent(OpenSearchCurl.jsonParser());
-            if (logger.isDebugEnabled()) {
-                logger.debug("response={}", contentMap);
-            }
-            if (contentMap.containsKey("value")) {
-                @SuppressWarnings("unchecked")
-                final List<Map<String, Object>> memberOfList = (List<Map<String, Object>>) contentMap.get("value");
-                final FessConfig fessConfig = ComponentUtil.getFessConfig();
-                for (final Map<String, Object> memberOf : memberOfList) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("member={}", memberOf);
-                    }
-                    String memberType = (String) memberOf.get("@odata.type");
-                    if (memberType == null) {
-                        logger.warn("@odata.type is null: {}", memberOf);
-                        continue;
-                    }
-                    memberType = memberType.toLowerCase(Locale.ENGLISH);
-                    final String id = (String) memberOf.get("id");
-                    if (StringUtil.isNotBlank(id)) {
-                        if (memberType.contains("group")) {
-                            groupList.add(id);
-                        } else if (memberType.contains("role")) {
-                            roleList.add(id);
-                        } else {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Unknown @odata.type: {}", memberOf);
-                            }
-                            groupList.add(id);
-                        }
-                        processParentGroup(user, groupList, roleList, id);
-                    } else {
-                        logger.warn("id is empty: {}", memberOf);
-                    }
-                    final String[] names = fessConfig.getEntraIdPermissionFields();
-                    final boolean useDomainServices = fessConfig.isEntraIdUseDomainServices();
-                    for (final String name : names) {
-                        final String value = (String) memberOf.get(name);
-                        if (StringUtil.isNotBlank(value)) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("{} is a member of {}", name, value);
-                            }
-                            if (memberType.contains("group")) {
-                                addGroupOrRoleName(groupList, value, useDomainServices);
-                            } else if (memberType.contains("role")) {
-                                addGroupOrRoleName(roleList, value, useDomainServices);
-                            } else {
-                                if (logger.isDebugEnabled()) {
-                                    logger.debug("Unknown @odata.type: {}", memberOf);
-                                }
-                                addGroupOrRoleName(groupList, value, useDomainServices);
-                            }
-                        } else if (logger.isDebugEnabled()) {
-                            logger.debug("{} is empty: {}", name, memberOf);
-                        }
-                    }
-                }
-                final String nextLink = (String) contentMap.get("@odata.nextLink");
-                if (StringUtil.isNotBlank(nextLink)) {
-                    processMemberOf(user, groupList, roleList, nextLink);
-                }
-            } else if (contentMap.containsKey("error")) {
-                logger.warn("Failed to access groups/roles: {}", contentMap);
-            }
-        } catch (final IOException e) {
-            logger.warn("Failed to access groups/roles in Entra ID.", e);
-        }
-    }
-
-    /**
      * Adds a group or role name to the specified list.
      * @param list The list to add the group or role name to.
      * @param value The group or role name value.
@@ -1060,16 +982,6 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             logger.debug("[processParentGroup] Completed for id: {}, depth: {}, added groups: {}, added roles: {}", id, depth,
                     groupsAndRoles.getFirst().length, groupsAndRoles.getSecond().length);
         }
-    }
-
-    /**
-     * Retrieves parent group information for the specified group ID.
-     * @param user The Entra ID user.
-     * @param id The group ID to get parent information for.
-     * @return A pair containing group names and role names.
-     */
-    protected Pair<String[], String[]> getParentGroup(final EntraIdUser user, final String id) {
-        return getParentGroup(user, id, 0);
     }
 
     /**
@@ -1368,14 +1280,20 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /**
      * Gets the state time-to-live from configuration.
      * Uses new entraid.state.ttl key with fallback to legacy aad.state.ttl.
-     * @return The state TTL in milliseconds.
+     * @return The state TTL in seconds. removeExpiredStates compares it against an elapsed time
+     *         that has already been divided by 1000.
      */
     protected long getStateTtl() {
         String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_STATE_TTL);
         if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_STATE_TTL, "3600");
+            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_STATE_TTL, DEFAULT_STATE_TTL);
         }
-        return Long.parseLong(value);
+        try {
+            return Long.parseLong(value.trim());
+        } catch (final NumberFormatException e) {
+            logger.warn("Invalid {}: {}. Using {} seconds.", ENTRAID_STATE_TTL, value, DEFAULT_STATE_TTL);
+            return Long.parseLong(DEFAULT_STATE_TTL);
+        }
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -508,6 +508,27 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getStateTtl_defaultsToOneHourInSeconds() {
+        // removeExpiredStates compares (now - created) / 1000 against this value, so the unit is
+        // seconds. The javadoc used to say milliseconds.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        assertEquals(3600L, authenticator.getStateTtl());
+    }
+
+    @Test
+    public void test_getStateTtl_fallsBackWhenTheConfiguredValueIsNotANumber() {
+        // A typo in conf/system.properties used to fail the login with a NumberFormatException
+        // rather than a message anyone could act on.
+        ComponentUtil.getFessConfig().setSystemProperty("entraid.state.ttl", "one hour");
+        try {
+            final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+            assertEquals(3600L, authenticator.getStateTtl());
+        } finally {
+            ComponentUtil.getFessConfig().setSystemProperty("entraid.state.ttl", "");
+        }
+    }
+
+    @Test
     public void test_addGroupOrRoleName() {
         EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
         List<String> list = new ArrayList<>();


### PR DESCRIPTION
## Unreachable code

**`processMemberOf()` (84 lines).** `updateMemberOf()` calls `processDirectMemberOf()`; the only
call to `processMemberOf()` is its own `@odata.nextLink` recursion, and nothing else in the tree
— `src/main` or `src/test` — reaches either entry point. The two methods are near-identical, so
they are exactly the shape where a fix lands in one copy and quietly misses the other.

**`getParentGroup(user, id)`**, the two-argument overload, has no callers.

Both removed. The three-argument `getParentGroup` and `processDirectMemberOf` are untouched.

## `getStateTtl()`

Two small corrections:

- The javadoc said "in milliseconds". `removeExpiredStates` compares it against an elapsed time
  that has already been divided by 1000, so the unit is **seconds** and the `3600` default is one
  hour, not 3.6.
- `Long.parseLong(value)` was unguarded, so a typo in `conf/system.properties` failed the login
  with a `NumberFormatException` rather than something an operator could act on. It now warns and
  falls back to the default, and trims the value.

## Tests

`EntraIdAuthenticator`'s unit test class, 2 new tests:

- `test_getStateTtl_defaultsToOneHourInSeconds`
- `test_getStateTtl_fallsBackWhenTheConfiguredValueIsNotANumber` — errored with a
  `NumberFormatException` before the change

```
Tests run: 133, Failures: 0, Errors: 0, Skipped: 0
```

(the whole `org.codelibs.fess.sso` package)
