### PR TITLE
fix(sso): stop the Entra ID refresh path calling Microsoft Graph on every request

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
@@ -74,6 +74,14 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
     public static class EntraIdUser implements FessUser {
         private static final long serialVersionUID = 1L;
 
+        /**
+         * How long before the access token expires {@link #refresh()} starts asking MSAL4J for a
+         * new one. It matches MSAL4J's own expiry buffer, so the token is renewed at the same
+         * instant it always was; what the guard removes is the silent acquisition -- and the
+         * Microsoft Graph call behind it -- on every other request.
+         */
+        protected static final long REFRESH_MARGIN = 5 * 60 * 1000L;
+
         /** User's group memberships. */
         protected volatile String[] groups;
 
@@ -156,16 +164,34 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                 }
                 return false;
             }
+            if (tokenExpiryTime - currentTime > REFRESH_MARGIN) {
+                // FessBaseAction.godHandPrologue calls this on every action request. A silent
+                // acquisition that succeeds runs updateMemberOf, which makes a synchronous
+                // Microsoft Graph call on the request thread, so it must not happen per request.
+                // Until the token is close to expiring there is nothing to acquire, and the
+                // groups this user was given at login are still the ones Entra ID issued them.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Token is still valid for {}ms. Skipping silent authentication.", tokenExpiryTime - currentTime);
+                }
+                return true;
+            }
             // Attempt to refresh token using MSAL4J silent authentication
             try {
                 final EntraIdAuthenticator authenticator = ComponentUtil.getComponent(EntraIdAuthenticator.class);
                 final IAuthenticationResult newResult = authenticator.refreshTokenSilently(this);
                 if (newResult != null) {
+                    // MSAL4J rounds its own buffer down to whole seconds, so for up to a second
+                    // either side of REFRESH_MARGIN it hands back the token it already had.
+                    // Re-reading the directory for a token that did not change would put the
+                    // per-request Graph call straight back.
+                    final boolean renewed = !newResult.accessToken().equals(authResult.accessToken());
                     authResult = newResult;
-                    authenticator.updateMemberOf(this);
-                    resetPermissions();
+                    if (renewed) {
+                        authenticator.updateMemberOf(this);
+                        resetPermissions();
+                    }
                     if (logger.isDebugEnabled()) {
-                        logger.debug("Token refreshed successfully via silent authentication");
+                        logger.debug("Silent authentication succeeded. renewed={}", renewed);
                     }
                     return true;
                 }

--- a/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
@@ -30,6 +30,7 @@ import org.codelibs.fess.app.web.search.SearchAction;
 import org.codelibs.fess.entity.RequestParameter;
 import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.exception.SsoMessageException;
+import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.sso.SsoManager;
 import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.util.ComponentUtil;
@@ -91,7 +92,14 @@ public class SsoAction extends FessLoginAction {
             loginCredential = ssoManager.getLoginCredential();
         } catch (final SsoLoginException e) {
             if (ssoManager.available()) {
-                logger.warn("Failed to process SSO login.", e);
+                if (e instanceof SsoStateException) {
+                    // The endpoint is anonymous, so a callback that matches no login this server
+                    // started is a rejected request rather than a fault. A stack trace per attempt
+                    // would let an unauthenticated client fill the log.
+                    logger.warn("Failed to process SSO login: {}", e.getMessage());
+                } else {
+                    logger.warn("Failed to process SSO login.", e);
+                }
                 saveError(messages -> messages.addErrorsSsoLoginError(GLOBAL));
             } else if (logger.isDebugEnabled()) {
                 logger.debug("Failed to process SSO login.", e);

--- a/src/main/java/org/codelibs/fess/exception/SsoStateException.java
+++ b/src/main/java/org/codelibs/fess/exception/SsoStateException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.exception;
+
+/**
+ * Exception thrown when an SSO callback does not match a login this server started.
+ *
+ * <p>Separate from {@link SsoLoginException} because the caller decides whether it happens: the
+ * SSO endpoint is anonymous, so anyone can send a callback carrying a state this server never
+ * issued, or replay one it has already consumed. That is a rejected request rather than a fault,
+ * and logging a full stack trace for each one lets an unauthenticated client fill the log. A
+ * genuine failure -- a token endpoint that will not answer, an unreachable directory, an
+ * unparsable response -- stays an {@link SsoLoginException} and keeps its stack trace.
+ */
+public class SsoStateException extends SsoLoginException {
+
+    /** Serial version UID for serialization compatibility. */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new SsoStateException with the specified detail message.
+     *
+     * @param message The detail message explaining which check rejected the callback
+     */
+    public SsoStateException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new SsoStateException with the specified detail message and cause.
+     *
+     * @param message The detail message explaining which check rejected the callback
+     * @param cause The underlying exception that caused this rejection
+     */
+    public SsoStateException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -52,6 +52,7 @@ import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist.LoginCredentialResolver;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.exception.SsoLoginException;
+import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.sso.SsoAuthenticator;
@@ -124,6 +125,9 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /** Configuration key for Entra ID reply URL. */
     protected static final String ENTRAID_REPLY_URL = "entraid.reply.url";
 
+    /** Configuration key for the OAuth2 response mode of the authorization request. */
+    protected static final String ENTRAID_RESPONSE_MODE = "entraid.response.mode";
+
     /** Configuration key for Entra ID default groups. */
     protected static final String ENTRAID_DEFAULT_GROUPS = "entraid.default.groups";
 
@@ -148,6 +152,15 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
 
     /** Legacy configuration key for Azure AD reply URL. */
     protected static final String AAD_REPLY_URL = "aad.reply.url";
+
+    /** Legacy configuration key for the OAuth2 response mode. */
+    protected static final String AAD_RESPONSE_MODE = "aad.response.mode";
+
+    /** Response mode that returns the authorization code in the callback query string. */
+    protected static final String RESPONSE_MODE_QUERY = "query";
+
+    /** Response mode that returns the authorization code in a form POST to the callback. */
+    protected static final String RESPONSE_MODE_FORM_POST = "form_post";
 
     /** Legacy configuration key for Azure AD default groups. */
     protected static final String AAD_DEFAULT_GROUPS = "aad.default.groups";
@@ -175,6 +188,9 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
 
     /** OAuth2 authorization code parameter name. */
     protected static final String CODE = "code";
+
+    /** Microsoft Graph error code returned when the application lacks the required permission. */
+    protected static final String PERMISSION_DENIED_ERROR_CODE = "Authorization_RequestDenied";
 
     /**
      * Scopes requested at the v2.0 authorization endpoint. msal4j already prepends
@@ -339,18 +355,18 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         storeStateInSession(request.getSession(), state, nonce);
         final String authUrl;
 
+        final String responseMode = getResponseMode();
         if (useV2Endpoint) {
             // v2.0 endpoint with MSAL4J (recommended)
             authUrl = getAuthority() + getTenant() + "/oauth2/v2.0/authorize?response_type=code&scope="
-                    + URLEncoder.encode(V2_SCOPES, Constants.UTF_8_CHARSET) + "&response_mode=query&redirect_uri="
+                    + URLEncoder.encode(V2_SCOPES, Constants.UTF_8_CHARSET) + "&response_mode=" + responseMode + "&redirect_uri="
                     + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id=" + getClientId() + "&state=" + state
                     + "&nonce=" + nonce;
         } else {
             // v1.0 endpoint for backward compatibility
-            authUrl = getAuthority() + getTenant()
-                    + "/oauth2/authorize?response_type=code&scope=directory.read.all&response_mode=query&redirect_uri="
-                    + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id=" + getClientId()
-                    + "&resource=https%3a%2f%2fgraph.microsoft.com" + "&state=" + state + "&nonce=" + nonce;
+            authUrl = getAuthority() + getTenant() + "/oauth2/authorize?response_type=code&scope=directory.read.all&response_mode="
+                    + responseMode + "&redirect_uri=" + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id="
+                    + getClientId() + "&resource=https%3a%2f%2fgraph.microsoft.com" + "&state=" + state + "&nonce=" + nonce;
         }
         if (logger.isDebugEnabled()) {
             logger.debug("redirect to: {} (using {} endpoint)", authUrl, useV2Endpoint ? "v2.0" : "v1.0");
@@ -528,7 +544,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         try {
             final JWTClaimsSet claimsSet = JWTParser.parse(idToken).getJWTClaimsSet();
             if (claimsSet == null) {
-                throw new SsoLoginException("could not validate nonce");
+                throw new SsoStateException("could not validate nonce");
             }
 
             final String nonce = (String) claimsSet.getClaim("nonce");
@@ -536,11 +552,14 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 logger.debug("nonce={}", nonce);
             }
             if (StringUtils.isEmpty(nonce) || !nonce.equals(stateData.getNonce())) {
-                throw new SsoLoginException("could not validate nonce");
+                throw new SsoStateException("could not validate nonce");
             }
         } catch (final SsoLoginException e) {
             throw e;
         } catch (final Exception e) {
+            // Not an SsoStateException: this is only reachable once the authorization code was
+            // redeemed, so an unparsable or unreadable ID token is a fault worth a stack trace,
+            // not a callback someone sent us.
             throw new SsoLoginException("could not validate nonce", e);
         }
     }
@@ -694,7 +713,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 return stateDataInSession;
             }
         }
-        throw new SsoLoginException("could not validate state");
+        throw new SsoStateException("could not validate state");
     }
 
     /**
@@ -722,9 +741,9 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         if (logger.isDebugEnabled()) {
             logger.debug("HTTP Method: {}", request.getMethod());
         }
-        // The authorization response arrives as a GET in query mode, which is what getAuthUrl now
-        // asks for. POST is still accepted so that a deployment already configured for form_post
-        // (tomcat.sameSiteCookies=none) keeps working.
+        // The authorization response arrives as a GET in query mode and as a POST in form_post
+        // mode; both are accepted because entraid.response.mode selects between them, and a login
+        // already in flight when that setting changes still has to complete.
         final String method = request.getMethod();
         if (!"GET".equalsIgnoreCase(method) && !"POST".equalsIgnoreCase(method)) {
             return false;
@@ -790,11 +809,21 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         }
 
         // Retrieve direct groups synchronously (parent group lookup is deferred)
-        processDirectMemberOf(user, groupList, roleList, groupIdsForParentLookup, "https://graph.microsoft.com/v1.0/me/memberOf");
+        final boolean resolved =
+                processDirectMemberOf(user, groupList, roleList, groupIdsForParentLookup, "https://graph.microsoft.com/v1.0/me/memberOf");
 
         if (logger.isDebugEnabled()) {
             logger.debug("[updateMemberOf] Direct groups retrieved. Total groups: {}, Total roles: {}, Group IDs for parent lookup: {}",
                     groupList.size(), roleList.size(), groupIdsForParentLookup.size());
+        }
+
+        if (!resolved && user.getGroupNames() != null) {
+            // Microsoft Graph did not answer with a membership list -- an expired token, a
+            // throttled tenant, a revoked permission. Writing what we have would replace the
+            // memberships this user logged in with by the configured defaults alone, silently
+            // taking away their search permissions until some later call happens to succeed.
+            logger.warn("Failed to resolve the Entra ID memberships of {}. Keeping the ones already resolved.", user.getName());
+            return;
         }
 
         // Set initial groups
@@ -849,8 +878,12 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @param roleList The list to add role names to.
      * @param groupIdsForParentLookup The list to collect group IDs for later parent lookup.
      * @param url The Microsoft Graph API URL.
+     * @return True if Microsoft Graph answered with a membership list, false if it reported an
+     *         error or could not be read. When this is false the lists hold whatever was collected
+     *         before the failure, which {@link #updateMemberOf} only writes when the user has no
+     *         memberships yet -- at login there is nothing better to fall back to.
      */
-    protected void processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
+    protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
             final List<String> groupIdsForParentLookup, final String url) {
         if (logger.isDebugEnabled()) {
             logger.debug("[processDirectMemberOf] Fetching direct memberships from URL: {}", url);
@@ -920,13 +953,19 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 }
                 final String nextLink = (String) contentMap.get("@odata.nextLink");
                 if (StringUtil.isNotBlank(nextLink)) {
-                    processDirectMemberOf(user, groupList, roleList, groupIdsForParentLookup, nextLink);
+                    return processDirectMemberOf(user, groupList, roleList, groupIdsForParentLookup, nextLink);
                 }
-            } else if (contentMap.containsKey("error")) {
-                logger.warn("Failed to access groups/roles: {}", contentMap);
+                return true;
             }
+            if (contentMap.containsKey("error")) {
+                logger.warn("Failed to access groups/roles: {}", contentMap);
+            } else {
+                logger.warn("Unexpected response while accessing groups/roles: {}", contentMap);
+            }
+            return false;
         } catch (final IOException e) {
             logger.warn("Failed to access groups/roles in Entra ID.", e);
+            return false;
         }
     }
 
@@ -1117,9 +1156,12 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /**
      * Asks Microsoft Graph which groups the specified group is a member of.
      *
-     * <p>A {@code Request_ResourceNotFound} error is a real answer -- the group does not exist --
-     * and comes back as an empty array so it can be cached. Everything else is thrown, so a
-     * transient failure is never mistaken for "this group has no parents".
+     * <p>Two error codes are real answers rather than failures and come back as an empty array so
+     * that the caller can cache them: {@code Request_ResourceNotFound}, because the group does not
+     * exist, and {@code Authorization_RequestDenied}, because a Graph permission that was never
+     * granted will not appear within the cache TTL -- throwing on it left nothing cached and made
+     * every login re-issue one failing request, and one stack trace, per group. Everything else is
+     * thrown, so a transient failure is never mistaken for "this group has no parents".
      *
      * @param user The Entra ID user.
      * @param id The group ID to get parent information for.
@@ -1139,23 +1181,42 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             if (logger.isDebugEnabled()) {
                 logger.debug("[getParentGroup] Response for id {}: {}", id, contentMap);
             }
-            if (contentMap.containsKey("value")) {
-                final String[] values = DocumentUtil.getValue(contentMap, "value", String[].class);
-                return values != null ? values : StringUtil.EMPTY_STRINGS;
-            }
-            if (contentMap.containsKey("error")) {
-                @SuppressWarnings("unchecked")
-                final Map<String, Object> errorMap = (Map<String, Object>) contentMap.get("error");
-                if ("Request_ResourceNotFound".equals(errorMap.get("code"))) {
+            return toMemberGroupIds(contentMap, id);
+        }
+    }
+
+    /**
+     * Classifies a {@code getMemberGroups} response body. See {@link #getMemberGroupIds} for which
+     * error codes count as an answer and which are failures.
+     *
+     * @param contentMap The parsed response body.
+     * @param id The group ID the response is for.
+     * @return The parent group IDs, never null.
+     * @throws IOException If the body reports a failure rather than an answer.
+     */
+    protected String[] toMemberGroupIds(final Map<String, Object> contentMap, final String id) throws IOException {
+        if (contentMap.containsKey("value")) {
+            final String[] values = DocumentUtil.getValue(contentMap, "value", String[].class);
+            return values != null ? values : StringUtil.EMPTY_STRINGS;
+        }
+        if (contentMap.containsKey("error")) {
+            if (contentMap.get("error") instanceof final Map<?, ?> errorMap) {
+                final Object code = errorMap.get("code");
+                if ("Request_ResourceNotFound".equals(code)) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("[getParentGroup] Resource not found for id {}: {}", id, contentMap);
                     }
                     return StringUtil.EMPTY_STRINGS;
                 }
-                throw new IOException("Failed to access parent groups for id " + id + ": " + contentMap);
+                if (PERMISSION_DENIED_ERROR_CODE.equals(code)) {
+                    logger.warn("Not allowed to read the parent groups of {}. Grant the Entra ID application"
+                            + " GroupMember.Read.All to resolve nested groups. {}", id, contentMap);
+                    return StringUtil.EMPTY_STRINGS;
+                }
             }
-            return StringUtil.EMPTY_STRINGS;
+            throw new IOException("Failed to access parent groups for id " + id + ": " + contentMap);
         }
