### PR TITLE
fix(sso): stop bouncing an unmatched SAML response back to the IdP

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -133,6 +133,16 @@ import jakarta.servlet.http.HttpSession;
  * saml.security.want_assertions_signed=true
  * </pre>
  *
+ * <h2>Session Cookie Settings (Required)</h2>
+ * <p>The IdP returns the assertion as a cross-site POST to the assertion consumer service.
+ * A {@code SameSite=Lax} cookie is not sent on such a request, so the shipped default in
+ * {@code tomcat_config.properties} has to be changed for SAML:</p>
+ * <pre>
+ * tomcat.sameSiteCookies = none
+ * </pre>
+ * <p>{@code none} is only accepted by browsers on a {@code Secure} cookie, so Fess must be
+ * served over HTTPS.</p>
+ *
  * @see <a href="https://fess.codelibs.org/">Fess Documentation</a>
  */
 public class SamlAuthenticator implements SsoAuthenticator {
@@ -311,9 +321,9 @@ public class SamlAuthenticator implements SsoAuthenticator {
 
             final HttpServletResponse response = LaResponseUtil.getResponse();
 
-            final HttpSession session = request.getSession(false);
-            if (session != null) {
-                final String requestId = (String) session.getAttribute(SAML_STATE);
+            if (containsSamlResponse(request)) {
+                final HttpSession session = request.getSession(false);
+                final String requestId = session == null ? null : (String) session.getAttribute(SAML_STATE);
                 if (StringUtil.isNotBlank(requestId)) {
                     session.removeAttribute(SAML_STATE);
                     try {
@@ -336,6 +346,14 @@ public class SamlAuthenticator implements SsoAuthenticator {
                         return null;
                     }
                 }
+                // The assertion arrived but the matching AuthnRequest ID is unreachable. Sending
+                // another AuthnRequest would come straight back here in the same state, looping
+                // forever, so fail once instead.
+                logger.warn("Received a SAML response with no matching AuthnRequest ID in the session."
+                        + " The assertion consumer service is a cross-site POST, which does not carry a SameSite=Lax cookie;"
+                        + " see tomcat.sameSiteCookies in tomcat_config.properties."
+                        + " An IdP-initiated (unsolicited) response is rejected for the same reason.");
+                return null;
             }
 
             try {
@@ -349,6 +367,25 @@ public class SamlAuthenticator implements SsoAuthenticator {
             }
 
         }).orElse(null);
+    }
+
+    /**
+     * Returns whether the request carries a SAML response, which is what the IdP posts to the
+     * assertion consumer service.
+     *
+     * <p>The session is deliberately not consulted here: it is the session cookie that goes
+     * missing when the browser refuses to send it on the cross-site POST, and a callback that is
+     * mistaken for a fresh visit is redirected back to the IdP forever.</p>
+     *
+     * <p>Only solicited responses are accepted. Fess binds every response to the ID of the
+     * AuthnRequest it sent, so an unsolicited (IdP-initiated) response has nothing to match
+     * against and is rejected rather than answered with a fresh AuthnRequest.</p>
+     *
+     * @param request The HTTP request.
+     * @return true if the request carries a SAML response.
+     */
+    protected boolean containsSamlResponse(final HttpServletRequest request) {
+        return StringUtil.isNotBlank(request.getParameter("SAMLResponse"));
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -30,12 +30,15 @@ import org.apache.logging.log4j.core.config.Property;
 
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
+import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.exception.SsoMessageException;
 import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.saml2.core.settings.Saml2Settings;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
 import org.junit.jupiter.api.Test;
+import org.lastaflute.web.login.credential.LoginCredential;
 
 public class SamlAuthenticatorTest extends UnitFessTestCase {
 
@@ -192,6 +195,96 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
         } catch (final SsoMessageException e) {
             assertNotNull(e.getCause());
             assertTrue(e.getCause().getMessage(), e.getCause().getMessage().contains("single logout service URL"));
+        }
+    }
+
+    // ===================================================================================
+    //                                                             Assertion Consumer Service
+    //                                                             ==========================
+
+    /** Minimal IdP settings, so that an AuthnRequest can actually be built. */
+    private void setUpIdp(final DynamicProperties systemProperties) {
+        systemProperties.setProperty("saml.idp.entityid", "https://idp.example.com/metadata");
+        systemProperties.setProperty("saml.idp.single_sign_on_service.url", "https://idp.example.com/sso");
+        systemProperties.setProperty("saml.idp.certfingerprint", "afe71c28ef740bc87425be13a2263d37971da1f9");
+    }
+
+    private void tearDownIdp(final DynamicProperties systemProperties) {
+        systemProperties.remove("saml.idp.entityid");
+        systemProperties.remove("saml.idp.single_sign_on_service.url");
+        systemProperties.remove("saml.idp.certfingerprint");
+    }
+
+    @Test
+    public void test_containsSamlResponse() throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+
+        assertFalse(authenticator.containsSamlResponse(getMockRequest()));
+
+        final MockletHttpServletRequest blank = getMockRequest();
+        blank.setParameter("SAMLResponse", "  ");
+        assertFalse(authenticator.containsSamlResponse(blank));
+
+        final MockletHttpServletRequest posted = getMockRequest();
+        posted.setParameter("SAMLResponse", "PHNhbWxwOlJlc3BvbnNlIC8+");
+        assertTrue(authenticator.containsSamlResponse(posted));
+    }
+
+    @Test
+    public void test_getLoginCredential_unmatchedResponseFailsInsteadOfRedirecting() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            setUpIdp(systemProperties);
+            // the IdP posts the assertion cross-site, so a SameSite=Lax cookie is not sent back
+            // and the session holding the AuthnRequest ID is unreachable
+            final MockletHttpServletRequest request = getMockRequest();
+            request.setMethod("POST");
+            request.setParameter("SAMLResponse", "PHNhbWxwOlJlc3BvbnNlIC8+");
+
+            // redirecting to the IdP again would come straight back in the same state
+            assertNull(authenticator.getLoginCredential());
+            assertEquals(1, appender.warnings().size());
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("no matching AuthnRequest ID"));
+        } finally {
+            tearDownIdp(systemProperties);
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_requestWithoutResponseStartsLogin() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+
+            final LoginCredential credential = authenticator.getLoginCredential();
+
+            assertTrue(String.valueOf(credential), credential instanceof ActionResponseCredential);
+            assertNotNull(request.getSession(false).getAttribute("SAML_STATE"));
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_requestWithoutResponseKeepsPendingRequestId() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            // a plain visit to /sso/ while a login is in flight must not consume the pending ID
+            final MockletHttpServletRequest request = getMockRequest();
+            request.getSession().setAttribute("SAML_STATE", "ONELOGIN_pending");
+
+            authenticator.getLoginCredential();
+
+            assertNotNull(request.getSession(false).getAttribute("SAML_STATE"));
+        } finally {
+            tearDownIdp(systemProperties);
         }
     }
 


