### PR TITLE
fix(admin): allow the SPNEGO pre-authentication password to be cleared

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
@@ -156,10 +156,7 @@ public class AdminGeneralAction extends FessAdminAction {
     @Secured({ ROLE })
     public HtmlResponse update(final EditForm form) {
         validate(form, messages -> {
-            // The SPNEGO library rejects this combination when it builds its configuration, and it
-            // does so lazily on the first login rather than here, so reject it at save time instead
-            // of letting SSO break silently until someone tries to log in.
-            if (!isCheckboxEnabled(form.spnegoAllowBasic) && isCheckboxEnabled(form.spnegoPromptNtlm)) {
+            if (isSpnegoNtlmPromptUnsupported(form)) {
                 messages.addErrorsSpnegoPromptNtlmRequiresBasic("spnegoPromptNtlm");
             }
         }, () -> asHtml(path_AdminGeneral_AdminGeneralJsp));
@@ -285,7 +282,15 @@ public class AdminGeneralAction extends FessAdminAction {
         fessConfig.setSystemProperty("spnego.login.client.module", form.spnegoLoginClientModule);
         fessConfig.setSystemProperty("spnego.login.server.module", form.spnegoLoginServerModule);
         fessConfig.setSystemProperty("spnego.preauth.username", form.spnegoPreauthUsername);
-        if (form.spnegoPreauthPassword != null && StringUtil.isNotBlank(form.spnegoPreauthPassword.replace("*", " "))) {
+        if (form.spnegoPreauthPassword == null || form.spnegoPreauthPassword.isEmpty()) {
+            // Unlike the other secrets on this screen, an empty pre-authentication password is a
+            // meaningful setting: the SPNEGO library only uses a keytab when both the user name and
+            // the password are empty. Keeping a stored password would leave a keytab configuration
+            // unreachable from here once any password had been saved.
+            fessConfig.setSystemProperty("spnego.preauth.password", null);
+        } else if (StringUtil.isNotBlank(form.spnegoPreauthPassword.replace("*", " "))) {
+            // Anything made only of the mask characters is the placeholder rendered by updateForm,
+            // which means the stored password was left untouched.
             fessConfig.setSystemProperty("spnego.preauth.password", form.spnegoPreauthPassword);
         }
         fessConfig.setSystemProperty("spnego.allow.basic", String.valueOf(isCheckboxEnabled(form.spnegoAllowBasic)));
@@ -516,6 +521,20 @@ public class AdminGeneralAction extends FessAdminAction {
             }
         }
         return false;
+    }
+
+    /**
+     * Checks whether the submitted SPNEGO settings ask for the NTLM prompt while Basic
+     * authentication is disabled. The SPNEGO library rejects that combination when it builds its
+     * configuration, and it does so lazily on the first login rather than at save time, so both the
+     * admin screen and the API reject it here instead of letting SSO break silently until someone
+     * tries to log in.
+     *
+     * @param form the form holding the settings to be stored
+     * @return true if the combination must be rejected
+     */
+    public static boolean isSpnegoNtlmPromptUnsupported(final EditForm form) {
+        return !isCheckboxEnabled(form.spnegoAllowBasic) && isCheckboxEnabled(form.spnegoPromptNtlm);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/general/ApiAdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/general/ApiAdminGeneralAction.java
@@ -82,10 +82,17 @@ public class ApiAdminGeneralAction extends FessApiAdminAction {
      */
     @Execute
     public JsonResponse<ApiResult> put$index(final EditBody body) {
-        validateApi(body, messages -> {});
         final EditBody newBody = new EditBody();
         AdminGeneralAction.updateForm(fessConfig, newBody);
         BeanUtil.copyBeanToBean(body, newBody, CopyOptions::excludeNull);
+        // The correlation rules apply to what will be stored, not to what the request carried: a
+        // request may send only one half of a correlated pair and let the stored value supply the
+        // other. The request body itself is still what gets validated against its own constraints.
+        validateApi(body, messages -> {
+            if (AdminGeneralAction.isSpnegoNtlmPromptUnsupported(newBody)) {
+                messages.addErrorsSpnegoPromptNtlmRequiresBasic("spnegoPromptNtlm");
+            }
+        });
         AdminGeneralAction.updateConfig(fessConfig, newBody);
         return asJson(new ApiResponse().status(Status.OK).result());
     }

--- a/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
@@ -105,6 +105,63 @@ public class AdminGeneralActionTest extends UnitFessTestCase {
         assertEquals("TRUSTED.EXAMPLE,PARTNER.EXAMPLE", reloaded.spnegoAllowedRealms);
     }
 
+    @Test
+    public void test_updateConfig_spnegoPreauthPassword_canBeCleared() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+
+        final EditForm form = createEditForm();
+        form.spnegoPreauthPassword = "secret";
+        AdminGeneralAction.updateConfig(fessConfig, form);
+        assertEquals("secret", ComponentUtil.getSystemProperties().getProperty("spnego.preauth.password"));
+
+        // Clearing the field must remove the key. The SPNEGO library only uses a keytab when both
+        // the pre-authentication user name and password are empty, so a password that cannot be
+        // cleared leaves a keytab configuration unreachable from this screen.
+        form.spnegoPreauthPassword = null;
+        AdminGeneralAction.updateConfig(fessConfig, form);
+        assertNull(ComponentUtil.getSystemProperties().getProperty("spnego.preauth.password"));
+
+        // An empty string reaches updateConfig through the API, which does not map "" to null.
+        form.spnegoPreauthPassword = "secret";
+        AdminGeneralAction.updateConfig(fessConfig, form);
+        form.spnegoPreauthPassword = "";
+        AdminGeneralAction.updateConfig(fessConfig, form);
+        assertNull(ComponentUtil.getSystemProperties().getProperty("spnego.preauth.password"));
+    }
+
+    @Test
+    public void test_updateConfig_spnegoPreauthPassword_maskKeepsStoredValue() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+
+        final EditForm form = createEditForm();
+        form.spnegoPreauthPassword = "secret";
+        AdminGeneralAction.updateConfig(fessConfig, form);
+
+        // updateForm renders a mask instead of the stored password, and submitting it back must
+        // leave the stored value alone rather than overwrite it with the mask.
+        final EditForm reloaded = createEditForm();
+        AdminGeneralAction.updateForm(fessConfig, reloaded);
+        AdminGeneralAction.updateConfig(fessConfig, reloaded);
+        assertEquals("secret", ComponentUtil.getSystemProperties().getProperty("spnego.preauth.password"));
+    }
+
+    @Test
+    public void test_isSpnegoNtlmPromptUnsupported() {
+        final EditForm form = createEditForm();
+
+        // The library requires Basic auth to be available before it can downgrade an NTLM token.
+        form.spnegoAllowBasic = null;
+        form.spnegoPromptNtlm = Constants.TRUE;
+        assertTrue(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(form));
+
+        form.spnegoAllowBasic = Constants.TRUE;
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(form));
+
+        form.spnegoAllowBasic = null;
+        form.spnegoPromptNtlm = null;
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(form));
+    }
+
     /**
      * Runs updateConfig for the given search engine type and asserts the stored property value.
      * The stored property is read back directly because isResultCollapsed() forces false for


### PR DESCRIPTION
Two gaps left by #3181 / #3220 in the General settings, both on the admin write path.

### 1. The SPNEGO pre-authentication password cannot be cleared

`updateConfig` stored the password only when the submitted value survived the mask check:

```java
if (form.spnegoPreauthPassword != null && StringUtil.isNotBlank(form.spnegoPreauthPassword.replace("*", " "))) {
```

That is the same shape as the other secrets on this screen, and for them it is right: the
form renders `**********` instead of the stored value, so an unchanged submission must not
overwrite it. Clearing the field simply did nothing.

For SPNEGO an empty password is not "unchanged", it is a configuration:

```java
boolean useKeyTab() {
    return this.canUseKeyTab && this.username.isEmpty() && this.password.isEmpty();
}
```

#3181 changed the coded defaults for `spnego.preauth.username` / `spnego.preauth.password`
to empty precisely so a keytab-based server login would work. But once any password had been
saved through this screen, the key could never be removed again, so `useKeyTab()` stayed
false and the keytab setup was unreachable without editing `system.properties` by hand.

An absent or empty submission now removes the key. A submission made only of mask characters
is still ignored, so the round trip through `updateForm` keeps behaving as before, and the
other secrets are untouched.

### 2. The NTLM prompt rule was not applied to the API

#3220 rejects `spnego.allow.basic=false` together with `spnego.prompt.ntlm=true`, because the
SPNEGO library refuses that combination when it builds its configuration — lazily, on the
first login, so without this check SSO breaks silently long after the save. The check lived
only in `AdminGeneralAction#update`, so `PUT /api/admin/general` could still store it.

Moving the same rule into the API needs one thing beyond copying it: the API merges the
request body over the stored settings, so a request that carries only one half of the pair
takes the other half from what is already stored. The check therefore runs on the merged
body, after `BeanUtil.copyBeanToBean`, while the request body itself is still what gets
validated against its own bean constraints. The rule is extracted to
`AdminGeneralAction#isSpnegoNtlmPromptUnsupported` so both paths share one definition.

## Tests

`AdminGeneralActionTest`: 10 tests, no failures (7 + 3).

- `test_updateConfig_spnegoPreauthPassword_canBeCleared` — a stored password is removed by a
  `null` submission (the HTML path, where LastaFlute maps an empty field to `null`) and by an
  empty string (the API path, which does not)
- `test_updateConfig_spnegoPreauthPassword_maskKeepsStoredValue` — an `updateForm` /
  `updateConfig` round trip leaves the stored password alone
- `test_isSpnegoNtlmPromptUnsupported` — the extracted rule

The first test fails against the previous code with `expected: <null> but was: <secret>`,
which is the defect it pins.

`mvn javadoc:jar` was regenerated from scratch: no new warnings from the touched files.
