### PR TITLE
fix(sso): serve the SAML SP metadata before the IdP is configured

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -449,6 +449,12 @@ public class SamlAuthenticator implements SsoAuthenticator {
 
     /**
      * Gets the metadata response.
+     *
+     * <p>The SP metadata is what the IdP is registered from, so it has to be obtainable before
+     * any {@code saml.idp.*} property exists. {@code setSPValidationOnly} therefore has to be
+     * applied to the settings before they are validated; constructing an {@link Auth} here would
+     * validate the IdP settings in its constructor and fail while they are still empty.</p>
+     *
      * @return The metadata response.
      */
     protected ActionResponse getMetadataResponse() {
@@ -456,18 +462,23 @@ public class SamlAuthenticator implements SsoAuthenticator {
             if (logger.isDebugEnabled()) {
                 logger.debug("Accessing metadata with SAML Authenticator");
             }
-            final HttpServletResponse response = LaResponseUtil.getResponse();
             try {
-                final Auth auth = new Auth(getSettings(), request, response);
-                final Saml2Settings settings = auth.getSettings();
+                final Saml2Settings settings = getSettings();
                 settings.setSPValidationOnly(true);
+                final List<String> settingsErrors = settings.checkSettings();
+                if (!settingsErrors.isEmpty()) {
+                    final String msg = settingsErrors.stream().collect(Collectors.joining(", "));
+                    throw new SsoMessageException(
+                            messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
+                            "Failed to process metadata.", new SsoProcessException(msg));
+                }
                 final String metadata = settings.getSPMetadata();
                 final List<String> errors = Saml2Settings.validateMetadata(metadata);
                 if (!errors.isEmpty()) {
                     final String msg = errors.stream().collect(Collectors.joining(", "));
                     throw new SsoMessageException(
                             messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
-                            "Failed to log out.", new SsoProcessException(msg));
+                            "Failed to process metadata.", new SsoProcessException(msg));
                 }
                 return new StreamResponse("metadata.xml").contentType("application/samlmetadata+xml").stream(out -> {
                     try (final Writer writer = new OutputStreamWriter(out.stream(), Constants.UTF_8_CHARSET)) {

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -39,6 +39,8 @@ import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.lastaflute.web.login.credential.LoginCredential;
+import org.lastaflute.web.response.ActionResponse;
+import org.lastaflute.web.response.StreamResponse;
 
 public class SamlAuthenticatorTest extends UnitFessTestCase {
 
@@ -285,6 +287,41 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertNotNull(request.getSession(false).getAttribute("SAML_STATE"));
         } finally {
             tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getMetadataResponse_withoutIdpSettings() throws Exception {
+        // the SP metadata is what the IdP is registered from, so it must not require saml.idp.*
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            systemProperties.setProperty(BASE_URL_KEY, "https://fess.example.com");
+
+            final ActionResponse response = authenticator.getResponse(SsoResponseType.METADATA);
+
+            assertTrue(String.valueOf(response), response instanceof StreamResponse);
+            assertEquals("metadata.xml", ((StreamResponse) response).getFileName());
+        } finally {
+            systemProperties.remove(BASE_URL_KEY);
+        }
+    }
+
+    @Test
+    public void test_getMetadataResponse_reportsInvalidSpSettings() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            // an SP entity ID that is not a URL leaves the ACS URL unset
+            systemProperties.setProperty("saml.sp.assertion_consumer_service.url", "not a url");
+
+            authenticator.getResponse(SsoResponseType.METADATA);
+            fail("SsoMessageException should be thrown");
+        } catch (final SsoMessageException e) {
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause().getMessage(), e.getCause().getMessage().contains("sp_acs_not_found"));
+        } finally {
+            systemProperties.remove("saml.sp.assertion_consumer_service.url");
         }
     }
 


### PR DESCRIPTION
## Problem

`/sso/metadata` publishes the SP metadata that the IdP is registered from, so it has to be reachable **before** any `saml.idp.*` property exists. It was not:

```java
final Auth auth = new Auth(getSettings(), request, response);
final Saml2Settings settings = auth.getSettings();
settings.setSPValidationOnly(true);
final String metadata = settings.getSPMetadata();
```

The `Auth` constructor calls `settings.checkSettings()`, and `spValidationOnly` is still `false` at that point, so `checkIdPSettings()` runs and the constructor throws `SettingsException`. Setting the flag on the returned settings afterwards is too late — nothing calls `checkSettings()` again.

With only `sso.type=saml` and `saml.sp.base.url` set — which is exactly what the documentation says is needed to fetch the metadata — the endpoint fails:

```
SsoMessageException: Failed to process metadata.
  cause=SettingsException: Invalid settings: idp_entityId_not_found, idp_sso_url_invalid,
        idp_cert_or_fingerprint_not_found_and_required
```

leaving no way to obtain the metadata without first supplying the values the metadata is meant to help configure.

## Fix

`Auth` is not needed here at all — `getSPMetadata()` is a `Saml2Settings` method, and neither the request nor the response is used. The settings are now built directly, `setSPValidationOnly(true)` is applied **before** validation, and `checkSettings()` is called explicitly so invalid SP settings are still reported rather than silently producing broken metadata.

With the flag set first, the same configuration produces valid metadata:

```
getSPMetadata OK, length=1358
Saml2Settings.validateMetadata(metadata) = []
```

Also corrects the `"Failed to log out."` text on the metadata validation error, which was copied from the logout path.

## Tests

2 added to `SamlAuthenticatorTest`:

- `test_getMetadataResponse_withoutIdpSettings` — with only `saml.sp.base.url` set, a `StreamResponse` for `metadata.xml` is returned. Fails before this change with `SsoMessageException: Failed to process metadata.`
- `test_getMetadataResponse_reportsInvalidSpSettings` — an unusable ACS URL is still reported as `sp_acs_not_found`, pinning that dropping `Auth` did not drop SP validation

```
org.codelibs.fess.sso package: Tests run: 164, Failures: 0, Errors: 0, Skipped: 0
mvn -o clean javadoc:jar: BUILD SUCCESS
formatter:format + license:format: no changes
```

Independent of #3239, which touches `getLoginCredential()` in the same class; the two do not overlap.
