### PR TITLE
test: stop tests rewriting shared log4j2 levels and pin capture levels explicitly

### DIFF
--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -28,18 +28,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.codelibs.fess.api.v2.SessionCsrfTokenManager;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.helper.ActivityHelper;
 import org.codelibs.fess.mylasta.action.FessUserBean;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
@@ -970,38 +965,18 @@ public class LoginHandlerTest extends UnitFessTestCase {
     }
 
     /**
-     * Attaches a DEBUG-level capturing appender to {@code loggerName}, runs {@code body}, then
-     * restores the original appender set and level. Only events emitted by {@code loggerName}
-     * itself are retained, so the surrounding framework chatter is filtered out.
+     * Attaches a DEBUG-level capturing appender to {@code loggerName} and runs {@code body}.
+     * Only events emitted by {@code loggerName} itself are retained, so the surrounding
+     * framework chatter is filtered out.
      */
     private static List<LogEvent> captureLogEvents(final String loggerName, final Executable body) throws Throwable {
-        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final LoggerConfig loggerCfg = ctx.getConfiguration().getLoggerConfig(loggerName);
-        final Level originalLevel = loggerCfg.getLevel();
-        final List<LogEvent> captured = new ArrayList<>();
-        final String appenderName = "login-handler-capture";
-        final AbstractAppender appender =
-                new AbstractAppender(appenderName, null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
-                    @Override
-                    public void append(final LogEvent event) {
-                        if (loggerName.equals(event.getLoggerName())) {
-                            captured.add(event.toImmutable());
-                        }
-                    }
-                };
-        appender.start();
-        loggerCfg.addAppender(appender, Level.DEBUG, null);
-        loggerCfg.setLevel(Level.DEBUG);
-        ctx.updateLoggers();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(loggerName, Level.DEBUG);
         try {
             body.execute();
         } finally {
-            loggerCfg.removeAppender(appenderName);
-            loggerCfg.setLevel(originalLevel);
-            ctx.updateLoggers();
-            appender.stop();
+            appender.detach();
         }
-        return captured;
+        return appender.events().stream().filter(event -> loggerName.equals(event.getLoggerName())).toList();
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -29,17 +28,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.app.web.base.login.LocalUserCredential;
 import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.mylasta.action.FessUserBean;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalEntity;
@@ -658,38 +652,18 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
     }
 
     /**
-     * Attaches a DEBUG-level capturing appender to {@code loggerName}, runs {@code body}, then
-     * restores the original appender set and level. Only events emitted by {@code loggerName}
-     * itself are retained, so the surrounding framework chatter is filtered out.
+     * Attaches a DEBUG-level capturing appender to {@code loggerName} and runs {@code body}.
+     * Only events emitted by {@code loggerName} itself are retained, so the surrounding
+     * framework chatter is filtered out.
      */
     private static List<LogEvent> captureLogEvents(final String loggerName, final Executable body) throws Throwable {
-        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final LoggerConfig loggerCfg = ctx.getConfiguration().getLoggerConfig(loggerName);
-        final Level originalLevel = loggerCfg.getLevel();
-        final List<LogEvent> captured = new ArrayList<>();
-        final String appenderName = "password-handler-capture";
-        final AbstractAppender appender =
-                new AbstractAppender(appenderName, null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
-                    @Override
-                    public void append(final LogEvent event) {
-                        if (loggerName.equals(event.getLoggerName())) {
-                            captured.add(event.toImmutable());
-                        }
-                    }
-                };
-        appender.start();
-        loggerCfg.addAppender(appender, Level.DEBUG, null);
-        loggerCfg.setLevel(Level.DEBUG);
-        ctx.updateLoggers();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(loggerName, Level.DEBUG);
         try {
             body.execute();
         } finally {
-            loggerCfg.removeAppender(appenderName);
-            loggerCfg.setLevel(originalLevel);
-            ctx.updateLoggers();
-            appender.stop();
+            appender.detach();
         }
-        return captured;
+        return appender.events().stream().filter(event -> loggerName.equals(event.getLoggerName())).toList();
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/sso/SsoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/sso/SsoActionTest.java
@@ -16,21 +16,16 @@
 package org.codelibs.fess.app.web.sso;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
 import org.codelibs.fess.exception.SsoMessageException;
 import org.codelibs.fess.exception.SsoProcessException;
 import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.mylasta.action.FessMessages;
 import org.codelibs.fess.sso.SsoManager;
 import org.codelibs.fess.sso.SsoResponseType;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
@@ -111,9 +106,9 @@ public class SsoActionTest extends UnitFessTestCase {
             final ActionResponse response = action.logout();
 
             assertSame(REDIRECT_TO_LOGIN, response);
-            assertEquals(1, appender.warnings().size());
-            assertNull(appender.warnings().get(0).getThrown(), "the rejected request must not be logged with a stack trace");
-            assertTrue(appender.warningMessages().get(0), appender.warningMessages().get(0).contains("not a logout callback"));
+            assertEquals(1, appender.eventsAt(Level.WARN).size());
+            assertNull(appender.eventsAt(Level.WARN).get(0).getThrown(), "the rejected request must not be logged with a stack trace");
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("not a logout callback"));
             assertEquals(1, action.savedErrors.size());
         } finally {
             appender.detach();
@@ -128,8 +123,8 @@ public class SsoActionTest extends UnitFessTestCase {
             final ActionResponse response = action.logout();
 
             assertSame(REDIRECT_TO_LOGIN, response);
-            assertEquals(1, appender.warnings().size());
-            assertNotNull(appender.warnings().get(0).getThrown(), "a genuine failure must keep its stack trace");
+            assertEquals(1, appender.eventsAt(Level.WARN).size());
+            assertNotNull(appender.eventsAt(Level.WARN).get(0).getThrown(), "a genuine failure must keep its stack trace");
             assertEquals(1, action.savedErrors.size());
         } finally {
             appender.detach();
@@ -157,46 +152,6 @@ public class SsoActionTest extends UnitFessTestCase {
         @Override
         protected HtmlResponse redirect(final Class<?> actionType) {
             return REDIRECT_TO_LOGIN;
-        }
-    }
-
-    /**
-     * Minimal in-memory log4j2 appender for asserting on emitted log messages.
-     * Mirrors {@code SamlAuthenticatorTest.LogCapturingAppender}, but also keeps the throwable.
-     */
-    static final class LogCapturingAppender extends AbstractAppender {
-        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
-        private final Logger boundLogger;
-
-        private LogCapturingAppender(final Logger logger) {
-            super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
-            this.boundLogger = logger;
-        }
-
-        static LogCapturingAppender attach(final Class<?> targetClass) {
-            final Logger logger = (Logger) LogManager.getLogger(targetClass);
-            final LogCapturingAppender appender = new LogCapturingAppender(logger);
-            appender.start();
-            logger.addAppender(appender);
-            return appender;
-        }
-
-        void detach() {
-            boundLogger.removeAppender(this);
-            stop();
-        }
-
-        @Override
-        public void append(final LogEvent event) {
-            events.add(event.toImmutable());
-        }
-
-        List<LogEvent> warnings() {
-            return events.stream().filter(e -> e.getLevel() == Level.WARN).toList();
-        }
-
-        List<String> warningMessages() {
-            return warnings().stream().map(e -> e.getMessage().getFormattedMessage()).toList();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/chat/ChatClientSourceFieldsTest.java
+++ b/src/test/java/org/codelibs/fess/chat/ChatClientSourceFieldsTest.java
@@ -23,12 +23,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.codelibs.fess.chat.ChatClient.ChatResult;
 import org.codelibs.fess.chat.ChatClient.ChatSearchResult;
 import org.codelibs.fess.entity.ChatMessage.ChatSource;
@@ -39,6 +33,7 @@ import org.codelibs.fess.llm.IntentDetectionResult;
 import org.codelibs.fess.llm.LlmChatResponse;
 import org.codelibs.fess.llm.LlmClientManager;
 import org.codelibs.fess.llm.LlmMessage;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Assertions;
@@ -224,31 +219,13 @@ public class ChatClientSourceFieldsTest extends UnitFessTestCase {
         final CapturingChatClient client = newChatClient(List.of(searchResultDoc()));
         final List<Map<String, Object>> searchResults = List.of(searchResultDoc());
 
-        final List<LogEvent> captured = new ArrayList<>();
-        final String loggerName = ChatClient.class.getName();
-        final LoggerContext ctx = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
-        final Configuration cfg = ctx.getConfiguration();
-        final LoggerConfig loggerCfg = cfg.getLoggerConfig(loggerName);
-        final Level originalLevel = loggerCfg.getLevel();
-        final AbstractAppender listAppender = new AbstractAppender("chat-client-degrade-appender", null,
-                PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
-            @Override
-            public void append(final LogEvent event) {
-                if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
-                    captured.add(event.toImmutable());
-                }
-            }
-        };
-        listAppender.start();
-        loggerCfg.addAppender(listAppender, Level.WARN, null);
-        loggerCfg.setLevel(Level.WARN);
-        ctx.updateLoggers();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(ChatClient.class);
         try {
             assertSame(searchResults, client.fetchContentForAnswer(searchResults, "install"),
                     "a fetcher failure must degrade to the raw search results");
 
-            final LogEvent warn = captured.stream()
-                    .filter(e -> loggerName.equals(e.getLoggerName()))
+            final LogEvent warn = appender.eventsAt(Level.WARN)
+                    .stream()
                     .filter(e -> e.getMessage().getFormattedMessage().contains("Failed to fetch answer content"))
                     .findFirst()
                     .orElse(null);
@@ -256,10 +233,7 @@ public class ChatClientSourceFieldsTest extends UnitFessTestCase {
             assertNotNull(warn.getThrown(), "the degrade WARN must carry the Throwable; only a stack trace identifies the bug");
             assertEquals("boom", warn.getThrown().getMessage());
         } finally {
-            loggerCfg.removeAppender("chat-client-degrade-appender");
-            loggerCfg.setLevel(originalLevel);
-            ctx.updateLoggers();
-            listAppender.stop();
+            appender.detach();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/chat/DefaultChatContentFetcherTest.java
+++ b/src/test/java/org/codelibs/fess/chat/DefaultChatContentFetcherTest.java
@@ -22,14 +22,11 @@ import java.util.Map;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.embedding.AbstractEmbeddingClient;
 import org.codelibs.fess.embedding.EmbeddingClientManager;
 import org.codelibs.fess.helper.ChunkVectorHelper;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
@@ -812,43 +809,18 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
         manager.available = false;
         f.embeddingManager = manager;
 
-        final String loggerName = DefaultChatContentFetcher.class.getName();
-        final LoggerContext ctx = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
-        final org.apache.logging.log4j.core.config.Configuration cfg = ctx.getConfiguration();
-        final org.apache.logging.log4j.core.config.LoggerConfig loggerCfg = cfg.getLoggerConfig(loggerName);
-        final Level originalLevel = loggerCfg.getLevel();
-        final List<LogEvent> captured = new ArrayList<>();
-        final AbstractAppender listAppender =
-                new AbstractAppender("test-list-appender-2", null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
-                    @Override
-                    public void append(final LogEvent event) {
-                        if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
-                            captured.add(event.toImmutable());
-                        }
-                    }
-                };
-        listAppender.start();
-        loggerCfg.addAppender(listAppender, Level.WARN, null);
-        loggerCfg.setLevel(Level.WARN);
-        ctx.updateLoggers();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(DefaultChatContentFetcher.class);
         try {
             // A persistently unavailable embedding provider must not silently return null forever --
             // exactly one WARN across repeated calls during the same outage, not zero and not one per call.
             for (int i = 0; i < 5; i++) {
                 assertNull(f.resolveQueryVector("query"));
             }
-            final long warnCount = captured.stream()
-                    .filter(e -> loggerName.equals(e.getLoggerName()))
-                    .filter(e -> Level.WARN.equals(e.getLevel()))
-                    .filter(e -> e.getMessage().getFormattedMessage().contains("Embedding client unavailable"))
-                    .count();
+            final long warnCount = appender.warnings().stream().filter(msg -> msg.contains("Embedding client unavailable")).count();
             org.junit.jupiter.api.Assertions.assertEquals(1L, warnCount,
                     "exactly 1 WARN must be emitted across 5 calls during the same outage; got " + warnCount);
         } finally {
-            loggerCfg.removeAppender("test-list-appender-2");
-            loggerCfg.setLevel(originalLevel);
-            ctx.updateLoggers();
-            listAppender.stop();
+            appender.detach();
         }
     }
 
@@ -860,25 +832,7 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
         manager.queryVector = new float[] { 1.0f };
         f.embeddingManager = manager;
 
-        final String loggerName = DefaultChatContentFetcher.class.getName();
-        final LoggerContext ctx = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
-        final org.apache.logging.log4j.core.config.Configuration cfg = ctx.getConfiguration();
-        final org.apache.logging.log4j.core.config.LoggerConfig loggerCfg = cfg.getLoggerConfig(loggerName);
-        final Level originalLevel = loggerCfg.getLevel();
-        final List<LogEvent> captured = new ArrayList<>();
-        final AbstractAppender listAppender =
-                new AbstractAppender("test-list-appender-3", null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
-                    @Override
-                    public void append(final LogEvent event) {
-                        if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
-                            captured.add(event.toImmutable());
-                        }
-                    }
-                };
-        listAppender.start();
-        loggerCfg.addAppender(listAppender, Level.WARN, null);
-        loggerCfg.setLevel(Level.WARN);
-        ctx.updateLoggers();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(DefaultChatContentFetcher.class);
         try {
             assertNull(f.resolveQueryVector("query")); // outage #1 -> 1st WARN
             manager.available = true;
@@ -886,18 +840,11 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
             manager.available = false;
             assertNull(f.resolveQueryVector("query")); // outage #2 -> must WARN again, not degrade to DEBUG forever
 
-            final long warnCount = captured.stream()
-                    .filter(e -> loggerName.equals(e.getLoggerName()))
-                    .filter(e -> Level.WARN.equals(e.getLevel()))
-                    .filter(e -> e.getMessage().getFormattedMessage().contains("Embedding client unavailable"))
-                    .count();
+            final long warnCount = appender.warnings().stream().filter(msg -> msg.contains("Embedding client unavailable")).count();
             org.junit.jupiter.api.Assertions.assertEquals(2L, warnCount,
                     "a distinct later outage must surface its own WARN; got " + warnCount);
         } finally {
-            loggerCfg.removeAppender("test-list-appender-3");
-            loggerCfg.setLevel(originalLevel);
-            ctx.updateLoggers();
-            listAppender.stop();
+            appender.detach();
         }
     }
 
@@ -1403,37 +1350,17 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
      * Runs {@code body} with a WARN-capturing appender attached to the fetcher's logger and returns
      * the first captured event whose formatted message contains {@code messageFragment}.
      */
-    private static LogEvent captureWarn(final String appenderName, final String messageFragment, final Runnable body) {
-        final String loggerName = DefaultChatContentFetcher.class.getName();
-        final LoggerContext ctx = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
-        final org.apache.logging.log4j.core.config.LoggerConfig loggerCfg = ctx.getConfiguration().getLoggerConfig(loggerName);
-        final Level originalLevel = loggerCfg.getLevel();
-        final List<LogEvent> captured = new ArrayList<>();
-        final AbstractAppender listAppender =
-                new AbstractAppender(appenderName, null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
-                    @Override
-                    public void append(final LogEvent event) {
-                        if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
-                            captured.add(event.toImmutable());
-                        }
-                    }
-                };
-        listAppender.start();
-        loggerCfg.addAppender(listAppender, Level.WARN, null);
-        loggerCfg.setLevel(Level.WARN);
-        ctx.updateLoggers();
+    private static LogEvent captureWarn(final String messageFragment, final Runnable body) {
+        final LogCapturingAppender appender = LogCapturingAppender.attach(DefaultChatContentFetcher.class);
         try {
             body.run();
-            return captured.stream()
-                    .filter(e -> loggerName.equals(e.getLoggerName()))
+            return appender.eventsAt(Level.WARN)
+                    .stream()
                     .filter(e -> e.getMessage().getFormattedMessage().contains(messageFragment))
                     .findFirst()
                     .orElse(null);
         } finally {
-            loggerCfg.removeAppender(appenderName);
-            loggerCfg.setLevel(originalLevel);
-            ctx.updateLoggers();
-            listAppender.stop();
+            appender.detach();
         }
     }
 
@@ -1441,7 +1368,7 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
     public void test_fetchFullContent_failureWarnCarriesStackTrace() {
         registerThrowingSearchHelper(new IllegalStateException("full-fetch boom"));
         final DefaultChatContentFetcher f = new DefaultChatContentFetcher();
-        final LogEvent warn = captureWarn("test-full-fetch-throwable-appender", "Failed to fetch full content", () -> {
+        final LogEvent warn = captureWarn("Failed to fetch full content", () -> {
             assertTrue(f.fetchFullContent(List.of("a")).isEmpty(), "a failed full fetch must degrade to an empty list");
         });
         assertNotNull(warn, "the failure must be logged at WARN");
@@ -1454,7 +1381,7 @@ public class DefaultChatContentFetcherTest extends UnitFessTestCase {
         registerQueryFieldConfig();
         registerThrowingSearchHelper(new IllegalStateException("highlight boom"));
         final DefaultChatContentFetcher f = new DefaultChatContentFetcher();
-        final LogEvent warn = captureWarn("test-highlight-throwable-appender", "Failed to fetch highlighted content", () -> {
+        final LogEvent warn = captureWarn("Failed to fetch highlighted content", () -> {
             assertTrue(f.fetchHighlightedContent(List.of("a"), "q").isEmpty(), "a failed highlight fetch must degrade to an empty list");
         });
         assertNotNull(warn, "the failure must be logged at WARN");

--- a/src/test/java/org/codelibs/fess/chunk/LengthChunkerTest.java
+++ b/src/test/java/org/codelibs/fess/chunk/LengthChunkerTest.java
@@ -18,16 +18,9 @@ package org.codelibs.fess.chunk;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
 import org.codelibs.fess.Constants;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
@@ -1156,42 +1149,6 @@ public class LengthChunkerTest extends UnitFessTestCase {
         @Override
         protected int getLookaheadPercent() {
             return testLookaheadPercent;
-        }
-    }
-
-    /**
-     * Minimal in-memory log4j2 appender for asserting on emitted log messages.
-     * Mirrors {@code OpenSearchEmbeddingClientTest.LogCapturingAppender}.
-     */
-    static final class LogCapturingAppender extends AbstractAppender {
-        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
-        private final Logger boundLogger;
-
-        private LogCapturingAppender(final Logger logger) {
-            super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
-            this.boundLogger = logger;
-        }
-
-        static LogCapturingAppender attach(final Class<?> targetClass) {
-            final Logger logger = (Logger) LogManager.getLogger(targetClass);
-            final LogCapturingAppender appender = new LogCapturingAppender(logger);
-            appender.start();
-            logger.addAppender(appender);
-            return appender;
-        }
-
-        void detach() {
-            boundLogger.removeAppender(this);
-            stop();
-        }
-
-        @Override
-        public void append(final LogEvent event) {
-            events.add(event.toImmutable());
-        }
-
-        List<String> warnings() {
-            return events.stream().filter(e -> e.getLevel() == Level.WARN).map(e -> e.getMessage().getFormattedMessage()).toList();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClientTest.java
+++ b/src/test/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClientTest.java
@@ -20,18 +20,11 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
 import org.codelibs.fess.embedding.EmbeddingException;
 import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
@@ -1801,66 +1794,6 @@ public class OpenSearchEmbeddingClientTest extends UnitFessTestCase {
 
         void initHttpClient() {
             httpClient = buildHttpClient();
-        }
-    }
-
-    /**
-     * Minimal in-memory log4j2 appender for asserting on emitted log messages.
-     * Mirrors {@code OllamaEmbeddingClientTest.LogCapturingAppender}.
-     */
-    static final class LogCapturingAppender extends AbstractAppender {
-        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
-        private final Logger boundLogger;
-
-        private LogCapturingAppender(final Logger logger) {
-            super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
-            this.boundLogger = logger;
-        }
-
-        static LogCapturingAppender attach(final Class<?> targetClass) {
-            final Logger logger = (Logger) LogManager.getLogger(targetClass);
-            final LogCapturingAppender appender = new LogCapturingAppender(logger);
-            appender.start();
-            logger.addAppender(appender);
-            return appender;
-        }
-
-        void detach() {
-            boundLogger.removeAppender(this);
-            stop();
-        }
-
-        @Override
-        public void append(final LogEvent event) {
-            events.add(event.toImmutable());
-        }
-
-        List<String> messagesAt(final Level level) {
-            return events.stream().filter(e -> e.getLevel() == level).map(e -> e.getMessage().getFormattedMessage()).toList();
-        }
-
-        List<String> warnings() {
-            return messagesAt(Level.WARN);
-        }
-
-        List<String> errors() {
-            return messagesAt(Level.ERROR);
-        }
-
-        /**
-         * Renders every captured event the way an appender's layout would: the formatted
-         * message <em>and</em> the attached throwable's stack trace, cause chain included.
-         *
-         * <p>Asserting only on {@link #messagesAt(Level)} is a trap for credential leaks:
-         * a leak carried by {@code logger.warn(pattern, args, throwable)} lives entirely in
-         * {@link LogEvent#getThrown()}, so a message-only assertion goes green while the
-         * rendered log line still prints the offending value.</p>
-         */
-        List<String> renderedEvents() {
-            return events.stream().map(e -> {
-                final Throwable thrown = e.getThrown();
-                return e.getMessage().getFormattedMessage() + (thrown != null ? System.lineSeparator() + renderThrowable(thrown) : "");
-            }).toList();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/filter/StaticThemeFilterTest.java
+++ b/src/test/java/org/codelibs/fess/filter/StaticThemeFilterTest.java
@@ -24,16 +24,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.codelibs.fess.theme.StaticThemeResponder;
 import org.codelibs.fess.theme.Theme;
 import org.codelibs.fess.theme.ThemeManifest;
 import org.codelibs.fess.theme.ThemeRegistry;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
 
@@ -305,27 +300,8 @@ public class StaticThemeFilterTest extends UnitFessTestCase {
         // harness. The firstFailure AtomicBoolean ensures exactly one WARN is emitted
         // no matter how many requests arrive.
         //
-        // Capture log4j2 output via a ListAppender attached to StaticThemeFilter's logger.
-        final String loggerName = StaticThemeFilter.class.getName();
-        final LoggerContext ctx = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
-        final org.apache.logging.log4j.core.config.Configuration cfg = ctx.getConfiguration();
-        final org.apache.logging.log4j.core.config.LoggerConfig loggerCfg = cfg.getLoggerConfig(loggerName);
-        // Temporarily set to WARN so the appender captures it.
-        final Level originalLevel = loggerCfg.getLevel();
-        final java.util.List<LogEvent> captured = new java.util.ArrayList<>();
-        final AbstractAppender listAppender =
-                new AbstractAppender("test-list-appender", null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY) {
-                    @Override
-                    public void append(final LogEvent event) {
-                        if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
-                            captured.add(event.toImmutable());
-                        }
-                    }
-                };
-        listAppender.start();
-        loggerCfg.addAppender(listAppender, Level.WARN, null);
-        loggerCfg.setLevel(Level.WARN);
-        ctx.updateLoggers();
+        // Capture log4j2 output via an appender bound to StaticThemeFilter's own logger.
+        final LogCapturingAppender appender = LogCapturingAppender.attach(StaticThemeFilter.class);
         try {
             // Create a fresh filter with NO registry injected -- ComponentUtil will throw.
             final StaticThemeFilter f = new StaticThemeFilter();
@@ -335,22 +311,12 @@ public class StaticThemeFilterTest extends UnitFessTestCase {
                 f.doFilter(new StubRequest("GET", "/search"), new StubResponse(), chain);
                 assertTrue(chain.called, "filter must pass through when registry is unavailable");
             }
-            // Count only WARN events from StaticThemeFilter's logger about ThemeRegistry.
-            final long warnCount = captured.stream()
-                    .filter(e -> loggerName.equals(e.getLoggerName()))
-                    .filter(e -> Level.WARN.equals(e.getLevel()))
-                    .filter(e -> {
-                        final String msg = e.getMessage().getFormattedMessage();
-                        return msg != null && msg.contains("ThemeRegistry");
-                    })
-                    .count();
+            // Count only WARN events about ThemeRegistry.
+            final long warnCount = appender.warnings().stream().filter(msg -> msg != null && msg.contains("ThemeRegistry")).count();
             org.junit.jupiter.api.Assertions.assertEquals(1L, warnCount,
                     "exactly 1 WARN must be emitted for ThemeRegistry unavailable across 5 requests; got " + warnCount);
         } finally {
-            loggerCfg.removeAppender("test-list-appender");
-            loggerCfg.setLevel(originalLevel);
-            ctx.updateLoggers();
-            listAppender.stop();
+            appender.detach();
         }
     }
 

--- a/src/test/java/org/codelibs/fess/helper/ChunkVectorHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ChunkVectorHelperTest.java
@@ -23,15 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.embedding.EmbeddingException;
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -2487,42 +2480,6 @@ public class ChunkVectorHelperTest extends UnitFessTestCase {
         @Override
         public String getIndexFieldId() {
             return "id";
-        }
-    }
-
-    /**
-     * Minimal in-memory log4j2 appender for asserting on emitted log messages.
-     * Mirrors {@code OpenSearchEmbeddingClientTest.LogCapturingAppender}.
-     */
-    static final class LogCapturingAppender extends AbstractAppender {
-        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
-        private final Logger boundLogger;
-
-        private LogCapturingAppender(final Logger logger) {
-            super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
-            this.boundLogger = logger;
-        }
-
-        static LogCapturingAppender attach(final Class<?> targetClass) {
-            final Logger logger = (Logger) LogManager.getLogger(targetClass);
-            final LogCapturingAppender appender = new LogCapturingAppender(logger);
-            appender.start();
-            logger.addAppender(appender);
-            return appender;
-        }
-
-        void detach() {
-            boundLogger.removeAppender(this);
-            stop();
-        }
-
-        @Override
-        public void append(final LogEvent event) {
-            events.add(event.toImmutable());
-        }
-
-        List<String> warnings() {
-            return events.stream().filter(e -> e.getLevel() == Level.WARN).map(e -> e.getMessage().getFormattedMessage()).toList();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientIndexSettingTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientIndexSettingTest.java
@@ -18,17 +18,9 @@ package org.codelibs.fess.opensearch.client;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
 import org.codelibs.fess.helper.ChunkVectorHelper;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
@@ -453,42 +445,6 @@ public class SearchEngineClientIndexSettingTest extends UnitFessTestCase {
         try (InputStream in = getClass().getClassLoader().getResourceAsStream(path)) {
             assertNotNull(in, path + " must exist");
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
-        }
-    }
-
-    /**
-     * Minimal in-memory log4j2 appender for asserting on emitted log messages.
-     * Mirrors {@code ChunkVectorHelperTest.LogCapturingAppender}/{@code OpenSearchEmbeddingClientTest.LogCapturingAppender}.
-     */
-    static final class LogCapturingAppender extends AbstractAppender {
-        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
-        private final Logger boundLogger;
-
-        private LogCapturingAppender(final Logger logger) {
-            super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
-            this.boundLogger = logger;
-        }
-
-        static LogCapturingAppender attach(final Class<?> targetClass) {
-            final Logger logger = (Logger) LogManager.getLogger(targetClass);
-            final LogCapturingAppender appender = new LogCapturingAppender(logger);
-            appender.start();
-            logger.addAppender(appender);
-            return appender;
-        }
-
-        void detach() {
-            boundLogger.removeAppender(this);
-            stop();
-        }
-
-        @Override
-        public void append(final LogEvent event) {
-            events.add(event.toImmutable());
-        }
-
-        List<String> warnings() {
-            return events.stream().filter(e -> e.getLevel() == Level.WARN).map(e -> e.getMessage().getFormattedMessage()).toList();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcherTest.java
+++ b/src/test/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcherTest.java
@@ -18,14 +18,8 @@ package org.codelibs.fess.rank.fusion;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.SearchRequestParams;
 import org.codelibs.fess.helper.ChunkVectorHelper;
@@ -36,6 +30,7 @@ import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.client.SearchEngineClient;
 import org.codelibs.fess.opensearch.client.SearchEngineClient.SearchCondition;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalEntity;
@@ -545,39 +540,6 @@ public class SemanticChunkSearcherTest extends UnitFessTestCase {
         protected OptionalEntity<SearchResponse> sendRequest(final String query, final SearchRequestParams params,
                 final OptionalThing<FessUserBean> userBean) {
             return OptionalEntity.empty();
-        }
-    }
-
-    /** Minimal in-memory log4j2 appender for asserting on emitted log messages. */
-    static final class LogCapturingAppender extends AbstractAppender {
-        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
-        private final org.apache.logging.log4j.core.Logger boundLogger;
-
-        private LogCapturingAppender(final org.apache.logging.log4j.core.Logger logger) {
-            super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
-            this.boundLogger = logger;
-        }
-
-        static LogCapturingAppender attach(final Class<?> targetClass) {
-            final org.apache.logging.log4j.core.Logger logger = (org.apache.logging.log4j.core.Logger) LogManager.getLogger(targetClass);
-            final LogCapturingAppender appender = new LogCapturingAppender(logger);
-            appender.start();
-            logger.addAppender(appender);
-            return appender;
-        }
-
-        void detach() {
-            boundLogger.removeAppender(this);
-            stop();
-        }
-
-        @Override
-        public void append(final LogEvent event) {
-            events.add(event.toImmutable());
-        }
-
-        List<String> messagesAt(final Level level) {
-            return events.stream().filter(e -> e.getLevel() == level).map(e -> e.getMessage().getFormattedMessage()).toList();
         }
     }
 

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -16,17 +16,7 @@
 package org.codelibs.fess.sso.saml;
 
 import java.lang.reflect.Field;
-import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
 
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
@@ -34,6 +24,7 @@ import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.exception.SsoMessageException;
 import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.sso.SsoResponseType;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.saml2.core.settings.Saml2Settings;
@@ -523,42 +514,6 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertEquals("http://localhost:8080/sso/logout", authenticator.buildDefaultUrl("/sso/logout"));
         } finally {
             systemProperties.remove(BASE_URL_KEY);
-        }
-    }
-
-    /**
-     * Minimal in-memory log4j2 appender for asserting on emitted log messages.
-     * Mirrors {@code LengthChunkerTest.LogCapturingAppender}.
-     */
-    static final class LogCapturingAppender extends AbstractAppender {
-        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
-        private final Logger boundLogger;
-
-        private LogCapturingAppender(final Logger logger) {
-            super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
-            this.boundLogger = logger;
-        }
-
-        static LogCapturingAppender attach(final Class<?> targetClass) {
-            final Logger logger = (Logger) LogManager.getLogger(targetClass);
-            final LogCapturingAppender appender = new LogCapturingAppender(logger);
-            appender.start();
-            logger.addAppender(appender);
-            return appender;
-        }
-
-        void detach() {
-            boundLogger.removeAppender(this);
-            stop();
-        }
-
-        @Override
-        public void append(final LogEvent event) {
-            events.add(event.toImmutable());
-        }
-
-        List<String> warnings() {
-            return events.stream().filter(e -> e.getLevel() == Level.WARN).map(e -> e.getMessage().getFormattedMessage()).toList();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/unit/LogCapturingAppender.java
+++ b/src/test/java/org/codelibs/fess/unit/LogCapturingAppender.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.unit;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+
+/**
+ * In-memory log4j2 appender for asserting on the messages a class emits.
+ *
+ * <p><b>Never mutate a {@link LoggerConfig} you do not own.</b> {@code log4j2.xml} declares
+ * configs for {@code org.codelibs}, {@code org.dbflute}, {@code org.lastaflute},
+ * {@code org.codelibs.fess.llm}, {@code org.codelibs.fess.chat} and
+ * {@code org.codelibs.fess.app.web.chat} only, so
+ * {@code configuration.getLoggerConfig(SomeFessClass.class.getName())} walks up and hands back
+ * the <em>shared</em> {@code org.codelibs} config. Calling {@code setLevel} on that handle
+ * rewrites the level for every {@code org.codelibs} logger in the JVM. CI runs surefire with
+ * {@code -Dparallel=classes}, so the classes running alongside see it.</p>
+ *
+ * <p>That is not merely a transient window. {@code AbstractConfiguration#addLoggerAppender}
+ * creates a per-logger {@code LoggerConfig} with {@code new LoggerConfig(name, ancestor.getLevel(),
+ * ...)} and registers it with {@code putIfAbsent}: the ancestor level is <em>snapshotted</em> and
+ * never revisited. An {@code attach} that lands inside somebody else's WARN window therefore pins
+ * the target logger at WARN for the rest of the surefire fork, and every later INFO/DEBUG
+ * assertion on that class sees an empty list while WARN assertions still pass.</p>
+ *
+ * <p>This appender avoids both halves of that trap: it installs a {@code LoggerConfig} dedicated
+ * to the target logger name at an explicit level before attaching, and removes it again on
+ * {@link #detach()}. Ancestor configs are never read for a level and never written.</p>
+ */
+public final class LogCapturingAppender extends AbstractAppender {
+
+    /** Level forced on the captured logger unless the caller asks for another one. */
+    private static final Level DEFAULT_LEVEL = Level.DEBUG;
+
+    private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+    private final String loggerName;
+
+    /** Set when this appender created the dedicated {@link LoggerConfig} and must remove it again. */
+    private final boolean ownsLoggerConfig;
+
+    /** Level to put back when the dedicated config was not ours to create. */
+    private final Level restoredLevel;
+
+    private LogCapturingAppender(final String loggerName, final boolean ownsLoggerConfig, final Level restoredLevel) {
+        super("LogCapturingAppender-" + UUID.randomUUID(), null, null, true, Property.EMPTY_ARRAY);
+        this.loggerName = loggerName;
+        this.ownsLoggerConfig = ownsLoggerConfig;
+        this.restoredLevel = restoredLevel;
+    }
+
+    /** Captures {@code targetClass}'s logger from {@link #DEFAULT_LEVEL} up. */
+    public static LogCapturingAppender attach(final Class<?> targetClass) {
+        return attach(targetClass.getName(), DEFAULT_LEVEL);
+    }
+
+    /** Captures {@code loggerName} from {@link #DEFAULT_LEVEL} up. */
+    public static LogCapturingAppender attach(final String loggerName) {
+        return attach(loggerName, DEFAULT_LEVEL);
+    }
+
+    /**
+     * Captures {@code loggerName} from {@code level} up. The level is applied to a
+     * {@code LoggerConfig} dedicated to {@code loggerName}, so no other logger is affected.
+     */
+    public static LogCapturingAppender attach(final String loggerName, final Level level) {
+        final LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        final Configuration configuration = context.getConfiguration();
+        final LoggerConfig resolved = configuration.getLoggerConfig(loggerName);
+        final boolean ownsLoggerConfig = !resolved.getName().equals(loggerName);
+        // Read before the setLevel below: in the borrow branch `dedicated` IS `resolved`, so
+        // reading afterwards would capture the level we just wrote and make detach() a no-op.
+        final Level restoredLevel = ownsLoggerConfig ? null : resolved.getLevel();
+        final LoggerConfig dedicated;
+        if (ownsLoggerConfig) {
+            // The ancestor's level is deliberately NOT copied: it may be mid-rewrite in another thread.
+            dedicated = new LoggerConfig(loggerName, level, resolved.isAdditive());
+            dedicated.setParent(resolved);
+            configuration.addLogger(loggerName, dedicated);
+        } else {
+            // A config declared for this exact name, or a leftover: borrow it and put its level back later.
+            dedicated = resolved;
+            dedicated.setLevel(level);
+        }
+        final LogCapturingAppender appender = new LogCapturingAppender(loggerName, ownsLoggerConfig, restoredLevel);
+        appender.start();
+        dedicated.addAppender(appender, null, null);
+        context.updateLoggers();
+        return appender;
+    }
+
+    /** Detaches the appender and undoes the {@link LoggerConfig} change {@link #attach} made. */
+    public void detach() {
+        final LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        final Configuration configuration = context.getConfiguration();
+        final LoggerConfig dedicated = configuration.getLoggerConfig(loggerName);
+        if (dedicated.getName().equals(loggerName)) {
+            dedicated.removeAppender(getName());
+            if (ownsLoggerConfig) {
+                configuration.removeLogger(loggerName);
+            } else if (restoredLevel != null) {
+                dedicated.setLevel(restoredLevel);
+            }
+        }
+        context.updateLoggers();
+        stop();
+    }
+
+    @Override
+    public void append(final LogEvent event) {
+        events.add(event.toImmutable());
+    }
+
+    /** Every captured event, in emission order. */
+    public List<LogEvent> events() {
+        return List.copyOf(events);
+    }
+
+    /** Captured events at exactly {@code level}. */
+    public List<LogEvent> eventsAt(final Level level) {
+        return events.stream().filter(e -> e.getLevel() == level).toList();
+    }
+
+    /** Formatted messages of the captured events at exactly {@code level}. */
+    public List<String> messagesAt(final Level level) {
+        return eventsAt(level).stream().map(e -> e.getMessage().getFormattedMessage()).toList();
+    }
+
+    /** Formatted messages captured at WARN. */
+    public List<String> warnings() {
+        return messagesAt(Level.WARN);
+    }
+
+    /** Formatted messages captured at ERROR. */
+    public List<String> errors() {
+        return messagesAt(Level.ERROR);
+    }
+
+    /**
+     * Renders every captured event the way an appender's layout would: the formatted message
+     * <em>and</em> the attached throwable's stack trace, cause chain included.
+     *
+     * <p>Asserting only on {@link #messagesAt(Level)} is a trap for credential leaks: a leak
+     * carried by {@code logger.warn(pattern, args, throwable)} lives entirely in
+     * {@link LogEvent#getThrown()}, so a message-only assertion goes green while the rendered
+     * log line still prints the offending value.</p>
+     */
+    public List<String> renderedEvents() {
+        return events.stream().map(e -> {
+            final Throwable thrown = e.getThrown();
+            return e.getMessage().getFormattedMessage() + (thrown != null ? System.lineSeparator() + renderThrowable(thrown) : "");
+        }).toList();
+    }
+
+    /** Renders a throwable and its whole cause chain the way a log layout would. */
+    private static String renderThrowable(final Throwable throwable) {
+        final StringWriter writer = new StringWriter();
+        try (PrintWriter printWriter = new PrintWriter(writer)) {
+            throwable.printStackTrace(printWriter);
+        }
+        return writer.toString();
+    }
+}

--- a/src/test/java/org/codelibs/fess/unit/LogCapturingAppenderTest.java
+++ b/src/test/java/org/codelibs/fess/unit/LogCapturingAppenderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.unit;
+
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the contract that keeps {@link LogCapturingAppender} usable while surefire runs with
+ * {@code -Dparallel=classes}: the level of the captured logger must not be inherited from an
+ * ancestor config another test class can be rewriting at that instant.
+ *
+ * <p>The ancestor used here is created by this test and lives under {@code fess.test.} rather
+ * than {@code org.codelibs}, so the test cannot itself commit the bug it guards against.</p>
+ */
+public class LogCapturingAppenderTest extends UnitFessTestCase {
+
+    private static final String ANCESTOR_NAME = "fess.test.logcapture";
+
+    private static final String TARGET_NAME = ANCESTOR_NAME + ".Target";
+
+    @Test
+    public void test_attach_ignoresAnAncestorLevelRaisedByAnotherThread() {
+        withAncestorAt(Level.WARN, () -> {
+            final LogCapturingAppender appender = LogCapturingAppender.attach(TARGET_NAME);
+            try {
+                LogManager.getLogger(TARGET_NAME).info("info survives");
+                LogManager.getLogger(TARGET_NAME).warn("warn survives");
+                assertEquals("an ancestor at WARN during attach() must not suppress INFO capture", List.of("info survives"),
+                        appender.messagesAt(Level.INFO));
+                assertEquals("WARN capture must keep working", List.of("warn survives"), appender.warnings());
+            } finally {
+                appender.detach();
+            }
+        });
+    }
+
+    @Test
+    public void test_attach_neverMutatesTheAncestorItResolvedThrough() {
+        withAncestorAt(Level.WARN, () -> {
+            final LogCapturingAppender appender = LogCapturingAppender.attach(TARGET_NAME);
+            try {
+                assertEquals("attach() must leave the shared ancestor config untouched", Level.WARN, ancestorLevel());
+            } finally {
+                appender.detach();
+            }
+            assertEquals("detach() must leave the shared ancestor config untouched", Level.WARN, ancestorLevel());
+        });
+    }
+
+    @Test
+    public void test_attach_restoresTheLevelOfAConfigDeclaredForTheExactName() {
+        // The borrow branch: a config already exists under the captured name, so attach() cannot
+        // create its own and has to put the level back. Reading the level after writing it would
+        // make that restore a silent no-op.
+        withAncestorAt(Level.WARN, () -> {
+            final LogCapturingAppender appender = LogCapturingAppender.attach(ANCESTOR_NAME, Level.DEBUG);
+            try {
+                LogManager.getLogger(ANCESTOR_NAME).debug("borrowed");
+                assertEquals("the borrowed config must be lowered to the requested level", List.of("borrowed"),
+                        appender.messagesAt(Level.DEBUG));
+            } finally {
+                appender.detach();
+            }
+            assertEquals("detach() must put the borrowed config's level back", Level.WARN, ancestorLevel());
+        });
+    }
+
+    @Test
+    public void test_detach_leavesNoPinnedLoggerConfigBehind() {
+        withAncestorAt(Level.WARN, () -> {
+            LogCapturingAppender.attach(TARGET_NAME).detach();
+            assertEquals("detach() must remove the LoggerConfig attach() created, or the next attach() reuses its level", ANCESTOR_NAME,
+                    configuration().getLoggerConfig(TARGET_NAME).getName());
+        });
+    }
+
+    // -------------------------------------------------------------------------------------
+    //                                                                                helpers
+    //                                                                                -------
+
+    private static Configuration configuration() {
+        return ((LoggerContext) LogManager.getContext(false)).getConfiguration();
+    }
+
+    private static Level ancestorLevel() {
+        return configuration().getLoggerConfig(ANCESTOR_NAME).getLevel();
+    }
+
+    /**
+     * Installs a {@code fess.test.logcapture} config at {@code level} for the duration of
+     * {@code body}. This stands in for the concurrent test class that raises a shared level.
+     */
+    private static void withAncestorAt(final Level level, final Runnable body) {
+        final LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        final Configuration configuration = context.getConfiguration();
+        configuration.addLogger(ANCESTOR_NAME, new LoggerConfig(ANCESTOR_NAME, level, false));
+        context.updateLoggers();
+        try {
+            body.run();
+        } finally {
+            configuration.removeLogger(ANCESTOR_NAME);
+            context.updateLoggers();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`SemanticChunkSearcherTest.test_register_logsRestartRequirementWhenDisabled` fails
intermittently on master with an empty INFO capture, while the WARN assertions in the same
class pass:

```
SemanticChunkSearcherTest.test_register_logsRestartRequirementWhenDisabled:342
  a disabled searcher must state the restart requirement at INFO: [] ==> expected: <true> but was: <false>
```

It has nothing to do with the commits it lands on. The trigger is a test in a different
package.

## Root cause

`log4j2.xml` declares `LoggerConfig`s for `org.codelibs`, `org.dbflute`, `org.lastaflute`,
`org.codelibs.fess.llm`, `org.codelibs.fess.chat` and `org.codelibs.fess.app.web.chat`
only. `configuration.getLoggerConfig(SomeFessClass.class.getName())` therefore walks up and
returns the **shared `org.codelibs` config**. Seven tests called `setLevel` on that handle,
which rewrites the level for every `org.codelibs` logger in the JVM. CI runs surefire with
`-Dparallel=classes -DthreadCount=4`, so whatever runs alongside sees it.

The damage outlives the window. `AbstractConfiguration#addLoggerAppender` builds the
per-logger config as `new LoggerConfig(name, ancestor.getLevel(), ...)` and registers it
with `putIfAbsent` — the ancestor level is snapshotted and never revisited. An `attach`
landing inside somebody else's WARN window pins the target logger at WARN for the rest of
the surefire fork, so INFO capture stays empty long after the level was restored, while
WARN capture keeps working.

Class timings in the surefire logs line up 4/4: the failing runs are the ones where
`StaticThemeFilterTest` (which raised the shared level) and `SemanticChunkSearcherTest`
overlap; in the passing runs `StaticThemeFilterTest` finishes just before
`SemanticChunkSearcherTest` starts.

## Fix

Both halves are addressed:

- Add `org.codelibs.fess.unit.LogCapturingAppender`. It installs a `LoggerConfig`
  **dedicated to the captured logger** at an explicit level before attaching, and removes
  it again on `detach()`. Ancestor configs are never read for a level and never written, so
  the capture level no longer depends on what another thread is doing.
- Move all thirteen capture sites onto it. That replaces seven near-identical private
  copies of the appender and five hand-rolled `getLoggerConfig(...).setLevel(...)` blocks
  (`StaticThemeFilterTest`, `ChatClientSourceFieldsTest`, `DefaultChatContentFetcherTest`,
  `PasswordChangeHandlerTest`, `LoginHandlerTest`), leaving no test that mutates a
  `LoggerConfig` it does not own.

`PasswordChangeHandlerTest` and `LoginHandlerTest` are worth calling out: they set the
shared config to DEBUG and restored the level they had *read*, so racing the WARN window
would have pinned `org.codelibs` at WARN permanently for the whole fork.

## Tests

`LogCapturingAppenderTest` pins the contract — capture survives an ancestor raised to WARN
at attach time, the ancestor is left untouched, no `LoggerConfig` is left behind, and a
borrowed config gets its level back. Its ancestor lives under `fess.test.` rather than
`org.codelibs`, so the guard cannot itself commit the bug it guards against.

Each assertion was confirmed to fail against the previous behaviour before the fix went in;
the first one reproduces the CI symptom exactly (`expected: <[info survives]> but was: <[]>`).

Verified with the CI settings:

```
mvn clean test -Dparallel=classes -DthreadCount=4 -DforkCount=1C -DreuseForks=true
Tests run: 7137, Failures: 0, Errors: 0, Skipped: 0
```

Test-only change; no production source is touched.
