### PR TITLE
fix(chunk): correct the break-opportunity and grapheme-cluster tables

### DIFF
--- a/src/main/java/org/codelibs/fess/chunk/ChunkBoundaryFinder.java
+++ b/src/main/java/org/codelibs/fess/chunk/ChunkBoundaryFinder.java
@@ -32,8 +32,14 @@ package org.codelibs.fess.chunk;
  */
 public class ChunkBoundaryFinder {
 
-    /** Zero-width joiner; splitting next to it breaks an emoji/grapheme sequence. */
-    protected static final int ZWJ = 0x200D;
+    /**
+     * Zero-width joiner; splitting next to it breaks an emoji/grapheme sequence.
+     *
+     * <p>{@code private}, unlike the {@code is*} predicates: a {@code static} field has no virtual
+     * dispatch, so a subclass redeclaring it would never be read. Override
+     * {@link #isClusterContinuation} or {@link #isClusterJoiner} instead.</p>
+     */
+    private static final int ZWJ = 0x200D;
 
     /** Returned in place of an offset when a tier has no candidate. */
     private static final int NO_CANDIDATE = -1;
@@ -42,15 +48,13 @@ public class ChunkBoundaryFinder {
      * How far the hard-cut fallback may walk back (then forward) to leave a grapheme cluster
      * intact, in code points.
      *
-     * <p>{@code protected} suggests a subclass can retune this budget by redeclaring the
-     * constant, but it cannot: the sole reader, {@link #adjustToClusterStart}, is {@code private}
-     * and binds this class's own constant at compile time -- {@code static} fields have no
-     * virtual dispatch, so a subclass's redeclaration is simply never read. This budget is not
-     * currently part of the swappable seam that {@link #isClusterContinuation} and the other
-     * {@code protected} predicates form; kept {@code protected} rather than narrowed to
-     * {@code private} to avoid an unrelated visibility change.</p>
+     * <p>Not part of the swappable seam that {@link #isClusterContinuation} and the other
+     * {@code protected} predicates form: a {@code static} field has no virtual dispatch, so a
+     * subclass redeclaring this constant would never be read. {@code package} rather than
+     * {@code private} only so {@link LengthChunker} can state the overshoot ceiling in terms of
+     * it.</p>
      */
-    protected static final int MAX_CLUSTER_ADJUST = 16;
+    static final int MAX_CLUSTER_ADJUST = 16;
 
     /**
      * Default constructor.
@@ -177,12 +181,14 @@ public class ChunkBoundaryFinder {
         // The scan's limitEnd is `bound`, and there is no forward search here: moving the overlap
         // start forward would skip text.
         final long packed = searchBackward(text, origin, base, bound, lookback);
+        // searchBackward only ever returns offsets in [max(origin + 1, base - lookback), base],
+        // which is inside (origin, bound] because base is, so no range re-check is needed here.
         final int strong = unpackStrong(packed);
-        if (strong != NO_CANDIDATE && strong > origin && strong <= bound) {
+        if (strong != NO_CANDIDATE) {
             return strong;
         }
         final int weakOrScript = unpackWeakOrScript(packed);
-        if (weakOrScript != NO_CANDIDATE && weakOrScript > origin && weakOrScript <= bound) {
+        if (weakOrScript != NO_CANDIDATE) {
             return weakOrScript;
         }
         return base;
@@ -261,13 +267,17 @@ public class ChunkBoundaryFinder {
                 }
                 runHasNewline |= isNewline(before);
                 runHasSpace |= isBreakableSpace(before);
-                runHasClosing |= isClosingBracket(before);
+                runHasClosing |= isClosingBracket(before) && !isDirectionAmbiguousQuote(before);
                 b -= beforeLen;
                 after = before;
                 continue;
             }
             final int candidate = runEnd == NO_CANDIDATE ? b : runEnd;
-            final boolean spaceSatisfied = runHasSpace || candidate >= limitEnd;
+            // No `|| candidate >= limitEnd` term here: findChunkEnd returns early when
+            // base >= bound, so every candidate is strictly below limitEnd on that path, and in
+            // snapOverlapStart limitEnd is the chunk end rather than the end of the text -- where
+            // "nothing follows, so the space requirement is moot" is simply untrue.
+            final boolean spaceSatisfied = runHasSpace;
             // A tier candidate is no more allowed to split a grapheme cluster than the hard cut
             // is; an offset that strands a combining mark or a joiner half is rejected and the
             // scan simply keeps looking. Without this the boundary search could split a cluster
@@ -389,6 +399,8 @@ public class ChunkBoundaryFinder {
                     sawSpace |= isBreakableSpace(next);
                     p += Character.charCount(next);
                 }
+                // Here the end of the text genuinely does satisfy the space requirement: a
+                // trailing "." with nothing after it still ends the sentence.
                 final boolean spaceSatisfied = sawSpace || p >= limitEnd;
                 final int afterCp = i + cpLen < limitEnd ? Character.codePointAt(text, i + cpLen) : -1;
                 final boolean blockedByDigit = isPunctuationRequiringNonDigit(cp) && afterCp >= 0 && Character.isDigit(afterCp);
@@ -474,8 +486,17 @@ public class ChunkBoundaryFinder {
      * Returns true if the code point is a break opportunity that behaves like a space.
      *
      * <p>Includes the code points {@link Character#isWhitespace(int)} reports as
-     * <em>non</em>-whitespace but that Fess's extracted text treats as separators
-     * (see {@code crawler.document.space.chars}).</p>
+     * <em>non</em>-whitespace but that render as a space: NEL, and the no-break spaces that
+     * {@code crawler.document.space.chars} normalises away before indexing but that survive in
+     * content Fess did not extract itself. They overlap that property without being derived from
+     * it.</p>
+     *
+     * <p>Deliberately excluded, although zero-width: {@code U+2060} WORD JOINER,
+     * {@code U+FEFF} ZWNBSP and {@code U+200C} ZWNJ exist precisely to <em>forbid</em> a break,
+     * so treating them as break opportunities inverted their meaning -- the ZWNJ case split
+     * single Persian words. {@code U+200B} ZERO WIDTH SPACE is the one member of that group that
+     * is a genuine break opportunity and is kept. {@code U+200D} ZWJ is a cluster joiner, handled
+     * by {@link #isClusterJoiner}.</p>
      *
      * @param cp the code point
      * @return true if the code point is a breakable space
@@ -494,9 +515,6 @@ public class ChunkBoundaryFinder {
         case 0x2007: // FIGURE SPACE
         case 0x202F: // NARROW NO-BREAK SPACE
         case 0x200B: // ZERO WIDTH SPACE
-        case 0x200C: // ZERO WIDTH NON-JOINER
-        case 0x2060: // WORD JOINER
-        case 0xFEFF: // ZERO WIDTH NO-BREAK SPACE / BOM
             return true;
         default:
             return false;
@@ -640,6 +658,8 @@ public class ChunkBoundaryFinder {
         case 0xFF0E: // ．
         case 0xFF0C: // ，
         case 0xFF1A: // ：
+        case 0x301C: // 〜
+        case 0xFF5E: // ～
             return true;
         default:
             return false;
@@ -663,6 +683,7 @@ public class ChunkBoundaryFinder {
         case 0xFF3D: // ］
         case 0xFF5D: // ｝
         case 0x300D: // 」
+        case 0xFF63: // ｣
         case 0x300F: // 』
         case 0x3011: // 】
         case 0x3015: // 〕
@@ -691,6 +712,7 @@ public class ChunkBoundaryFinder {
         case 0xFF3B: // ［
         case 0xFF5B: // ｛
         case 0x300C: // 「
+        case 0xFF62: // ｢
         case 0x300E: // 『
         case 0x3010: // 【
         case 0x3014: // 〔
@@ -713,6 +735,30 @@ public class ChunkBoundaryFinder {
      */
     protected boolean isSkippableAfterBoundary(final int cp) {
         return isBreakableSpace(cp) || isClosingBracket(cp);
+    }
+
+    /**
+     * Returns true if the code point is an ASCII quote, which cannot be told apart from its own
+     * opening form.
+     *
+     * <p>{@code '} and {@code "} are listed as closing marks -- {@code he said "go." then} must
+     * still reach its sentence end through them -- but they are just as often word-internal
+     * ({@code don't}, {@code O'Brien}) or an <em>opening</em> quote. Standing alone in a trailing
+     * run they therefore do not make a WEAK candidate the way {@code 」} or {@code )} do; a run
+     * that also contains a space still does. The curly forms {@code ’} and {@code ”} are
+     * unambiguous and are not affected.</p>
+     *
+     * <p>Known limitation: because they stay skippable, a run of "space then opening quote" still
+     * ends the chunk <em>after</em> the quote, leaving it orphaned at the end of the previous
+     * chunk. Excluding only a trailing ambiguous-quote tail from the run would need the run
+     * bookkeeping to distinguish its right edge from its interior; the outcome is lossless and
+     * purely cosmetic, so it is not worth that complexity.</p>
+     *
+     * @param cp the code point
+     * @return true if the code point is a direction-ambiguous ASCII quote
+     */
+    protected boolean isDirectionAmbiguousQuote(final int cp) {
+        return cp == '\'' || cp == '"';
     }
 
     /**
@@ -768,6 +814,27 @@ public class ChunkBoundaryFinder {
         if (cp >= 0xFE00 && cp <= 0xFE0F || cp >= 0xE0100 && cp <= 0xE01EF) {
             return true;
         }
+        if (cp >= 0x1F3FB && cp <= 0x1F3FF) {
+            // Emoji modifiers (skin tone): general category Sk, so getType() misses them.
+            return true;
+        }
+        if (cp >= 0xE0020 && cp <= 0xE007F) {
+            // Tag characters: the payload of an emoji tag sequence such as the Scotland flag.
+            return true;
+        }
+        if (cp >= 0x1160 && cp <= 0x11FF || cp >= 0xD7B0 && cp <= 0xD7FF) {
+            // Conjoining Hangul jamo: the vowel and trailing-consonant halves are Lo, but they
+            // compose with the leading jamo in front of them (UAX #29 GB6-GB8).
+            return true;
+        }
+        if (cp == 0xFF9E || cp == 0xFF9F) {
+            // Halfwidth katakana voiced and semi-voiced sound marks: Lm, but they modify the kana
+            // in front of them exactly as their fullwidth combining forms do.
+            return true;
+        }
+        if (isNoBreakGlue(cp)) {
+            return true;
+        }
         if (cp == 0x0E33 || cp == 0x0EB3) {
             // THAI/LAO SARA AM: general category Lo, but UAX #29 gives it GCB=SpacingMark, so it
             // belongs to the cluster of the consonant in front of it.
@@ -794,8 +861,41 @@ public class ChunkBoundaryFinder {
      * @param cp the code point immediately before the candidate boundary
      * @return true if a boundary must not be placed right after this code point
      */
+    /**
+     * Returns true if the code point exists specifically to forbid a break on both of its sides.
+     *
+     * <p>{@code U+2060} WORD JOINER and {@code U+FEFF} ZWNBSP are defined as no-break glue, and
+     * {@code U+200C} ZWNJ separates two glyphs of the <em>same</em> word (Persian
+     * {@code می‌رود}, Devanagari conjunct suppression). All three used to be treated as
+     * <em>preferred</em> break opportunities, which inverted their meaning. Consulted from both
+     * cluster predicates so the prohibition also binds the hard-cut fallback, not just the tier
+     * candidates. {@code U+200B} ZERO WIDTH SPACE is deliberately absent: it is a genuine break
+     * opportunity and stays in {@link #isBreakableSpace}.</p>
+     *
+     * @param cp the code point
+     * @return true if no boundary may be placed on either side of this code point
+     */
+    protected boolean isNoBreakGlue(final int cp) {
+        return cp == 0x2060 || cp == 0xFEFF || cp == 0x200C;
+    }
+
     protected boolean isClusterJoiner(final int cp) {
         if (cp == ZWJ) {
+            return true;
+        }
+        if (cp == '\r') {
+            // UAX #29 GB3: CR and LF are one cluster, so a boundary may not fall between them.
+            return true;
+        }
+        if (isNoBreakGlue(cp)) {
+            return true;
+        }
+        if (cp >= 0x2066 && cp <= 0x2068 || cp >= 0x202A && cp <= 0x202B || cp >= 0x202D && cp <= 0x202E) {
+            // Bidi isolate/embedding/override initiators. Cutting immediately after one leaves the
+            // opening control in the previous chunk with nothing to scope, and re-directs
+            // everything after it in the next one. This does not pair initiators with their
+            // terminators -- a cut further inside the run is still possible -- it only refuses the
+            // worst case, which is also the cheapest to detect.
             return true;
         }
         // Khmer coeng subscripts the consonant that follows it, and the Thai/Lao pre-base vowels

--- a/src/test/java/org/codelibs/fess/chunk/ChunkBoundaryFinderTest.java
+++ b/src/test/java/org/codelibs/fess/chunk/ChunkBoundaryFinderTest.java
@@ -40,14 +40,24 @@ public class ChunkBoundaryFinderTest extends UnitFessTestCase {
         assertTrue(finder.breakableSpace(0x00A0)); // NBSP
         assertTrue(finder.breakableSpace(0x2007)); // FIGURE SPACE
         assertTrue(finder.breakableSpace(0x202F)); // NNBSP
-        assertTrue(finder.breakableSpace(0x200B)); // ZWSP
-        assertTrue(finder.breakableSpace(0x200C)); // ZWNJ
-        assertTrue(finder.breakableSpace(0x2060)); // WORD JOINER
-        assertTrue(finder.breakableSpace(0xFEFF)); // ZWNBSP / BOM
+        assertTrue(finder.breakableSpace(0x200B)); // ZWSP -- the one zero-width genuine break
         assertTrue(finder.breakableSpace(0x0085)); // NEL
         assertFalse(finder.breakableSpace('a'));
         assertFalse(finder.breakableSpace(0x3042)); // HIRAGANA A
         assertFalse(finder.breakableSpace(0x200D)); // ZWJ is a joiner, not a break
+    }
+
+    @Test
+    public void test_isBreakableSpace_excludesTheCodePointsThatForbidABreak() {
+        // These exist precisely to prevent a break; treating them as break opportunities inverted
+        // their meaning. ZWNJ in particular separates two glyphs of the SAME word.
+        assertFalse(finder.breakableSpace(0x2060)); // WORD JOINER
+        assertFalse(finder.breakableSpace(0xFEFF)); // ZWNBSP / BOM
+        assertFalse(finder.breakableSpace(0x200C)); // ZWNJ
+        assertFalse(finder.skippable(0x2060));
+        assertFalse(finder.skippable(0x200C));
+        // ...and a boundary may not be placed right after a ZWNJ either.
+        assertTrue(finder.clusterJoiner(0x200C));
     }
 
     @Test
@@ -982,6 +992,138 @@ public class ChunkBoundaryFinderTest extends UnitFessTestCase {
         return builder.toString();
     }
 
+    // ===================================================================================
+    //                                                     Break-opportunity refinements
+    //                                                     -----------------------------
+
+    @Test
+    public void test_findChunkEnd_neverBreaksAtANoBreakCodePoint() {
+        // "a<WORD JOINER>b", "a<BOM>b", Persian mi-ravad with its ZWNJ.
+        assertTrue(finder.findChunkEnd("aa\u2060bb", 0, 3, 5, 3, 0) != 3);
+        assertTrue(finder.findChunkEnd("aa\uFEFFbb", 0, 3, 5, 3, 0) != 3);
+        assertTrue(finder.findChunkEnd("aa\u2060bb", 0, 2, 5, 3, 0) != 2, "nor on the other side of the glue");
+        final String persian = "\u0645\u06CC\u200C\u0631\u0648\u062F";
+        for (int ideal = 1; ideal < persian.length(); ideal++) {
+            final int result = finder.findChunkEnd(persian, 0, ideal, persian.length(), 4, 0);
+            assertTrue(result != 3, "a boundary must not follow the ZWNJ, ideal=" + ideal);
+        }
+    }
+
+    @Test
+    public void test_isDirectionAmbiguousQuote_onlyTheAsciiForms() {
+        assertTrue(finder.ambiguousQuote('\''));
+        assertTrue(finder.ambiguousQuote('"'));
+        // The curly forms are unambiguous and keep their full closing-mark behaviour.
+        assertFalse(finder.ambiguousQuote(0x2019));
+        assertFalse(finder.ambiguousQuote(0x201D));
+        assertFalse(finder.ambiguousQuote(0x300D));
+        // They stay skippable, so a quoted sentence end still reaches its terminator.
+        assertTrue(finder.skippable('"'));
+        assertTrue(finder.skippable('\''));
+    }
+
+    @Test
+    public void test_findChunkEnd_quotedSentenceEndStillReachesItsTerminator() {
+        // Regression guard for the change above: the run "\" " contains a space, so the period
+        // behind it must still be found.
+        final String text = "he said \"go.\" then we left";
+        assertEquals(14, finder.findChunkEnd(text, 0, 18, text.length(), 12, 0));
+    }
+
+    @Test
+    public void test_findChunkEnd_apostropheInsideAContractionIsNotABoundary() {
+        final String text = "abcdefghijklmnop don't stop";
+        final int apostrophe = text.indexOf('\'');
+        for (int ideal = apostrophe + 1; ideal <= apostrophe + 2; ideal++) {
+            final int result = finder.findChunkEnd(text, 0, ideal, text.length(), 6, 0);
+            assertTrue(result <= apostrophe - 3, "ideal=" + ideal + " cut a contraction at " + result);
+        }
+    }
+
+    @Test
+    public void test_findChunkEnd_openingQuoteIsStillSwallowedByASpaceRun() {
+        // Documented limitation: an ASCII quote stays skippable so that a quoted sentence end can
+        // reach its terminator, which means a run of "space + opening quote" still ends the chunk
+        // after the quote. Lossless and cosmetic; pinned so the behaviour is a decision, not an
+        // accident.
+        final String text = "The manual says \"never restart the server\"";
+        final int quote = text.indexOf('"');
+        assertEquals(quote + 1, finder.findChunkEnd(text, 0, quote + 2, text.length(), 8, 0));
+    }
+
+    @Test
+    public void test_halfwidthCornerBracketsMatchTheirFullwidthTwins() {
+        assertTrue(finder.openingBracket(0xFF62)); // ｢
+        assertTrue(finder.closingBracket(0xFF63)); // ｣
+        assertTrue(finder.skippable(0xFF63));
+        assertFalse(finder.openingBracket(0xFF63));
+        assertFalse(finder.closingBracket(0xFF62));
+    }
+
+    @Test
+    public void test_findChunkEnd_waveDashBetweenDigitsIsNotABoundary() {
+        assertTrue(finder.requiringNonDigit(0x301C)); // 〜
+        assertTrue(finder.requiringNonDigit(0xFF5E)); // ～
+        // 開始は１０〜２０分です -- the wave dash is a numeric range, not a clause break.
+        final String text = "\u958B\u59CB\u306F\uFF11\uFF10\u301C\uFF12\uFF10\u5206\u3067\u3059";
+        assertTrue(finder.findChunkEnd(text, 0, 7, text.length(), 7, 0) != 6, "a wave dash between fullwidth digits must not end a chunk");
+    }
+
+    // ===================================================================================
+    //                                                       Grapheme-cluster completeness
+    //                                                       -----------------------------
+
+    @Test
+    public void test_isClusterContinuation_coversTheRemainingUax29Cases() {
+        assertTrue(finder.clusterContinuation(0x1F3FB)); // EMOJI MODIFIER FITZPATRICK TYPE-1-2 (Sk)
+        assertTrue(finder.clusterContinuation(0x1F3FF)); // EMOJI MODIFIER FITZPATRICK TYPE-6 (Sk)
+        assertTrue(finder.clusterContinuation(0xE0020)); // TAG SPACE (Cf)
+        assertTrue(finder.clusterContinuation(0xE007F)); // CANCEL TAG (Cf)
+        assertTrue(finder.clusterContinuation(0x1160)); // HANGUL JUNGSEONG FILLER (Lo)
+        assertTrue(finder.clusterContinuation(0x11A8)); // HANGUL JONGSEONG KIYEOK (Lo)
+        assertTrue(finder.clusterContinuation(0xD7CB)); // HANGUL JONGSEONG NIEUN-RIEUL (Lo)
+        assertTrue(finder.clusterContinuation(0xFF9E)); // HALFWIDTH KATAKANA VOICED SOUND MARK (Lm)
+        assertTrue(finder.clusterContinuation(0xFF9F)); // HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+        assertFalse(finder.clusterContinuation(0x1100)); // a LEADING jamo starts a cluster
+        assertFalse(finder.clusterContinuation(0x30AB)); // カ starts a cluster
+    }
+
+    @Test
+    public void test_isClusterJoiner_coversCarriageReturnAndBidiInitiators() {
+        assertTrue(finder.clusterJoiner('\r')); // UAX #29 GB3: CRLF is one cluster
+        assertTrue(finder.clusterJoiner(0x2066)); // LEFT-TO-RIGHT ISOLATE
+        assertTrue(finder.clusterJoiner(0x2068)); // FIRST STRONG ISOLATE
+        assertTrue(finder.clusterJoiner(0x202B)); // RIGHT-TO-LEFT EMBEDDING
+        assertTrue(finder.clusterJoiner(0x202E)); // RIGHT-TO-LEFT OVERRIDE
+        // The terminators are not initiators: a boundary after a POP is fine.
+        assertFalse(finder.clusterJoiner(0x2069)); // POP DIRECTIONAL ISOLATE
+        assertFalse(finder.clusterJoiner(0x202C)); // POP DIRECTIONAL FORMATTING
+        assertFalse(finder.clusterJoiner('\n'));
+    }
+
+    @Test
+    public void test_findChunkEnd_neverSplitsTheseClusters() {
+        // Literal expectations, not the predicates under test.
+        final String[] fixtures = { "AB\uD83D\uDC4D\uD83C\uDFFDCD", // 👍 + skin tone
+                "AB\uD83C\uDFF4\uDB40\uDC67\uDB40\uDC62CD", // 🏴 + tag characters
+                "AB\uD55C\u11ABCD", // 한 + trailing jamo
+                "AB\uFF76\uFF9ECD", // ｶ + halfwidth voiced mark
+                "AB\r\nCD" };
+        final int[][] forbidden = { { 4 }, { 4, 6 }, { 3 }, { 3 }, { 3 } };
+        for (int f = 0; f < fixtures.length; f++) {
+            final String text = fixtures[f];
+            for (int ideal = 1; ideal < text.length(); ideal++) {
+                for (final int lookback : new int[] { 0, 2, 8 }) {
+                    final int result = finder.findChunkEnd(text, 0, ideal, text.length(), lookback, 0);
+                    for (final int bad : forbidden[f]) {
+                        assertTrue(result != bad,
+                                "fixture " + f + " ideal=" + ideal + " lookback=" + lookback + " split a cluster at " + bad);
+                    }
+                }
+            }
+        }
+    }
+
     /** Exposes the protected character predicates for assertion. */
     private static final class ExposedFinder extends ChunkBoundaryFinder {
         boolean breakableSpace(final int cp) {
@@ -1030,6 +1172,14 @@ public class ChunkBoundaryFinderTest extends UnitFessTestCase {
 
         boolean requiringNonDigit(final int cp) {
             return isPunctuationRequiringNonDigit(cp);
+        }
+
+        boolean ambiguousQuote(final int cp) {
+            return isDirectionAmbiguousQuote(cp);
+        }
+
+        boolean noBreakGlue(final int cp) {
+            return isNoBreakGlue(cp);
         }
     }
 }


### PR DESCRIPTION
Closes #3229. Stacked on #3232 (which is itself stacked on #3211), so the diff shown here is only this change. GitHub retargets automatically as the stack merges.

## 1. Six code points that exist to *forbid* a break were preferred break opportunities

`U+2060` WORD JOINER, `U+FEFF` ZWNBSP and `U+200C` ZWNJ were in `isBreakableSpace`, which inverted their meaning:

```
"a<U+2060>b"     ->  "a<U+2060>" ||| "b"     (WORD JOINER means "never break here")
"a<U+FEFF>b"     ->  "a<U+FEFF>" ||| "b"
"می‌رود"          ->  "می<U+200C>" ||| "رود"  (one Persian word, split at its own joiner)
```

They are now **no-break glue**, consulted from both cluster predicates so the prohibition binds the hard-cut fallback too, not only the tier candidates. `U+200B` ZERO WIDTH SPACE is the one member of that group that is a genuine break opportunity and stays breakable.

The javadoc justified the whole set with "see `crawler.document.space.chars`". That does not hold: the property is consumed by `DocumentHelper.getContent` → `TextUtil.normalizeText(...).spaceChars(...)`, which *normalises those characters away* before indexing rather than establishing them as break opportunities — and the two members that actually survive into `content` (`U+0085` NEL, `U+2060`) are not in it. The cross-reference is corrected.

## 2. ASCII `'` and `"` cut English contractions

They are listed as closing marks, and a closing mark alone in a trailing run makes a WEAK candidate:

```
"we really don't know"  ->  "we really don'" ||| "t know"
"it's" -> "it'" ||| "s"        "O'Brien" -> "O'" ||| "Brien"
```

Unlike `」` or `)`, the ASCII forms cannot be told apart from their own *opening* form. They stay skippable — so `he said "go." then` still reaches its sentence end *through* the quote, which is pinned by a new regression test — but no longer justify a WEAK candidate on their own. A run that also contains a space still does.

**Documented limitation, pinned by a test rather than left implicit:** a run of "space then opening quote" therefore still ends the chunk *after* the quote, leaving `The manual says "` at the end of a chunk. Excluding only a trailing ambiguous-quote tail would need the run bookkeeping to distinguish its right edge from its interior; the outcome is lossless and purely cosmetic, so it is not worth that complexity.

## 3. Grapheme-cluster coverage was general-category-based

`isClusterContinuation` tested `Mn`/`Mc`/`Me` plus ZWJ and variation selectors, so it missed every case UAX #29 expresses another way. All of these were verified split before this change:

| sequence | was |
|---|---|
| skin tone `👍🏽` (U+1F3FB-FF, `Sk`) | `👍` \| `🏽` |
| emoji tag sequence `🏴󠁧󠁢󠁳󠁣󠁴󠁿` (U+E0020-E007F, `Cf`) | split at every tag character |
| conjoining Hangul jamo (`Lo`) | `한` \| `ᆫ` |
| halfwidth voiced mark `ｶﾞ` (U+FF9E, `Lm`) | `ｶ` \| `ﾞ` |
| CRLF (GB3) | `\r` \| `\n` |

Regional-indicator flag pairs remain a deliberate omission — splitting is lossless, so a flag merely renders as two letters.

## 4. Two table gaps

- `｢` U+FF62 / `｣` U+FF63 were the only halfwidth Japanese punctuation with no entry (`｡` `､` `･` all had one), so halfwidth-quoted Japanese lost the bracket handling its fullwidth twin gets.
- `〜` and `～` join the non-digit rule, so a fullwidth numeric range is no longer split at the wave dash.

## 5. Dead code and visibility

Three conditions were proven unreachable by differential mutation over 3,000,000 in-contract calls (0 behavioural differences) and are removed:

- `searchBackward`'s `|| candidate >= limitEnd` in `spaceSatisfied` — `findChunkEnd` returns early when `base >= bound`, and `snapOverlapStart` silently repurposes it from "end of text" to "end of *chunk*", where the space requirement is not moot at all. `searchForward`'s mirror of the same term is **kept** and now carries a comment: there a trailing `.` with nothing after it genuinely does end the sentence.
- `snapOverlapStart`'s two `> origin && <= bound` re-checks — `searchBackward` already guarantees the range.

`ZWJ` is now `private` and `MAX_CLUSTER_ADJUST` package-private. Both are `static`, so a subclass redeclaring them was never read; `MAX_CLUSTER_ADJUST` carried an eleven-line javadoc apologising for exactly that, which the visibility change deletes instead of documenting.

## Testing

11 new tests plus one existing assertion inverted (it asserted that WORD JOINER, BOM and ZWNJ *were* breakable — the behaviour this PR reverses). Every new test was verified by mutating the production table and observing it fail: 8 of 93 red under a combined mutation of the glue set, the quote rule, skin tones, tag characters, jamo, halfwidth marks, CR, the halfwidth bracket and the wave dash. The cluster tests assert against **literal offsets**, not the predicates under test, so weakening a predicate cannot make them vacuous.

Full suite: 7014 tests, 0 failures. `formatter:validate`, `license:check` and `javadoc:jar` clean.
