### PR TITLE
fix(sso/spnego): mirror the library's Authorization parsing so the realm allow list cannot be bypassed

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -22,6 +22,7 @@ import java.util.Base64;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,6 +32,7 @@ import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist.LoginCredentialResolver;
 import org.codelibs.fess.app.web.base.login.SpnegoCredential;
 import org.codelibs.fess.exception.SsoLoginException;
+import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.sso.SsoAuthenticator;
 import org.codelibs.fess.sso.SsoResponseType;
@@ -111,6 +113,13 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
 
     /** Upper bound on the length of a client-supplied value embedded in a log message. */
     protected static final int MAX_LOGGED_REALM_LENGTH = 64;
+
+    /**
+     * Characters that must not be copied verbatim into a log message. {@code \p{Cntrl}} alone is
+     * ASCII-only, so the Unicode break characters a log viewer still renders as a new line are
+     * listed explicitly.
+     */
+    private static final Pattern LOG_UNSAFE_PATTERN = Pattern.compile("[\\p{Cntrl}\\u0085\\u2028\\u2029]");
 
     /** The underlying SPNEGO authenticator instance. */
     protected volatile org.codelibs.spnego.SpnegoAuthenticator authenticator = null;
@@ -282,7 +291,9 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 logger.debug("username={}", Arrays.toString(username));
             }
             if (username.length == 2 && StringUtil.isNotBlank(username[1]) && !isAllowedRealm(username[1])) {
-                throw new SsoLoginException(realmRejectedMessage(username[1]));
+                // A refused realm is a rejected request, not a fault: /sso is anonymous, so a stack
+                // trace per attempt would let an unauthenticated client fill the log.
+                throw new SsoStateException(realmRejectedMessage(username[1]));
             }
             return new SpnegoCredential(username[0]);
         }).orElse(null);
@@ -300,12 +311,14 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
      * exists the typed realm is gone, which would leave the allow list unable to govern this path.
      *
      * @param request the current request
-     * @throws SsoLoginException if the realm named in the header is not allowed
+     * @throws SsoStateException if the realm named in the header is not allowed
      */
     protected void rejectDisallowedBasicRealm(final HttpServletRequest request) {
         final String realm = getBasicRealm(request.getHeader(Constants.AUTHZ_HEADER));
         if (realm != null && !isAllowedRealm(realm)) {
-            throw new SsoLoginException(realmRejectedMessage(realm));
+            // A refused realm is a rejected request, not a fault: /sso is anonymous, so a stack
+            // trace per attempt would let an unauthenticated client fill the log.
+            throw new SsoStateException(realmRejectedMessage(realm));
         }
     }
 
@@ -334,13 +347,30 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
         if (authzHeader == null) {
             return null;
         }
