### PR TITLE
fix(sso): share one MSAL4J application so Entra ID silent refresh can work

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -275,6 +275,12 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /** Use V2 endpoint. */
     protected boolean useV2Endpoint = true;
 
+    /** Shared MSAL4J client application. Holds the token cache that silent refresh reads. */
+    protected volatile ConfidentialClientApplication clientApplication;
+
+    /** Identifies the configuration {@link #clientApplication} was built from. */
+    protected volatile String clientApplicationKey;
+
     /**
      * Initializes the Entra ID authenticator.
      * Registers this authenticator with the SSO manager and sets up group cache.
@@ -539,6 +545,51 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Returns the shared MSAL4J client application.
+     *
+     * <p>Each {@link ConfidentialClientApplication} owns its own in-memory token cache, and
+     * {@code acquireTokenSilently} throws {@code NO_TOKEN_IN_CACHE} on a miss. Building one per
+     * call therefore made silent refresh impossible: the tokens acquired at login went into an
+     * instance that was thrown away immediately afterwards. One instance per authenticator keeps
+     * them reachable. MSAL4J documents the application as thread safe and meant to be reused.
+     *
+     * <p>The instance is rebuilt when the client id, secret or tenant changes, because all three
+     * are editable from the admin screen while Fess is running.
+     *
+     * @return The client application.
+     */
+    protected ConfidentialClientApplication getClientApplication() {
+        final String clientId = getClientId();
+        final String clientSecret = getClientSecret();
+        final String authority = getAuthority() + getTenant() + "/";
+        // The secret is reduced to a hash so the key can never carry it into a log or a heap dump
+        // label; a collision would only mean the application is not rebuilt after a secret change.
+        final String key = authority + '\n' + clientId + '\n' + clientSecret.hashCode();
+        final ConfidentialClientApplication current = clientApplication;
+        if (current != null && key.equals(clientApplicationKey)) {
+            return current;
+        }
+        synchronized (this) {
+            if (clientApplication != null && key.equals(clientApplicationKey)) {
+                return clientApplication;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("Building a client application for authority={}", authority);
+            }
+            try {
+                clientApplication = ConfidentialClientApplication
+                        .builder(clientId, com.microsoft.aad.msal4j.ClientCredentialFactory.createFromSecret(clientSecret))
+                        .authority(authority)
+                        .build();
+                clientApplicationKey = key;
+                return clientApplication;
+            } catch (final Exception e) {
+                throw new SsoLoginException("Failed to build an Entra ID client application.", e);
+            }
+        }
+    }
+
+    /**
      * Obtains an access token using a refresh token.
      * @param refreshToken The refresh token to use for token acquisition.
      * @return The authentication result containing the access token.
@@ -549,10 +600,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             logger.debug("refreshToken={}, authority={}", maskSecret(refreshToken), authority);
         }
         try {
-            final ConfidentialClientApplication app = ConfidentialClientApplication
-                    .builder(getClientId(), com.microsoft.aad.msal4j.ClientCredentialFactory.createFromSecret(getClientSecret()))
-                    .authority(authority)
-                    .build();
+            final ConfidentialClientApplication app = getClientApplication();
 
             final RefreshTokenParameters parameters =
                     RefreshTokenParameters.builder(Collections.singleton("https://graph.microsoft.com/.default"), refreshToken).build();
@@ -580,10 +628,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             logger.debug("authCode={}, authority={}, uri={}", maskSecret(authCode), authority, currentUri);
         }
         try {
-            final ConfidentialClientApplication app = ConfidentialClientApplication
-                    .builder(getClientId(), com.microsoft.aad.msal4j.ClientCredentialFactory.createFromSecret(getClientSecret()))
-                    .authority(authority)
-                    .build();
+            final ConfidentialClientApplication app = getClientApplication();
 
             final AuthorizationCodeParameters parameters = AuthorizationCodeParameters.builder(authCode, new URI(currentUri))
                     .scopes(Collections.singleton("https://graph.microsoft.com/.default"))
@@ -605,12 +650,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The new authentication result, or null if silent refresh failed.
      */
     public IAuthenticationResult refreshTokenSilently(final EntraIdCredential.EntraIdUser user) {
-        final String authority = getAuthority() + getTenant() + "/";
         try {
-            final ConfidentialClientApplication app = ConfidentialClientApplication
-                    .builder(getClientId(), com.microsoft.aad.msal4j.ClientCredentialFactory.createFromSecret(getClientSecret()))
-                    .authority(authority)
-                    .build();
+            final ConfidentialClientApplication app = getClientApplication();
 
             final SilentParameters parameters = SilentParameters
                     .builder(Collections.singleton("https://graph.microsoft.com/.default"), user.getAuthenticationResult().account())

--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -71,6 +71,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.microsoft.aad.msal4j.AuthorizationCodeParameters;
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
+import com.microsoft.aad.msal4j.IAccount;
 import com.microsoft.aad.msal4j.IAuthenticationResult;
 import com.microsoft.aad.msal4j.RefreshTokenParameters;
 import com.microsoft.aad.msal4j.SilentParameters;
@@ -1399,7 +1400,35 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
 
     @Override
     public String logout(final FessUserBean user) {
+        // The client application is shared for the whole server so that its token cache survives
+        // between a login and its refresh. MSAL4J's TokenCache is a set of unbounded LinkedHashMaps
+        // with no eviction, and removeAccount() is the only way anything leaves it, so a user who
+        // logs out has to be dropped explicitly or they stay resident until the JVM restarts.
+        if (user.getFessUser() instanceof final EntraIdUser entraIdUser) {
+            final IAuthenticationResult authResult = entraIdUser.getAuthenticationResult();
+            if (authResult != null && authResult.account() != null) {
+                removeAccount(authResult.account());
+            }
+        }
+        // Null keeps the existing behaviour: Fess does not sign the user out at Entra ID.
         return null;
+    }
+
+    /**
+     * Drops an account's tokens from the shared client application's cache.
+     *
+     * @param account The account to evict.
+     */
+    protected void removeAccount(final IAccount account) {
+        try {
+            getClientApplication().removeAccount(account).join();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Removed an account from the token cache.");
+            }
+        } catch (final Exception e) {
+            // Logging out must not fail because the cache could not be pruned.
+            logger.warn("Failed to remove an account from the Entra ID token cache.", e);
+        }
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -23,6 +23,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -40,8 +41,10 @@ import org.codelibs.core.misc.Pair;
 import org.codelibs.curl.Curl;
 import org.codelibs.curl.CurlResponse;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
+import org.codelibs.fess.app.web.base.login.EntraIdCredential;
 import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
@@ -54,6 +57,9 @@ import jakarta.servlet.http.HttpSession;
 
 import com.google.common.cache.CacheBuilder;
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
+import com.microsoft.aad.msal4j.IAccount;
+import com.microsoft.aad.msal4j.IAuthenticationResult;
+import com.microsoft.aad.msal4j.ITenantProfile;
 
 public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
@@ -98,6 +104,141 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
             assertTrue("config change must rebuild", afterSecretChange != authenticator.getClientApplication());
         } finally {
             setEntraIdConfig("", "", "");
+        }
+    }
+
+    @Test
+    public void test_logout_evictsTheUsersTokensFromTheSharedCache() {
+        // MSAL4J's TokenCache is five unbounded LinkedHashMaps with no eviction; the only way
+        // anything leaves is removeAccount(). Now that one application is shared for the whole
+        // server, never calling it would keep every user who ever logged in resident until restart.
+        final List<IAccount> removed = new ArrayList<>();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected void removeAccount(final IAccount account) {
+                removed.add(account);
+            }
+
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                // keep the constructor off Microsoft Graph
+            }
+        };
+        ComponentUtil.register(authenticator, EntraIdAuthenticator.class.getCanonicalName());
+        final TestAccount account = new TestAccount();
+        final EntraIdUser user = new EntraIdCredential(new TestAuthenticationResult(account)).getUser();
+
+        assertNull(authenticator.logout(new FessUserBean(user)));
+
+        assertEquals(1, removed.size());
+        assertSame(account, removed.get(0));
+    }
+
+    @Test
+    public void test_logout_ignoresAUserThatIsNotAnEntraIdUser() {
+        // SPNEGO, SAML and LDAP users reach the same logout hook.
+        final List<IAccount> removed = new ArrayList<>();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected void removeAccount(final IAccount account) {
+                removed.add(account);
+            }
+        };
+
+        assertNull(authenticator.logout(new FessUserBean(new TestFessUser())));
+        assertTrue(removed.isEmpty());
+    }
+
+    /** A FessUser that is not an EntraIdUser, standing in for the other authenticators. */
+    private static class TestFessUser implements org.codelibs.fess.entity.FessUser {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String getName() {
+            return "not-an-entraid-user";
+        }
+
+        @Override
+        public String[] getRoleNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getGroupNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getPermissions() {
+            return new String[0];
+        }
+    }
+
+    private static class TestAccount implements IAccount {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String homeAccountId() {
+            return "home-account-id";
+        }
+
+        @Override
+        public String environment() {
+            return "login.microsoftonline.com";
+        }
+
+        @Override
+        public String username() {
+            return "taro@contoso.onmicrosoft.com";
+        }
+
+        @Override
+        public Map<String, ITenantProfile> getTenantProfiles() {
+            return Collections.emptyMap();
+        }
+    }
+
+    private static class TestAuthenticationResult implements IAuthenticationResult {
+        private static final long serialVersionUID = 1L;
+        private final IAccount account;
+
+        TestAuthenticationResult(final IAccount account) {
+            this.account = account;
+        }
+
+        @Override
+        public String accessToken() {
+            return "access-token";
+        }
+
+        @Override
+        public String idToken() {
+            return "id-token";
+        }
+
+        @Override
+        public IAccount account() {
+            return account;
+        }
+
+        @Override
+        public ITenantProfile tenantProfile() {
+            return null;
+        }
+
+        @Override
+        public String environment() {
+            return "login.microsoftonline.com";
+        }
+
+        @Override
+        public String scopes() {
+            return "https://graph.microsoft.com/.default";
+        }
+
+        @Override
+        public Date expiresOnDate() {
+            return new Date(Long.MAX_VALUE);
         }
     }
 

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -42,6 +42,7 @@ import org.codelibs.curl.CurlResponse;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
 import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