### PR DESCRIPTION
## Problem

`getLoginCredential()` decided whether a request was an assertion consumer service callback by looking for `SAML_STATE` in the session:

```java
final HttpSession session = request.getSession(false);
if (session != null) {
    final String requestId = (String) session.getAttribute(SAML_STATE);
    if (StringUtil.isNotBlank(requestId)) {
        ...
    }
}
// otherwise: build a new AuthnRequest and redirect to the IdP
```

That is the one piece of state that goes missing when the session cookie is not returned, so a callback without it was mistaken for a fresh visit and answered with a **new AuthnRequest** — which the IdP answers with another assertion, in the same state, forever.

The assertion arrives as a **cross-site POST** (SAML's HTTP-POST binding), and a `SameSite=Lax` cookie is not sent on one. Fess ships `tomcat.sameSiteCookies = lax` in `tomcat_config.properties`, applied to the Tomcat `CookieProcessor` in `FessBoot`; because the attribute is set *explicitly*, Chrome's two-minute "Lax + POST" grace period does not apply either — that only covers cookies with no `SameSite` attribute at all.

So on a default install, SAML SSO loops until the browser gives up with `ERR_TOO_MANY_REDIRECTS`, unless the deployment sets `tomcat.sameSiteCookies = none`.

This is the same failure #3215 identified and fixed for Entra ID. SAML cannot take the same route — #3215 switched Entra ID to `response_mode=query` so the callback becomes a top-level GET, but the HTTP-POST binding is not optional for a SAML assertion consumer service. The loop itself is broken instead.

## Fix

**Detect the callback without the session.** A request is treated as a callback when it carries `SAMLResponse`. That does not depend on the cookie, so the callback is never mistaken for a fresh visit.

**Fail once instead of bouncing.** A callback with no matching AuthnRequest ID now logs a warning naming the likely cause and returns `null`, so `SsoAction` shows the SSO login error and goes to the login page — the same shape as `EntraIdAuthenticator` after #3215.

As a side effect, a plain visit to `/sso/` while a login is in flight no longer consumes the pending AuthnRequest ID, so the assertion that follows is still matched instead of costing an extra round trip.

The required cookie setting is documented on the class. A companion fess-docs change covers the same ground in the SAML configuration guide.

### Behaviour change worth calling out

An **IdP-initiated (unsolicited) response is now rejected** rather than answered with a fresh AuthnRequest.

It previously succeeded only via that extra round trip, and only where the session cookie survived — i.e. never under the shipped `lax` default. It is not documented (neither `fess-docs` nor this repo mentions IdP-initiated SSO or `RelayState`), not tested, and #3214 made Fess bind every response to an AuthnRequest ID it sent, so an unsolicited response has nothing to match against. Preserving it would mean carrying a marker through `RelayState` purely to allow one bounce, which is not worth the machinery for an undocumented accident. Raising this here in case that judgement should go the other way.

## Tests

3 added to `SamlAuthenticatorTest`:

- `test_containsSamlResponse` — absent / blank / present
- `test_getLoginCredential_unmatchedResponseFailsInsteadOfRedirecting` — a `SAMLResponse` with no reachable session returns `null` and warns
- `test_getLoginCredential_requestWithoutResponseKeepsPendingRequestId` — a plain visit leaves `SAML_STATE` intact
- `test_getLoginCredential_requestWithoutResponseStartsLogin` — the normal entry path still issues an AuthnRequest

The two behavioural ones fail before this change: the callback returned an `ActionResponseCredential` (the redirect that caused the loop), and the pending ID was consumed.

```
org.codelibs.fess.sso package: Tests run: 166, Failures: 0, Errors: 0, Skipped: 0
mvn -o clean javadoc:jar: BUILD SUCCESS
formatter:format + license:format: no changes
```