-        final int schemeEnd = authzHeader.indexOf(' ');
-        if (schemeEnd <= 0 || !Constants.BASIC_HEADER.equalsIgnoreCase(authzHeader.substring(0, schemeEnd))) {
+        // The scheme is separated from the token exactly the way SpnegoProvider#parseAuthHeader
+        // separates it: the scheme is matched case-insensitively at offset 0, any run of whitespace
+        // after it is skipped, and the trimmed remainder is the token. Diverging from that -- by
+        // splitting on a literal space, for instance -- leaves headers the library still
+        // authenticates (a tab as the separator, or no separator at all) resolving to no realm
+        // here, which silently reopens the spnego.allowed.realms bypass this check exists to close.
+        final int schemeLength = Constants.BASIC_HEADER.length();
+        if (authzHeader.length() < schemeLength || !authzHeader.regionMatches(true, 0, Constants.BASIC_HEADER, 0, schemeLength)) {
+            return null;
+        }
+        int index = schemeLength;
+        while (index < authzHeader.length() && Character.isWhitespace(authzHeader.charAt(index))) {
+            index++;
+        }
+        if (index >= authzHeader.length()) {
+            return null;
+        }
+        final String token = authzHeader.substring(index).trim();
+        if (token.isEmpty()) {
             return null;
         }
         final byte[] decoded;
         try {
-            decoded = Base64.getDecoder().decode(authzHeader.substring(schemeEnd + 1).trim());
+            decoded = Base64.getDecoder().decode(token);
         } catch (final IllegalArgumentException e) {
             // A malformed token is the library's to reject; do not turn it into a realm failure.
             return null;
@@ -368,14 +398,17 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
      */
     protected static String sanitizeForLog(final String value) {
         final String bounded = value.length() > MAX_LOGGED_REALM_LENGTH ? value.substring(0, MAX_LOGGED_REALM_LENGTH) + "..." : value;
-        return bounded.replaceAll("\\p{Cntrl}", "?");
+        return LOG_UNSAFE_PATTERN.matcher(bounded).replaceAll("?");
     }
 
     /**
      * Masks an Authorization header so that only its authentication scheme remains.
      *
      * The credential part must never reach the log: a Basic token carries the user name and the
-     * password, and even a short prefix of it decodes back to readable characters.
+     * password, and even a short prefix of it decodes back to readable characters. The scheme that
+     * survives is still client-controlled, so it is bounded and sanitized like any other value
+     * taken from the request. The scheme ends at the first whitespace, matching how the library and
+     * {@link #getBasicRealm(String)} split the header.
      *
      * @param authzHeader the raw Authorization header value (may be null)
      * @return the scheme followed by a mask, or "null" when the header is absent
@@ -384,11 +417,16 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
         if (authzHeader == null) {
             return "null";
         }
-        final int index = authzHeader.indexOf(' ');
-        if (index <= 0) {
+        int index = 0;
+        while (index < authzHeader.length() && !Character.isWhitespace(authzHeader.charAt(index))) {
+            index++;
+        }
+        // Nothing before the first whitespace, or no whitespace at all, means no scheme can be
+        // named without echoing part of the credential.
+        if (index == 0 || index == authzHeader.length()) {
             return "***";
         }
-        return authzHeader.substring(0, index) + " ***";
+        return sanitizeForLog(authzHeader.substring(0, index)) + " ***";
     }
 
     /**
@@ -614,7 +652,7 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             }
         }
         if (allowedRealms.isEmpty()) {
-            logger.warn("No allowed Kerberos realm could be determined; accepting realm={} without validation.", realm);
+            logger.warn("No allowed Kerberos realm could be determined; accepting realm={} without validation.", sanitizeForLog(realm));
             return true;
         }
         return allowedRealms.stream().anyMatch(r -> r.equalsIgnoreCase(realm));

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
@@ -23,6 +23,7 @@ import java.util.Base64;
 
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.exception.SsoLoginException;
+import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.spnego.SpnegoHttpFilter.Constants;
@@ -55,8 +56,21 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
                 (proxy, method, args) -> "getHeader".equals(method.getName()) ? value : null);
     }
 
+    /**
+     * Encodes credentials only. Header separator tests must build their header literally, because
+     * {@link #basic(String)} hardcodes a single space and would hide the very divergence they check.
+     */
+    private static String token(final String credentials) {
+        return Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
     private static String basic(final String credentials) {
-        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + token(credentials);
+    }
+
+    /** Builds a one-character string without a source escape, keeping raw break characters out of this file. */
+    private static String ch(final int codePoint) {
+        return String.valueOf((char) codePoint);
     }
 
     @Test
@@ -83,6 +97,39 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getBasicRealm_separatorMatchesLibraryParsing() {
+        // SpnegoProvider#parseAuthHeader matches the scheme case-insensitively and then skips a run
+        // of any whitespace, possibly empty. Every header below is authenticated by the library, so
+        // each one has to yield its realm here as well; a header this check cannot read is a header
+        // the spnego.allowed.realms list cannot govern. These are built literally on purpose.
+        final String credentials = token("alice@PARTNER.COM:secret");
+        assertEquals("PARTNER.COM", SpnegoAuthenticator.getBasicRealm("Basic " + credentials));
+        assertEquals("PARTNER.COM", SpnegoAuthenticator.getBasicRealm("Basic\t" + credentials));
+        assertEquals("PARTNER.COM", SpnegoAuthenticator.getBasicRealm("Basic\t " + credentials));
+        // No separator at all: the library takes everything after the scheme as the token.
+        assertEquals("PARTNER.COM", SpnegoAuthenticator.getBasicRealm("Basic" + credentials));
+        assertEquals("PARTNER.COM", SpnegoAuthenticator.getBasicRealm("basic\t" + credentials));
+        assertEquals("PARTNER.COM", SpnegoAuthenticator.getBasicRealm("BASIC" + credentials));
+
+        // A user name without a realm names nothing to check, whichever separator was used.
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basic\t" + token("alice:secret")));
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basic" + token("CORP\\alice:secret")));
+    }
+
+    @Test
+    public void test_getBasicRealm_ignoresNonBasicAndTokenlessHeaders() {
+        // A Negotiate token is not Basic credentials; decoding it here would invent a realm from
+        // arbitrary bytes. The realm of that path comes from the principal after the handshake.
+        assertNull(SpnegoAuthenticator.getBasicRealm("Negotiate " + token("alice@PARTNER.COM:secret")));
+        // A scheme with no token authenticates nobody, so there is no realm to reject.
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basic"));
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basic   "));
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basic\t"));
+        assertNull(SpnegoAuthenticator.getBasicRealm(""));
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basi"));
+    }
+
+    @Test
     public void test_sanitizeForLog() {
         assertEquals("CORP.EXAMPLE", SpnegoAuthenticator.sanitizeForLog("CORP.EXAMPLE"));
         // A newline would otherwise let an unauthenticated client forge a log line.
@@ -105,6 +152,23 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
         assertTrue(e.getMessage().contains("FOREIGN.EXAMPLE"));
         assertTrue(e.getMessage().contains("spnego.allowed.realms"));
         // The decoded token holds the password; it must never reach the message or the log.
+        assertFalse(e.getMessage().contains("secret"));
+    }
+
+    @Test
+    public void test_rejectDisallowedBasicRealm_rejectsForeignRealmBehindNonSpaceSeparator() {
+        final SpnegoAuthenticator authenticator = new SpnegoAuthenticator() {
+            @Override
+            protected boolean isAllowedRealm(final String realm) {
+                return false;
+            }
+        };
+        // The library authenticates a tab-separated header, so the allow list has to reach it too.
+        // SsoStateException, not a plain SsoLoginException: /sso is anonymous, and SsoAction logs a
+        // full stack trace for anything else, which one crafted header per request would exploit.
+        final SsoStateException e = assertThrows(SsoStateException.class,
+                () -> authenticator.rejectDisallowedBasicRealm(requestWithAuthz("Basic\t" + token("alice@FOREIGN.EXAMPLE:secret"))));
+        assertTrue(e.getMessage().contains("FOREIGN.EXAMPLE"));
         assertFalse(e.getMessage().contains("secret"));
     }
 
@@ -333,6 +397,33 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
         assertEquals("***", SpnegoAuthenticator.maskAuthzHeader("dXNlcjpwYXNzd29yZA=="));
         assertEquals("***", SpnegoAuthenticator.maskAuthzHeader(""));
         assertEquals("***", SpnegoAuthenticator.maskAuthzHeader(" leading-space"));
+    }
+
+    @Test
+    public void test_sanitizeForLog_unicodeLineBreaks() {
+        // \p{Cntrl} without the UNICODE flag covers ASCII only, so these three would otherwise reach
+        // the log intact and let an unauthenticated client forge a line in it.
+        assertEquals("EVIL?WARN forged", SpnegoAuthenticator.sanitizeForLog("EVIL" + ch(0x0085) + "WARN forged"));
+        assertEquals("EVIL?WARN forged", SpnegoAuthenticator.sanitizeForLog("EVIL" + ch(0x2028) + "WARN forged"));
+        assertEquals("EVIL?WARN forged", SpnegoAuthenticator.sanitizeForLog("EVIL" + ch(0x2029) + "WARN forged"));
+    }
+
+    @Test
+    public void test_maskAuthzHeader_boundsAndSanitizesTheScheme() {
+        // The surviving scheme is client-controlled and ends up in an exception message that is
+        // logged, so it is bounded like the realm instead of echoing up to the container's header
+        // limit.
+        final String masked = SpnegoAuthenticator.maskAuthzHeader("S".repeat(8192) + " dXNlcjpwYXNzd29yZA==");
+        assertEquals(SpnegoAuthenticator.MAX_LOGGED_REALM_LENGTH + 3 + 4, masked.length());
+        assertTrue(masked.endsWith("... ***"));
+
+        // Neither NUL nor NEL is whitespace, so both survive the scheme scan and have to be
+        // stripped before the value is logged.
+        assertEquals("Ba?ic ***", SpnegoAuthenticator.maskAuthzHeader("Ba" + ch(0x0000) + "ic dXNlcjpwYXNzd29yZA=="));
+        assertEquals("Ba?ic ***", SpnegoAuthenticator.maskAuthzHeader("Ba" + ch(0x0085) + "ic dXNlcjpwYXNzd29yZA=="));
+
+        // A tab-separated header names its scheme rather than degrading to a bare mask.
+        assertEquals("Basic ***", SpnegoAuthenticator.maskAuthzHeader("Basic\tdXNlcjpwYXNzd29yZA=="));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`spnego.allowed.realms` can be bypassed on the Basic authentication fallback.

`getBasicRealm` splits the `Authorization` header on a literal space. The spnego library's `SpnegoProvider#parseAuthHeader` does not: it matches the scheme case-insensitively with `regionMatches`, then skips a run of *any* `Character.isWhitespace` — a run that may be empty.

So a client that separates the scheme from the token with a tab, or with no separator at all, is authenticated normally by the library while this check reads no realm and the allow list is never applied.

`rejectDisallowedBasicRealm` is the only enforcement point on this path. The check that runs after authentication cannot help: the library builds the principal as `typed-name@server-realm`, and `KerberosPrincipal` collapses `alice@FOREIGN@SERVER` down to `alice@SERVER`, so the post-authentication check always sees the server realm.

Effect when `sso.type=spnego` and `spnego.allow.basic=true` (the default), over HTTPS: a user from a realm that was never allow-listed is admitted under the bare short name and resolves to the same-named local user, inheriting its groups, roles and document permissions. This contradicts the documented behaviour that the allow list also covers the Basic fallback.

## Change

`getBasicRealm` now separates the scheme from the token exactly the way the library does. Everything after the Base64 decode is unchanged. A comment records that the two parsers must not diverge and why.

Three related hardening fixes on the same anonymous path:

- **Realm rejection throws `SsoStateException`** instead of a plain `SsoLoginException`. `/sso` is anonymous and `SsoAction.index()` logs anything else with a full stack trace, so one crafted header per request was enough to fill the log. `SsoStateException` extends `SsoLoginException` and exists for exactly this distinction; neither exception carries a cause, so no diagnostic detail is lost.
- **`maskAuthzHeader` bounds and sanitizes the scheme** it echoes. The scheme is client-controlled and was copied into a logged exception message with no length cap and no control-character stripping, while the realm path was already bounded to 64 characters. Its scheme detection now matches the parser above, so a tab-separated header reports its scheme instead of degrading to `***`.
- **`sanitizeForLog` covers Unicode line breaks.** `\p{Cntrl}` without the Unicode flag is ASCII-only, so U+0085, U+2028 and U+2029 passed through into the log. The regex is also precompiled instead of being rebuilt on every call.

`isAllowedRealm`'s fail-open warning now sanitizes the realm as well. That branch is unreachable today because a `KerberosPrincipal` cannot carry a blank realm, but it is now fed attacker-controlled input.

## Tests

`SpnegoAuthenticatorTest` 24 -> 29; `Spnego*Test` 31 total, all green.

The existing `basic()` helper hardcodes `"Basic " + base64`, and every previous `getBasicRealm` test went through it — which is why the divergence was not caught. The new separator tests build their headers literally and cover a tab, a tab plus a space, no separator at all, a lowercase scheme and an uppercase scheme, plus the negative cases (a `Negotiate` header, a scheme with no token, a truncated scheme).

Reverting only the parsing change turns two of them red: the tab vector reads `null` instead of `PARTNER.COM`, and `rejectDisallowedBasicRealm` throws nothing at all for a header the library would authenticate.

A differential check against the released library jar — comparing, for each header shape, the realm the library would authenticate against with the realm this method reports — now shows no disagreement across 16 shapes, including vertical tab, form feed, U+001C, U+2028 and mixed whitespace runs.
