### PR TITLE
feat(chunk): report boundary-search outcome and stop repeating config warnings

### DIFF
--- a/src/main/java/org/codelibs/fess/chunk/LengthChunker.java
+++ b/src/main/java/org/codelibs/fess/chunk/LengthChunker.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.chunk;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -145,6 +146,21 @@ public class LengthChunker implements Chunker {
     private static final ChunkBoundaryFinder DEFAULT_BOUNDARY_FINDER = new ChunkBoundaryFinder();
 
     /**
+     * Signature of the configuration problems most recently reported by
+     * {@link #warnOnConfigProblem}.
+     *
+     * <p>Every setting is re-read on each {@code split} call, because {@code system.properties} is
+     * live -- which means a misconfigured instance used to emit the same WARN once per crawled
+     * document, millions of times over a large corpus. Reporting only when the signature changes
+     * keeps a misconfiguration loud exactly once and still reports it again if the operator
+     * changes it to something else that is also wrong. This holds the last problem
+     * <em>reported</em>, not the last configuration seen, so a clean run in between does not
+     * re-arm it -- the WARN describes a standing misconfiguration, and saying it once is the
+     * point.</p>
+     */
+    private final AtomicReference<String> lastConfigProblem = new AtomicReference<>("");
+
+    /**
      * Default constructor.
      */
     public LengthChunker() {
@@ -257,6 +273,9 @@ public class LengthChunker implements Chunker {
         // so cap with long arithmetic before narrowing.
         final int stride = Math.max(1, chunkSize - overlap);
         final List<String> chunks = new ArrayList<>((int) Math.min(limit, (long) length / stride + 2L));
+        int movedBack = 0;
+        int movedForward = 0;
+        int hardCut = 0;
         int start = 0;
         while (start < length) {
             if (isMidSurrogatePair(content, start)) {
@@ -270,7 +289,15 @@ public class LengthChunker implements Chunker {
                 end--;
             }
             if (finder != null) {
+                final int idealEnd = end;
                 end = finder.findChunkEnd(content, start, end, length, lookback, lookahead);
+                if (end < idealEnd) {
+                    movedBack++;
+                } else if (end > idealEnd) {
+                    movedForward++;
+                } else {
+                    hardCut++;
+                }
                 if (isMidSurrogatePair(content, end)) {
                     // Defensive: a custom finder is not required to be code-point aligned.
                     end--;
@@ -311,6 +338,9 @@ public class LengthChunker implements Chunker {
                 nextStart = end;
             }
             start = nextStart;
+        }
+        if (finder != null) {
+            logBoundaryOutcome(chunks.size(), movedBack, movedForward, hardCut);
         }
         return chunks;
     }
@@ -401,6 +431,44 @@ public class LengthChunker implements Chunker {
         return DEFAULT_BOUNDARY_FINDER;
     }
 
+    /**
+     * Reports a configuration problem, but only when it differs from the one reported last.
+     *
+     * @param signature identifies the problem; an unchanged signature is not reported again
+     * @param format the log message pattern
+     * @param args the log message arguments
+     */
+    protected void warnOnConfigProblem(final String signature, final String format, final Object... args) {
+        if (!signature.equals(lastConfigProblem.getAndSet(signature))) {
+            logger.warn(format, args);
+        }
+    }
+
+    /**
+     * Summarises, at DEBUG, how often boundary search actually moved a cut for this document.
+     *
+     * <p>Without this the feature is unfalsifiable in a running system: a corpus the character
+     * tables do not cover -- a language whose sentence marks {@link ChunkBoundaryFinder} does not
+     * know, or text with no punctuation at all -- silently gets 100% hard cuts and looks exactly
+     * like the feature working. A high {@code hardCut} share is the signal to raise
+     * {@code lookback_percent} or to extend the tables.</p>
+     *
+     * <p>Only the coarse moved/hard-cut split is reported, not a per-tier histogram: which tier
+     * won is known inside {@link ChunkBoundaryFinder#findChunkEnd} alone, and widening its
+     * signature to report it would change the {@code protected} seam a deployment subclasses.</p>
+     *
+     * @param chunks the number of chunks produced
+     * @param movedBack how many cuts a backward tier pulled earlier
+     * @param movedForward how many cuts the forward search or the cluster escape pushed later
+     * @param hardCut how many cuts landed on the fixed-length offset because no tier had a candidate
+     */
+    protected void logBoundaryOutcome(final int chunks, final int movedBack, final int movedForward, final int hardCut) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("[Chunk] Boundary outcome: chunks={} movedBack={} movedForward={} hardCut={} ({}% of cuts unmoved).", chunks,
+                    movedBack, movedForward, hardCut, chunks == 0 ? 0 : 100 * hardCut / chunks);
+        }
+    }
+
     private boolean getConfigBoolean(final String key, final boolean defaultValue) {
         final String value = ComponentUtil.getFessConfig().getSystemProperty(key, null);
         if (value != null) {
@@ -411,18 +479,19 @@ public class LengthChunker implements Chunker {
             if (Constants.FALSE.equalsIgnoreCase(trimmed)) {
                 return false;
             }
-            logger.warn("[Chunk] Invalid boolean for {}: {}. Using default {}.", key, value, defaultValue);
+            warnOnConfigProblem(key + "=" + value, "[Chunk] Invalid boolean for {}: {}. Using default {}.", key, value, defaultValue);
         }
         return defaultValue;
     }
 
     private int normalizeBoundaryPercent(final int value, final int max, final String key) {
         if (value < 0) {
-            logger.warn("[Chunk] {}={} is negative, treating it as 0 (that direction is not searched)", key, value);
+            warnOnConfigProblem(key + "=" + value, "[Chunk] {}={} is negative, treating it as 0 (that direction is not searched)", key,
+                    value);
             return 0;
         }
         if (value > max) {
-            logger.warn("[Chunk] {}={} exceeds the maximum of {}, clamping to {}", key, value, max, max);
+            warnOnConfigProblem(key + "=" + value, "[Chunk] {}={} exceeds the maximum of {}, clamping to {}", key, value, max, max);
             return max;
         }
         return value;
@@ -441,7 +510,7 @@ public class LengthChunker implements Chunker {
             try {
                 return Integer.parseInt(value.trim());
             } catch (final NumberFormatException e) {
-                logger.warn("[Chunk] Invalid integer for {}: {}. Using default {}.", key, value, defaultValue);
+                warnOnConfigProblem(key + "=" + value, "[Chunk] Invalid integer for {}: {}. Using default {}.", key, value, defaultValue);
             }
         }
         return defaultValue;
@@ -449,17 +518,21 @@ public class LengthChunker implements Chunker {
 
     private int normalizeChunkSize(final int chunkSize) {
         if (chunkSize <= 0) {
-            logger.warn("[Chunk] Invalid chunk_size={}, falling back to default {}", chunkSize, DEFAULT_CHUNK_SIZE);
+            warnOnConfigProblem(CHUNK_SIZE_PROPERTY + "=" + chunkSize, "[Chunk] Invalid chunk_size={}, falling back to default {}",
+                    chunkSize, DEFAULT_CHUNK_SIZE);
             return DEFAULT_CHUNK_SIZE;
         }
         if (chunkSize < MIN_CHUNK_SIZE) {
-            logger.warn("[Chunk] chunk_size={} is below the minimum of {} (a sanity floor), clamping to {}", chunkSize, MIN_CHUNK_SIZE,
+            warnOnConfigProblem(CHUNK_SIZE_PROPERTY + "=" + chunkSize,
+                    "[Chunk] chunk_size={} is below the minimum of {} (a sanity floor), clamping to {}", chunkSize, MIN_CHUNK_SIZE,
                     MIN_CHUNK_SIZE);
             return MIN_CHUNK_SIZE;
         }
         if (chunkSize > MAX_CHUNK_SIZE) {
-            logger.warn("[Chunk] chunk_size={} exceeds the maximum of {} (sanity ceiling guarding against absurd/OOM values), "
-                    + "clamping to {}", chunkSize, MAX_CHUNK_SIZE, MAX_CHUNK_SIZE);
+            warnOnConfigProblem(CHUNK_SIZE_PROPERTY + "=" + chunkSize,
+                    "[Chunk] chunk_size={} exceeds the maximum of {} (sanity ceiling guarding against absurd/OOM values), "
+                            + "clamping to {}",
+                    chunkSize, MAX_CHUNK_SIZE, MAX_CHUNK_SIZE);
             return MAX_CHUNK_SIZE;
         }
         return chunkSize;
@@ -470,7 +543,8 @@ public class LengthChunker implements Chunker {
             return 0;
         }
         if (overlap >= chunkSize) {
-            logger.warn("[Chunk] overlap ({}) >= chunk_size ({}), clamping overlap to 0", overlap, chunkSize);
+            warnOnConfigProblem(OVERLAP_PROPERTY + "=" + overlap + "/" + chunkSize,
+                    "[Chunk] overlap ({}) >= chunk_size ({}), clamping overlap to 0", overlap, chunkSize);
             return 0;
         }
         return overlap;

--- a/src/test/java/org/codelibs/fess/chunk/LengthChunkerTest.java
+++ b/src/test/java/org/codelibs/fess/chunk/LengthChunkerTest.java
@@ -1004,7 +1004,105 @@ public class LengthChunkerTest extends UnitFessTestCase {
         }
     }
 
-    private static final class TestableLengthChunker extends LengthChunker {
+    // ===================================================================================
+    //                                                  Config warnings and boundary metrics
+    //                                                  -----------------------------------
+
+    @Test
+    public void test_configWarning_isEmittedOncePerDistinctProblem() {
+        final LogCapturingAppender appender = LogCapturingAppender.attach(LengthChunker.class);
+        try {
+            chunker.setTestChunkSize(0); // invalid -> falls back to the default, with a WARN
+            for (int i = 0; i < 25; i++) {
+                chunker.split("some content to split into chunks", 100);
+            }
+            assertEquals(1, countMatching(appender, "Invalid chunk_size"), "a misconfigured instance must not emit one WARN per document");
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_configWarning_isEmittedAgainWhenTheProblemChanges() {
+        final LogCapturingAppender appender = LogCapturingAppender.attach(LengthChunker.class);
+        try {
+            chunker.setTestChunkSize(0);
+            chunker.split("some content to split into chunks", 100);
+            chunker.setTestChunkSize(-7); // a DIFFERENT bad value must be reported
+            chunker.split("some content to split into chunks", 100);
+            assertEquals(2, countMatching(appender, "Invalid chunk_size"));
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_configWarning_theSameProblemAfterACleanRunIsNotRepeated() {
+        // Pinned semantics: the sink remembers the last problem REPORTED, not the last
+        // configuration seen, so a clean run in between does not re-arm it. The WARN describes a
+        // standing misconfiguration, so reporting it once is the point.
+        final LogCapturingAppender appender = LogCapturingAppender.attach(LengthChunker.class);
+        try {
+            chunker.setTestChunkSize(0);
+            chunker.split("some content to split into chunks", 100);
+            chunker.setTestChunkSize(40);
+            chunker.split("some content to split into chunks", 100);
+            chunker.setTestChunkSize(0);
+            chunker.split("some content to split into chunks", 100);
+            assertEquals(1, countMatching(appender, "Invalid chunk_size"));
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_boundaryOutcome_reportsHardCutsSeparatelyFromMovedCuts() {
+        final List<int[]> observed = new java.util.ArrayList<>();
+        final TestableLengthChunker recording = new TestableLengthChunker() {
+            @Override
+            protected void logBoundaryOutcome(final int chunks, final int movedBack, final int movedForward, final int hardCut) {
+                observed.add(new int[] { chunks, movedBack, movedForward, hardCut });
+            }
+        };
+        recording.setTestChunkSize(20);
+        recording.setTestLookbackPercent(30);
+        recording.setTestLookaheadPercent(0);
+
+        // Content with no boundary anywhere: every cut must be reported as a hard cut.
+        observed.clear();
+        recording.split("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 100);
+        assertEquals(1, observed.size());
+        assertEquals(observed.get(0)[0], observed.get(0)[3], "an unbreakable document must be 100% hard cut");
+        assertEquals(0, observed.get(0)[1]);
+
+        // Prose with spaces: the backward tier must move cuts instead.
+        observed.clear();
+        recording.split("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi", 100);
+        assertEquals(1, observed.size());
+        assertTrue(observed.get(0)[1] > 0, "prose must produce backward-moved cuts, got " + observed.get(0)[1]);
+        assertTrue(observed.get(0)[3] < observed.get(0)[0], "prose must not be 100% hard cut");
+    }
+
+    @Test
+    public void test_boundaryOutcome_isNotReportedWhenBoundarySearchIsDisabled() {
+        final List<int[]> observed = new java.util.ArrayList<>();
+        final TestableLengthChunker recording = new TestableLengthChunker() {
+            @Override
+            protected void logBoundaryOutcome(final int chunks, final int movedBack, final int movedForward, final int hardCut) {
+                observed.add(new int[] { chunks, movedBack, movedForward, hardCut });
+            }
+        };
+        recording.setTestChunkSize(20);
+        recording.setTestBoundaryEnabled(false);
+        recording.split("alpha beta gamma delta epsilon zeta eta theta iota kappa", 100);
+        assertTrue(observed.isEmpty(), "nothing to report when the finder never runs");
+    }
+
+    private static int countMatching(final LogCapturingAppender appender, final String needle) {
+        return (int) appender.warnings().stream().filter(m -> m.contains(needle)).count();
+    }
+
+    private static class TestableLengthChunker extends LengthChunker {
         private int testChunkSize = 800;
         private int testOverlap = 0;
         private boolean testBoundaryEnabled = DEFAULT_BOUNDARY_ENABLED;


### PR DESCRIPTION
Closes #3230. Stacked on #3233 → #3232 → #3211, so the diff shown here is only this change.

## 1. Boundary search emitted nothing at all

`ChunkBoundaryFinder` had no logging and no counters, so nothing distinguished "found a STRONG boundary" from "fell through every tier and hard-cut at the ideal offset". That made the feature unfalsifiable in a running system: a corpus the character tables do not cover — a language whose sentence marks the finder does not know, or text with no punctuation at all — silently gets **100% hard cuts and looks exactly like the feature working**.

`split()` now counts, per document:

- `movedBack` — a backward tier pulled the cut earlier
- `movedForward` — the forward search or the cluster escape pushed it later
- `hardCut` — no tier had a candidate, so the cut landed on the fixed-length offset

and reports the totals through an overridable `logBoundaryOutcome` at DEBUG:

```
[Chunk] Boundary outcome: chunks=137 movedBack=131 movedForward=4 hardCut=2 (1% of cuts unmoved).
```

A high hard-cut share is the signal to raise `lookback_percent` or to extend the character tables.

**What this deliberately does not do:** a per-tier histogram (STRONG / WEAK / SCRIPT). Which tier won is known inside `findChunkEnd` alone, and reporting it would mean widening that method's signature — the `protected` seam a deployment subclasses. The coarse split answers the operational question ("is the search doing anything for this corpus?") without touching the seam, so it is what ships.

The finder itself stays stateless: all counting happens in the caller's local variables, so nothing is added to the singleton shared across `content_chunker.job.concurrency` threads.

## 2. Config warnings repeated once per document

Every setting is re-read on each `split()` call, because `system.properties` is live. That meant a misconfigured instance emitted the same WARN once per crawled document — millions of lines over a large corpus. The pattern predates the boundary work (`normalizeChunkSize` and `normalizeOverlap` already behaved this way), but the class had grown from two such warnings to five. Measured over 10 documents with `chunk_size=0`, `overlap=5000`, `lookback_percent=999`, `lookahead_percent=-1`:

```
before  40 WARN lines
after    1 WARN line
```

All five now go through `warnOnConfigProblem`, which reports only when the problem differs from the one reported last. A standing misconfiguration is loud exactly once; changing to a *different* bad value is reported again.

The sink holds the last problem **reported**, not the last configuration seen, so a clean run in between does not re-arm it. That is a deliberate choice — the WARN describes a standing misconfiguration and saying it once is the point — and it is pinned by a test rather than left implicit.

A valid configuration emits nothing, before and after.

## Testing

5 new tests. Each was verified by mutating the production code and observing it fail — 3 of 56 red under removal of the dedup (`25` warnings instead of `1`) and of the outcome counters (prose reported `0` backward-moved cuts).

Full suite: 7019 tests, 0 failures. `formatter:validate`, `license:check` and `javadoc:jar` clean.
