### PR TITLE
fix(sso): publish the lazily computed SAML and OIDC permission caches safely

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/login/OpenIdConnectCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/OpenIdConnectCredential.java
@@ -119,8 +119,17 @@ public class OpenIdConnectCredential implements LoginCredential, FessCredential 
         /** The user roles. */
         protected String[] roles;
 
-        /** The user permissions. */
-        protected String[] permissions;
+        /**
+         * The user permissions.
+         *
+         * <p>Lazily computed by {@link #getPermissions()} and never invalidated afterwards.
+         * {@code volatile} for the same reason as in
+         * {@link org.codelibs.fess.app.web.base.login.SamlCredential.SamlUser}: the enclosing bean is
+         * a session attribute shared by concurrent requests, and the array is written after the
+         * session publication, so an unsynchronized reader could see the reference before the
+         * elements.</p>
+         */
+        protected volatile String[] permissions;
 
         /**
          * Creates a new OpenID Connect user.

--- a/src/main/java/org/codelibs/fess/app/web/base/login/SamlCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/SamlCredential.java
@@ -143,8 +143,17 @@ public class SamlCredential implements LoginCredential, FessCredential {
 
         /**
          * The permissions of the user.
+         *
+         * <p>Lazily computed by {@link #getPermissions()} and never invalidated afterwards.
+         * {@code volatile} because the enclosing {@link org.codelibs.fess.mylasta.action.FessUserBean}
+         * is a session attribute read by every concurrent request of that session, while the array
+         * is written on whichever thread calls {@code getPermissions()} first. That write is not
+         * ordered by the session publication -- LastaFlute stores the bean before the login success
+         * callback that warms this cache -- so without {@code volatile} a request already in flight
+         * could observe the reference while the elements are still unwritten and see an incomplete
+         * permission set. Two threads racing to compute it is harmless; they produce equal arrays.</p>
          */
-        protected String[] permissions;
+        protected volatile String[] permissions;
 
         /**
          * The name ID of the user.


### PR DESCRIPTION
Found while reviewing `src/main/java/org/codelibs/fess/sso/saml` for 15.8. Not a 15.8 regression -- it predates the SAML work -- but the fix is one keyword per class and brings the two remaining SSO users in line with `EntraIdCredential`, which already does this.

## The race

`SamlCredential.SamlUser#getPermissions()` and `OpenIdConnectCredential.OpenIdUser#getPermissions()` are check-then-act lazy caches over a plain field:

```java
if (permissions == null) {
    ...
    permissions = permissionSet.toArray(new String[permissionSet.size()]);
}
return permissions;
```

The instance is genuinely shared across threads: `FessUserBean` wraps the `FessUser`, and LastaFlute stores the bean as a session attribute, so every concurrent request of that session reads it -- `RoleQueryHelper` and `ViewHelper` call `getPermissions()` on each search.

There is no pre-existing happens-before covering the array write. `TypicalLoginAssist#loginRedirect` runs `doLogin(...)` -- hence `sessionManager.setAttribute(...)` -- **before** the login success callback, and that callback is where the cache is first warmed (`SsoAction` -> `ActivityHelper#login` -> `u.getPermissions()`). The bean is never re-published afterwards: `FessBaseAction.godHandPrologue` calls `refresh()`, which does not `setAttribute` again, and neither `SamlUser` nor `OpenIdUser` overrides `refresh()`.

So a request already in flight for the same session can read the reference while the elements are still unwritten, and see an incomplete permission set. Fewer permissions, never more, so it fails closed -- a search silently returns too few documents rather than too many. The window is narrow, the cache is warmed on the login thread, and on x86 TSO you will essentially never observe it; on weaker memory models it is reachable.

## The fix

Mark the field `volatile` in both classes, matching `EntraIdCredential.EntraIdUser`, which already declares `groups`/`roles`/`permissions` `volatile`.

`volatile` alone is sufficient here. Entra ID additionally synchronizes `getPermissions()` because `setGroups`/`setRoles`/`resetPermissions` can invalidate the cache mid-session, and a slow reader could otherwise overwrite a freshly reset value. Neither `SamlUser` nor `OpenIdUser` ever invalidates, so two threads racing to compute produce equal arrays and the last write wins harmlessly.

## Verification

- `mvn -o clean test -Dtest='org.codelibs.fess.app.web.base.login.*Test,org.codelibs.fess.sso.**.*Test'` -- 246 tests, 0 failures.
- `mvn -o clean javadoc:jar` -- success (CI runs this; `clean` matters, a stale `target/` gives a false pass).
- `mvn formatter:format && mvn license:format` -- no incidental reformatting.

No test is added: a memory-visibility fix has no deterministic unit test, and asserting on `volatile` via reflection would pin the mechanism rather than the behaviour.
