### PR TITLE
fix(sso/spnego): correct the logger level bound and sharpen SPNEGO diagnostics

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -155,21 +155,27 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
      * @return The configured SPNEGO authenticator instance
      * @throws SsoLoginException if SPNEGO initialization fails
      */
-    protected synchronized org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
-        if (authenticator != null) {
-            return authenticator;
+    protected org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
+        final org.codelibs.spnego.SpnegoAuthenticator current = authenticator;
+        if (current != null) {
+            return current;
         }
-        try {
-            // NOTE: The underlying SpnegoFilterConfig is a JVM-wide singleton, so the SPNEGO
-            // configuration is effectively cached for the lifetime of the process. Changes to the
-            // spnego.* settings therefore require a Fess restart to take effect.
-            final SpnegoConfig spnegoConfig = new SpnegoConfig();
-            warnInsecureSettings(spnegoConfig);
-            final SpnegoFilterConfig config = SpnegoFilterConfig.getInstance(spnegoConfig);
-            authenticator = new org.codelibs.spnego.SpnegoAuthenticator(config);
-            return authenticator;
-        } catch (final Exception e) {
-            throw new SsoLoginException("Failed to initialize SPNEGO.", e);
+        synchronized (this) {
+            if (authenticator != null) {
+                return authenticator;
+            }
+            try {
+                // NOTE: The underlying SpnegoFilterConfig is a JVM-wide singleton, so the SPNEGO
+                // configuration is effectively cached for the lifetime of the process. Changes to the
+                // spnego.* settings therefore require a Fess restart to take effect.
+                final SpnegoConfig spnegoConfig = new SpnegoConfig();
+                warnInsecureSettings(spnegoConfig);
+                final SpnegoFilterConfig config = SpnegoFilterConfig.getInstance(spnegoConfig);
+                authenticator = new org.codelibs.spnego.SpnegoAuthenticator(config);
+                return authenticator;
+            } catch (final Exception e) {
+                throw new SsoLoginException("Failed to initialize SPNEGO.", e);
+            }
         }
     }
 
@@ -227,7 +233,10 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 if (logger.isDebugEnabled()) {
                     logger.debug(msg);
                 }
-                throw new SsoLoginException(e.getMessage() + " " + msg, e);
+                // The library reports why the handshake failed; keep it, but not every exception
+                // carries a message and "null <msg>" helps nobody diagnose an SSO failure.
+                final String detail = e.getMessage();
+                throw new SsoLoginException(detail == null ? msg : detail + " " + msg, e);
             }
 
             // context/auth loop not yet complete
@@ -259,7 +268,8 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 logger.debug("username={}", Arrays.toString(username));
             }
             if (username.length == 2 && StringUtil.isNotBlank(username[1]) && !isAllowedRealm(username[1])) {
-                throw new SsoLoginException("Kerberos realm is not allowed: realm=" + username[1]);
+                throw new SsoLoginException("Kerberos realm is not allowed: realm=" + username[1] + ". Add it to " + SPNEGO_ALLOWED_REALMS
+                        + " to accept logins from this realm.");
             }
             return new SpnegoCredential(username[0]);
         }).orElse(null);
