### PR TITLE
fix(admin): apply the SPNEGO NTLM/Basic rule only when SPNEGO is the active SSO type

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
@@ -61,6 +61,13 @@ public class AdminGeneralAction extends FessAdminAction {
 
     private static final String DUMMY_PASSWORD = "**********";
 
+    /**
+     * The {@code sso.type} value that selects the SPNEGO provider. {@link org.codelibs.fess.sso.SsoManager}
+     * resolves the provider by looking up a component named {@code ssoType + "Authenticator"}, so this
+     * literal is the identifier and there is no constant for it elsewhere.
+     */
+    private static final String SSO_TYPE_SPNEGO = "spnego";
+
     private static final Logger logger = LogManager.getLogger(AdminGeneralAction.class);
 
     // ===================================================================================
@@ -572,11 +579,23 @@ public class AdminGeneralAction extends FessAdminAction {
      * configuration, and it does so lazily on the first login rather than at save time, so both the
      * admin screen and the API reject it here instead of letting SSO break silently until someone
      * tries to log in.
+     * <p>
+     * The rule only applies when the settings being stored also select SPNEGO as the SSO provider.
+     * The SPNEGO configuration is built by the SPNEGO authenticator alone, so with any other
+     * {@code sso.type} the stored combination is dormant and cannot break a login. Rejecting it
+     * regardless of the type would pin an error on a SPNEGO checkbox and block every unrelated
+     * change on this screen for installations that never enabled SPNEGO. The gate reads the
+     * submitted type rather than the stored one, so the save that switches {@code sso.type} to
+     * spnego is itself rejected until the combination is fixed: that save is the first one whose
+     * result would be a broken SPNEGO login.
      *
      * @param form the form holding the settings to be stored
      * @return true if the combination must be rejected
      */
     public static boolean isSpnegoNtlmPromptUnsupported(final EditForm form) {
+        if (!SSO_TYPE_SPNEGO.equals(form.ssoType)) {
+            return false;
+        }
         return !isCheckboxEnabled(form.spnegoAllowBasic) && isCheckboxEnabled(form.spnegoPromptNtlm);
     }
 

--- a/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/general/AdminGeneralActionTest.java
@@ -199,20 +199,53 @@ public class AdminGeneralActionTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_isSpnegoNtlmPromptUnsupported() {
-        final EditForm form = createEditForm();
-
+    public void test_isSpnegoNtlmPromptUnsupported_spnego_rejectsNtlmPromptWithoutBasic() {
         // The library requires Basic auth to be available before it can downgrade an NTLM token.
-        form.spnegoAllowBasic = null;
-        form.spnegoPromptNtlm = Constants.TRUE;
+        assertTrue(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(createSpnegoForm("spnego", Constants.FALSE, Constants.TRUE)));
+    }
+
+    @Test
+    public void test_isSpnegoNtlmPromptUnsupported_spnego_allowsNtlmPromptWithBasic() {
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(createSpnegoForm("spnego", Constants.TRUE, Constants.TRUE)));
+    }
+
+    @Test
+    public void test_isSpnegoNtlmPromptUnsupported_spnego_allowsNtlmPromptDisabled() {
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(createSpnegoForm("spnego", Constants.FALSE, Constants.FALSE)));
+    }
+
+    @Test
+    public void test_isSpnegoNtlmPromptUnsupported_otherSsoType_leavesDormantSettingsAlone() {
+        // sso.type=none is the default, so a stored combination that no authenticator ever reads
+        // must not block saving an unrelated setting on this screen.
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(createSpnegoForm(Constants.NONE, Constants.FALSE, Constants.TRUE)));
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(createSpnegoForm("saml", Constants.FALSE, Constants.TRUE)));
+    }
+
+    @Test
+    public void test_isSpnegoNtlmPromptUnsupported_missingSsoType_isNotSpnego() {
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(createSpnegoForm(null, Constants.FALSE, Constants.TRUE)));
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(createSpnegoForm(StringUtil.EMPTY, Constants.FALSE, Constants.TRUE)));
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(createSpnegoForm(" ", Constants.FALSE, Constants.TRUE)));
+    }
+
+    @Test
+    public void test_isSpnegoNtlmPromptUnsupported_switchingToSpnegoIsStillRejected() {
+        // The gate reads the submitted type, so turning SPNEGO on while the stored checkboxes hold
+        // the unsupported combination is rejected instead of being saved into a broken login.
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final EditForm stored = createEditForm();
+        stored.ssoType = Constants.NONE;
+        stored.spnegoAllowBasic = Constants.FALSE;
+        stored.spnegoPromptNtlm = Constants.TRUE;
+        AdminGeneralAction.updateConfig(fessConfig, stored);
+
+        final EditForm form = createEditForm();
+        AdminGeneralAction.updateForm(fessConfig, form);
+        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(form));
+
+        form.ssoType = "spnego";
         assertTrue(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(form));