+        return StringUtil.EMPTY_STRINGS;
     }
 
     /**
@@ -1362,6 +1423,34 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             return value;
         }
         return request.getRequestURL().toString();
+    }
+
+    /**
+     * Gets the OAuth2 response mode to ask the authorization endpoint for.
+     *
+     * <p>Defaults to {@code query}. Fess ships {@code tomcat.sameSiteCookies = lax}, and a Lax
+     * cookie is not sent on the cross-site POST that {@code form_post} produces, so a form_post
+     * callback arrives without JSESSIONID and the login loops. A deployment that sets
+     * {@code tomcat.sameSiteCookies = none} can select {@code form_post} to keep the
+     * authorization code out of the callback URL, and therefore out of browser history and any
+     * front-end proxy log.
+     *
+     * @return Either {@code query} or {@code form_post}.
+     */
+    protected String getResponseMode() {
+        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_RESPONSE_MODE);
+        if (StringUtil.isBlank(value)) {
+            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_RESPONSE_MODE, RESPONSE_MODE_QUERY);
+        }
+        if (StringUtil.isBlank(value)) {
+            return RESPONSE_MODE_QUERY;
+        }
+        value = value.trim();
+        if (RESPONSE_MODE_QUERY.equals(value) || RESPONSE_MODE_FORM_POST.equals(value)) {
+            return value;
+        }
+        logger.warn("Invalid {}: {}. Using {}.", ENTRAID_RESPONSE_MODE, value, RESPONSE_MODE_QUERY);
+        return RESPONSE_MODE_QUERY;
     }
 
     @Override