@@ -339,10 +349,10 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             if (SpnegoHttpFilter.Constants.LOGGER_LEVEL.equals(name)) {
                 final String logLevel = getProperty(SPNEGO_LOGGER_LEVEL, StringUtil.EMPTY);
                 if (StringUtil.isNotBlank(logLevel)) {
-                    if (logLevel.chars().allMatch(Character::isDigit)) {
+                    if (isSupportedLoggerLevel(logLevel)) {
                         return logLevel;
                     }
-                    logger.warn("Invalid spnego.logger.level (must be numeric): {}. Falling back to auto-detection.", logLevel);
+                    logger.warn("Invalid spnego.logger.level (must be 0-7): {}. Falling back to auto-detection.", logLevel);
                 }
                 if (logger.isDebugEnabled()) {
                     return "3";
@@ -405,6 +415,25 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             // and Fess calls SpnegoAuthenticator#authenticate directly instead of installing that
             // filter, so honoring the key here would advertise an exclusion that never happens.
             return null;
+        }
+
+        /**
+         * Determines whether a configured logger level is one the SPNEGO library can consume.
+         *
+         * The library parses the value with {@link Integer#parseInt(String)}, so a value that only
+         * looks numeric still fails initialization once it overflows an int. Anything it does not
+         * recognize is mapped to INFO, which makes the documented 0-7 range the useful bound.
+         *
+         * @param value The configured logger level (not blank)
+         * @return true if the value can be handed to the library
+         */
+        protected static boolean isSupportedLoggerLevel(final String value) {
+            try {
+                final int level = Integer.parseInt(value);
+                return level >= 0 && level <= 7;
+            } catch (final NumberFormatException e) {
+                return false;
+            }
         }
 
         /**

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
@@ -114,6 +114,43 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_isSupportedLoggerLevel() {
+        // The library switches on 1-7 and maps everything else, including 0, to INFO.
+        assertTrue(SpnegoAuthenticator.SpnegoConfig.isSupportedLoggerLevel("0"));
+        assertTrue(SpnegoAuthenticator.SpnegoConfig.isSupportedLoggerLevel("7"));
+        // Outside the documented range the value carries no meaning.
+        assertFalse(SpnegoAuthenticator.SpnegoConfig.isSupportedLoggerLevel("8"));
+        assertFalse(SpnegoAuthenticator.SpnegoConfig.isSupportedLoggerLevel("-1"));
+        // All-digit strings are not automatically parseable: the library uses Integer.parseInt.
+        assertFalse(SpnegoAuthenticator.SpnegoConfig.isSupportedLoggerLevel("99999999999"));
+        assertFalse(SpnegoAuthenticator.SpnegoConfig.isSupportedLoggerLevel("abc"));
+    }
+
+    @Test
+    public void test_getInitParameter_loggerLevel_outOfRangeFallsBack() {
+        SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+        DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            // An all-digit value that overflows an int used to be passed through and made the
+            // library fail with NumberFormatException while building its configuration.
+            systemProperties.setProperty("spnego.logger.level", "99999999999");
+            String level = config.getInitParameter(Constants.LOGGER_LEVEL);
+            assertFalse("99999999999".equals(level));
+            assertTrue(SpnegoAuthenticator.SpnegoConfig.isSupportedLoggerLevel(level));
+
+            // A value above the documented range is ignored as well.
+            systemProperties.setProperty("spnego.logger.level", "8");
+            assertFalse("8".equals(config.getInitParameter(Constants.LOGGER_LEVEL)));
+
+            // The quietest documented level is still passed through unchanged.
+            systemProperties.setProperty("spnego.logger.level", "7");
+            assertEquals("7", config.getInitParameter(Constants.LOGGER_LEVEL));
+        } finally {
+            systemProperties.remove("spnego.logger.level");
+        }
+    }
+
+    @Test
     public void test_getResourcePath_throwsWhenMissing() {
         SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
         // A missing resource must raise SsoLoginException rather than returning null.


### PR DESCRIPTION
Follow-ups to #3181 / #3216 in `SpnegoAuthenticator`. Four independent defects, no behaviour
change for a correctly configured server.

### 1. `spnego.logger.level` guard accepts values the library cannot parse

#3216 added a guard so a non-numeric level falls back to auto-detection, but it checked
`chars().allMatch(Character::isDigit)`. The library consumes the value with
`Integer.parseInt`, so an all-digit value that overflows an int — `99999999999` — passed the
guard and then failed initialization with `NumberFormatException`, which surfaces as
`SsoLoginException: Failed to initialize SPNEGO.` and takes SSO down entirely.

Bound the value to the documented 0-7 range by parsing it, which is also the range the
library's own switch distinguishes.

### 2. `null` prefix on the authorization failure message

```java
throw new SsoLoginException(e.getMessage() + " " + msg, e);
```

Not every cause carries a message, and this is the message an operator reads when SPNEGO
fails. It produced `null Failed to process Authorization Header: Negotiate ***`. Use the
cause's message only when there is one.

### 3. Realm rejection did not name the setting that fixes it

The realm allow list added in #3181 rejects any realm other than the server realm unless
`spnego.allowed.realms` lists it. That is a real behaviour change for a Kerberos setup with
a cross-realm trust — an AD domain tree or a trusted forest presents client principals from
a realm other than the server's — and the message named only the realm:

```
Kerberos realm is not allowed: realm=CHILD.EXAMPLE.COM
```

It now names `spnego.allowed.realms` too, so the log says how to accept the realm.

### 4. `getAuthenticator()` serialized every login

The method was `synchronized` in full while only its first invocation does any work, so each
login took the monitor, and the `volatile` on the field it reads was redundant because every
access already happened inside the lock. `isAllowedRealm` calls it a second time per login.

Read the volatile field first and take the lock only to initialize. The field's `volatile`
now carries its weight, and `destroy()` stays `synchronized` on the same monitor.

## Tests

`SpnegoAuthenticatorTest`: 19 tests, no failures (17 + 2).

- `test_isSupportedLoggerLevel` — `0` and `7` accepted, `8`, `-1`, `99999999999` and `abc`
  rejected
- `test_getInitParameter_loggerLevel_outOfRangeFallsBack` — an overflowing all-digit value
  is replaced by auto-detection instead of being handed to the library; `7` still passes
  through unchanged

The second test fails against the previous guard, which is the regression it pins.
