### PR TITLE
feat(chunk): recognise non-Latin sentence marks and protect orthographic clusters

### DIFF
--- a/src/main/java/org/codelibs/fess/chunk/ChunkBoundaryFinder.java
+++ b/src/main/java/org/codelibs/fess/chunk/ChunkBoundaryFinder.java
@@ -535,8 +535,24 @@ public class ChunkBoundaryFinder {
         case 0x2047: // ⁇
         case 0x2048: // ⁈
         case 0x2049: // ⁉
-        case 0x06D4: // Arabic full stop
-        case 0x1362: // Ethiopic full stop
+        case 0x06D4: // ۔ Arabic full stop
+        case 0x061F: // ؟ Arabic question mark
+        case 0x0589: // ։ Armenian full stop
+        case 0x05C3: // ׃ Hebrew sof pasuq
+        case 0x037E: // ; Greek question mark
+        case 0x0964: // । Devanagari danda
+        case 0x0965: // ॥ Devanagari double danda
+        case 0x0F0D: // ། Tibetan shad
+        case 0x0F0E: // ༎ Tibetan nyis shad
+        case 0x104B: // ။ Myanmar section
+        case 0x17D4: // ។ Khmer khan
+        case 0x17D5: // ៕ Khmer bariyoosan
+        case 0x1362: // ። Ethiopic full stop
+        case 0x1803: // ᠃ Mongolian full stop
+        case 0x1805: // ᠅ Mongolian four dots
+        case 0x166E: // ᙮ Canadian syllabics full stop
+        case 0x10FB: // ჻ Georgian paragraph separator
+        case 0x0E5B: // ๛ Thai khomut (end of a passage)
         case 0x2E3C: // stenographic full stop
             return true;
         default:
@@ -569,6 +585,16 @@ public class ChunkBoundaryFinder {
         case 0x2015: // ―
         case 0x301C: // 〜
         case 0xFF5E: // ～
+        case 0x060C: // ، Arabic comma
+        case 0x061B: // ؛ Arabic semicolon
+        case 0x055D: // ՝ Armenian comma
+        case 0x1363: // ፣ Ethiopic comma
+        case 0x1802: // ᠂ Mongolian comma
+        case 0x1804: // ᠄ Mongolian colon
+        case 0x104A: // ၊ Myanmar little section (a phrase break, not a sentence end)
+        case 0x17D6: // ៖ Khmer camnuc pii kuuh
+        case 0x0F0B: // ་ Tibetan tsheg -- the intersyllabic separator Tibetan uses for a space
+        case 0x0E5A: // ๚ Thai angkhankhu
             return true;
         default:
             return false;
@@ -727,9 +753,10 @@ public class ChunkBoundaryFinder {
      * Returns true if the code point continues the grapheme cluster started by the preceding
      * code point, so a boundary must not be placed in front of it.
      *
-     * <p>Covers combining marks, variation selectors and the zero-width joiner. Regional
-     * indicator pairs (flag emoji) are deliberately <em>not</em> covered: splitting is lossless,
-     * so a flag merely renders as two letters across the chunk boundary.</p>
+     * <p>Covers combining marks, variation selectors, the zero-width joiner and the Thai/Lao
+     * SARA AM. Regional indicator pairs (flag emoji) are deliberately <em>not</em> covered:
+     * splitting is lossless, so a flag merely renders as two letters across the chunk
+     * boundary.</p>
      *
      * @param cp the code point
      * @return true if a boundary must not be placed before this code point
@@ -739,6 +766,11 @@ public class ChunkBoundaryFinder {
             return true;
         }
         if (cp >= 0xFE00 && cp <= 0xFE0F || cp >= 0xE0100 && cp <= 0xE01EF) {
+            return true;
+        }
+        if (cp == 0x0E33 || cp == 0x0EB3) {
+            // THAI/LAO SARA AM: general category Lo, but UAX #29 gives it GCB=SpacingMark, so it
+            // belongs to the cluster of the consonant in front of it.
             return true;
         }
         final int type = Character.getType(cp);
@@ -751,7 +783,9 @@ public class ChunkBoundaryFinder {
      * be placed right after it either.
      *
      * <p>This is the backward-looking counterpart of {@link #isClusterContinuation}, which asks
-     * the same question about the code point <em>at</em> the candidate boundary. {@link
+     * the same question about the code point <em>at</em> the candidate boundary. It carries the
+     * cases where the <em>preceding</em> code point is an ordinary spacing letter that
+     * nonetheless owns the one after it -- the Khmer coeng and the Thai/Lao pre-base vowels. {@link
      * #adjustToClusterStart} tests both directions, so both must be overridable for a subclass
      * that redefines cluster joining to take full effect: overriding only
      * {@link #isClusterContinuation} would leave this direction on the built-in zero-width-joiner
@@ -761,6 +795,13 @@ public class ChunkBoundaryFinder {
      * @return true if a boundary must not be placed right after this code point
      */
     protected boolean isClusterJoiner(final int cp) {
-        return cp == ZWJ;
+        if (cp == ZWJ) {
+            return true;
+        }
+        // Khmer coeng subscripts the consonant that follows it, and the Thai/Lao pre-base vowels
+        // are written before the consonant they belong to. Both are ordinary spacing letters, so
+        // isClusterContinuation cannot see them -- but a boundary placed immediately after one
+        // strands it from its base, which is what a hard cut through scriptio-continua text hits.
+        return cp == 0x17D2 || cp >= 0x0E40 && cp <= 0x0E44 || cp >= 0x0EC0 && cp <= 0x0EC4;
     }
 }

--- a/src/test/java/org/codelibs/fess/chunk/ChunkBoundaryFinderTest.java
+++ b/src/test/java/org/codelibs/fess/chunk/ChunkBoundaryFinderTest.java
@@ -837,6 +837,151 @@ public class ChunkBoundaryFinderTest extends UnitFessTestCase {
         }
     }
 
+    // ===================================================================================
+    //                                                       Non-Latin sentence and clause marks
+    //                                                       ------------------------------------
+
+    @Test
+    public void test_isSentenceTerminator_coversNonLatinScripts() {
+        assertTrue(finder.sentenceTerminator(0x0964)); // । DEVANAGARI DANDA
+        assertTrue(finder.sentenceTerminator(0x0965)); // ॥ DEVANAGARI DOUBLE DANDA
+        assertTrue(finder.sentenceTerminator(0x061F)); // ؟ ARABIC QUESTION MARK
+        assertTrue(finder.sentenceTerminator(0x0589)); // ։ ARMENIAN FULL STOP
+        assertTrue(finder.sentenceTerminator(0x05C3)); // ׃ HEBREW SOF PASUQ
+        assertTrue(finder.sentenceTerminator(0x037E)); // ; GREEK QUESTION MARK
+        assertTrue(finder.sentenceTerminator(0x0F0D)); // ། TIBETAN SHAD
+        assertTrue(finder.sentenceTerminator(0x0F0E)); // ༎ TIBETAN NYIS SHAD
+        assertTrue(finder.sentenceTerminator(0x104B)); // ။ MYANMAR SECTION
+        assertTrue(finder.sentenceTerminator(0x17D4)); // ។ KHMER KHAN
+        assertTrue(finder.sentenceTerminator(0x17D5)); // ៕ KHMER BARIYOOSAN
+        assertTrue(finder.sentenceTerminator(0x1803)); // ᠃ MONGOLIAN FULL STOP
+        assertTrue(finder.sentenceTerminator(0x1805)); // ᠅ MONGOLIAN FOUR DOTS
+        assertTrue(finder.sentenceTerminator(0x166E)); // ᙮ CANADIAN SYLLABICS FULL STOP
+        assertTrue(finder.sentenceTerminator(0x10FB)); // ჻ GEORGIAN PARAGRAPH SEPARATOR
+        assertTrue(finder.sentenceTerminator(0x0E5B)); // ๛ THAI KHOMUT
+        // U+104A is a phrase break, not a sentence end -- it belongs to the WEAK tier.
+        assertFalse(finder.sentenceTerminator(0x104A));
+        assertFalse(finder.sentenceTerminator(0x060C)); // ، is a comma
+    }
+
+    @Test
+    public void test_isClauseSeparator_coversNonLatinScripts() {
+        assertTrue(finder.clauseSeparator(0x060C)); // ، ARABIC COMMA
+        assertTrue(finder.clauseSeparator(0x061B)); // ؛ ARABIC SEMICOLON
+        assertTrue(finder.clauseSeparator(0x055D)); // ՝ ARMENIAN COMMA
+        assertTrue(finder.clauseSeparator(0x1363)); // ፣ ETHIOPIC COMMA
+        assertTrue(finder.clauseSeparator(0x1802)); // ᠂ MONGOLIAN COMMA
+        assertTrue(finder.clauseSeparator(0x1804)); // ᠄ MONGOLIAN COLON
+        assertTrue(finder.clauseSeparator(0x104A)); // ၊ MYANMAR LITTLE SECTION
+        assertTrue(finder.clauseSeparator(0x17D6)); // ៖ KHMER CAMNUC PII KUUH
+        assertTrue(finder.clauseSeparator(0x0F0B)); // ་ TIBETAN TSHEG
+        assertTrue(finder.clauseSeparator(0x0E5A)); // ๚ THAI ANGKHANKHU
+        assertFalse(finder.clauseSeparator(0x0964)); // । is a sentence end
+    }
+
+    @Test
+    public void test_findChunkEnd_dandaBeatsANearerSpaceInDevanagari() {
+        // ...करता है। व्यवस्थापक प्रबंधन -- the ideal offset sits past a space that is NEARER than the
+        // danda, so only a STRONG classification of the danda can reach back past it.
+        final String text = "\u092F\u0939 \u0916\u094B\u091C \u0938\u0930\u094D\u0935\u0930 \u0939\u0948\u0964 "
+                + "\u0935\u094D\u092F\u0935\u0938\u094D\u0925\u093E\u092A\u0915 \u092A\u094D\u0930\u092C\u0902\u0927\u0928";
+        final int danda = text.indexOf('\u0964');
+        final int nearerSpace = text.indexOf(' ', danda + 2);
+        assertTrue(nearerSpace > danda + 2, "fixture must place a space between the danda and the ideal offset");
+        assertEquals(danda + 2, finder.findChunkEnd(text, 0, nearerSpace + 3, text.length(), 30, 0),
+                "the danda must outrank the nearer space");
+    }
+
+    @Test
+    public void test_findChunkEnd_arabicQuestionMarkBeatsANearerSpace() {
+        final String text = "\u0645\u0648\u0627\u0642\u0639 \u0627\u0644\u0648\u064A\u0628\u061F \u0646\u0639\u0645 "
+                + "\u064A\u0645\u0643\u0646\u0647 \u0630\u0644\u0643";
+        final int mark = text.indexOf('\u061F');
+        final int nearerSpace = text.indexOf(' ', mark + 2);
+        assertEquals(mark + 2, finder.findChunkEnd(text, 0, nearerSpace + 3, text.length(), 30, 0),
+                "the Arabic question mark must outrank the nearer space");
+    }
+
+    @Test
+    public void test_findChunkEnd_khmerKhanAndMyanmarSectionBeatANearerSpace() {
+        final String khmer = "\u1781\u17C2\u179A\u17D4 \u17A2\u1793\u1780 \u1782\u179A\u1794";
+        final int khan = khmer.indexOf('\u17D4');
+        assertEquals(khan + 2, finder.findChunkEnd(khmer, 0, khmer.indexOf(' ', khan + 2) + 3, khmer.length(), 30, 0));
+        final String myanmar = "\u1017\u101E\u100A\u104B \u1005\u102E\u1019 \u1001\u1014\u1037";
+        final int section = myanmar.indexOf('\u104B');
+        assertEquals(section + 2, finder.findChunkEnd(myanmar, 0, myanmar.indexOf(' ', section + 2) + 3, myanmar.length(), 30, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_myanmarLittleSectionIsOnlyAWeakBreak() {
+        // ၊ is a phrase break: a real sentence end further back must still outrank it.
+        final String text = "\u1017\u101E\u104B \u1005\u102E\u1019\u104A \u1001\u1014\u1037\u1019";
+        final int section = text.indexOf('\u104B');
+        assertEquals(section + 2, finder.findChunkEnd(text, 0, text.length() - 1, text.length(), 30, 0),
+                "the section mark (STRONG) must beat the little section (WEAK)");
+    }
+
+    // ===================================================================================
+    //                                                          Orthographic clusters
+    //                                                          ----------------------
+    // Pre-base vowels and the Khmer coeng are ordinary spacing letters, so isClusterContinuation
+    // cannot see them -- but the letter they own comes AFTER them, so a boundary placed directly
+    // behind one strands it. This is what a hard cut through scriptio-continua text hits.
+
+    @Test
+    public void test_isClusterJoiner_coversKhmerCoengAndPreBaseVowels() {
+        assertTrue(finder.clusterJoiner(0x200D)); // ZWJ
+        assertTrue(finder.clusterJoiner(0x17D2)); // KHMER SIGN COENG
+        assertTrue(finder.clusterJoiner(0x0E40)); // THAI SARA E
+        assertTrue(finder.clusterJoiner(0x0E44)); // THAI SARA AI MAIMALAI
+        assertTrue(finder.clusterJoiner(0x0EC0)); // LAO VOWEL SIGN E
+        assertTrue(finder.clusterJoiner(0x0EC4)); // LAO VOWEL SIGN AI
+        assertFalse(finder.clusterJoiner(0x0E45)); // THAI LAKKHANGYAO is not pre-base
+        assertFalse(finder.clusterJoiner('a'));
+    }
+
+    @Test
+    public void test_isClusterContinuation_coversThaiAndLaoSaraAm() {
+        // General category Lo, but UAX #29 gives it GCB=SpacingMark.
+        assertTrue(finder.clusterContinuation(0x0E33)); // THAI SARA AM
+        assertTrue(finder.clusterContinuation(0x0EB3)); // LAO VOWEL SIGN AM
+    }
+
+    @Test
+    public void test_findChunkEnd_neverStrandsAKhmerCoengOrAPreBaseVowel() {
+        final String khmer = repeatCodePoints("\u1792\u17D2\u179C\u17BE\u179B\u17B7\u1794\u17B7\u1780\u17D2\u179A\u1798", 40);
+        assertNoStrandedJoiner(khmer);
+        final String thai = repeatCodePoints(
+                "\u0E19\u0E35\u0E48\u0E04\u0E37\u0E2D\u0E40\u0E0B\u0E34\u0E23\u0E4C\u0E1F\u0E40\u0E27\u0E2D\u0E23\u0E4C", 40);
+        assertNoStrandedJoiner(thai);
+    }
+
+    private void assertNoStrandedJoiner(final String text) {
+        for (int ideal = 1; ideal < text.length(); ideal++) {
+            for (final int lookback : new int[] { 0, 4, 16, 64 }) {
+                final int result = finder.findChunkEnd(text, 0, ideal, text.length(), lookback, 0);
+                if (result > 0 && result < text.length()) {
+                    // Deliberately NOT expressed through the predicates under test: a literal set,
+                    // so weakening the predicates cannot make this assertion vacuous.
+                    final int before = Character.codePointBefore(text, result);
+                    assertFalse(before == 0x17D2 || before >= 0x0E40 && before <= 0x0E44 || before >= 0x0EC0 && before <= 0x0EC4,
+                            "ideal=" + ideal + " lookback=" + lookback + " stranded U+" + Integer.toHexString(before) + " at " + result);
+                    final int at = Character.codePointAt(text, result);
+                    assertFalse(at == 0x0E33 || at == 0x0EB3,
+                            "ideal=" + ideal + " lookback=" + lookback + " stranded SARA AM at " + result);
+                }
+            }
+        }
+    }
+
+    private String repeatCodePoints(final String unit, final int times) {
+        final StringBuilder builder = new StringBuilder(unit.length() * times);
+        for (int i = 0; i < times; i++) {
+            builder.append(unit);
+        }
+        return builder.toString();
+    }
+
     /** Exposes the protected character predicates for assertion. */
     private static final class ExposedFinder extends ChunkBoundaryFinder {
         boolean breakableSpace(final int cp) {


### PR DESCRIPTION
Closes #3228. Stacked on #3211 — the base is that PR's branch, so the diff shown here is only this change. GitHub will retarget it to `master` when #3211 merges.

## Problem

`ChunkBoundaryFinder` recognised sentence and clause marks for Latin and CJK only. For several writing systems the STRONG tier was therefore unreachable, so the chunker fell back to the blind fixed-length cut the boundary search exists to replace. U+2E3C STENOGRAPHIC FULL STOP was in the table while the Devanagari danda was not.

Tier census over sample documents at the shipped defaults, **before** this change:

| script | STRONG |
|---|---|
| Hindi (Devanagari) | 0% |
| Burmese | 0% |
| Arabic / Hebrew | only when the text happens to use an ASCII `.` |

```
Hindi, 1648 chars:   cut@1593  ...है। व्यवस्थापक ||| प्रबंधन स्क्री
```

The cut should fall right after the danda; it landed 15 characters later, after the first word of the next sentence.

## Changes

**STRONG tier** — `।` `॥` (Devanagari), `؟` (Arabic), `։` (Armenian), `׃` (Hebrew), `;` U+037E (Greek), `།` `༎` (Tibetan), `။` (Myanmar), `។` `៕` (Khmer), `᠃` `᠅` (Mongolian), `᙮` (Canadian syllabics), `჻` (Georgian), `๛` (Thai).

**WEAK tier** — `،` `؛` (Arabic), `՝` (Armenian), `፣` (Ethiopic), `᠂` `᠄` (Mongolian), `၊` (Myanmar), `៖` (Khmer), `๚` (Thai), and `་` (Tibetan tsheg) — the intersyllabic separator Tibetan writes instead of a space, which is what gives Tibetan any break opportunity at all.

`၊` MYANMAR LITTLE SECTION is a phrase break rather than a sentence end, so it is WEAK while `။` MYANMAR SECTION is STRONG.

**Orthographic clusters.** Cuts through these scripts also broke syllable clusters — the Khmer example above ended a chunk on a dangling U+17D2 COENG with its consonant in the next chunk. The coeng subscripts the consonant that *follows* it, and the Thai and Lao pre-base vowels are written *before* the consonant they belong to. All are ordinary spacing letters, so `isClusterContinuation` could not see them. They are now cluster **joiners** (a boundary may not be placed right after them). Thai/Lao SARA AM is general category `Lo` but carries `GCB=SpacingMark`, so it is a cluster continuation.

After: every script above cuts at its own sentence mark, and a sweep of every offset × four lookback windows over Khmer and Thai corpora strands **0** coengs and **0** pre-base vowels.

## Remaining limitation

Scriptio-continua text with no punctuation *and* no phrase spaces (Thai, Khmer, Lao written that way) still produces no candidate in any tier and falls back to the hard cut — now at least without splitting a cluster. Covering that properly needs a syllable-boundary source such as `java.text.BreakIterator`, which allocates and is locale-dependent; that needs measuring against the current allocation-free scan before being adopted, so it is deliberately not in this PR.

## Testing

10 new tests. Every one was verified by mutating the production table and observing it fail (8 of 82 red under a combined mutation of the joiner set, the danda, the Arabic question mark, the Myanmar and Khmer marks, and the little section).

Two anti-tautology measures, both learned from the review of #3211:

- the behavioural tests place a space **nearer** the ideal offset than the mark under test, so a merely-WEAK classification picks the space and only a STRONG one reaches back to the mark. Without this, the space that follows the mark produces the same offset and the test cannot tell the tiers apart;
- the cluster sweep asserts against **literal code points**, not against the predicates under test, so weakening a predicate cannot make the assertion vacuous.

Full suite: 7003 tests, 0 failures. `formatter:validate`, `license:check` and `javadoc:jar` clean.