--- a/src/main/resources/fess_sso++.xml
+++ b/src/main/resources/fess_sso++.xml
@@ -3,6 +3,14 @@
 	"http://dbflute.org/meta/lastadi10.dtd">
 <components>
 	<component name="entraidAuthenticator" class="org.codelibs.fess.sso.entraid.EntraIdAuthenticator">
+		<!-- Tunables with no entraid.* configuration key. Uncomment to override a default.
+		<property name="maxStates">10</property>
+		<property name="graphConnectTimeout">10000</property>
+		<property name="graphReadTimeout">30000</property>
+		<property name="acquisitionTimeout">30000</property>
+		<property name="groupCacheExpiry">600</property>
+		<property name="maxGroupDepth">10</property>
+		-->
 	</component>
 	<component name="oicAuthenticator" class="org.codelibs.fess.sso.oic.OpenIdConnectAuthenticator">
 	</component>

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -43,6 +43,7 @@ import org.codelibs.curl.CurlResponse;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential;
 import org.codelibs.fess.exception.SsoLoginException;
+import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -201,19 +202,41 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     private static class TestAuthenticationResult implements IAuthenticationResult {
         private static final long serialVersionUID = 1L;
         private final IAccount account;
+        private final Date expiresOn;
+        private final String accessToken;
+        private final String idToken;
 
         TestAuthenticationResult(final IAccount account) {
+            this(account, new Date(Long.MAX_VALUE));
+        }
+
+        TestAuthenticationResult(final IAccount account, final Date expiresOn) {
+            this(account, expiresOn, "access-token", "id-token");
+        }
+
+        TestAuthenticationResult(final IAccount account, final Date expiresOn, final String accessToken) {
+            this(account, expiresOn, accessToken, "id-token");
+        }
+
+        TestAuthenticationResult(final IAccount account, final String idToken) {
+            this(account, new Date(Long.MAX_VALUE), "access-token", idToken);
+        }
+
+        TestAuthenticationResult(final IAccount account, final Date expiresOn, final String accessToken, final String idToken) {
             this.account = account;
+            this.expiresOn = expiresOn;
+            this.accessToken = accessToken;
+            this.idToken = idToken;
         }
 
         @Override
         public String accessToken() {
-            return "access-token";
+            return accessToken;
         }
 
         @Override
         public String idToken() {
-            return "id-token";
+            return idToken;
         }
 
         @Override
@@ -238,7 +261,7 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
         @Override
         public Date expiresOnDate() {
-            return new Date(Long.MAX_VALUE);
+            return expiresOn;
         }
     }
 
