### PR TITLE
fix(sso/spnego): enforce the realm allow list on the Basic fallback

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -16,7 +16,9 @@
 package org.codelibs.fess.sso.spnego;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -49,6 +51,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
@@ -105,6 +108,9 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
 
     /** Configuration key for SPNEGO logger level. */
     protected static final String SPNEGO_LOGGER_LEVEL = "spnego.logger.level";
+
+    /** Upper bound on the length of a client-supplied value embedded in a log message. */
+    protected static final int MAX_LOGGED_REALM_LENGTH = 64;
 
     /** The underlying SPNEGO authenticator instance. */
     protected volatile org.codelibs.spnego.SpnegoAuthenticator authenticator = null;
@@ -169,9 +175,12 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 // configuration is effectively cached for the lifetime of the process. Changes to the
                 // spnego.* settings therefore require a Fess restart to take effect.
                 final SpnegoConfig spnegoConfig = new SpnegoConfig();
-                warnInsecureSettings(spnegoConfig);
                 final SpnegoFilterConfig config = SpnegoFilterConfig.getInstance(spnegoConfig);
                 authenticator = new org.codelibs.spnego.SpnegoAuthenticator(config);
+                // Warn only once initialization has succeeded. A failed attempt leaves authenticator
+                // null and is retried on the next login, so warning before this point repeats the
+                // same message for every attempt, and the settings cannot matter until SPNEGO runs.
+                warnInsecureSettings(spnegoConfig);
                 return authenticator;
             } catch (final Exception e) {
                 throw new SsoLoginException("Failed to initialize SPNEGO.", e);
@@ -221,6 +230,11 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             final HttpServletResponse response = LaResponseUtil.getResponse();
             final SpnegoHttpServletResponse spnegoResponse = new SpnegoHttpServletResponse(response);
 
+            // The Basic path destroys the realm before a principal exists, so it has to be checked
+            // here, against the request. Doing it before authenticating also keeps a rejected realm
+            // from causing an AS-REQ to a foreign KDC.
+            rejectDisallowedBasicRealm(request);
+
             // client/caller principal
             final SpnegoPrincipal principal;
             try {
@@ -268,12 +282,93 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 logger.debug("username={}", Arrays.toString(username));
             }
             if (username.length == 2 && StringUtil.isNotBlank(username[1]) && !isAllowedRealm(username[1])) {
-                throw new SsoLoginException("Kerberos realm is not allowed: realm=" + username[1] + ". Add it to " + SPNEGO_ALLOWED_REALMS
-                        + " to accept logins from this realm.");
+                throw new SsoLoginException(realmRejectedMessage(username[1]));
             }
             return new SpnegoCredential(username[0]);
         }).orElse(null);
 