-
-        form.spnegoAllowBasic = Constants.TRUE;
-        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(form));
-
-        form.spnegoAllowBasic = null;
-        form.spnegoPromptNtlm = null;
-        assertFalse(AdminGeneralAction.isSpnegoNtlmPromptUnsupported(form));
     }
 
     /**
@@ -243,6 +276,24 @@ public class AdminGeneralActionTest extends UnitFessTestCase {
 
         assertEquals("fesenType=" + fesenType + ", resultCollapsed=" + formValue, expectedValue,
                 ComponentUtil.getSystemProperties().getProperty(Constants.RESULT_COLLAPSED_PROPERTY));
+    }
+
+    /**
+     * Creates a form carrying the three fields the SPNEGO NTLM prompt rule correlates. The
+     * checkbox fields are always set explicitly, because isCheckboxEnabled reads an absent field
+     * as disabled and a fixture that leaves one out could not tell the two apart.
+     *
+     * @param ssoType the submitted sso.type value
+     * @param spnegoAllowBasic the submitted spnegoAllowBasic checkbox value
+     * @param spnegoPromptNtlm the submitted spnegoPromptNtlm checkbox value
+     * @return the form to pass to isSpnegoNtlmPromptUnsupported
+     */
+    private EditForm createSpnegoForm(final String ssoType, final String spnegoAllowBasic, final String spnegoPromptNtlm) {
+        final EditForm form = createEditForm();
+        form.ssoType = ssoType;
+        form.spnegoAllowBasic = spnegoAllowBasic;
+        form.spnegoPromptNtlm = spnegoPromptNtlm;
+        return form;
     }
 
     /**


### PR DESCRIPTION
## Problem

`AdminGeneralAction.update()` rejects a save when `spnego.allow.basic` is off while `spnego.prompt.ntlm` is on. The rule itself is right — `SpnegoFilterConfig.setNtlmSupport` throws `IllegalArgumentException("If prompt ntlm is true, then allow basic auth must also be true.")` while building the configuration, so storing that combination breaks SPNEGO login at initialisation.

The rule is not gated on `sso.type`, though, so it fires for every SSO type including the default `none`. An installation whose stored combination is simply dormant — no SPNEGO authenticator ever reads it — is blocked from saving any unrelated setting on the General screen, with the error pinned to a SPNEGO checkbox. In 15.7 `validate` was a no-op here and the same save succeeded, so this is a regression.

## Change

Gate the check on the submitted `sso.type`:

```java
if (!SSO_TYPE_SPNEGO.equals(form.ssoType)) {
    return false;
}
```

The gate reads the submitted type rather than the stored one, so the save that switches `sso.type` to spnego is itself rejected until the combination is fixed — that save is the first one whose result would be a broken SPNEGO login.

Both call sites inherit the gate. The API path (`ApiAdminGeneralAction.put$index`) already validates the merged body, and `updateForm` fills `ssoType` from `getSsoType()`, which falls back to `none` and is never null, so the API gates on the effective type rather than on a partial request body.

## Tests

`AdminGeneralActionTest` 11 -> 16. The pre-existing `test_isSpnegoNtlmPromptUnsupported` asserted the ungated behaviour, so it was replaced by six cases; its substantive assertion (Basic disabled + NTLM enabled must be rejected) survives verbatim in the spnego-typed case.

Covered: spnego + the unsupported combination is still rejected; spnego + either half changed is accepted; `none` and `saml` leave a dormant combination alone; null/blank `sso.type` is not spnego; and an end-to-end case that stores the combination under `sso.type=none`, reloads through `updateForm`, then flips only the type and is rejected.

Removing only the three-line gate turns three of these red; restoring it returns 16/16. The three spnego-typed tests stay green either way, which is the point — they pin the rule, not the gate.