@@ -1234,10 +1257,11 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         }
 
         @Override
-        protected void processDirectMemberOf(EntraIdUser user, List<String> groupList, List<String> roleList,
+        protected boolean processDirectMemberOf(EntraIdUser user, List<String> groupList, List<String> roleList,
                 List<String> groupIdsForParentLookup, String url) {
             processDirectMemberOfCalled.set(true);
             // Don't call super to avoid actual API calls in tests
+            return true;
         }
 
         // Expose protected methods for testing
@@ -1250,5 +1274,376 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         public List<String> getDefaultRoleList() {
             return super.getDefaultRoleList();
         }
+    }
+
+    // ===================================================================================
+    //                                                        Regressions guarded from 15.7
+    //                                                        ==============================
+
+    @Test
+    public void test_updateMemberOf_keepsTheResolvedGroupsWhenGraphReportsAnError() {
+        // godHandPrologue refreshes the user on every action request, so updateMemberOf can run
+        // long after login. A throttled or newly unauthorised Graph used to leave the user with
+        // the configured defaults alone, silently taking away every permission they logged in
+        // with, until some later call happened to succeed.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
+                    final List<String> groupIdsForParentLookup, final String url) {
+                return false;
+            }
+        };
+        final EntraIdUser user = newUserWithoutGraph();
+        user.setGroups(new String[] { "group-a", "group-b" });
+        user.setRoles(new String[] { "role-a" });
+
+        authenticator.updateMemberOf(user);
+
+        assertEquals(2, user.getGroupNames().length);
+        assertEquals("group-a", user.getGroupNames()[0]);
+        assertEquals(1, user.getRoleNames().length);
+    }
+
+    @Test
+    public void test_updateMemberOf_stillSetsTheDefaultsWhenNothingWasResolvedYet() {
+        // At login there is nothing to keep, so a failed lookup must not leave groups null.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
+                    final List<String> groupIdsForParentLookup, final String url) {
+                return false;
+            }
+        };
+        final EntraIdUser user = newUserWithoutGraph();
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        try {
+            fessConfig.setSystemProperty("entraid.default.groups", "everyone");
+            authenticator.updateMemberOf(user);
+
+            assertEquals(1, user.getGroupNames().length);
+            assertEquals("everyone", user.getGroupNames()[0]);
+        } finally {
+            fessConfig.setSystemProperty("entraid.default.groups", "");
+        }
+    }
+
+    @Test
+    public void test_updateMemberOf_replacesTheGroupsWhenGraphAnswers() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
+                    final List<String> groupIdsForParentLookup, final String url) {
+                groupList.add("group-c");
+                return true;
+            }
+        };
+        final EntraIdUser user = newUserWithoutGraph();
+        user.setGroups(new String[] { "group-a" });
+
+        authenticator.updateMemberOf(user);
+
+        assertEquals(1, user.getGroupNames().length);
+        assertEquals("group-c", user.getGroupNames()[0]);
+    }
+
+    /**
+     * Builds a user without letting its constructor reach Microsoft Graph. The tests below drive
+     * {@code updateMemberOf} directly, so the registered component only has to stay quiet.
+     */
+    private EntraIdUser newUserWithoutGraph() {
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                // keep the constructor off Microsoft Graph
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+        return new EntraIdCredential(new TestAuthenticationResult(new TestAccount())).getUser();
+    }
+
+    @Test
+    public void test_toMemberGroupIds_treatsADeniedPermissionAsAnAnswerSoItCanBeCached() throws Exception {
+        // A Graph permission that was never granted will not appear within the cache TTL.
+        // Throwing left nothing cached, so every login re-issued one failing request, and one
+        // stack trace, per direct group.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Map<String, Object> contentMap = new HashMap<>();
+        contentMap.put("error", Map.of("code", "Authorization_RequestDenied", "message", "Insufficient privileges"));
+
+        assertEquals(0, authenticator.toMemberGroupIds(contentMap, "group-a").length);
+    }
+
+    @Test
+    public void test_toMemberGroupIds_treatsAMissingGroupAsAnAnswer() throws Exception {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Map<String, Object> contentMap = new HashMap<>();
+        contentMap.put("error", Map.of("code", "Request_ResourceNotFound", "message", "not found"));
+
+        assertEquals(0, authenticator.toMemberGroupIds(contentMap, "group-a").length);
+    }
+
+    @Test
+    public void test_toMemberGroupIds_throwsOnATransientFailure() {
+        // Throttling must stay uncached so the parents are resolved on the next attempt.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Map<String, Object> contentMap = new HashMap<>();
+        contentMap.put("error", Map.of("code", "TooManyRequests", "message", "throttled"));
+
+        try {
+            authenticator.toMemberGroupIds(contentMap, "group-a");
+            fail("a throttled response must not be mistaken for an answer");
+        } catch (final IOException e) {
+            assertTrue(e.getMessage().contains("group-a"));
+        }
+    }
+
+    @Test
+    public void test_toMemberGroupIds_throwsWhenTheErrorIsNotAnObject() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Map<String, Object> contentMap = new HashMap<>();
+        contentMap.put("error", "invalid_grant");
+
+        try {
+            authenticator.toMemberGroupIds(contentMap, "group-a");
+            fail("an unparsable error must not be mistaken for an answer");
+        } catch (final IOException e) {
+            assertTrue(e.getMessage().contains("group-a"));
+        }
+    }
+
+    @Test
+    public void test_toMemberGroupIds_returnsTheValues() throws Exception {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Map<String, Object> contentMap = new HashMap<>();
+        contentMap.put("value", List.of("parent-a", "parent-b"));
+
+        assertEquals(2, authenticator.toMemberGroupIds(contentMap, "group-a").length);
+    }
+
+    @Test
+    public void test_refresh_doesNotTouchGraphWhileTheTokenIsStillFresh() {
+        // FessBaseAction.godHandPrologue calls refresh() on every action request. Once the MSAL4J
+        // application became shared, acquireTokenSilently started succeeding, and every success
+        // ran updateMemberOf -- a synchronous Microsoft Graph call on the request thread.
+        final AtomicBoolean touched = new AtomicBoolean(false);
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                touched.set(true);
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                touched.set(true);
+                return null;
+            }
+        };
+        ComponentUtil.register(authenticator, EntraIdAuthenticator.class.getCanonicalName());
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
+        final EntraIdUser user =
+                new EntraIdCredential(new TestAuthenticationResult(new TestAccount(), new Date(now + 60 * 60 * 1000L))).getUser();
+        touched.set(false);
+
+        assertTrue(user.refresh());
+        assertFalse(touched.get());
+    }
+
+    @Test
+    public void test_refresh_acquiresSilentlyOnceTheTokenIsCloseToExpiring() {
+        final AtomicBoolean refreshed = new AtomicBoolean(false);
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                // keep the constructor and the refresh off Microsoft Graph
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                refreshed.set(true);
+                return null;
+            }
+        };
+        ComponentUtil.register(authenticator, EntraIdAuthenticator.class.getCanonicalName());
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
+        final EntraIdUser user =
+                new EntraIdCredential(new TestAuthenticationResult(new TestAccount(), new Date(now + 30 * 1000L))).getUser();
+
+        assertTrue(user.refresh());
+        assertTrue(refreshed.get());
+    }
+
+    @Test
+    public void test_refresh_reportsAnExpiredToken() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                // keep the constructor off Microsoft Graph
+            }
+        };
+        ComponentUtil.register(authenticator, EntraIdAuthenticator.class.getCanonicalName());
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
+        final EntraIdUser user = new EntraIdCredential(new TestAuthenticationResult(new TestAccount(), new Date(now - 1000L))).getUser();
+
+        assertFalse(user.refresh());
+    }
+
+    @Test
+    public void test_getAuthUrl_usesTheConfiguredResponseMode() {
+        // 15.7 hard-coded form_post and 15.8 hard-codes query. A deployment that sets
+        // tomcat.sameSiteCookies=none may prefer form_post to keep the authorization code out of
+        // the callback URL, so the mode has to be selectable rather than compiled in.
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final HttpServletRequest request = newAuthUrlRequest();
+        try {
+            assertTrue(authenticator.getAuthUrl(request).contains("&response_mode=query&"));
+
+            fessConfig.setSystemProperty("entraid.response.mode", "form_post");
+            assertTrue(authenticator.getAuthUrl(request).contains("&response_mode=form_post&"));
+
+            authenticator.setUseV2Endpoint(false);
+            assertTrue(authenticator.getAuthUrl(request).contains("&response_mode=form_post&"));
+        } finally {
+            fessConfig.setSystemProperty("entraid.response.mode", "");
+        }
+    }
+
+    @Test
+    public void test_getResponseMode_fallsBackWhenTheConfiguredValueIsNotAResponseMode() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        try {
+            fessConfig.setSystemProperty("entraid.response.mode", "fragment");
+            assertEquals("query", authenticator.getResponseMode());
+        } finally {
+            fessConfig.setSystemProperty("entraid.response.mode", "");
+        }
+    }
+
+    @Test
+    public void test_getResponseMode_readsTheLegacyAzureAdKey() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        try {
+            fessConfig.setSystemProperty("aad.response.mode", " form_post ");
+            assertEquals("form_post", authenticator.getResponseMode());
+        } finally {
+            fessConfig.setSystemProperty("aad.response.mode", "");
+        }
+    }
+
+    @Test
+    public void test_validateState_reportsACallbackThatMatchesNoLogin() {
+        // The SSO endpoint is anonymous, so anyone can send a state this server never issued.
+        // SsoAction logs SsoStateException without a stack trace so that cannot fill the log.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final HttpSession session = newAuthUrlRequest().getSession();
+        try {
+            authenticator.validateState(session, "never-issued");
+            fail("expected SsoStateException");
+        } catch (final SsoStateException e) {
+            assertEquals("could not validate state", e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_validateNonce_reportsAMismatchAsAStateFailure() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        try {
+            authenticator.validateNonce(new EntraIdAuthenticator.StateData("expected-nonce", 0L),
+                    new TestAuthenticationResult(new TestAccount(), plainIdToken("some-other-nonce")));
+            fail("expected SsoStateException");
+        } catch (final SsoStateException e) {
+            assertEquals("could not validate nonce", e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_validateNonce_acceptsTheNonceItIssued() throws Exception {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        authenticator.validateNonce(new EntraIdAuthenticator.StateData("expected-nonce", 0L),
+                new TestAuthenticationResult(new TestAccount(), plainIdToken("expected-nonce")));
+    }
+
+    @Test
+    public void test_validateNonce_keepsTheStackTraceOfAnUnreadableIdToken() {
+        // Only reachable once the authorization code was redeemed, so this is a fault an operator
+        // has to be able to diagnose -- not a callback someone sent us. It must not be reduced to
+        // the stack-free SsoStateException log line.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        try {
+            authenticator.validateNonce(new EntraIdAuthenticator.StateData("expected-nonce", 0L),
+                    new TestAuthenticationResult(new TestAccount(), "not-a-jwt"));
+            fail("expected SsoLoginException");
+        } catch (final SsoStateException e) {
+            fail("an unreadable ID token must keep its cause: " + e);
+        } catch (final SsoLoginException e) {
+            assertNotNull(e.getCause());
+        }
+    }
+
+    /** Builds an unsigned JWT carrying the given nonce; validateNonce only reads the claims. */
+    private String plainIdToken(final String nonce) {
+        final java.util.Base64.Encoder encoder = java.util.Base64.getUrlEncoder().withoutPadding();
+        return encoder.encodeToString("{\"alg\":\"none\"}".getBytes(StandardCharsets.UTF_8)) + "."
+                + encoder.encodeToString(("{\"nonce\":\"" + nonce + "\"}").getBytes(StandardCharsets.UTF_8)) + ".";
+    }
+
+    @Test
+    public void test_getResponseMode_ignoresABlankLegacyKey() {
+        // getSystemProperty only applies the default when the key is absent, so a key left empty
+        // by the admin screen would otherwise warn about entraid.response.mode on every redirect.
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        try {
+            fessConfig.setSystemProperty("aad.response.mode", "");
+            assertEquals("query", authenticator.getResponseMode());
+        } finally {
+            fessConfig.setSystemProperty("aad.response.mode", "");
+        }
+    }
+
+    @Test
+    public void test_refresh_doesNotReReadTheDirectoryForAnUnchangedToken() {
+        // MSAL4J rounds its expiry buffer down to whole seconds, so around REFRESH_MARGIN it
+        // returns the token it already had. Treating that as a renewal would restore the
+        // per-request Microsoft Graph call.
+        final AtomicBoolean updated = new AtomicBoolean(false);
+        final AtomicReference<IAuthenticationResult> current = new AtomicReference<>();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                updated.set(true);
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                return current.get();
+            }
+        };
+        ComponentUtil.register(authenticator, EntraIdAuthenticator.class.getCanonicalName());
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
+        final TestAuthenticationResult sameToken = new TestAuthenticationResult(new TestAccount(), new Date(now + 30 * 1000L));
+        current.set(sameToken);
+        final EntraIdUser user = new EntraIdCredential(sameToken).getUser();
+        updated.set(false);
+
+        assertTrue(user.refresh());
+        assertFalse(updated.get());
+
+        current.set(new TestAuthenticationResult(new TestAccount(), new Date(now + 30 * 1000L), "renewed-access-token"));
+        assertTrue(user.refresh());
+        assertTrue(updated.get());
+    }
+
+    private HttpServletRequest newAuthUrlRequest() {
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        return request;
     }
 }


### PR DESCRIPTION
## Why

A review of the Entra ID SSO code against `fess-15.7.0` turned up one regression that costs a
Microsoft Graph round trip on every request, plus four problems found while confirming it.

### Microsoft Graph on every request

`FessBaseAction.godHandPrologue` calls `FessUser.refresh()` for every action request of a
logged-in user. `EntraIdUser.refresh()` then attempts a silent token acquisition and, on success,
calls `updateMemberOf` — a **synchronous** `GET /me/memberOf` on the request thread, plus a
`TimeoutManager` task and an audit log line.

That code is unchanged since 15.7. What changed is its callee: sharing one
`ConfidentialClientApplication` so silent refresh could work also made it *succeed every time*.
Before, each call built a throwaway application whose token cache was empty, so the acquisition
always missed and returned null, and `updateMemberOf` only ever ran at login.

`refresh()` now returns early while the token is outside MSAL4J's own expiry buffer, and re-reads
the directory only when the access token actually changed. MSAL4J rounds that buffer down to whole
seconds, so without the second check there is a window where it hands back the token it already
had and the per-request lookup returns.

Note this never applied to `/api/v2`, `/api/v1`, `/json`, `/suggest` or `/mcp` — `webApiFilter` is
mapped ahead of `lastaToActionFilter`, so those are not actions and never reach
`godHandPrologue`. The JSP UI and the admin screens are what was affected.

### Losing a user's groups mid-session

When Microsoft Graph answered with an error, `updateMemberOf` still wrote the result, replacing the
memberships the user logged in with by `entraid.default.groups`/`default.roles` alone — so an
expired token, a throttled tenant or a revoked permission silently took away their search
permissions until some later call happened to succeed. Harmless in 15.7 because it only ran at
login; not harmless once it runs per request. `processDirectMemberOf` now reports whether it got an
answer, and the previously resolved memberships are kept when it did not.

### A permission that will never be granted, retried forever

`getMemberGroupIds` threw on every Graph error except `Request_ResourceNotFound`, so nothing was
cached. That is right for throttling, wrong for a tenant that has not granted
`GroupMember.Read.All`: it re-issued one failing request, and one stack trace, per direct group on
every login. `Authorization_RequestDenied` is now an answer that can be cached, like
`Request_ResourceNotFound`. Throttling and transport failures still stay uncached. The
classification moved into `toMemberGroupIds` because the old branch had no test coverage at all.

### Response mode

`response_mode` was compiled in — `form_post` in 15.7, `query` since. `query` is the right default
because Fess ships `tomcat.sameSiteCookies = lax`, which does not send the session cookie on the
cross-site POST that `form_post` produces. But a deployment that sets `sameSiteCookies = none` may
prefer `form_post` to keep the authorization code out of the callback URL. `entraid.response.mode`
(legacy `aad.response.mode`) selects between them, defaulting to `query`.

### Stack traces from an anonymous endpoint

`/sso/` is anonymous, so anyone can send a callback carrying a state this server never issued.
That produced a WARN with a full stack trace per request. `validateState` and a nonce mismatch now
throw `SsoStateException`, which `SsoAction` logs as a single line. Everything else — a token
endpoint that will not answer, an unreachable directory, an unparsable response — keeps its stack
trace. In particular the wrapper in `validateNonce` deliberately does not use the new type: it is
only reachable once the authorization code was redeemed, so it is a fault an operator has to be
able to diagnose.

## Also

`fess_sso++.xml` now lists the tunables that have no configuration key, commented out, following
the shipped example in `fess_se++.xml`.

## Testing

The Entra ID authenticator test class is up to 77 tests, and 165 pass across the SSO packages. Each fix
was reverted individually to confirm its test fails without it. `mvn formatter:format`,
`license:format` and a forced `javadoc:javadoc` are clean.

Documentation for the callback change and the new setting is in codelibs/fess-docs.