@@ -52,8 +53,89 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
 import com.google.common.cache.CacheBuilder;
+import com.microsoft.aad.msal4j.ConfidentialClientApplication;
 
 public class EntraIdAuthenticatorTest extends UnitFessTestCase {
+
+    private void setEntraIdConfig(final String clientId, final String clientSecret, final String tenant) {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        fessConfig.setSystemProperty("entraid.client.id", clientId);
+        fessConfig.setSystemProperty("entraid.client.secret", clientSecret);
+        fessConfig.setSystemProperty("entraid.tenant", tenant);
+    }
+
+    @Test
+    public void test_getClientApplication_isReusedSoItsTokenCacheSurvives() {
+        // A fresh ConfidentialClientApplication starts with an empty TokenCache, and
+        // acquireTokenSilently throws NO_TOKEN_IN_CACHE on a miss. Building one per call therefore
+        // made silent refresh impossible; the tokens acquired at login have to stay reachable.
+        try {
+            setEntraIdConfig("11111111-1111-1111-1111-111111111111", "secret-1", "contoso.onmicrosoft.com");
+            final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+
+            assertSame(authenticator.getClientApplication(), authenticator.getClientApplication());
+        } finally {
+            setEntraIdConfig("", "", "");
+        }
+    }
+
+    @Test
+    public void test_getClientApplication_isRebuiltWhenTheConfigurationChanges() {
+        // The client id, secret and tenant are editable from the admin screen at runtime.
+        try {
+            setEntraIdConfig("11111111-1111-1111-1111-111111111111", "secret-1", "contoso.onmicrosoft.com");
+            final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+            final ConfidentialClientApplication first = authenticator.getClientApplication();
+
+            setEntraIdConfig("11111111-1111-1111-1111-111111111111", "secret-2", "contoso.onmicrosoft.com");
+            final ConfidentialClientApplication afterSecretChange = authenticator.getClientApplication();
+            assertTrue("secret change must rebuild", first != afterSecretChange);
+
+            setEntraIdConfig("22222222-2222-2222-2222-222222222222", "secret-2", "contoso.onmicrosoft.com");
+            assertTrue("config change must rebuild", afterSecretChange != authenticator.getClientApplication());
+
+            setEntraIdConfig("22222222-2222-2222-2222-222222222222", "secret-2", "fabrikam.onmicrosoft.com");
+            assertTrue("config change must rebuild", afterSecretChange != authenticator.getClientApplication());
+        } finally {
+            setEntraIdConfig("", "", "");
+        }
+    }
+
+    @Test
+    public void test_getClientApplication_isBuiltOnceUnderConcurrentAccess() throws Exception {
+        try {
+            setEntraIdConfig("11111111-1111-1111-1111-111111111111", "secret-1", "contoso.onmicrosoft.com");
+            final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+            final int threads = 8;
+            final CountDownLatch start = new CountDownLatch(1);
+            final List<ConfidentialClientApplication> seen = Collections.synchronizedList(new ArrayList<>());
+            final List<Thread> workers = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                final Thread t = new Thread(() -> {
+                    try {
+                        start.await();
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    seen.add(authenticator.getClientApplication());
+                });
+                workers.add(t);
+                t.start();
+            }
+            start.countDown();
+            for (final Thread t : workers) {
+                t.join(10000L);
+            }
+
+            assertEquals(threads, seen.size());
+            // Two instances means two token caches, and a login cached in one is invisible to the
+            // other when its refresh comes round.
+            seen.forEach(app -> assertSame(seen.get(0), app));
+        } finally {
+            setEntraIdConfig("", "", "");
+        }
+    }
 
     /** Lets a test move the clock that state expiry is measured against. */
     private final AtomicLong clock = new AtomicLong(1_000_000L);


### PR DESCRIPTION
## Problem

`getAccessToken()` (both overloads) and `refreshTokenSilently()` each built their own client
application:

```java
final ConfidentialClientApplication app = ConfidentialClientApplication
        .builder(getClientId(), ClientCredentialFactory.createFromSecret(getClientSecret()))
        .authority(authority)
        .build();
```

Every `ConfidentialClientApplication` owns its own in-memory `TokenCache`
(`AbstractClientApplicationBase`: `super.tokenCache = new TokenCache(builder.tokenCacheAccessAspect)`),
and no `ITokenCacheAccessAspect` is configured, so nothing persists it. msal4j's
`AcquireTokenSilentSupplier` then does:

```java
res = clientApplication.tokenCache.getCachedAuthenticationResult(account, requestAuthority, scopes, clientId);
if (res == null) {
    throw new MsalClientException(AuthenticationErrorMessage.NO_TOKEN_IN_CACHE, AuthenticationErrorCode.CACHE_MISS);
}
```

The tokens acquired at login went into an instance discarded immediately afterwards, so
`acquireTokenSilently` looked in an empty cache **every time**. `refreshTokenSilently()` always
threw, always returned `null`, and `EntraIdCredential.refresh()` never took its success branch:

```java
final IAuthenticationResult newResult = authenticator.refreshTokenSilently(this);
if (newResult != null) {        // never
    authResult = newResult;
    authenticator.updateMemberOf(this);
    ...
}
```

So `updateMemberOf()` never ran again after login. A user's groups and roles were whatever they
had been at login for the whole life of the session, no matter what changed in Entra ID.

## Fix

Hold one application per authenticator — which is what msal4j documents as the intended usage,
and what keeps the token cache alive between the login and its refresh.

`getClientApplication()` rebuilds it when the client id, secret or tenant changes, because all
three are editable from the admin screen while Fess is running. The build is double-checked under
a lock so concurrent logins share one cache rather than racing to create two. The cache key
reduces the secret to a hash so it cannot travel into a log line or a heap dump label.

Also drops a now-unused local in `refreshTokenSilently()`.

## What this deliberately does not change

When a refresh genuinely fails, `refresh()` still returns `false` and
`FessBaseAction.godHandPrologue` still discards that value:

```java
final boolean result = u.getFessUser().refresh();
if (logger.isDebugEnabled()) { logger.debug("Refreshed user info: result={}", result); }
```

Acting on it would log the user out, and it would affect every `FessUser` implementation — LDAP,
OpenID Connect, SAML — not just Entra ID. That belongs in its own change.

Note also that the cache is in-memory: it does not survive a restart, and it is not shared across
a cluster. In both cases the behaviour degrades to what it is today (the refresh fails, the
session keeps its existing token until it expires), not to something worse.

## Tests

`EntraIdAuthenticator`'s unit test class, 3 new tests:

- `test_getClientApplication_isReusedSoItsTokenCacheSurvives`
- `test_getClientApplication_isRebuiltWhenTheConfigurationChanges` — secret, client id and tenant
  each independently
- `test_getClientApplication_isBuiltOnceUnderConcurrentAccess` — 8 threads must share one instance

Falsification: with the reuse check removed so the application is rebuilt every call, the first
and third fail.

The end-to-end refresh — login, wait for expiry, silent re-acquisition — needs a real tenant and
is not covered here. What is covered is the mechanism that made it impossible.

```
Tests run: 134, Failures: 0, Errors: 0, Skipped: 0
```

(the whole `org.codelibs.fess.sso` package)
