### PR TITLE
fix(sso): harden the Entra ID login, refresh and configuration paths

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
@@ -56,11 +56,12 @@ public class LogoutHandler {
     /**
      * Processes one {@code /api/v2/auth/logout} POST request.
      *
-     * <p>Invokes {@link FessLoginAssist#logout()} (swallowing failures so the
-     * call remains idempotent) and then invalidates the underlying
-     * {@link HttpSession} when one exists. Rejects non-{@code POST} methods
-     * with {@link V2ErrorCode#METHOD_NOT_ALLOWED}; otherwise always writes a
-     * success envelope of {@code {"ok": true}}.</p>
+     * <p>Runs the SSO logout for the bound user, invokes
+     * {@link FessLoginAssist#logout()} (swallowing failures so the call remains
+     * idempotent) and then invalidates the underlying {@link HttpSession} when
+     * one exists. Rejects non-{@code POST} methods with
+     * {@link V2ErrorCode#METHOD_NOT_ALLOWED}; otherwise always writes a success
+     * envelope of {@code {"ok": true}}.</p>
      *
      * @param req the incoming HTTP request
      * @param res the HTTP response to write to
@@ -77,6 +78,7 @@ public class LogoutHandler {
             // Mirror LogoutAction.index(): the LOGOUT record must be written BEFORE logout()
             // drops the user bean, otherwise the audit line degrades to "user:-".
             recordLogoutActivity(assist);
+            runSsoLogout(assist);
             assist.logout();
         } catch (final Exception e) {
             // logout is idempotent — no session or unavailable login subsystem; log WARN for
@@ -110,6 +112,31 @@ public class LogoutHandler {
             ComponentUtil.getActivityHelper().logout(assist.getSavedUserBean());
         } catch (final RuntimeException e) {
             logger.warn("[v2/logout] failed to write the LOGOUT audit record", e);
+        }
+    }
+
+    /**
+     * Runs the SSO logout for the bound user, mirroring {@code LogoutAction.index()} so a session
+     * ended through the v2 API is torn down at the identity provider as well as locally.
+     *
+     * <p>For Entra ID this is the only thing that evicts the user's tokens from the MSAL4J token
+     * cache shared by the whole application ({@code EntraIdAuthenticator.logout()} calls
+     * {@code removeAccount}). That cache expires nothing by itself, so skipping this call leaves
+     * the tokens of everyone who logs out through the v2 API resident for the life of the JVM.</p>
+     *
+     * <p>{@code SsoManager.logout} answers with the provider's single-logout URL. The v2 API has
+     * no redirect semantics -- it always writes a JSON envelope -- so the URL is deliberately
+     * discarded; a client that wants a front-channel single logout has to navigate there itself.
+     * Like the audit write, failures are logged and swallowed: the local logout below must still
+     * happen and the endpoint must stay idempotent. An absent user bean is simply skipped.</p>
+     *
+     * @param assist the login assist still holding the user bean to be logged out
+     */
+    private void runSsoLogout(final FessLoginAssist assist) {
+        try {
+            assist.getSavedUserBean().ifPresent(user -> ComponentUtil.getSsoManager().logout(user));
+        } catch (final RuntimeException e) {
+            logger.warn("[v2/logout] failed to run the SSO logout", e);
         }
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
@@ -454,18 +454,61 @@ public class AdminGeneralAction extends FessAdminAction {
         form.spnegoLoggerLevel = fessConfig.getSystemProperty("spnego.logger.level", StringUtil.EMPTY);
 
         // Entra ID
-        form.entraidClientId = StringUtil.isNotBlank(fessConfig.getSystemProperty("entraid.client.id")) ? DUMMY_PASSWORD : StringUtil.EMPTY;
+        form.entraidClientId =
+                StringUtil.isNotBlank(entraidProperty(fessConfig, "entraid.client.id", "aad.client.id", StringUtil.EMPTY)) ? DUMMY_PASSWORD
+                        : StringUtil.EMPTY;
         form.entraidClientSecret =
-                StringUtil.isNotBlank(fessConfig.getSystemProperty("entraid.client.secret")) ? DUMMY_PASSWORD : StringUtil.EMPTY;
-        form.entraidTenant = fessConfig.getSystemProperty("entraid.tenant", StringUtil.EMPTY);
-        form.entraidAuthority = fessConfig.getSystemProperty("entraid.authority", "https://login.microsoftonline.com/");
-        form.entraidReplyUrl = fessConfig.getSystemProperty("entraid.reply.url", StringUtil.EMPTY);
-        form.entraidStateTtl = fessConfig.getSystemProperty("entraid.state.ttl", "3600");
-        form.entraidDefaultGroups = fessConfig.getSystemProperty("entraid.default.groups", StringUtil.EMPTY);
-        form.entraidDefaultRoles = fessConfig.getSystemProperty("entraid.default.roles", StringUtil.EMPTY);
-        form.entraidPermissionFields = fessConfig.getSystemProperty("entraid.permission.fields", "mail");
-        form.entraidUseDs = Constants.TRUE.equalsIgnoreCase(fessConfig.getSystemProperty("entraid.use.ds", Constants.TRUE)) ? Constants.TRUE
+                StringUtil.isNotBlank(entraidProperty(fessConfig, "entraid.client.secret", "aad.client.secret", StringUtil.EMPTY))
+                        ? DUMMY_PASSWORD
+                        : StringUtil.EMPTY;
+        form.entraidTenant = entraidProperty(fessConfig, "entraid.tenant", "aad.tenant", StringUtil.EMPTY);
+        form.entraidAuthority = entraidProperty(fessConfig, "entraid.authority", "aad.authority", "https://login.microsoftonline.com/");
+        form.entraidReplyUrl = entraidProperty(fessConfig, "entraid.reply.url", "aad.reply.url", StringUtil.EMPTY);
+        form.entraidStateTtl = entraidProperty(fessConfig, "entraid.state.ttl", "aad.state.ttl", "3600");
+        form.entraidDefaultGroups = entraidProperty(fessConfig, "entraid.default.groups", "aad.default.groups", StringUtil.EMPTY);
+        form.entraidDefaultRoles = entraidProperty(fessConfig, "entraid.default.roles", "aad.default.roles", StringUtil.EMPTY);
+        form.entraidPermissionFields = entraidProperty(fessConfig, "entraid.permission.fields", "aad.permission.fields", "mail");
+        form.entraidUseDs = Constants.TRUE.equalsIgnoreCase(entraidProperty(fessConfig, "entraid.use.ds", "aad.use.ds", Constants.TRUE))
+                ? Constants.TRUE
                 : Constants.FALSE;
+    }
+
+    /**
+     * Resolves an Entra ID setting the way {@code EntraIdAuthenticator} and {@code FessProp} do:
+     * the new {@code entraid.*} key first, then the legacy {@code aad.*} key it replaced, then the
+     * hard-coded default. Only non-blank values count, because a key that is present but empty is
+     * not a configured value.
+     *
+     * <p>updateForm has to follow the same chain the consumers follow. Reading only the new key
+     * renders the hard-coded default on a deployment that is configured through the legacy keys,
+     * and updateConfig then writes that default to the new key -- which every getter prefers --
+     * so opening this screen for an unrelated change and pressing Update would silently move a
+     * sovereign-cloud {@code aad.authority}, a tuned {@code aad.state.ttl}, a non-default
+     * {@code aad.permission.fields} or {@code aad.use.ds=false} back to the shipped default.</p>
+     *
+     * <p>With the legacy value rendered, saving migrates it into the new key instead: the same
+     * setting stays in effect and the screen becomes the migration path the legacy keys never
+     * had. The two masked credential fields go through here as well so a legacy-only deployment
+     * shows them as configured; the mask-only guard in updateConfig then skips the write and
+     * leaves {@code aad.client.id}/{@code aad.client.secret} in place.</p>
+     *
+     * @param fessConfig the current Fess configuration
+     * @param newKey the {@code entraid.*} property key
+     * @param legacyKey the {@code aad.*} property key it replaced
+     * @param defaultValue the value to render when neither key holds one
+     * @return the first non-blank of the new key, the legacy key and the default
+     */
+    private static String entraidProperty(final FessConfig fessConfig, final String newKey, final String legacyKey,
+            final String defaultValue) {
+        final String value = fessConfig.getSystemProperty(newKey);
+        if (StringUtil.isNotBlank(value)) {
+            return value;
+        }
+        final String legacyValue = fessConfig.getSystemProperty(legacyKey);
+        if (StringUtil.isNotBlank(legacyValue)) {
+            return legacyValue;
+        }
+        return defaultValue;
     }
 
     private void updateProperty(final String key, final String value) {

--- a/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
@@ -19,6 +19,7 @@ import static org.codelibs.core.stream.StreamUtil.stream;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -91,8 +92,19 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
         /** User's computed permissions. */
         protected volatile String[] permissions;
 
-        /** Entra ID authentication result. */
-        protected IAuthenticationResult authResult;
+        /**
+         * Entra ID authentication result. Volatile because {@link #refresh()} replaces it from
+         * whichever request thread wins the renewal while the other request threads sharing this
+         * session-scoped instance keep reading it.
+         */
+        protected volatile IAuthenticationResult authResult;
+
+        /**
+         * Set for as long as one thread is inside the silent acquisition in {@link #refresh()}.
+         * A plain flag rather than a lock: the losing threads must carry on with the token they
+         * already hold instead of queueing behind an acquisition that can take tens of seconds.
+         */
+        private final AtomicBoolean refreshing = new AtomicBoolean();
 
         /**
          * Constructs an Entra ID user with the authentication result.
@@ -175,6 +187,25 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                 }
                 return true;
             }
+            // Lastaflute keeps one FessUserBean -- and therefore one EntraIdUser -- as a session
+            // attribute, and FessBaseAction.godHandPrologue calls refresh() on every action
+            // request, so all the requests a session has in flight arrive here together once the
+            // token enters REFRESH_MARGIN. Each of them would see a renewed token, run
+            // updateMemberOf -- a synchronous Microsoft Graph call on a request thread -- and
+            // schedule another parent group lookup, and the last one to assign would decide which
+            // of the results authResult ends up holding. One renewal per rollover is enough.
+            // Not a lock, and deliberately not a synchronized method: the acquisition runs for up
+            // to the authenticator's acquisition timeout plus the Graph calls behind
+            // updateMemberOf, and getPermissions() takes this object's monitor, so waiting here
+            // would stall every concurrent search of this user for that whole time.
+            if (!refreshing.compareAndSet(false, true)) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Another request is already renewing the token. Skipping silent authentication.");
+                }
+                // The token this thread holds has not expired yet -- the check above proved it --
+                // so the request may proceed while the winner renews.
+                return true;
+            }
             // Attempt to refresh token using MSAL4J silent authentication
             try {
                 final EntraIdAuthenticator authenticator = ComponentUtil.getComponent(EntraIdAuthenticator.class);
@@ -199,6 +230,8 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Silent token refresh failed: {}", e.getMessage());
                 }
+            } finally {
+                refreshing.set(false);
             }
             // For MSAL4J, if silent refresh fails, return true if token is still valid
             // Actual refresh will happen during next authentication request

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -802,7 +802,8 @@ public interface FessProp {
 
     /**
      * Gets the permission fields for Entra ID authentication.
-     * Uses new entraid.permission.fields key with fallback to legacy aad.permission.fields.
+     * Uses new entraid.permission.fields key with fallback to legacy aad.permission.fields,
+     * and to {@code mail} when neither key holds a value.
      * @return Array of permission field names.
      */
     default String[] getEntraIdPermissionFields() {
@@ -810,18 +811,31 @@ public interface FessProp {
         if (StringUtil.isBlank(value)) {
             value = getSystemProperty("aad.permission.fields", "mail");
         }
+        if (StringUtil.isBlank(value)) {
+            // getSystemProperty only substitutes the default when the key is absent, so a key
+            // that is present but empty arrives here as "". Splitting it would leave no
+            // permission field at all, and the only permissions the user would get are the raw
+            // group object IDs -- every document ACL'd by group mail address turns invisible.
+            value = "mail";
+        }
         return split(value, ",").get(stream -> stream.filter(StringUtil::isNotBlank).map(String::trim).toArray(n -> new String[n]));
     }
 
     /**
      * Checks if domain services are enabled for Entra ID authentication.
-     * Uses new entraid.use.ds key with fallback to legacy aad.use.ds.
+     * Uses new entraid.use.ds key with fallback to legacy aad.use.ds, and to {@code true} when
+     * neither key holds a value.
      * @return true if domain services are enabled, false otherwise.
      */
     default boolean isEntraIdUseDomainServices() {
         String value = getSystemProperty("entraid.use.ds", null);
         if (StringUtil.isBlank(value)) {
             value = getSystemProperty("aad.use.ds", "true");
+        }
+        if (StringUtil.isBlank(value)) {
+            // A present-but-empty key is not the default: getSystemProperty returns "" and the
+            // comparison below would answer false, flipping the documented default of true.
+            value = Constants.TRUE;
         }
         return Constants.TRUE.equalsIgnoreCase(value);
     }

--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -40,10 +41,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.Pair;
-import org.codelibs.core.net.UuidUtil;
 import org.codelibs.core.stream.StreamUtil;
 import org.codelibs.core.timer.TimeoutManager;
 import org.codelibs.curl.Curl;
+import org.codelibs.curl.CurlException;
 import org.codelibs.curl.CurlRequest;
 import org.codelibs.curl.CurlResponse;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
@@ -63,6 +64,7 @@ import org.codelibs.opensearch.runner.net.OpenSearchCurl;
 import org.dbflute.optional.OptionalEntity;
 import org.dbflute.optional.OptionalThing;
 import org.lastaflute.web.login.credential.LoginCredential;
+import org.lastaflute.web.login.exception.LoginFailureException;
 import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.response.HtmlResponse;
 import org.lastaflute.web.util.LaRequestUtil;
@@ -109,6 +111,13 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
 
     /** Default state time-to-live in seconds. */
     protected static final String DEFAULT_STATE_TTL = "3600";
+
+    /**
+     * Authority used when none is configured. Also used when the configured value is present but
+     * blank: an empty authority would make {@link #getAuthUrl} build a scheme-less, and therefore
+     * relative, redirect that sends the browser back into Fess instead of to Microsoft.
+     */
+    protected static final String DEFAULT_AUTHORITY = "https://login.microsoftonline.com/";
 
     /** Configuration key for Entra ID authority URL. */
     protected static final String ENTRAID_AUTHORITY = "entraid.authority";
@@ -192,6 +201,21 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /** Microsoft Graph error code returned when the application lacks the required permission. */
     protected static final String PERMISSION_DENIED_ERROR_CODE = "Authorization_RequestDenied";
 
+    /** HTTP status Microsoft Graph answers with while it is throttling the caller. */
+    protected static final int HTTP_TOO_MANY_REQUESTS = 429;
+
+    /** HTTP status Microsoft Graph answers with while it is temporarily unavailable. */
+    protected static final int HTTP_SERVICE_UNAVAILABLE = 503;
+
+    /** Backoff applied when a throttled response carries no usable {@code Retry-After} header. */
+    protected static final long DEFAULT_GRAPH_THROTTLE_SECONDS = 60L;
+
+    /**
+     * Upper bound on the backoff. {@code Retry-After} is whatever the service says it is, and an
+     * unreasonably large value would leave nested groups unresolved for the rest of the day.
+     */
+    protected static final long MAX_GRAPH_THROTTLE_SECONDS = 60L * 60L;
+
     /**
      * Scopes requested at the v2.0 authorization endpoint. msal4j already prepends
      * {@code openid profile offline_access} to the token request (its
@@ -270,6 +294,12 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /** Group cache expiry time in seconds. */
     protected long groupCacheExpiry = 10 * 60L;
 
+    /**
+     * Maximum number of groups kept in {@link #groupCache}. The cache is keyed by group id, so a
+     * tenant with many groups would otherwise grow it without bound until every entry expired.
+     */
+    protected int maxGroupCacheSize = 10000;
+
     /** Maximum depth for processing nested groups to prevent infinite loops. */
     protected int maxGroupDepth = 10;
 
@@ -289,14 +319,21 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      */
     protected int maxStates = 10;
 
-    /** Use V2 endpoint. */
-    protected boolean useV2Endpoint = true;
+    /**
+     * Point in time, as epoch milliseconds, until which Microsoft Graph asked us to stop calling
+     * it. Zero means it never did. Read on the login path, written from whichever thread was
+     * throttled, hence volatile.
+     */
+    protected volatile long graphThrottledUntil;
 
-    /** Shared MSAL4J client application. Holds the token cache that silent refresh reads. */
-    protected volatile ConfidentialClientApplication clientApplication;
-
-    /** Identifies the configuration {@link #clientApplication} was built from. */
-    protected volatile String clientApplicationKey;
+    /**
+     * Shared MSAL4J client application together with the configuration it was built from.
+     *
+     * <p>A single reference is what makes the pair consistent: with the application and its key in
+     * two separate fields, a reader interleaved between the two writes pairs the old application
+     * with the new key and hands back the stale one indefinitely.
+     */
+    protected volatile ClientApplicationHolder clientApplicationHolder;
 
     /**
      * Initializes the Entra ID authenticator.
@@ -308,7 +345,18 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             logger.debug("Initializing {}", this.getClass().getSimpleName());
         }
         ComponentUtil.getSsoManager().register(this);
-        groupCache = CacheBuilder.newBuilder().expireAfterWrite(groupCacheExpiry, TimeUnit.SECONDS).build();
+        groupCache = createGroupCache();
+    }
+
+    /**
+     * Builds the parent group cache. Both bounds matter: the expiry keeps a group whose
+     * membership changed from being served forever, and the size keeps a large tenant from
+     * holding every group it ever resolved until the expiry comes round.
+     *
+     * @return The cache.
+     */
+    protected Cache<String, Pair<String[], String[]>> createGroupCache() {
+        return CacheBuilder.newBuilder().maximumSize(maxGroupCacheSize).expireAfterWrite(groupCacheExpiry, TimeUnit.SECONDS).build();
     }
 
     @Override
@@ -319,29 +367,84 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             }
             final HttpSession session = request.getSession(false);
             if (containsAuthenticationData(request)) {
-                if (session == null) {
-                    // Redirecting again would send the user straight back here without a session,
-                    // looping forever. The usual cause is the session cookie not being sent on the
-                    // callback; see tomcat.sameSiteCookies in tomcat_config.properties.
+                if (session != null) {
+                    try {
+                        return processAuthenticationData(request);
+                    } catch (final SsoLoginException e) {
+                        throw e;
+                    } catch (final Exception e) {
+                        // Wrapped rather than returned as null so SsoAction logs it at WARN and
+                        // shows the SSO error message, the same as it already does for the other
+                        // authenticators. Swallowing it here left a failed login invisible unless
+                        // DEBUG logging happened to be on.
+                        throw new SsoLoginException("Failed to process a login request on Entra ID.", e);
+                    }
+                }
+                if (!hasExpiredSession(request)) {
+                    // No session, and no session id came back either: the browser is not returning
+                    // the cookie at all (form_post with SameSite=Lax or Strict, or cookies off).
+                    // Redirecting would send the user straight back here in the same state, so
+                    // this is where the loop has to stop. Returning null makes SsoAction show the
+                    // SSO error message and fall back to the local login form.
                     logger.warn("Received an Entra ID authentication response without a session."
-                            + " The session cookie was not sent back with the callback request.");
+                            + " The session cookie was not sent back with the callback request."
+                            + " See tomcat.sameSiteCookies in tomcat_config.properties.");
                     return null;
                 }
-                try {
-                    return processAuthenticationData(request);
-                } catch (final SsoLoginException e) {
-                    throw e;
-                } catch (final Exception e) {
-                    // Wrapped rather than returned as null so SsoAction logs it at WARN and shows
-                    // the SSO error message, the same as it already does for the other
-                    // authenticators. Swallowing it here left a failed login invisible unless
-                    // DEBUG logging happened to be on.
-                    throw new SsoLoginException("Failed to process a login request on Entra ID.", e);
+                // The browser did return a session id and the container rejected it, so cookies
+                // demonstrably work and the session merely expired while the user was at
+                // Microsoft. Start the login again rather than dropping them on a login form that
+                // has no SSO link. This cannot loop: getAuthUrl creates a fresh session, so the
+                // next callback either finds it or arrives with no session id at all, which is
+                // the branch above.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("The session of an Entra ID callback had expired. Restarting the login.");
                 }
             }
 
+            validateConfiguration();
             return new ActionResponseCredential(() -> HtmlResponse.fromRedirectPathAsIs(getAuthUrl(request)));
         }).orElse(null);
+    }
+
+    /**
+     * Returns whether the request carries a session id that the container no longer recognises.
+     *
+     * <p>This is what tells an expired session apart from a browser that is not sending the
+     * cookie: a request with no session id at all cannot have lost one.
+     *
+     * @param request The HTTP servlet request.
+     * @return True if a session id was sent and it is no longer valid.
+     */
+    protected boolean hasExpiredSession(final HttpServletRequest request) {
+        return request.getRequestedSessionId() != null && !request.isRequestedSessionIdValid();
+    }
+
+    /**
+     * Fails the login when Entra ID cannot possibly answer for want of configuration.
+     *
+     * <p>Without this an unconfigured server redirects to
+     * {@code https://login.microsoftonline.com//oauth2/v2.0/authorize?...&amp;client_id=} and logs
+     * nothing, so the administrator sees only a Microsoft error page. It is thrown from here
+     * rather than from the {@link ActionResponseCredential} supplier because {@code SsoAction}
+     * executes that supplier outside the block that catches {@link SsoLoginException}, and it is
+     * not checked in {@code init()} because {@code fess_sso++.xml} registers every authenticator
+     * unconditionally -- including when {@code sso.type} selects another one.
+     */
+    protected void validateConfiguration() {
+        final List<String> missing = new ArrayList<>();
+        if (StringUtil.isBlank(getTenant())) {
+            missing.add(ENTRAID_TENANT);
+        }
+        if (StringUtil.isBlank(getClientId())) {
+            missing.add(ENTRAID_CLIENT_ID);
+        }
+        if (StringUtil.isBlank(getClientSecret())) {
+            missing.add(ENTRAID_CLIENT_SECRET);
+        }
+        if (!missing.isEmpty()) {
+            throw new SsoLoginException("Entra ID is not configured. The following settings are empty: " + String.join(", ", missing));
+        }
     }
 
     /**
@@ -350,26 +453,21 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The authorization URL to redirect the user to.
      */
     protected String getAuthUrl(final HttpServletRequest request) {
-        final String state = UuidUtil.create();
-        final String nonce = UuidUtil.create();
+        // UUID.randomUUID is backed by SecureRandom and varies in 122 bits. The state is the
+        // only thing standing between a login and a forged callback (RFC 6749 section 10.12), and
+        // org.codelibs.core.net.UuidUtil, which this used to call, keeps the first 16 hex
+        // characters constant for the life of the JVM and varies under 32 bits per call.
+        final String state = UUID.randomUUID().toString();
+        final String nonce = UUID.randomUUID().toString();
         storeStateInSession(request.getSession(), state, nonce);
-        final String authUrl;
 
         final String responseMode = getResponseMode();
-        if (useV2Endpoint) {
-            // v2.0 endpoint with MSAL4J (recommended)
-            authUrl = getAuthority() + getTenant() + "/oauth2/v2.0/authorize?response_type=code&scope="
-                    + URLEncoder.encode(V2_SCOPES, Constants.UTF_8_CHARSET) + "&response_mode=" + responseMode + "&redirect_uri="
-                    + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id=" + getClientId() + "&state=" + state
-                    + "&nonce=" + nonce;
-        } else {
-            // v1.0 endpoint for backward compatibility
-            authUrl = getAuthority() + getTenant() + "/oauth2/authorize?response_type=code&scope=directory.read.all&response_mode="
-                    + responseMode + "&redirect_uri=" + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id="
-                    + getClientId() + "&resource=https%3a%2f%2fgraph.microsoft.com" + "&state=" + state + "&nonce=" + nonce;
-        }
+        final String authUrl = getAuthority() + getTenant() + "/oauth2/v2.0/authorize?response_type=code&scope="
+                + URLEncoder.encode(V2_SCOPES, Constants.UTF_8_CHARSET) + "&response_mode=" + responseMode + "&redirect_uri="
+                + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id=" + getClientId() + "&state=" + state
+                + "&nonce=" + nonce;
         if (logger.isDebugEnabled()) {
-            logger.debug("redirect to: {} (using {} endpoint)", authUrl, useV2Endpoint ? "v2.0" : "v1.0");
+            logger.debug("redirect to: {}", authUrl);
         }
         return authUrl;
 
@@ -579,33 +677,99 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The client application.
      */
     protected ConfidentialClientApplication getClientApplication() {
-        final String clientId = getClientId();
-        final String clientSecret = getClientSecret();
-        final String authority = getAuthority() + getTenant() + "/";
-        // The secret is reduced to a hash so the key can never carry it into a log or a heap dump
-        // label; a collision would only mean the application is not rebuilt after a secret change.
-        final String key = authority + '\n' + clientId + '\n' + clientSecret.hashCode();
-        final ConfidentialClientApplication current = clientApplication;
-        if (current != null && key.equals(clientApplicationKey)) {
-            return current;
+        final ClientApplicationHolder current = clientApplicationHolder;
+        final String key = buildClientApplicationKey();
+        if (current != null && current.getKey().equals(key)) {
+            return current.getApplication();
         }
         synchronized (this) {
-            if (clientApplication != null && key.equals(clientApplicationKey)) {
-                return clientApplication;
+            // The four settings are read again, and the key recomputed, inside the monitor. They
+            // are four independent reads of mutable configuration, so a key built on the fast path
+            // can mix values from before and after an admin save; publishing an application built
+            // from that mixture would leave it in place indefinitely.
+            final String currentKey = buildClientApplicationKey();
+            final ClientApplicationHolder holder = clientApplicationHolder;
+            if (holder != null && holder.getKey().equals(currentKey)) {
+                return holder.getApplication();
             }
+            final String clientId = getClientId();
+            final String clientSecret = getClientSecret();
+            final String authority = getAuthority() + getTenant() + "/";
             if (logger.isDebugEnabled()) {
                 logger.debug("Building a client application for authority={}", authority);
             }
             try {
-                clientApplication = ConfidentialClientApplication
+                final ConfidentialClientApplication application = ConfidentialClientApplication
                         .builder(clientId, com.microsoft.aad.msal4j.ClientCredentialFactory.createFromSecret(clientSecret))
                         .authority(authority)
                         .build();
-                clientApplicationKey = key;
-                return clientApplication;
+                clientApplicationHolder =
+                        new ClientApplicationHolder(buildClientApplicationKey(clientId, clientSecret, authority), application);
+                return application;
             } catch (final Exception e) {
                 throw new SsoLoginException("Failed to build an Entra ID client application.", e);
             }
+        }
+    }
+
+    /**
+     * Reads the configuration the client application depends on and reduces it to a key.
+     *
+     * @return The key.
+     */
+    protected String buildClientApplicationKey() {
+        return buildClientApplicationKey(getClientId(), getClientSecret(), getAuthority() + getTenant() + "/");
+    }
+
+    /**
+     * Reduces the configuration the client application depends on to a key.
+     *
+     * @param clientId The client id.
+     * @param clientSecret The client secret.
+     * @param authority The authority URL.
+     * @return The key.
+     */
+    protected String buildClientApplicationKey(final String clientId, final String clientSecret, final String authority) {
+        // The secret is reduced to a hash so the key can never carry it into a log or a heap dump
+        // label; a collision would only mean the application is not rebuilt after a secret change.
+        return authority + '\n' + clientId + '\n' + clientSecret.hashCode();
+    }
+
+    /**
+     * A client application and the configuration key it was built from, published together so a
+     * reader can never see one without the other.
+     */
+    protected static final class ClientApplicationHolder {
+        private final String key;
+        private final ConfidentialClientApplication application;
+
+        /**
+         * Constructs a holder.
+         *
+         * @param key The configuration key.
+         * @param application The application built from it.
+         */
+        public ClientApplicationHolder(final String key, final ConfidentialClientApplication application) {
+            this.key = key;
+            this.application = application;
+        }
+
+        /**
+         * Gets the configuration key.
+         *
+         * @return The key.
+         */
+        public String getKey() {
+            return key;
+        }
+
+        /**
+         * Gets the client application.
+         *
+         * @return The application.
+         */
+        public ConfidentialClientApplication getApplication() {
+            return application;
         }
     }
 
@@ -788,7 +952,13 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * Updates the user's group and role membership information with lazy loading for parent groups.
      * Direct groups are retrieved synchronously, while parent groups are fetched asynchronously
      * to avoid login delays when users have many nested group memberships.
+     *
+     * <p>When Microsoft Graph does not answer with a membership list, the memberships already on
+     * the user are kept; if there are none yet -- which is the case at login -- the login is
+     * failed rather than completed with the configured defaults alone.
+     *
      * @param user The Entra ID user to update.
+     * @throws LoginFailureException If the first membership lookup for this user failed.
      */
     public void updateMemberOf(final EntraIdUser user) {
         if (logger.isDebugEnabled()) {
@@ -817,13 +987,27 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                     groupList.size(), roleList.size(), groupIdsForParentLookup.size());
         }
 
-        if (!resolved && user.getGroupNames() != null) {
+        if (!resolved) {
             // Microsoft Graph did not answer with a membership list -- an expired token, a
-            // throttled tenant, a revoked permission. Writing what we have would replace the
-            // memberships this user logged in with by the configured defaults alone, silently
-            // taking away their search permissions until some later call happens to succeed.
-            logger.warn("Failed to resolve the Entra ID memberships of {}. Keeping the ones already resolved.", user.getName());
-            return;
+            // throttled tenant, a revoked permission.
+            if (user.getGroupNames() != null) {
+                // Refresh path. Writing what we have would replace the memberships this user
+                // logged in with by the configured defaults alone, silently taking away their
+                // search permissions until some later call happens to succeed.
+                logger.warn("Failed to resolve the Entra ID memberships of {}. Keeping the ones already resolved.", user.getName());
+                return;
+            }
+            // First resolution, so there is nothing to keep. Handing out a session carrying the
+            // configured defaults alone would look like a successful login and quietly truncate
+            // every search result for its whole lifetime, and refresh() does not try again until
+            // the token is nearly expired. Failing the login is the honest answer.
+            //
+            // LoginFailureException specifically: this runs inside the resolver that
+            // FessLoginAssist passes to TypicalLoginAssist.findLoginUser, which calls it directly
+            // without wrapping anything, and SsoAction only catches LoginFailureException around
+            // fessLoginAssist.loginRedirect(). Any other type escapes to the generic error page
+            // instead of the standard SSO error message.
+            throw new LoginFailureException("Failed to resolve the Entra ID memberships of " + user.getName() + ".");
         }
 
         // Set initial groups
@@ -880,8 +1064,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @param url The Microsoft Graph API URL.
      * @return True if Microsoft Graph answered with a membership list, false if it reported an
      *         error or could not be read. When this is false the lists hold whatever was collected
-     *         before the failure, which {@link #updateMemberOf} only writes when the user has no
-     *         memberships yet -- at login there is nothing better to fall back to.
+     *         before the failure, and {@link #updateMemberOf} discards them: it keeps the
+     *         memberships the user already had, or fails the login when there are none yet.
      */
     protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
             final List<String> groupIdsForParentLookup, final String url) {
@@ -963,7 +1147,10 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 logger.warn("Unexpected response while accessing groups/roles: {}", contentMap);
             }
             return false;
-        } catch (final IOException e) {
+        } catch (final IOException | CurlException e) {
+            // curl4j reports a transport failure as CurlException, which is unchecked, so catching
+            // IOException alone let it escape as an unhandled RuntimeException instead of taking
+            // this controlled path.
             logger.warn("Failed to access groups/roles in Entra ID.", e);
             return false;
         }
@@ -1103,6 +1290,16 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         if (logger.isDebugEnabled()) {
             logger.debug("[getParentGroup] Cache MISS for id: {}, fetching from API", id);
         }
+        if (isGraphThrottled()) {
+            // Microsoft Graph asked us to back off, so walking it would fail once per group on
+            // every login until the tenant recovered. The empty pair is deliberately not written
+            // to groupCache: caching it would keep the parent group permissions away for the whole
+            // cache TTL even once the throttle had lapsed, which is what #3223 removed.
+            if (logger.isDebugEnabled()) {
+                logger.debug("[getParentGroup] Skipping the lookup for id {} while Microsoft Graph is throttling.", id);
+            }
+            return new Pair<>(StringUtil.EMPTY_STRINGS, StringUtil.EMPTY_STRINGS);
+        }
         try {
             return groupCache.get(id, () -> loadParentGroup(user, id, depth));
         } catch (final ExecutionException | UncheckedExecutionException e) {
@@ -1110,9 +1307,81 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             // briefly unreachable Graph must not pin an empty result for the whole cache TTL.
             // UncheckedExecutionException matters because the Graph JSON parser throws
             // CurlException, a RuntimeException, on a non-JSON error body.
-            logger.warn("Failed to process group cache for id: {}", id, e);
+            if (isGraphThrottled()) {
+                // The reason is already stated by the single WARN that set the throttle; a stack
+                // trace per group would bury it.
+                logger.warn("Failed to process group cache for id {} while Microsoft Graph is throttling: {}", id, e.getMessage());
+            } else {
+                logger.warn("Failed to process group cache for id: {}", id, e);
+            }
             return new Pair<>(StringUtil.EMPTY_STRINGS, StringUtil.EMPTY_STRINGS);
         }
+    }
+
+    /**
+     * Returns whether Microsoft Graph is still inside the backoff a throttled response asked for.
+     *
+     * @return True while the parent group walk has to be skipped.
+     */
+    protected boolean isGraphThrottled() {
+        final long until = graphThrottledUntil;
+        // The clock is read only once a throttle has actually been recorded, so the ordinary path
+        // does not depend on the system helper at all.
+        return until > 0L && ComponentUtil.getSystemHelper().getCurrentTimeAsLong() < until;
+    }
+
+    /**
+     * Records the backoff a throttled Microsoft Graph response asked for, if it is one.
+     *
+     * <p>Nothing is cached in response to it. 15.7 cached an empty result for the cache TTL, and
+     * #3223 removed that because it silently took the parent group permissions away for ten
+     * minutes. An explicit backoff does the job the negative cache was reaching for -- the next
+     * logins skip the walk instead of re-issuing one failing request, and one stack trace, per
+     * group -- without outliving the condition that caused it.
+     *
+     * @param response The response to inspect.
+     */
+    protected void applyGraphThrottle(final CurlResponse response) {
+        // curl4j does not throw on a non-2xx response, it hands back the error stream, so the
+        // status code is the only place a 429 is visible.
+        final int statusCode = response.getHttpStatusCode();
+        if (statusCode != HTTP_TOO_MANY_REQUESTS && statusCode != HTTP_SERVICE_UNAVAILABLE) {
+            return;
+        }
+        final long seconds = parseRetryAfterSeconds(response.getHeaderValue("Retry-After"));
+        final long until = ComponentUtil.getSystemHelper().getCurrentTimeAsLong() + seconds * 1000L;
+        if (until > graphThrottledUntil) {
+            graphThrottledUntil = until;
+            // One line per throttling episode: every group after this one short-circuits in
+            // getParentGroup without reaching Graph, so nothing repeats it per group.
+            logger.warn("Microsoft Graph returned {} for a group membership lookup."
+                    + " Nested groups are not resolved for the next {} seconds.", statusCode, seconds);
+        }
+    }
+
+    /**
+     * Reads a {@code Retry-After} header as a number of seconds.
+     *
+     * @param value The header value, which may be null.
+     * @return The backoff in seconds, always positive and bounded by
+     *         {@link #MAX_GRAPH_THROTTLE_SECONDS}.
+     */
+    protected long parseRetryAfterSeconds(final String value) {
+        if (StringUtil.isNotBlank(value)) {
+            try {
+                final long seconds = Long.parseLong(value.trim());
+                if (seconds > 0L) {
+                    return Math.min(seconds, MAX_GRAPH_THROTTLE_SECONDS);
+                }
+            } catch (final NumberFormatException e) {
+                // RFC 9110 also allows an HTTP-date here. Microsoft Graph sends delay-seconds, so
+                // rather than parse a format we never see, fall back to the default.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Retry-After is not a number of seconds: {}", value);
+                }
+            }
+        }
+        return DEFAULT_GRAPH_THROTTLE_SECONDS;
     }
 
     /**
@@ -1163,6 +1432,9 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * every login re-issue one failing request, and one stack trace, per group. Everything else is
      * thrown, so a transient failure is never mistaken for "this group has no parents".
      *
+     * <p>A throttled reply is recorded by {@link #applyGraphThrottle} before the body is looked
+     * at, so the groups after this one skip the walk instead of each producing their own failure.
+     *
      * @param user The Entra ID user.
      * @param id The group ID to get parent information for.
      * @return The parent group IDs, never null.
@@ -1177,6 +1449,9 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 createGraphRequest(Curl.post(url), user.getAuthenticationResult().accessToken()).header("Content-type", "application/json")
                         .body("{\"securityEnabledOnly\":false}")
                         .execute()) {
+            // Before the body: a throttled reply is not required to be JSON, and the parser throws
+            // CurlException when it is not.
+            applyGraphThrottle(response);
             final Map<String, Object> contentMap = response.getContent(OpenSearchCurl.jsonParser());
             if (logger.isDebugEnabled()) {
                 logger.debug("[getParentGroup] Response for id {}: {}", id, contentMap);
@@ -1261,7 +1536,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                     logger.debug("[processGroup] Completed for id: {}, added {} entries", id, groupList.size() - initialSize);
                 }
             }
-        } catch (final IOException e) {
+        } catch (final IOException | CurlException e) {
+            // See processDirectMemberOf: curl4j's transport failure is the unchecked CurlException.
             logger.warn("Failed to access groups/roles in Entra ID for id: {}", id, e);
         }
     }
@@ -1384,7 +1660,13 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     protected String getAuthority() {
         String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_AUTHORITY);
         if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_AUTHORITY, "https://login.microsoftonline.com/");
+            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_AUTHORITY, DEFAULT_AUTHORITY);
+        }
+        if (StringUtil.isBlank(value)) {
+            // getSystemProperty only falls back to the default when the key is absent, so a legacy
+            // aad.authority that is present but empty arrives here as "". Left alone, getAuthUrl
+            // would build a scheme-less URL and redirect the browser back inside Fess.
+            return DEFAULT_AUTHORITY;
         }
         return value;
     }
@@ -1475,6 +1757,14 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Sets the maximum number of groups kept in the parent group cache.
+     * @param maxGroupCacheSize The maximum number of cached groups.
+     */
+    public void setMaxGroupCacheSize(final int maxGroupCacheSize) {
+        this.maxGroupCacheSize = maxGroupCacheSize;
+    }
+
+    /**
      * Sets the maximum group depth for nested group processing.
      * @param maxGroupDepth The maximum depth for nested groups.
      */
@@ -1521,10 +1811,22 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     }
 
     /**
-     * Enable to use V2 endpoint.
-     * @param useV2Endpoint true if using V2 endpoint.
+     * Kept only so an out-of-tree {@code fess_sso+entraidAuthenticator.xml} that still sets this
+     * property keeps loading. The value is ignored.
+     *
+     * <p>The v1.0 endpoint is not supported. msal4j hardcodes {@code oauth2/v2.0/token} as the
+     * token endpoint of an AAD authority and offers no v1 alternative, so an authorization code
+     * minted at {@code /oauth2/authorize} could never be redeemed -- the v1.0 branch this used to
+     * select produced a login that always failed.
+     *
+     * @param useV2Endpoint Ignored.
+     * @deprecated The v1.0 endpoint is unsupported; the authorization request is always v2.0.
      */
+    @Deprecated
     public void setUseV2Endpoint(final boolean useV2Endpoint) {
-        this.useV2Endpoint = useV2Endpoint;
+        if (!useV2Endpoint) {
+            logger.warn("useV2Endpoint=false is ignored. The Entra ID v1.0 endpoint is not supported:"
+                    + " msal4j only redeems authorization codes at the v2.0 token endpoint.");
+        }
     }
 }

