### PR TITLE
fix(sso): stop the async parent group lookup being lost by a concurrent reader

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
@@ -112,7 +112,14 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
         }
 
         @Override
-        public String[] getPermissions() {
+        public synchronized String[] getPermissions() {
+            // Synchronized on the same monitor as setGroups/setRoles/resetPermissions. Computing
+            // the value is a check-then-act -- read `permissions == null`, read `groups`, write
+            // `permissions` -- and the parent group lookup scheduled at login runs on a
+            // TimeoutManager thread while the user is already searching. Without the lock a reader
+            // that started first can finish last and overwrite the freshly reset value with one
+            // computed from the direct groups alone; nothing resets it again, so the parent group
+            // permissions stay missing for the rest of the session.
             if (permissions == null) {
                 final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
                 final Set<String> permissionSet = new HashSet<>();
@@ -156,7 +163,7 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                 if (newResult != null) {
                     authResult = newResult;
                     authenticator.updateMemberOf(this);
-                    permissions = null;
+                    resetPermissions();
                     if (logger.isDebugEnabled()) {
                         logger.debug("Token refreshed successfully via silent authentication");
                     }
@@ -200,7 +207,7 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
          * Resets permissions to force recalculation on next getPermissions() call.
          * This is called after asynchronous parent group lookup completes.
          */
-        public void resetPermissions() {
+        public synchronized void resetPermissions() {
             this.permissions = null;
         }
     }

--- a/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.base.login;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
+import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.sso.entraid.EntraIdAuthenticator;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.aad.msal4j.IAccount;
+import com.microsoft.aad.msal4j.IAuthenticationResult;
+import com.microsoft.aad.msal4j.ITenantProfile;
+
+public class EntraIdUserPermissionTest extends UnitFessTestCase {
+
+    private static IAuthenticationResult authResult() {
+        final IAccount account = new IAccount() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String homeAccountId() {
+                return "home-account-id";
+            }
+
+            @Override
+            public String environment() {
+                return "login.microsoftonline.com";
+            }
+
+            @Override
+            public String username() {
+                return "taro@contoso.onmicrosoft.com";
+            }
+
+            @Override
+            public Map<String, ITenantProfile> getTenantProfiles() {
+                return Collections.emptyMap();
+            }
+        };
+        return new IAuthenticationResult() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String accessToken() {
+                return "access-token";
+            }
+
+            @Override
+            public String idToken() {
+                return "id-token";
+            }
+
+            @Override
+            public IAccount account() {
+                return account;
+            }
+
+            @Override
+            public ITenantProfile tenantProfile() {
+                return null;
+            }
+
+            @Override
+            public String environment() {
+                return "login.microsoftonline.com";
+            }
+
+            @Override
+            public String scopes() {
+                return "https://graph.microsoft.com/.default";
+            }
+
+            @Override
+            public Date expiresOnDate() {
+                return new Date(Long.MAX_VALUE);
+            }
+        };
+    }
+
+    /**
+     * Builds an EntraIdUser without letting its constructor talk to Microsoft Graph.
+     */
+    private EntraIdUser newUser() {
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                // the test drives setGroups/setRoles itself
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+        return new EntraIdUser(authResult());
+    }
+
+    @Test
+    public void test_getPermissions_doesNotPinAStaleValueWhenTheAsyncLookupLands() throws Exception {
+        // scheduleParentGroupLookup runs on a TimeoutManager thread while the user is already
+        // logged in and searching. getPermissions() is a check-then-act -- read `permissions ==
+        // null`, read `groups`, write `permissions` -- so a reader that started before the async
+        // task can finish after it and overwrite the fresh value with one computed from the
+        // direct groups alone. Nothing sets `permissions` back to null after that, so the parent
+        // group permissions stay missing for the rest of the session.
+        final CountDownLatch readerIsInside = new CountDownLatch(1);
+        final CountDownLatch asyncTaskIsDone = new CountDownLatch(1);
+        ComponentUtil.register(new SystemHelper() {
+            @Override
+            public String getSearchRoleByGroup(final String name) {
+                if ("direct-group".equals(name)) {
+                    // The reader has read `groups` and is now mid-computation.
+                    readerIsInside.countDown();
+                    try {
+                        asyncTaskIsDone.await(10L, TimeUnit.SECONDS);
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                return super.getSearchRoleByGroup(name);
+            }
+        }, "systemHelper");
+
+        final EntraIdUser user = newUser();
+        user.setGroups(new String[] { "direct-group" });
+        user.setRoles(new String[0]);
+
+        final Thread reader = new Thread(() -> user.getPermissions());
+        reader.start();
+        assertTrue(readerIsInside.await(10L, TimeUnit.SECONDS));
+
+        // What scheduleParentGroupLookup does once the parent groups arrive, on its own thread so
+        // that it can be made to wait for the reader rather than deadlocking with it.
+        final Thread asyncLookup = new Thread(() -> {
+            user.setGroups(new String[] { "direct-group", "parent-group" });
+            user.setRoles(new String[0]);
+            user.resetPermissions();
+        });
+        asyncLookup.start();
+        // Give the async task time to get as far as it is able to before the reader finishes.
+        Thread.sleep(200L);
+
+        asyncTaskIsDone.countDown();
+        reader.join(10000L);
+        asyncLookup.join(10000L);
+
+        final String[] permissions = user.getPermissions();
+        assertTrue("parent-group missing from " + Arrays.toString(permissions),
+                Arrays.stream(permissions).anyMatch(p -> p.contains("parent-group")));
+    }
+}


### PR DESCRIPTION
## Problem

#2977 introduced the asynchronous parent-group lookup and, as part of it, made `EntraIdUser`'s
fields `volatile` and its setters `synchronized`. `getPermissions()` was left outside that lock —
but it is a check-then-act, not a single field access:

```java
public String[] getPermissions() {
    if (permissions == null) {                 // read
        ...
        stream(groups).of(...)                 // read
        stream(roles).of(...)                  // read
        permissions = permissionSet...;        // write
    }
    return permissions;
}
```

`volatile` makes each of those accesses atomic. It does not make the sequence atomic.

`scheduleParentGroupLookup()` runs on a `TimeoutManager` thread roughly a second after login,
while the user is already searching. A reader that entered `getPermissions()` before the lookup
finished can write its result *after* it:

| reader (request thread) | `scheduleParentGroupLookup` (TimeoutManager thread) |
|---|---|
| `permissions == null` → true | |
| reads `groups` — direct groups only | |
| computing… | `setGroups(direct + parent)` |
| | `setRoles(...)` |
| | `resetPermissions()` → `permissions = null` |
| `permissions = <computed from direct only>` | |

Nothing resets `permissions` again, so the parent-group permissions stay missing **for the rest of
the session**. The user silently cannot see documents granted through a nested group, and whether
it happens depends on whether their first search lands inside the lookup window — so it reproduces
intermittently and looks like "sometimes some documents are missing".

## Fix

Synchronize `getPermissions()` and `resetPermissions()` on the same monitor `setGroups` and
`setRoles` already use. Either the reader completes first and the reset that follows forces a
recomputation, or the writer completes first and the reader sees the new groups. Neither order
leaves a stale value pinned.

`refresh()` also wrote `permissions = null` directly; it now goes through `resetPermissions()` so
that write takes the lock too.

`getPermissions()` is called once per request and the monitor is per user, so contention is
between a user's own concurrent requests and the one background task — and after the first call
the body is a field read.

## Tests

New `EntraIdUserPermissionTest`, one deterministic test — no sleeps deciding the outcome, no
retry loop. A `SystemHelper` whose `getSearchRoleByGroup` blocks on a latch parks the reader
mid-computation, so the interleaving above is forced rather than hoped for.

Before the fix it fails with the actual lost permission:

```
parent-group missing from [1home-account-id, 2direct-group, 1taro, 1taro@contoso.onmicrosoft.com]
```

```
Tests run: 148, Failures: 0, Errors: 0, Skipped: 0
```

(`org.codelibs.fess.sso` plus `org.codelibs.fess.app.web.base.login`)

## Note

`LdapUser` calls `permissionChanged` from a similar background update and is worth a look, but it
is a different class with a different lifecycle and is not touched here.
