### PR TITLE
fix(sso): request the OIDC scopes at the Entra ID authorization endpoint

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -176,6 +176,15 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     protected static final String CODE = "code";
 
     /**
+     * Scopes requested at the v2.0 authorization endpoint. msal4j already prepends
+     * {@code openid profile offline_access} to the token request (its
+     * {@code OAuthAuthorizationGrant.COMMON_SCOPES}), so naming them here as well means consent is
+     * asked for the same set the token exchange goes on to request, rather than relying on the
+     * app registration's static permissions happening to include them.
+     */
+    protected static final String V2_SCOPES = "openid profile offline_access https://graph.microsoft.com/.default";
+
+    /**
      * Response parameters whose values are credentials. Their values are truncated before being
      * written to a debug log; every other parameter is logged verbatim so that a failed login can
      * still be diagnosed from {@code state}, {@code error} and {@code error_description}.
@@ -325,8 +334,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
 
         if (useV2Endpoint) {
             // v2.0 endpoint with MSAL4J (recommended)
-            authUrl = getAuthority() + getTenant()
-                    + "/oauth2/v2.0/authorize?response_type=code&scope=https://graph.microsoft.com/.default&response_mode=query&redirect_uri="
+            authUrl = getAuthority() + getTenant() + "/oauth2/v2.0/authorize?response_type=code&scope="
+                    + URLEncoder.encode(V2_SCOPES, Constants.UTF_8_CHARSET) + "&response_mode=query&redirect_uri="
                     + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id=" + getClientId() + "&state=" + state
                     + "&nonce=" + nonce;
         } else {

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -145,6 +147,32 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
         assertTrue(authUrl.contains("response_mode=query"));
         assertFalse(authUrl.contains("response_mode=form_post"));
+    }
+
+    @Test
+    public void test_getAuthUrl_requestsTheOidcScopesUpFront() {
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+
+        final String authUrl = authenticator.getAuthUrl(getMockRequest());
+
+        // msal4j already prepends these to the token request (OAuthAuthorizationGrant's
+        // COMMON_SCOPES), so asking for them at the authorization endpoint too keeps consent and
+        // the token exchange asking for the same thing.
+        final String scope = URLDecoder.decode(authUrl.replaceFirst("(?s).*[?&]scope=([^&]*).*", "$1"), StandardCharsets.UTF_8);
+        assertEquals("openid profile offline_access https://graph.microsoft.com/.default", scope);
+    }
+
+    @Test
+    public void test_getAuthUrl_encodesTheScopeParameter() {
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+
+        final String authUrl = authenticator.getAuthUrl(getMockRequest());
+
+        // A multi-valued scope is space separated, which cannot be sent raw.
+        assertFalse(authUrl.contains("scope=openid profile"));
+        assertTrue(authUrl.contains("&client_id="));
     }
 
     @Test


### PR DESCRIPTION
## Problem

The v2.0 authorization request asked for one scope:

```java
"/oauth2/v2.0/authorize?response_type=code&scope=https://graph.microsoft.com/.default&..."
```

`.default` resolves to whatever delegated permissions the app registration has been granted, so
whether an `id_token` and a refresh token come back depends on that registration happening to
include `openid`, `profile` and `offline_access`. `validateNonce()` reads
`authData.idToken()` unconditionally, so a registration without `openid` fails the login with a
confusing message.

Meanwhile msal4j **already** asks for those three at the token endpoint — `COMMON_SCOPES` in
`OAuthAuthorizationGrant`:

```java
this.scopes = new HashSet<>(AbstractMsalAuthorizationGrant.COMMON_SCOPES);   // openid profile offline_access
```

So the two halves of the same flow were asking for different things: consent was collected for one
set, the token exchange requested another.

## Fix

Ask for the same set at the authorization endpoint:

```
scope=openid profile offline_access https://graph.microsoft.com/.default
```

Microsoft documents `.default` as combinable with exactly these three. The scope parameter is now
URL encoded, which a space-separated value requires — previously the single scope happened to
contain no characters needing it.

The v1.0 branch is untouched: it identifies the resource with the `resource` parameter rather than
through scopes.

## Scope of the claim

This is a consistency and robustness fix, not a repair of a confirmed breakage. Because msal4j
adds the OIDC scopes at the token step, an existing deployment whose app registration has consent
for them is already getting an id_token and a refresh token today. What changes is that the
authorization request no longer depends on that being true.

## Tests

`EntraIdAuthenticator`'s unit test class, 2 new tests, the first failing before the change
(`expected: <openid profile offline_access https://graph.microsoft.com/.default> but was:
<https://graph.microsoft.com/.default>`):

- `test_getAuthUrl_requestsTheOidcScopesUpFront` — decodes the `scope` parameter out of the built
  URL and compares it exactly
- `test_getAuthUrl_encodesTheScopeParameter` — a raw space would truncate the query string

```
Tests run: 133, Failures: 0, Errors: 0, Skipped: 0
```

(the whole `org.codelibs.fess.sso` package)