--- a/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
@@ -21,12 +21,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
-import org.codelibs.core.net.UuidUtil;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist.LoginCredentialResolver;
 import org.codelibs.fess.app.web.base.login.OpenIdConnectCredential;
@@ -150,7 +150,14 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
      * @return the authorization URL
      */
     protected String getAuthUrl(final HttpServletRequest request) {
-        final String state = UuidUtil.create();
+        // UUID.randomUUID is backed by SecureRandom and varies in 122 bits. The state is the only
+        // thing standing between a login and a forged callback (RFC 6749 section 10.12), and
+        // org.codelibs.core.net.UuidUtil, which this used to call, is
+        // hex(localIP) + hex(identityHashCode(RANDOM)) + hex((int) (currentTimeMillis() >> 32)) +
+        // hex(SecureRandom.nextInt()): its first 16 hex characters are constant for the life of
+        // the JVM and under 32 bits actually vary per call. The value is only ever compared with
+        // equals() against the copy held in the session, so its length and format are free.
+        final String state = UUID.randomUUID().toString();
         request.getSession().setAttribute(OIC_STATE, state);
         return new AuthorizationCodeRequestUrl(getOicAuthServerUrl(), getOicClientId())//
                 .setScopes(Arrays.asList(getOicScope()))//

--- a/src/main/resources/fess_sso++.xml
+++ b/src/main/resources/fess_sso++.xml
@@ -9,6 +9,7 @@
 		<property name="graphReadTimeout">30000</property>
 		<property name="acquisitionTimeout">30000</property>
 		<property name="groupCacheExpiry">600</property>
+		<property name="maxGroupCacheSize">10000</property>
 		<property name="maxGroupDepth">10</property>
 		-->
 	</component>

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LogoutHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LogoutHandlerTest.java
@@ -29,6 +29,7 @@ import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.helper.ActivityHelper;
 import org.codelibs.fess.mylasta.action.FessUserBean;
+import org.codelibs.fess.sso.SsoManager;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
@@ -130,6 +131,83 @@ public class LogoutHandlerTest extends UnitFessTestCase {
         assertEquals(200, res.status, res.body());
         assertTrue(res.body().contains("\"ok\":true"), res.body());
         assertEquals(1, assist.logoutCount, "logout must still be performed when the audit write fails");
+    }
+
+    // ── SSO: the v2 logout must tear the session down at the identity provider too ──
+
+    @Test
+    public void logout_runsTheSsoLogoutForTheBoundUser() throws Exception {
+        // Regression: the handler called FessLoginAssist.logout() but never
+        // SsoManager.logout(user), which LogoutAction.index() does. For Entra ID that call is the
+        // only thing that takes the account out of the MSAL4J token cache shared by the whole
+        // application (EntraIdAuthenticator.logout -> removeAccount), and msal4j's TokenCache
+        // evicts nothing by itself -- so the tokens of everyone who logged out through the v2 API
+        // stayed resident for the life of the JVM.
+        final List<String> ssoLogouts = new ArrayList<>();
+        ComponentUtil.register(new SsoManager() {
+            @Override
+            public String logout(final FessUserBean user) {
+                ssoLogouts.add(user.getUserId());
+                // A real SLO URL. The v2 API has no redirect semantics, so it must be ignored.
+                return "https://login.microsoftonline.com/common/oauth2/v2.0/logout";
+            }
+        }, "ssoManager");
+        final StubLoginAssist assist = new StubLoginAssist("carol");
+        ComponentUtil.register(assist, FessLoginAssist.class.getCanonicalName());
+
+        final CapturingResponse res = new CapturingResponse();
+        new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
+
+        assertEquals(200, res.status, res.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("carol"), ssoLogouts,
+                "the v2 logout must run the SSO logout for the user still bound to the session");
+        assertEquals(1, assist.logoutCount, "the local logout must still run");
+        // The single-logout URL is discarded: the envelope stays the plain idempotent success.
+        assertTrue(res.body().contains("\"ok\":true"), res.body());
+    }
+
+    @Test
+    public void logout_ssoFailureStillLogsOutAndReturnsOk() throws Exception {
+        // An unreachable identity provider must not strand the caller in a logged-in session:
+        // the local logout has to run anyway and the endpoint has to stay idempotent.
+        ComponentUtil.register(new SsoManager() {
+            @Override
+            public String logout(final FessUserBean user) {
+                throw new IllegalStateException("the identity provider is unreachable");
+            }
+        }, "ssoManager");
+        final StubLoginAssist assist = new StubLoginAssist("carol");
+        ComponentUtil.register(assist, FessLoginAssist.class.getCanonicalName());
+
+        final CapturingResponse res = new CapturingResponse();
+        new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
+
+        assertEquals(200, res.status, res.body());
+        assertTrue(res.body().contains("\"ok\":true"), res.body());
+        assertEquals(1, assist.logoutCount, "logout must still be performed when the SSO logout fails");
+    }
+
+    @Test
+    public void logout_withoutAUserBean_doesNotTouchTheSsoManager() throws Exception {
+        // The endpoint is fire-and-forget, so it is routinely called with no session at all.
+        final List<String> ssoLogouts = new ArrayList<>();
+        ComponentUtil.register(new SsoManager() {
+            @Override
+            public String logout(final FessUserBean user) {
+                ssoLogouts.add(String.valueOf(user));
+                return null;
+            }
+        }, "ssoManager");
+        final StubLoginAssist assist = new StubLoginAssist("carol");
+        assist.logout();
+        assist.logoutCount = 0;
+        ComponentUtil.register(assist, FessLoginAssist.class.getCanonicalName());
+
+        final CapturingResponse res = new CapturingResponse();
+        new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
+
+        assertEquals(200, res.status, res.body());
+        assertTrue(ssoLogouts.isEmpty(), "an absent user bean must not reach SsoManager.logout: " + ssoLogouts);
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.ldap.LdapManager;
@@ -143,6 +144,58 @@ public class AdminGeneralActionTest extends UnitFessTestCase {
         AdminGeneralAction.updateForm(fessConfig, reloaded);
         AdminGeneralAction.updateConfig(fessConfig, reloaded);
         assertEquals("secret", ComponentUtil.getSystemProperties().getProperty("spnego.preauth.password"));
+    }
+
+    @Test
+    public void test_updateForm_legacyEntraIdSettingsSurviveAnUpdate() {
+        // A deployment configured only through the legacy aad.* keys still works: both
+        // EntraIdAuthenticator and FessProp fall back to them and no migration exists. updateForm
+        // read only the entraid.* keys, so it rendered the shipped defaults for the four settings
+        // that have a non-empty one, and updateConfig then wrote those defaults to the entraid.*
+        // keys -- which every getter prefers. Opening this screen for an unrelated change and
+        // pressing Update therefore moved a sovereign-cloud tenant onto the commercial cloud,
+        // reset a tuned state TTL, put the permission field back to mail and re-enabled domain
+        // services, all without a log line.
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        fessConfig.setSystemProperty("aad.authority", "https://login.microsoftonline.us/");
+        fessConfig.setSystemProperty("aad.state.ttl", "600");
+        fessConfig.setSystemProperty("aad.permission.fields", "userPrincipalName");
+        fessConfig.setSystemProperty("aad.use.ds", Constants.FALSE);
+        fessConfig.setSystemProperty("aad.tenant", "legacy-tenant");
+        fessConfig.setSystemProperty("aad.client.id", "legacy-client-id");
+        fessConfig.setSystemProperty("aad.client.secret", "legacy-client-secret");
+
+        final EditForm form = createEditForm();
+        AdminGeneralAction.updateForm(fessConfig, form);
+
+        // The screen must show what is actually in effect, not the shipped default.
+        assertEquals("https://login.microsoftonline.us/", form.entraidAuthority);
+        assertEquals("600", form.entraidStateTtl);
+        assertEquals("userPrincipalName", form.entraidPermissionFields);
+        assertEquals(Constants.FALSE, form.entraidUseDs);
+        assertEquals("legacy-tenant", form.entraidTenant);
+        // A legacy-only deployment does have credentials; an empty box would say otherwise.
+        assertTrue("entraidClientId was rendered empty", StringUtil.isNotBlank(form.entraidClientId));
+        assertTrue("entraidClientSecret was rendered empty", StringUtil.isNotBlank(form.entraidClientSecret));
+
+        AdminGeneralAction.updateConfig(fessConfig, form);
+
+        // Saving is now a migration of the legacy values into the new keys, not a clobber.
+        assertEquals("https://login.microsoftonline.us/", ComponentUtil.getSystemProperties().getProperty("entraid.authority"));
+        assertEquals("600", ComponentUtil.getSystemProperties().getProperty("entraid.state.ttl"));
+        assertEquals("userPrincipalName", ComponentUtil.getSystemProperties().getProperty("entraid.permission.fields"));
+        assertEquals(Constants.FALSE, ComponentUtil.getSystemProperties().getProperty("entraid.use.ds"));
+
+        // What the consumers see is unchanged by the round trip.
+        assertEquals("userPrincipalName", fessConfig.getEntraIdPermissionFields()[0]);
+        assertFalse(fessConfig.isEntraIdUseDomainServices());
+
+        // The masked credential fields go back as the mask, which updateConfig skips, so the
+        // legacy secrets stay where they are instead of being replaced by "**********".
+        assertEquals("legacy-client-id", ComponentUtil.getSystemProperties().getProperty("aad.client.id"));
+        assertEquals("legacy-client-secret", ComponentUtil.getSystemProperties().getProperty("aad.client.secret"));
+        assertNull(ComponentUtil.getSystemProperties().getProperty("entraid.client.id"));
+        assertNull(ComponentUtil.getSystemProperties().getProperty("entraid.client.secret"));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
@@ -21,6 +21,9 @@ import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
 import org.codelibs.fess.helper.SystemHelper;
@@ -36,6 +39,10 @@ import com.microsoft.aad.msal4j.ITenantProfile;
 public class EntraIdUserPermissionTest extends UnitFessTestCase {
 
     private static IAuthenticationResult authResult() {
+        return authResult(new Date(Long.MAX_VALUE), "access-token");
+    }
+
+    private static IAuthenticationResult authResult(final Date expiresOn, final String accessToken) {
         final IAccount account = new IAccount() {
             private static final long serialVersionUID = 1L;
 
@@ -64,7 +71,7 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
 
             @Override
             public String accessToken() {
-                return "access-token";
+                return accessToken;
             }
 
             @Override
@@ -94,7 +101,7 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
 
             @Override
             public Date expiresOnDate() {
-                return new Date(Long.MAX_VALUE);
+                return expiresOn;
             }
         };
     }
@@ -164,5 +171,99 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
         final String[] permissions = user.getPermissions();
         assertTrue("parent-group missing from " + Arrays.toString(permissions),
                 Arrays.stream(permissions).anyMatch(p -> p.contains("parent-group")));
+    }
+
+    @Test
+    public void test_refresh_renewsOnceWhenConcurrentRequestsShareTheUser() throws Exception {
+        // Lastaflute keeps the FessUserBean -- and therefore one EntraIdUser -- as a session
+        // attribute, and FessBaseAction.godHandPrologue calls refresh() on every action request,
+        // so all the requests a session has in flight arrive in the REFRESH_MARGIN window
+        // together. Each of them used to see a renewed access token and run updateMemberOf, which
+        // is a synchronous Microsoft Graph GET /me/memberOf on a request thread plus another
+        // scheduled parent group lookup. Doubling the Graph traffic at every token rollover is
+        // exactly what the per-request guard was added to remove.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
+        // Inside REFRESH_MARGIN, so refresh() really attempts the silent acquisition.
+        final IAuthenticationResult initial = authResult(new Date(now + 30 * 1000L), "access-token");
+
+        final AtomicInteger memberOfCalls = new AtomicInteger();
+        final CountDownLatch winnerIsAcquiring = new CountDownLatch(1);
+        final CountDownLatch loserIsDone = new CountDownLatch(1);
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                memberOfCalls.incrementAndGet();
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                // Hold the acquisition open the way a real MSAL4J round trip does, so the second
+                // request reaches refresh() while this one is still inside it.
+                winnerIsAcquiring.countDown();
+                try {
+                    loserIsDone.await(10L, TimeUnit.SECONDS);
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return authResult(new Date(now + 30 * 1000L), "renewed-access-token");
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+
+        final EntraIdUser user = new EntraIdUser(initial);
+        // The constructor resolves the memberships once; only what refresh() adds is under test.
+        memberOfCalls.set(0);
+
+        final AtomicBoolean winnerResult = new AtomicBoolean();
+        final Thread winner = new Thread(() -> winnerResult.set(user.refresh()));
+        winner.start();
+        assertTrue(winnerIsAcquiring.await(10L, TimeUnit.SECONDS));
+
+        // The session's second concurrent request. Its token has not expired, so it must be let
+        // through rather than blocked behind the acquisition, and it must not renew again.
+        assertTrue(user.refresh());
+        loserIsDone.countDown();
+        winner.join(10000L);
+
+        assertTrue(winnerResult.get());
+        assertEquals(1, memberOfCalls.get(), "a concurrent refresh must not make a second Microsoft Graph round trip");
+        // Last-writer-wins used to be able to leave the older of the two results in place.
+        assertEquals("renewed-access-token", user.getAuthenticationResult().accessToken());
+    }
+
+    @Test
+    public void test_refresh_stillRenewsOnEveryRollover() throws Exception {
+        // The counterpart of the test above: the guard must only suppress a *concurrent* renewal.
+        // A sequential refresh has to keep re-reading the directory, otherwise a session would
+        // never pick up a group change again, and the flag has to be released on the way out.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
+        final IAuthenticationResult initial = authResult(new Date(now + 30 * 1000L), "access-token");
+
+        final AtomicInteger memberOfCalls = new AtomicInteger();
+        final AtomicReference<IAuthenticationResult> next = new AtomicReference<>();
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void updateMemberOf(final EntraIdUser user) {
+                memberOfCalls.incrementAndGet();
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                return next.get();
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+
+        final EntraIdUser user = new EntraIdUser(initial);
+        memberOfCalls.set(0);
+
+        next.set(authResult(new Date(now + 30 * 1000L), "second-access-token"));
+        assertTrue(user.refresh());
+        assertEquals(1, memberOfCalls.get(), "the first rollover must re-read the directory");
+
+        next.set(authResult(new Date(now + 30 * 1000L), "third-access-token"));
+        assertTrue(user.refresh());
+        assertEquals(2, memberOfCalls.get(), "the guard must be released once the acquisition is over");
+        assertEquals("third-access-token", user.getAuthenticationResult().accessToken());
     }
 }

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
@@ -409,6 +409,39 @@ public class FessPropTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getEntraIdPermissionFields_blankLegacyKeyStillYieldsTheDefault() {
+        final Map<String, String> systemPropMap = new HashMap<>();
+        FessProp.propMap.clear();
+        FessConfig fessConfig = new FessConfig.SimpleImpl() {
+            @Override
+            public String getSystemProperty(final String key, final String defaultValue) {
+                return systemPropMap.getOrDefault(key, defaultValue);
+            }
+
+            @Override
+            public String getSystemProperty(final String key) {
+                return systemPropMap.get(key);
+            }
+        };
+
+        // getSystemProperty substitutes the default only when the key is absent, so a legacy key
+        // that is present but empty -- what the admin screen leaves behind for a cleared field --
+        // came back as "" and split into no fields at all. The only permissions such a user then
+        // gets are the raw group object IDs, so every document ACL'd by group mail turns
+        // invisible to them.
+        systemPropMap.put("aad.permission.fields", "");
+        String[] fields = fessConfig.getEntraIdPermissionFields();
+        assertEquals(1, fields.length);
+        assertEquals("mail", fields[0]);
+
+        // Both keys present and blank, which is what saving the admin screen twice produces.
+        systemPropMap.put("entraid.permission.fields", "  ");
+        fields = fessConfig.getEntraIdPermissionFields();
+        assertEquals(1, fields.length);
+        assertEquals("mail", fields[0]);
+    }
+
+    @Test
     public void test_isEntraIdUseDomainServices_withNewKey() {
         final Map<String, String> systemPropMap = new HashMap<>();
         FessProp.propMap.clear();
@@ -471,6 +504,32 @@ public class FessPropTest extends UnitFessTestCase {
         };
 
         // Test default value (true) when no key is set
+        assertTrue(fessConfig.isEntraIdUseDomainServices());
+    }
+
+    @Test
+    public void test_isEntraIdUseDomainServices_blankLegacyKeyKeepsTheDocumentedDefault() {
+        final Map<String, String> systemPropMap = new HashMap<>();
+        FessProp.propMap.clear();
+        FessConfig fessConfig = new FessConfig.SimpleImpl() {
+            @Override
+            public String getSystemProperty(final String key, final String defaultValue) {
+                return systemPropMap.getOrDefault(key, defaultValue);
+            }
+
+            @Override
+            public String getSystemProperty(final String key) {
+                return systemPropMap.get(key);
+            }
+        };
+
+        // A present-but-empty legacy key is not a configured "false": getSystemProperty hands
+        // back "", which never equals "true", so the documented default of true silently flipped.
+        systemPropMap.put("aad.use.ds", "");
+        assertTrue(fessConfig.isEntraIdUseDomainServices());
+
+        // Both keys present and blank, which is what saving the admin screen twice produces.
+        systemPropMap.put("entraid.use.ds", "  ");
         assertTrue(fessConfig.isEntraIdUseDomainServices());
     }
 

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.codelibs.core.misc.Pair;
 import org.codelibs.curl.Curl;
 import org.codelibs.curl.CurlResponse;
+import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
 import org.codelibs.fess.app.web.base.login.EntraIdCredential;
 import org.codelibs.fess.exception.SsoLoginException;
@@ -52,10 +53,13 @@ import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.lastaflute.web.login.credential.LoginCredential;
+import org.lastaflute.web.login.exception.LoginFailureException;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
 import com.microsoft.aad.msal4j.IAccount;
@@ -81,6 +85,27 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
             final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
 
             assertSame(authenticator.getClientApplication(), authenticator.getClientApplication());
+        } finally {
+            setEntraIdConfig("", "", "");
+        }
+    }
+
+    @Test
+    public void test_getClientApplication_publishesTheApplicationAndItsKeyTogether() {
+        // The application and the configuration it was built from used to be two separate
+        // volatile fields, read one after the other. A reader that landed between the two writes
+        // paired the old application with the new key and kept returning the stale one. One
+        // reference makes that unrepresentable, and the key it carries is the one the published
+        // application was actually built from.
+        try {
+            setEntraIdConfig("11111111-1111-1111-1111-111111111111", "secret-1", "contoso.onmicrosoft.com");
+            final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+
+            final ConfidentialClientApplication application = authenticator.getClientApplication();
+
+            assertNotNull(authenticator.clientApplicationHolder);
+            assertSame(application, authenticator.clientApplicationHolder.getApplication());
+            assertEquals(authenticator.buildClientApplicationKey(), authenticator.clientApplicationHolder.getKey());
         } finally {
             setEntraIdConfig("", "", "");
         }
@@ -384,15 +409,20 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_getAuthUrl_requestsQueryResponseModeOnV1Endpoint() {
+    public void test_getAuthUrl_alwaysUsesTheV2Endpoint() {
+        // msal4j hardcodes oauth2/v2.0/token as the token endpoint of an AAD authority, so a code
+        // minted at the v1.0 /oauth2/authorize could never be redeemed. The setter is kept so an
+        // out-of-tree fess_sso+entraidAuthenticator.xml still loads, but it no longer selects a
+        // login that always fails.
         ComponentUtil.register(new SystemHelper(), "systemHelper");
         final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
         authenticator.setUseV2Endpoint(false);
 
         final String authUrl = authenticator.getAuthUrl(getMockRequest());
 
+        assertTrue(authUrl.contains("/oauth2/v2.0/authorize?"));
+        assertFalse(authUrl.contains("resource=https%3a%2f%2fgraph.microsoft.com"));
         assertTrue(authUrl.contains("response_mode=query"));
-        assertFalse(authUrl.contains("response_mode=form_post"));
     }
 
     @Test
@@ -511,6 +541,145 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         assertNull(request.getSession(false));
 
         assertNull(authenticator.getLoginCredential());
+    }
+
+    @Test
+    public void test_getLoginCredential_restartsTheLoginWhenTheSessionMerelyExpired() {
+        // The browser did send a session id, so it stores and returns cookies; the container just
+        // no longer knows that session. 15.7 recovered by bouncing back to Entra ID, and dropping
+        // the user on the local login form instead leaves them stuck -- that form has no SSO link.
+        // This cannot loop: getAuthUrl creates a session, so the next callback either finds it or
+        // arrives with no session id at all, which is the branch the sibling test pins.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        request.setParameter("code", "0.AXkAauthorizationcodevalue");
+        request.setParameter("state", "2b1f5c3e-0000-0000-0000-000000000000");
+        request.addCookie(new Cookie("jsessionid", "AB1C2D3E4F5061728394A5B6C7D8E9F0"));
+        assertNull(request.getSession(false));
+        assertNotNull(request.getRequestedSessionId());
+        assertFalse(request.isRequestedSessionIdValid());
+
+        try {
+            setEntraIdConfig("11111111-1111-1111-1111-111111111111", "secret-1", "contoso.onmicrosoft.com");
+
+            final LoginCredential credential = authenticator.getLoginCredential();
+
+            assertTrue(credential instanceof ActionResponseCredential);
+        } finally {
+            setEntraIdConfig("", "", "");
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_reportsAnUnconfiguredTenantInsteadOfRedirecting() {
+        // Unconfigured, Fess used to redirect to
+        // https://login.microsoftonline.com//oauth2/v2.0/authorize?...&client_id= and log nothing,
+        // so the only symptom was a Microsoft error page.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        setEntraIdConfig("", "", "");
+
+        try {
+            authenticator.getLoginCredential();
+            fail("expected SsoLoginException");
+        } catch (final SsoLoginException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("entraid.tenant"));
+            assertTrue(e.getMessage(), e.getMessage().contains("entraid.client.id"));
+            assertTrue(e.getMessage(), e.getMessage().contains("entraid.client.secret"));
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_reportsThePartiallyConfiguredKeysOnly() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+
+        try {
+            setEntraIdConfig("11111111-1111-1111-1111-111111111111", "secret-1", "");
+
+            authenticator.getLoginCredential();
+            fail("expected SsoLoginException");
+        } catch (final SsoLoginException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("entraid.tenant"));
+            assertFalse(e.getMessage(), e.getMessage().contains("entraid.client.id"));
+        } finally {
+            setEntraIdConfig("", "", "");
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_thrownEagerlyRatherThanFromTheRedirectSupplier() {
+        // SsoAction runs the ActionResponseCredential supplier outside the block that catches
+        // SsoLoginException, so a throw from inside the lambda reaches the generic error page
+        // instead of the SSO error message. The check therefore has to happen before the
+        // credential is built, not when it is executed.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setMethod("GET");
+        setEntraIdConfig("", "", "");
+
+        try {
+            authenticator.getLoginCredential();
+            fail("expected SsoLoginException before any credential was returned");
+        } catch (final SsoLoginException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void test_getAuthUrl_issuesAnUnguessableState() {
+        // org.codelibs.core.net.UuidUtil is hex(localIP) + hex(identityHashCode(RANDOM)) +
+        // hex((int) (currentTimeMillis() >> 32)) + hex(SecureRandom.nextInt()): the first 16 hex
+        // characters never change within a JVM and the timestamp word moves every ~49.7 days, so
+        // under 32 bits actually vary per call. RFC 6749 section 10.12 wants the state
+        // unguessable.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Set<String> states = new HashSet<>();
+        final Set<String> prefixes = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            final String state = URLDecoder.decode(
+                    authenticator.getAuthUrl(newAuthUrlRequest()).replaceFirst("(?s).*[&?]state=([^&]*).*", "$1"), StandardCharsets.UTF_8);
+            states.add(state);
+            prefixes.add(state.replace("-", "").substring(0, 16));
+        }
+
+        assertEquals(200, states.size());
+        // The whole point: a fixed leading half is what UuidUtil produced.
+        assertTrue("distinct prefixes: " + prefixes.size(), prefixes.size() > 190);
+    }
+
+    @Test
+    public void test_getAuthUrl_issuesADistinctNoncePerRequest() {
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Set<String> nonces = new HashSet<>();
+        for (int i = 0; i < 50; i++) {
+            nonces.add(authenticator.getAuthUrl(newAuthUrlRequest()).replaceFirst("(?s).*&nonce=([^&]*).*", "$1"));
+        }
+
+        assertEquals(50, nonces.size());
+    }
+
+    @Test
+    public void test_createGroupCache_isBounded() {
+        // Every sibling cache in Fess caps its size; this one only had an expiry, so a tenant with
+        // many groups grew it without bound until the TTL came round.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        assertTrue(authenticator.maxGroupCacheSize > 0);
+        authenticator.setMaxGroupCacheSize(2);
+
+        final Cache<String, Pair<String[], String[]>> cache = authenticator.createGroupCache();
+        for (int i = 0; i < 10; i++) {
+            cache.put("group-" + i, new Pair<>(new String[0], new String[0]));
+        }
+        cache.cleanUp();
+
+        assertTrue("size=" + cache.size(), cache.size() <= 2);
     }
 
     @Test
@@ -782,6 +951,114 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_applyGraphThrottle_honoursTheRetryAfterGraphSent() {
+        // curl4j does not throw on a non-2xx response -- CurlRequest hands back the error stream --
+        // so a Graph 429 arrives as an ordinary parsed body and the status code is the only place
+        // the throttling is visible.
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final CurlResponse response = new CurlResponse();
+        response.setHttpStatusCode(429);
+        response.setHeaders(Map.of("Retry-After", List.of("120")));
+
+        authenticator.applyGraphThrottle(response);
+
+        assertEquals(clock.get() + 120_000L, authenticator.graphThrottledUntil);
+        assertTrue(authenticator.isGraphThrottled());
+
+        clock.addAndGet(120_000L);
+        assertFalse("the backoff has to lapse on its own", authenticator.isGraphThrottled());
+    }
+
+    @Test
+    public void test_applyGraphThrottle_alsoBacksOffOnServiceUnavailable() {
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final CurlResponse response = new CurlResponse();
+        response.setHttpStatusCode(503);
+
+        authenticator.applyGraphThrottle(response);
+
+        // No Retry-After: the default backoff applies rather than none at all.
+        assertEquals(clock.get() + 60_000L, authenticator.graphThrottledUntil);
+    }
+
+    @Test
+    public void test_applyGraphThrottle_ignoresAnOrdinaryResponse() {
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final CurlResponse ok = new CurlResponse();
+        ok.setHttpStatusCode(200);
+        final CurlResponse forbidden = new CurlResponse();
+        forbidden.setHttpStatusCode(403);
+
+        authenticator.applyGraphThrottle(ok);
+        authenticator.applyGraphThrottle(forbidden);
+
+        assertEquals(0L, authenticator.graphThrottledUntil);
+        assertFalse(authenticator.isGraphThrottled());
+    }
+
+    @Test
+    public void test_parseRetryAfterSeconds_fallsBackAndStaysBounded() {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+
+        assertEquals(30L, authenticator.parseRetryAfterSeconds(" 30 "));
+        assertEquals(60L, authenticator.parseRetryAfterSeconds(null));
+        assertEquals(60L, authenticator.parseRetryAfterSeconds(""));
+        assertEquals(60L, authenticator.parseRetryAfterSeconds("0"));
+        // RFC 9110 also allows an HTTP-date; Graph sends delay-seconds, so this is a fallback.
+        assertEquals(60L, authenticator.parseRetryAfterSeconds("Wed, 21 Oct 2026 07:28:00 GMT"));
+        // An unbounded value would leave nested groups unresolved for the rest of the day.
+        assertEquals(3600L, authenticator.parseRetryAfterSeconds("999999"));
+    }
+
+    @Test
+    public void test_getParentGroup_skipsTheWalkWhileGraphIsThrottling() {
+        // 15.7 cached an empty result for the cache TTL, which #3223 removed because it silently
+        // took the parent group permissions away for ten minutes. The backoff replaces it: the
+        // walk is skipped while Graph asked us to wait, nothing is written to the cache, and it
+        // resumes by itself.
+        final ScriptedAuthenticator authenticator = newScriptedAuthenticator();
+        ComponentUtil.register(new SystemHelper() {
+            @Override
+            public long getCurrentTimeAsLong() {
+                return clock.get();
+            }
+        }, "systemHelper");
+        authenticator.parents.put("group-a", new String[] { "group-b" });
+        authenticator.graphThrottledUntil = clock.get() + 60_000L;
+
+        final Pair<String[], String[]> throttled = authenticator.getParentGroup(null, "group-a", 0);
+
+        assertEquals(0, throttled.getFirst().length);
+        assertTrue(authenticator.lookups.isEmpty());
+        assertNull(authenticator.groupCache.getIfPresent("group-a"), "a skipped walk must not be cached");
+
+        clock.addAndGet(60_000L);
+        final Pair<String[], String[]> recovered = authenticator.getParentGroup(null, "group-a", 0);
+
+        assertEquals(1, recovered.getFirst().length);
+        assertEquals("group-b", recovered.getFirst()[0]);
+    }
+
+    @Test
+    public void test_getParentGroup_stillServesACachedAnswerWhileThrottling() {
+        // The backoff exists to stop Graph being called, not to throw away memberships that were
+        // already resolved.
+        final ScriptedAuthenticator authenticator = newScriptedAuthenticator();
+        ComponentUtil.register(new SystemHelper() {
+            @Override
+            public long getCurrentTimeAsLong() {
+                return clock.get();
+            }
+        }, "systemHelper");
+        authenticator.parents.put("group-a", new String[] { "group-b" });
+        assertEquals(1, authenticator.getParentGroup(null, "group-a", 0).getFirst().length);
+
+        authenticator.graphThrottledUntil = clock.get() + 60_000L;
+
+        assertEquals(1, authenticator.getParentGroup(null, "group-a", 0).getFirst().length);
+    }
+
+    @Test
     public void test_getStateTtl_defaultsToOneHourInSeconds() {
         // removeExpiredStates compares (now - created) / 1000 against this value, so the unit is
         // seconds. The javadoc used to say milliseconds.
@@ -943,16 +1220,21 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         assertEquals(0, roleList.size());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
-    public void test_setUseV2Endpoint() {
-        EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+    public void test_setUseV2Endpoint_isKeptAsANoOpForOutOfTreeDiFiles() {
+        // Removing the public setter would break a fess_sso+entraidAuthenticator.xml that still
+        // sets the property, so it stays -- but it no longer changes anything.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
 
-        // Test parameter accepts final boolean (compile-time verification)
         authenticator.setUseV2Endpoint(true);
+        final String afterTrue = authenticator.getAuthUrl(getMockRequest());
         authenticator.setUseV2Endpoint(false);
+        final String afterFalse = authenticator.getAuthUrl(getMockRequest());
 
-        // Verify method signature is correct
-        assertTrue(true);
+        assertTrue(afterTrue.contains("/oauth2/v2.0/authorize?"));
+        assertTrue(afterFalse.contains("/oauth2/v2.0/authorize?"));
     }
 
     @Test
@@ -1305,8 +1587,17 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_updateMemberOf_stillSetsTheDefaultsWhenNothingWasResolvedYet() {
-        // At login there is nothing to keep, so a failed lookup must not leave groups null.
+    public void test_updateMemberOf_failsTheLoginWhenTheFirstLookupFails() {
+        // At login there is nothing to keep, and curl4j does not throw on a non-2xx response, so a
+        // Graph 429/403/401 on /me/memberOf used to parse cleanly, log a WARN and hand the user a
+        // working session carrying the configured defaults alone -- silently truncated search
+        // results for its whole lifetime, with refresh() not retrying until the token was nearly
+        // expired.
+        //
+        // LoginFailureException specifically: TypicalLoginAssist calls this resolver directly
+        // without wrapping anything, and SsoAction only catches LoginFailureException around
+        // loginRedirect(), so any other type would reach the generic error page instead of the
+        // standard SSO error message.
         final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
             @Override
             protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
@@ -1318,13 +1609,70 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         try {
             fessConfig.setSystemProperty("entraid.default.groups", "everyone");
+
+            try {
+                authenticator.updateMemberOf(user);
+                fail("expected LoginFailureException");
+            } catch (final LoginFailureException e) {
+                assertTrue(e.getMessage(), e.getMessage().contains(user.getName()));
+            }
+
+            assertNull(user.getGroupNames(), "a half-permissioned session must not be handed out");
+        } finally {
+            fessConfig.setSystemProperty("entraid.default.groups", "");
+        }
+    }
+
+    @Test
+    public void test_updateMemberOf_appliesTheDefaultsWhenTheLookupFindsNoMemberships() {
+        // A user who genuinely belongs to nothing is a successful answer, not a failure, and the
+        // configured defaults are exactly what they are meant to get.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
+                    final List<String> groupIdsForParentLookup, final String url) {
+                return true;
+            }
+        };
+        final EntraIdUser user = newUserWithoutGraph();
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        try {
+            fessConfig.setSystemProperty("entraid.default.groups", "everyone");
+            fessConfig.setSystemProperty("entraid.default.roles", "guest");
+
             authenticator.updateMemberOf(user);
 
             assertEquals(1, user.getGroupNames().length);
             assertEquals("everyone", user.getGroupNames()[0]);
+            assertEquals(1, user.getRoleNames().length);
+            assertEquals("guest", user.getRoleNames()[0]);
         } finally {
             fessConfig.setSystemProperty("entraid.default.groups", "");
+            fessConfig.setSystemProperty("entraid.default.roles", "");
         }
+    }
+
+    @Test
+    public void test_processDirectMemberOf_reportsATransportFailureInsteadOfLettingItEscape() {
+        // curl4j reports a transport failure as CurlException, which is unchecked, so
+        // catch (IOException) alone let it escape as an unhandled RuntimeException -- out of the
+        // EntraIdUser constructor and past every caller. The same one-line widening is applied to
+        // processGroup, whose Graph URL is not injectable and so is covered by inspection only.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        authenticator.setGraphConnectTimeout(500);
+        authenticator.setGraphReadTimeout(500);
+        final EntraIdUser user = newUserWithoutGraph();
+        final int deadPort;
+        try (ServerSocket socket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            deadPort = socket.getLocalPort();
+        } catch (final IOException e) {
+            throw new IllegalStateException(e);
+        }
+
+        final boolean resolved = authenticator.processDirectMemberOf(user, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                "http://127.0.0.1:" + deadPort + "/v1.0/me/memberOf");
+
+        assertFalse(resolved);
     }
 
     @Test
@@ -1503,9 +1851,6 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
             fessConfig.setSystemProperty("entraid.response.mode", "form_post");
             assertTrue(authenticator.getAuthUrl(request).contains("&response_mode=form_post&"));
-
-            authenticator.setUseV2Endpoint(false);
-            assertTrue(authenticator.getAuthUrl(request).contains("&response_mode=form_post&"));
         } finally {
             fessConfig.setSystemProperty("entraid.response.mode", "");
         }
@@ -1591,6 +1936,22 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         final java.util.Base64.Encoder encoder = java.util.Base64.getUrlEncoder().withoutPadding();
         return encoder.encodeToString("{\"alg\":\"none\"}".getBytes(StandardCharsets.UTF_8)) + "."
                 + encoder.encodeToString(("{\"nonce\":\"" + nonce + "\"}").getBytes(StandardCharsets.UTF_8)) + ".";
+    }
+
+    @Test
+    public void test_getAuthority_fallsBackWhenTheLegacyKeyIsPresentButBlank() {
+        // getSystemProperty returns the default only when the key is absent, so an aad.authority
+        // that exists and is empty came back as "". getAuthUrl then built a scheme-less, and
+        // therefore relative, URL that redirected the browser back inside Fess.
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        try {
+            fessConfig.setSystemProperty("aad.authority", "");
+
+            assertEquals("https://login.microsoftonline.com/", authenticator.getAuthority());
+        } finally {
+            fessConfig.setSystemProperty("aad.authority", "");
+        }
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticatorTest.java
@@ -18,8 +18,10 @@ package org.codelibs.fess.sso.oic;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.misc.DynamicProperties;
@@ -28,6 +30,8 @@ import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Unit tests for {@link OpenIdConnectAuthenticator}.
@@ -244,6 +248,32 @@ public class OpenIdConnectAuthenticatorTest extends UnitFessTestCase {
         final var credential = authenticator.getLoginCredential();
         assertNotNull(credential);
         assertTrue(credential instanceof ActionResponseCredential);
+    }
+
+    @Test
+    public void test_getAuthUrl_issuesAnUnguessableState() {
+        // The state is the only thing standing between a login and a forged callback
+        // (RFC 6749 section 10.12), and org.codelibs.core.net.UuidUtil -- which getAuthUrl used
+        // to call -- is hex(localIP) + hex(identityHashCode(RANDOM)) +
+        // hex((int) (currentTimeMillis() >> 32)) + hex(SecureRandom.nextInt()): the first 16 hex
+        // characters never change within a JVM and the timestamp word moves every ~49.7 days, so
+        // under 32 bits actually varied per call.
+        final Set<String> states = new HashSet<>();
+        final Set<String> prefixes = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            final HttpServletRequest request = getMockRequest();
+            authenticator.getAuthUrl(request);
+            // getAuthUrl stashes the same value it puts in the URL, and getLoginCredential only
+            // ever compares the two with equals(), so nothing depends on its length or format.
+            final String state = (String) request.getSession().getAttribute(OpenIdConnectAuthenticator.OIC_STATE);
+            assertNotNull(state, "no state was stored in the session");
+            states.add(state);
+            prefixes.add(state.replace("-", "").substring(0, 16));
+        }
+
+        assertEquals(200, states.size());
+        // The whole point: a fixed leading half is what UuidUtil produced.
+        assertTrue("distinct prefixes: " + prefixes.size(), prefixes.size() > 190);
     }
 
     @Test


### PR DESCRIPTION
A review of the Entra ID SSO path against 15.7 turned up one behavioural regression and a set of defects that predate it. Each finding below was verified against the code before being fixed; three initial claims were refuted during that pass and are not acted on here.

## Regression against 15.7

**A callback that lost its session no longer recovers.** In 15.7 the guard was `session != null && containsAuthenticationData(request)`, so a session-less callback fell through to the redirect branch and `getAuthUrl` created a session and bounced back to the identity provider, which returned a fresh code from its own SSO cookie. The guard added since then returns `null` instead, and `SsoAction` shows an error and redirects to the local login form — which has no SSO link, so the only way back in is to navigate to a page that redirects to `/sso`. With no `<session-timeout>` in `web.xml`, Tomcat's 30-minute default applies, so this fires when a user takes too long at the sign-in page, or lands on a restarted node.

The guard is not vestigial: the loop it prevents is still reachable when the browser returns no session cookie at all (`form_post` with `SameSite=Lax`, `SameSite=Strict`, or cookies disabled). The fix distinguishes the two causes with `getRequestedSessionId() != null && !isRequestedSessionIdValid()` — a stale session id proves the browser stores and returns cookies, so restarting the login is self-bounding; the no-cookie cases still stop on the warning.

## Microsoft Graph

- **Throttling is now honoured.** curl4j does not throw on a non-2xx response, so a 429 arrived as a parsed error body and reached the failure path, where nothing is cached. Every subsequent login re-issued one failing request, and one stack trace, per group — amplifying the throttling that caused it, while `Retry-After` was ignored. `Retry-After` is now read into a bounded backoff and the parent group walk is skipped while it lasts. This is deliberately not a negative cache: caching an empty result is exactly what #3223 removed, because it took the parent group permissions away for the whole cache TTL.
- **A failed first membership lookup fails the login.** At login `groups` is still `null`, so the existing "keep what we resolved" guard cannot fire and the user was written the configured default groups alone. Because an HTTP error parses cleanly into a response body, a throttled or permission-denied tenant produced a working session whose search results were silently truncated for its entire lifetime — and `refresh()` does not retry until the token is within five minutes of expiring. The refresh path is unchanged and still keeps the memberships already resolved.
- **`CurlException` is caught alongside `IOException`.** curl4j reports a transport failure as an unchecked `CurlException`, so the existing catch let it escape as an unhandled `RuntimeException` instead of taking the controlled path.
- The parent group cache is now bounded by size as well as by expiry, matching every other cache in the codebase.

## Client application and token refresh

- **The shared client application and its configuration key are published together.** As two independent volatiles they were read non-atomically, so a reader interleaved between the two writes could pair the old application with the new key and keep returning the stale one. Separately, the key was composed from four independent property reads, so a save could produce a key mixing old and new values and publish an application built from that mixture, which then persisted. The key is now recomputed inside the monitor.
- **The token is renewed once per rollover.** `FessBaseAction.godHandPrologue` calls `refresh()` on every action request against one session-scoped user object, so every request in flight when the token entered the refresh margin ran its own silent acquisition, its own synchronous Graph call through `updateMemberOf`, and scheduled its own parent group task; the last assignment decided which result survived. Guarded with a compare-and-set rather than a lock, so the losing requests carry on with the token they already hold instead of queueing behind an acquisition that can take tens of seconds while `getPermissions()` holds the same monitor. `authResult` is now `volatile`.
- **`POST /api/v2/auth/logout` runs the SSO logout**, as `LogoutAction` already does. For Entra ID that call is the only thing that evicts a user from the MSAL4J token cache shared by the whole application, and that cache expires nothing on its own.

## Configuration

- **A legacy `aad.*` key that is present but empty no longer defeats the default.** `getSystemProperty(key, default)` substitutes the default only when the key is *absent*, so an empty value reached `getAuthority()` as an empty authority — making the authorization URL scheme-less, and therefore relative, so the browser was redirected back inside Fess. The same shape emptied the Entra ID permission fields and flipped the domain services default from `true` to `false`.
- **The admin General screen renders the setting actually in effect.** It read only the `entraid.*` keys, so a deployment configured through the legacy keys saw the shipped defaults in the form, and saving the screen for an unrelated change wrote them to the `entraid.*` keys — which every getter prefers. A sovereign-cloud `aad.authority`, a tuned `aad.state.ttl`, custom `aad.permission.fields` or `aad.use.ds=false` were silently replaced, with nothing logged. Reading through the same new key → legacy key → default chain the consumers use turns a save into a migration of the legacy values instead. This behaviour is identical in 15.7, so it is not a regression.
- **Missing required settings are reported.** With the tenant, client id or client secret empty, Fess built `.../oauth2/v2.0/authorize?...&client_id=` and redirected there, logging nothing — the administrator saw only a provider error page. This is thrown eagerly from `getLoginCredential`, because `SsoAction` executes the `ActionResponseCredential` supplier outside the block that catches `SsoLoginException`, and not from `init()`, because every authenticator is registered unconditionally even when another SSO type is selected.
- **`state` and `nonce` use `UUID.randomUUID()`.** The previous generator holds its first 16 hex characters constant for the life of the JVM and varies under 32 bits per call, below what RFC 6749 section 10.12 asks of an unguessable `state`. The OpenID Connect authenticator shared the generator and is changed with it.
- **The v1.0 authorization branch is removed.** msal4j only redeems authorization codes at the v2.0 token endpoint, so a code minted at `/oauth2/authorize` could never be exchanged — the branch produced a login that always failed. It had no configuration key and was reachable only from the DI setter, which is kept as a deprecated no-op that warns when passed `false`.

## Refuted while reviewing — not changed here

- *`authResult` being non-volatile breaks permissions.* `refresh()` calls the synchronized `resetPermissions()`, which publishes the write, and `getPermissions()` only reads `authResult.account()`, whose values are invariant across refreshes. The real defect was the read-modify-write on the two lines above it, fixed above.
- *A Graph timeout hands the user default-only permissions.* A timeout surfaces as an unchecked `CurlException` and aborts the login. The reachable path is an HTTP-level error, which is what is fixed above.
- *An anonymous client can flood the log with stack traces by cancelling at the consent screen.* The state is validated before the error branch, so a stray callback throws the message-only state exception first.

## Not addressed

- Bounding the MSAL4J token cache by account count. Growth is O(distinct users who ever logged in) and never shrinks; the logout paths above are the only eviction. A cap needs an eviction-policy decision, and `ITokenCacheAccessAspect` is the wrong hook — its contract serialises the whole cache on every access.
- Adding `entraid.response.mode` to the admin General screen. It is the only `entraid.*` key with no field there, though it remains settable through `system.properties` and is documented.

## Verification

`mvn formatter:format license:format` reports no changes, `mvn javadoc:javadoc` is error-free, and 1151 tests across the `sso`, `app.web.base`, `app.web.admin.general`, `app.web.logout`, `api.v2` and `mylasta` packages pass. Each new test was checked against the unfixed code first and fails there with the symptom it describes.