+    }
+
+    /**
+     * Rejects a Basic authentication attempt whose user name names a Kerberos realm that is not
+     * allowed.
+     *
+     * The SPNEGO handshake carries the client's real realm in the principal, so it can be validated
+     * after the fact. Basic authentication cannot: the library authenticates the name the user
+     * typed but then builds the principal from the <em>server</em> realm, and KerberosPrincipal
+     * collapses the resulting two-realm name back to that server realm. By the time a principal
+     * exists the typed realm is gone, which would leave the allow list unable to govern this path.
+     *
+     * @param request the current request
+     * @throws SsoLoginException if the realm named in the header is not allowed
+     */
+    protected void rejectDisallowedBasicRealm(final HttpServletRequest request) {
+        final String realm = getBasicRealm(request.getHeader(Constants.AUTHZ_HEADER));
+        if (realm != null && !isAllowedRealm(realm)) {
+            throw new SsoLoginException(realmRejectedMessage(realm));
+        }
+    }
+
+    /**
+     * Builds the message reported when a Kerberos realm is refused.
+     *
+     * @param realm the rejected realm
+     * @return the message, with the realm sanitized for logging
+     */
+    protected static String realmRejectedMessage(final String realm) {
+        return "Kerberos realm is not allowed: realm=" + sanitizeForLog(realm) + ". Add it to " + SPNEGO_ALLOWED_REALMS
+                + " to accept logins from this realm.";
+    }
+
+    /**
+     * Extracts the Kerberos realm from the user name of a Basic {@code Authorization} header.
+     *
+     * Only the user name half of the decoded token is inspected. The password is never returned and
+     * never logged.
+     *
+     * @param authzHeader the raw Authorization header value (may be null)
+     * @return the realm the client typed, or null when the header is not Basic, cannot be decoded,
+     *         or names no realm
+     */
+    protected static String getBasicRealm(final String authzHeader) {
+        if (authzHeader == null) {
+            return null;
+        }
+        final int schemeEnd = authzHeader.indexOf(' ');
+        if (schemeEnd <= 0 || !Constants.BASIC_HEADER.equalsIgnoreCase(authzHeader.substring(0, schemeEnd))) {
+            return null;
+        }
+        final byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(authzHeader.substring(schemeEnd + 1).trim());
+        } catch (final IllegalArgumentException e) {
+            // A malformed token is the library's to reject; do not turn it into a realm failure.
+            return null;
+        }
+        final String credentials = new String(decoded, StandardCharsets.UTF_8);
+        final int colon = credentials.indexOf(':');
+        final String user = colon < 0 ? credentials : credentials.substring(0, colon);
+        // The library drops a NetBIOS "DOMAIN\" prefix before authenticating, so mirror it here.
+        final String name = user.substring(user.indexOf('\\') + 1);
+        final int at = name.indexOf('@');
+        if (at < 0 || at == name.length() - 1) {
+            return null;
+        }
+        return name.substring(at + 1);
+    }
+
+    /**
+     * Bounds a client-supplied value and strips its control characters.
+     *
+     * A realm refused on the Basic path comes straight from an unauthenticated request and is
+     * written to the application log, so a raw newline would let a client forge log lines.
+     *
+     * @param value the client-supplied value
+     * @return a value safe to embed in a log message
+     */
+    protected static String sanitizeForLog(final String value) {
+        final String bounded = value.length() > MAX_LOGGED_REALM_LENGTH ? value.substring(0, MAX_LOGGED_REALM_LENGTH) + "..." : value;
+        return bounded.replaceAll("\\p{Cntrl}", "?");
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
@@ -17,6 +17,10 @@ package org.codelibs.fess.sso.spnego;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.unit.UnitFessTestCase;
@@ -24,6 +28,8 @@ import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.spnego.SpnegoHttpFilter.Constants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 public class SpnegoAuthenticatorTest extends UnitFessTestCase {
 
@@ -41,6 +47,89 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
         systemProperties.remove("spnego.login.client.module");
         systemProperties.remove("spnego.exclude.dirs");
         super.tearDown(testInfo);
+    }
+
+    /** Builds a request stub that answers only getHeader(), which is all the check reads. */
+    private HttpServletRequest requestWithAuthz(final String value) {
+        return (HttpServletRequest) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { HttpServletRequest.class },
+                (proxy, method, args) -> "getHeader".equals(method.getName()) ? value : null);
+    }
+
+    private static String basic(final String credentials) {
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void test_getBasicRealm() {
+        // Only a Basic header carrying a realm yields one.
+        assertEquals("FOREIGN.EXAMPLE", SpnegoAuthenticator.getBasicRealm(basic("alice@FOREIGN.EXAMPLE:secret")));
+        // The library strips a NetBIOS domain prefix before authenticating, so the realm is what
+        // follows '@', not the prefix.
+        assertEquals("FOREIGN.EXAMPLE", SpnegoAuthenticator.getBasicRealm(basic("CORP\\alice@FOREIGN.EXAMPLE:secret")));
+        // A password containing '@' or ':' must not be mistaken for a realm.
+        assertEquals("FOREIGN.EXAMPLE", SpnegoAuthenticator.getBasicRealm(basic("alice@FOREIGN.EXAMPLE:p@ss:word")));
+
+        // No realm to check.
+        assertNull(SpnegoAuthenticator.getBasicRealm(null));
+        assertNull(SpnegoAuthenticator.getBasicRealm(basic("alice:secret")));
+        assertNull(SpnegoAuthenticator.getBasicRealm(basic("CORP\\alice:secret")));
+        assertNull(SpnegoAuthenticator.getBasicRealm(basic("alice@:secret")));
+        // Other schemes carry the realm in the principal instead and are validated after the
+        // handshake; they must not be decoded here.
+        assertNull(SpnegoAuthenticator.getBasicRealm("Negotiate YIIFoAYGKwYBBQUCoIIF"));
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basic"));
+        // A malformed token belongs to the library to reject, not to this check.
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basic !!!not-base64!!!"));
+    }
+
+    @Test
+    public void test_sanitizeForLog() {
+        assertEquals("CORP.EXAMPLE", SpnegoAuthenticator.sanitizeForLog("CORP.EXAMPLE"));
+        // A newline would otherwise let an unauthenticated client forge a log line.
+        assertEquals("EVIL??WARN forged", SpnegoAuthenticator.sanitizeForLog("EVIL\r\nWARN forged"));
+        final String bounded = SpnegoAuthenticator.sanitizeForLog("R".repeat(200));
+        assertEquals(SpnegoAuthenticator.MAX_LOGGED_REALM_LENGTH + 3, bounded.length());
+        assertTrue(bounded.endsWith("..."));
+    }
+
+    @Test
+    public void test_rejectDisallowedBasicRealm_rejectsForeignRealm() {
+        final SpnegoAuthenticator authenticator = new SpnegoAuthenticator() {
+            @Override
+            protected boolean isAllowedRealm(final String realm) {
+                return false;
+            }
+        };
+        final SsoLoginException e = assertThrows(SsoLoginException.class,
+                () -> authenticator.rejectDisallowedBasicRealm(requestWithAuthz(basic("alice@FOREIGN.EXAMPLE:secret"))));
+        assertTrue(e.getMessage().contains("FOREIGN.EXAMPLE"));
+        assertTrue(e.getMessage().contains("spnego.allowed.realms"));
+        // The decoded token holds the password; it must never reach the message or the log.
+        assertFalse(e.getMessage().contains("secret"));
+    }
+
+    @Test
+    public void test_rejectDisallowedBasicRealm_acceptsAllowedRealm() {
+        final SpnegoAuthenticator authenticator = new SpnegoAuthenticator() {
+            @Override
+            protected boolean isAllowedRealm(final String realm) {
+                return "PARTNER.EXAMPLE".equals(realm);
+            }
+        };
+        authenticator.rejectDisallowedBasicRealm(requestWithAuthz(basic("alice@PARTNER.EXAMPLE:secret")));
+    }
+
+    @Test
+    public void test_rejectDisallowedBasicRealm_skipsCheckWhenNoRealmIsNamed() {
+        // A plain user name and a non-Basic scheme must not reach the allow list, because
+        // isAllowedRealm resolves the server realm through the library and would otherwise force
+        // SPNEGO initialization on every Negotiate handshake. Any such attempt fails here, since
+        // this authenticator has no usable SPNEGO configuration.
+        final SpnegoAuthenticator authenticator = new SpnegoAuthenticator();
+        authenticator.rejectDisallowedBasicRealm(requestWithAuthz(null));
+        authenticator.rejectDisallowedBasicRealm(requestWithAuthz("Negotiate YIIFoAYGKwYBBQUCoIIF"));
+        authenticator.rejectDisallowedBasicRealm(requestWithAuthz(basic("alice:secret")));
+        authenticator.rejectDisallowedBasicRealm(requestWithAuthz(basic("CORP\\alice:secret")));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoFilterConfigBoundaryTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoFilterConfigBoundaryTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.sso.spnego;
+
+import java.io.File;
+import java.lang.reflect.Field;
+
+import javax.security.auth.login.Configuration;
+
+import org.codelibs.core.misc.DynamicProperties;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.spnego.SpnegoFilterConfig;
+import org.codelibs.spnego.SpnegoHttpFilter.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+/**
+ * Boundary test that actually runs the SPNEGO library's configuration constructor against the
+ * values Fess produces.
+ *
+ * <p>
+ * A library regression once made the {@code SpnegoFilterConfig} constructor resolve the configured
+ * login.conf location with {@code new File(new URI(loginConfPath))}. Fess hands it a plain absolute
+ * file system path, because {@code SpnegoConfig#getResourcePath} resolves a packaged resource with
+ * {@code File#getAbsolutePath()}, so the constructor threw
+ * {@code IllegalArgumentException: URI is not absolute} and every SPNEGO login failed. Neither the
+ * existing Fess tests nor the library's own suite ever executed that constructor, so both builds
+ * stayed green while SSO was completely broken.
+ * </p>
+ *
+ * <p>
+ * This test crosses the boundary on purpose: it feeds a real {@link SpnegoAuthenticator.SpnegoConfig}
+ * into {@link SpnegoFilterConfig#getInstance(jakarta.servlet.FilterConfig)} with JAAS fixtures under
+ * {@code src/test/resources/spnego/} and asserts the resulting configuration. The first method pins
+ * the plain-path contract that broke; the second pins that a {@code file:} URI is still accepted, so
+ * the library fix cannot later be "simplified" into a path-only parser.
+ * </p>
+ *
+ * <p>
+ * The whole Fess suite shares one JVM, and both {@code SpnegoFilterConfig} and
+ * {@link Configuration} are JVM-wide cached singletons, so this class saves and restores that global
+ * state itself rather than relying on any other test to leave it clean.
+ * </p>
+ */
+public class SpnegoFilterConfigBoundaryTest extends UnitFessTestCase {
+
+    /** Fess system property naming the JAAS login configuration resource. */
+    private static final String SPNEGO_LOGIN_CONF = "spnego.login.conf";
+
+    /** Fess system property naming the Kerberos configuration resource. */
+    private static final String SPNEGO_KRB5_CONF = "spnego.krb5.conf";
+
+    /** Classpath location of the JAAS fixture, namespaced so it cannot shadow Fess's own defaults. */
+    private static final String TEST_LOGIN_CONF = "spnego/test_auth_login.conf";
+
+    /** Classpath location of the krb5 fixture (only set as a system property, never parsed here). */
+    private static final String TEST_KRB5_CONF = "spnego/test_krb5.conf";
+
+    /** JVM system property the library sets from the login.conf init parameter. */
+    private static final String JAAS_CONFIG_PROPERTY = "java.security.auth.login.config";
+
+    /** JVM system property the library sets from the krb5.conf init parameter. */
+    private static final String KRB5_CONFIG_PROPERTY = "java.security.krb5.conf";
+
+    /** The library singleton captured before the test replaced it. */
+    private Object savedFilterConfigInstance;
+
+    /** The JAAS configuration captured before the test forced a reload. */
+    private Configuration savedJaasConfiguration;
+
+    /** The {@value #KRB5_CONFIG_PROPERTY} value captured before the library overwrote it. */
+    private String savedKrb5ConfigProperty;
+
+    /** The {@value #JAAS_CONFIG_PROPERTY} value captured before the library overwrote it. */
+    private String savedJaasConfigProperty;
+
+    @Override
+    protected void setUp(final TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+
+        // SpnegoFilterConfig caches its instance in a private static field and offers no reset, so
+        // the constructor under test would never run a second time in this JVM.
+        final Field instanceField = getInstanceField();
+        savedFilterConfigInstance = instanceField.get(null);
+        instanceField.set(null, null);
+
+        // Configuration is a JVM-wide cached singleton that reads java.security.auth.login.config
+        // only on first use. If an earlier test touched JAAS, the library's module lookup would see
+        // a stale configuration and fail with "The client module name was not found in the login
+        // file". Clearing it forces a reload from the property the library is about to set.
+        try {
+            savedJaasConfiguration = Configuration.getConfiguration();
+        } catch (final Exception | Error e) {
+            savedJaasConfiguration = null;
+        }
+        Configuration.setConfiguration(null);
+
+        savedKrb5ConfigProperty = System.getProperty(KRB5_CONFIG_PROPERTY);
+        savedJaasConfigProperty = System.getProperty(JAAS_CONFIG_PROPERTY);
+
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        systemProperties.setProperty(SPNEGO_LOGIN_CONF, TEST_LOGIN_CONF);
+        systemProperties.setProperty(SPNEGO_KRB5_CONF, TEST_KRB5_CONF);
+    }
+
+    @Override
+    protected void tearDown(final TestInfo testInfo) throws Exception {
+        try {
+            final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+            systemProperties.remove(SPNEGO_KRB5_CONF);
+            systemProperties.remove(SPNEGO_LOGIN_CONF);
+
+            restoreSystemProperty(JAAS_CONFIG_PROPERTY, savedJaasConfigProperty);
+            restoreSystemProperty(KRB5_CONFIG_PROPERTY, savedKrb5ConfigProperty);
+
+            Configuration.setConfiguration(savedJaasConfiguration);
+
+            getInstanceField().set(null, savedFilterConfigInstance);
+        } finally {
+            super.tearDown(testInfo);
+        }
+    }
+
+    /**
+     * Returns the library's private static singleton field, made accessible.
+     *
+     * <p>
+     * The field lives on a class loaded from the classpath (unnamed module), so no
+     * {@code --add-opens} is required.
+     * </p>
+     *
+     * @return the accessible {@code SpnegoFilterConfig.instance} field
+     * @throws Exception if the field no longer exists
+     */
+    private static Field getInstanceField() throws Exception {
+        final Field field = SpnegoFilterConfig.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        return field;
+    }
+
+    /**
+     * Restores a JVM system property, removing it when it was not set before.
+     *
+     * @param key the property name
+     * @param value the captured value, or null if the property was absent
+     */
+    private static void restoreSystemProperty(final String key, final String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+
+    /**
+     * The regression discriminator: the library must accept the plain absolute path Fess supplies.
+     *
+     * @throws Exception if the library rejects the configuration
+     */
+    @Test
+    public void test_getInstance_acceptsPlainAbsolutePathFromClasspath() throws Exception {
+        final SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig();
+
+        // Contract: Fess hands the library a plain absolute path, not a file: URI. Pinning this
+        // here makes a future library that quietly re-requires a URI fail readably.
+        final String loginConf = config.getInitParameter(Constants.LOGIN_CONF);
+        assertFalse(loginConf.startsWith("file:"));
+        assertTrue(new File(loginConf).isAbsolute());
+
+        // The boundary: this constructor is what the regression broke.
+        final SpnegoFilterConfig result = SpnegoFilterConfig.getInstance(config);
+        assertNotNull(result);
+
+        // toString() is the only public view of the parsed state.
+        final String s = result.toString();
+        assertTrue(s.contains("clientLoginModule=spnego-client"));
+        assertTrue(s.contains("serverLoginModule=spnego-server"));
+        assertTrue(s.contains("canUseKeyTab=true"));
+        assertTrue(s.contains("allowBasic=true"));
+        assertTrue(s.contains("allowUnsecure=false"));
+        assertTrue(s.contains("allowLocalhost=false"));
+
+        // The library forwards the same value to JAAS, which accepts a path as well as a URL.
+        assertEquals(loginConf, System.getProperty(JAAS_CONFIG_PROPERTY));
+    }
+
+    /**
+     * Control: a {@code file:} URI must keep working too, so the fix is not narrowed to paths only.
+     *
+     * @throws Exception if the library rejects the configuration
+     */
+    @Test
+    public void test_getInstance_alsoAcceptsFileUri() throws Exception {
+        final SpnegoAuthenticator.SpnegoConfig config = new SpnegoAuthenticator.SpnegoConfig() {
+            @Override
+            protected String getResourcePath(final String path) {
+                return new File(super.getResourcePath(path)).toURI().toString();
+            }
+        };
+
+        final String loginConf = config.getInitParameter(Constants.LOGIN_CONF);
+        assertTrue(loginConf.startsWith("file:"));
+
+        final SpnegoFilterConfig result = SpnegoFilterConfig.getInstance(config);
+        assertNotNull(result);
+
+        final String s = result.toString();
+        assertTrue(s.contains("clientLoginModule=spnego-client"));
+        assertTrue(s.contains("serverLoginModule=spnego-server"));
+        assertTrue(s.contains("canUseKeyTab=true"));
+
+        assertEquals(loginConf, System.getProperty(JAAS_CONFIG_PROPERTY));
+    }
+}

--- a/src/test/resources/spnego/test_auth_login.conf
+++ b/src/test/resources/spnego/test_auth_login.conf
@@ -1,0 +1,11 @@
+spnego-client {
+    com.sun.security.auth.module.Krb5LoginModule required;
+};
+
+spnego-server {
+    com.sun.security.auth.module.Krb5LoginModule required
+    storeKey=true
+    useKeyTab=true
+    keyTab="file:///nonexistent/fess-test.keytab"
+    principal="HTTP/localhost@TEST.EXAMPLE";
+};

--- a/src/test/resources/spnego/test_krb5.conf
+++ b/src/test/resources/spnego/test_krb5.conf
@@ -1,0 +1,4 @@
+[libdefaults]
+    default_realm = TEST.EXAMPLE
+[realms]
+    TEST.EXAMPLE = { kdc = kdc.test.example }


### PR DESCRIPTION
## Summary

`spnego.allowed.realms`, added in 15.8, was inert on the HTTP Basic fallback, and
nothing in either this repository or the SPNEGO library ever executed the
library's configuration constructor. This fixes the first and closes the test gap
that hid a total SPNEGO outage.

## The Basic fallback bypassed the allow list

The Negotiate path carries the client's real realm in the principal, so it can be
validated after the handshake. Basic cannot:

1. The library authenticates the name the user typed, then builds the principal
   as `typedName + "@" + serverRealm`.
2. `SpnegoPrincipal` wraps `KerberosPrincipal`, which normalizes a two-realm name
   by keeping the segment after the second `@` — `alice@CORP.EXAMPLE@EXAMPLE`
   becomes `alice@EXAMPLE`.

So the realm Fess inspected was always its own, and the allow list always
permitted the login. Because a Basic login is authenticated directly against the
realm the user types, no cross-realm trust is required: any realm reachable from
the server's `krb5.conf` could be used, and the resulting Fess user is the bare
account name.

The fix recovers the typed realm from the `Authorization` header and checks it
before authenticating, so a rejected realm never triggers an AS-REQ to a foreign
KDC. A name with no realm (`alice`, `DOMAIN\alice`) does not reach the allow list
at all, leaving the Negotiate path and its cost unchanged.

Only the user name half of the decoded token is inspected; the password is never
returned or logged. The rejected realm originates in an unauthenticated request
and is written to the log, so it is length-bounded and stripped of control
characters.

## Warning repeated on every retry

`warnInsecureSettings` ran before initialization. A failed attempt leaves the
authenticator null and is retried on the next login, so the same warning was
emitted for every attempt. It now runs once initialization has succeeded.

## Test gap

`SpnegoFilterConfigBoundaryTest` runs `SpnegoFilterConfig.getInstance()` against
the values Fess produces, using JAAS fixtures under `src/test/resources/spnego/`.
It needs no KDC: the last KDC-free point is the return of `getInstance()`, and
the regression lived at step 2 of that constructor.

Verified to discriminate — against the library build that required a `file:` URI
it fails with `IllegalArgumentException: URI is not absolute` at
`SpnegoFilterConfig.loginConfExists`, and it passes against the fixed build. A
second method pins that a `file:` URI is still accepted, so the library fix
cannot later be narrowed to paths only.

The class saves and restores the three pieces of JVM-global state it touches (the
library singleton, the JAAS `Configuration`, and the two system properties the
library sets), because the whole suite shares one JVM.

## Not changed

Two candidate issues were investigated and deliberately left alone:

- The fail-open branch in `isAllowedRealm` when no realm can be determined is
  unreachable: `KerberosPrincipal` throws rather than yielding a blank realm, so
  initialization fails first.
- Memoizing an initialization failure would be a regression. `SpnegoFilterConfig`
  is a first-wins JVM singleton, so an administrator who corrects a keytab path
  or a downed KDC would need a full restart to recover.

## Testing

- `org.codelibs.fess.sso.**` slice: 202 tests, 0 failures, run in a clean worktree
- `SpnegoAuthenticatorTest` 19 to 24 tests; `SpnegoFilterConfigBoundaryTest` 2 new
- `mvn formatter:format license:format` reports no changes
- `mvn javadoc:jar` clean

Note on the full suite: `mvn test` for the whole project is currently red in my
environment with `NoClassDefFoundError` in unrelated tests. It reproduces on
unmodified `master` with a clean build, and the failing set differs between runs
(QueryHelperTest and LabelTypeHelperTest in one run, StaticThemeResponderTest and
ParameterUtilTest in another), so it is pre-existing and unrelated to this change.

Docs for the realm behaviour are in codelibs/fess-docs.
