### PR TITLE
fix(sso): recover an Entra ID session whose access token expired

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
@@ -83,6 +83,20 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
          */
         protected static final long REFRESH_MARGIN = 5 * 60 * 1000L;
 
+        /**
+         * How long a silent acquisition that failed is left alone before another one is attempted
+         * for this session. A refresh token that has been revoked, an account that has been
+         * disabled, and an account a {@code logout()} elsewhere evicted from the shared MSAL4J
+         * cache all fail for good, and {@link #refresh()} runs on every action request, so
+         * retrying one unconditionally would put back the per-request round trip
+         * {@link #REFRESH_MARGIN} was introduced to remove. A minute matches the backoff
+         * {@code EntraIdAuthenticator} applies to a throttled Microsoft Graph, holds a session
+         * whose renewal cannot succeed to one acquisition a minute rather than one per request,
+         * and is short enough that a failure early in {@link #REFRESH_MARGIN} still leaves four
+         * more attempts before the token actually expires.
+         */
+        protected static final long RENEWAL_THROTTLE_INTERVAL = 60 * 1000L;
+
         /** User's group memberships. */
         protected volatile String[] groups;
 
@@ -127,6 +141,14 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
          * already hold instead of queueing behind an acquisition that can take tens of seconds.
          */
         private final AtomicBoolean refreshing = new AtomicBoolean();
+
+        /**
+         * Point in time, as epoch milliseconds, until which {@link #refresh()} attempts no further
+         * silent acquisition. Zero means none has failed yet. Written by whichever request thread
+         * ran the failing acquisition while the other request threads sharing this session-scoped
+         * instance keep reading it, hence volatile.
+         */
+        protected volatile long renewalThrottledUntil;
 
         /**
          * Constructs an Entra ID user with the authentication result.
@@ -197,13 +219,8 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
             // Check if token is still valid by comparing absolute timestamps
             final long tokenExpiryTime = authResult.expiresOnDate().getTime(); // milliseconds since epoch
             final long currentTime = ComponentUtil.getSystemHelper().getCurrentTimeAsLong(); // milliseconds since epoch
-            if (tokenExpiryTime < currentTime) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Token expired: expiryTime={}, currentTime={}", tokenExpiryTime, currentTime);
-                }
-                return false;
-            }
-            if (tokenExpiryTime - currentTime > REFRESH_MARGIN) {
+            final boolean expired = tokenExpiryTime < currentTime;
+            if (!expired && tokenExpiryTime - currentTime > REFRESH_MARGIN) {
                 // FessBaseAction.godHandPrologue calls this on every action request; a silent
                 // acquisition is a network call, so it must not happen per request. Until the
                 // token is close to expiring there is nothing to acquire, and the groups this
@@ -212,6 +229,24 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                     logger.debug("Token is still valid for {}ms. Skipping silent authentication.", tokenExpiryTime - currentTime);
                 }
                 return true;
+            }
+            // An expired access token still goes through the acquisition below rather than
+            // straight out of here. MSAL4J's silent flow spends the cached refresh token, which
+            // outlives the access token by hours, so a user who was idle across the expiry is
+            // recoverable -- and giving up instead was permanent, because godHandPrologue
+            // discards this result: nothing logged the user out, and every later request took the
+            // same early exit, so the session kept a dead token and stopped re-reading its group
+            // memberships for as long as it lasted.
+            //
+            // Attempting it is not free, though: an acquisition that cannot succeed would be
+            // repeated on every request of a session that keeps searching, so one failure holds
+            // the next attempt off for RENEWAL_THROTTLE_INTERVAL.
+            if (isRenewalThrottled(currentTime)) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("A silent authentication has just failed. Not retrying before {}. expired={}", renewalThrottledUntil,
+                            expired);
+                }
+                return !expired;
             }
             // Lastaflute keeps one FessUserBean -- and therefore one EntraIdUser -- as a session
             // attribute, and FessBaseAction.godHandPrologue calls refresh() on every action
@@ -227,15 +262,16 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Another request is already renewing the token. Skipping silent authentication.");
                 }
-                // The token this thread holds has not expired yet -- the check above proved it --
-                // so the request may proceed while the winner renews.
-                return true;
+                // A token that has not expired yet lets this request proceed while the winner
+                // renews. An expired one does not, and whether the winner recovers it is not this
+                // thread's to report.
+                return !expired;
             }
             // Attempt to refresh token using MSAL4J silent authentication
             try {
                 final EntraIdAuthenticator authenticator = ComponentUtil.getComponent(EntraIdAuthenticator.class);
                 final IAuthenticationResult newResult = authenticator.refreshTokenSilently(this);
-                if (newResult != null) {
+                if (newResult != null && newResult.expiresOnDate().getTime() >= currentTime) {
                     // MSAL4J rounds its own buffer down to whole seconds, so for up to a second
                     // either side of REFRESH_MARGIN it hands back the token it already had.
                     // Re-reading the directory for a token that did not change would put the
@@ -252,16 +288,54 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                     }
                     return true;
                 }
+                // refreshTokenSilently answers null instead of throwing, so a revoked refresh
+                // token, a disabled account, and an account evicted from the shared MSAL4J cache
+                // all arrive here rather than in the catch below. A result that is itself already
+                // expired is treated the same way: keeping it would leave nothing to renew from
+                // and no record that the renewal has to be held off.
+                applyRenewalThrottle(currentTime);
+                logger.warn("Silent authentication returned no usable access token for {}. expired={}. Next attempt in {} seconds.",
+                        getName(), expired, RENEWAL_THROTTLE_INTERVAL / 1000L);
             } catch (final Exception e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Silent token refresh failed: {}", e.getMessage());
-                }
+                // At WARN, not DEBUG: this is the same anti-pattern #3218 removed from
+                // getLoginCredential, where a login that failed was invisible unless debug
+                // logging happened to be on. The throttle applied first is what keeps a
+                // persistent failure to one line per interval instead of one per request.
+                applyRenewalThrottle(currentTime);
+                logger.warn("Failed to renew the access token of {}. expired={}. Next attempt in {} seconds.", getName(), expired,
+                        RENEWAL_THROTTLE_INTERVAL / 1000L, e);
             } finally {
                 refreshing.set(false);
             }
-            // For MSAL4J, if silent refresh fails, return true if token is still valid
-            // Actual refresh will happen during next authentication request
-            return true;
+            // The silent acquisition produced nothing. A token that has not expired yet still
+            // authorises this request and MSAL4J is asked again once the throttle lapses, but an
+            // expired one leaves nothing to carry on with.
+            return !expired;
+        }
+
+        /**
+         * Returns whether a silent acquisition failed recently enough that another one has to wait.
+         *
+         * @param currentTime The current time in epoch milliseconds.
+         * @return True while the silent acquisition has to be skipped.
+         */
+        protected boolean isRenewalThrottled(final long currentTime) {
+            final long until = renewalThrottledUntil;
+            return until > 0L && currentTime < until;
+        }
+
+        /**
+         * Records that a silent acquisition produced no usable token, so that the requests this
+         * session makes over the next {@link #RENEWAL_THROTTLE_INTERVAL} do not repeat it.
+         *
+         * <p>Shaped after {@code EntraIdAuthenticator#applyGraphThrottle}, with a fixed interval
+         * rather than a negotiated one: MSAL4J reports the failure as a null result, so there is
+         * no {@code Retry-After} to read.
+         *
+         * @param currentTime The current time in epoch milliseconds.
+         */
+        protected void applyRenewalThrottle(final long currentTime) {
+            renewalThrottledUntil = currentTime + RENEWAL_THROTTLE_INTERVAL;
         }
 
         /**

--- a/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.fess.app.web.base.login.EntraIdCredential.EntraIdUser;
@@ -357,5 +358,215 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
         final String[] afterPermissions = user.getPermissions();
         assertTrue("resolved-group missing from " + Arrays.toString(afterPermissions),
                 Arrays.stream(afterPermissions).anyMatch(p -> p.contains("resolved-group")));
+    }
+
+    /**
+     * Registers a SystemHelper whose clock the test drives, the way EntraIdAuthenticatorTest does.
+     */
+    private void registerClock(final AtomicLong clock) {
+        ComponentUtil.register(new SystemHelper() {
+            @Override
+            public long getCurrentTimeAsLong() {
+                return clock.get();
+            }
+        }, "systemHelper");
+    }
+
+    @Test
+    public void test_refresh_attemptsARenewalWhenTheTokenHasExpired() {
+        // FessBaseAction.godHandPrologue discards this result, so returning false without asking
+        // MSAL4J for anything never ended the session: it left it holding a dead access token and
+        // taking the same early exit on every later request, which is what stopped its group
+        // memberships from ever being re-read again. MSAL4J's silent flow spends the cached
+        // refresh token, which outlives the access token by hours, so an expired access token is
+        // precisely the case worth one attempt.
+        final AtomicLong clock = new AtomicLong(1_700_000_000_000L);
+        registerClock(clock);
+        final AtomicInteger acquisitions = new AtomicInteger();
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void scheduleUpdateMemberOf(final EntraIdUser user) {
+                // the constructor must not reach Microsoft Graph. Overriding the scheduling and
+                // not updateMemberOf: the base implementation hands a real task to TimeoutManager,
+                // so overriding only the body still leaves a timer thread racing this test.
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                acquisitions.incrementAndGet();
+                return null;
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+
+        final EntraIdUser user = new EntraIdUser(authResult(new Date(clock.get() - 1L), "expired-access-token"));
+
+        // The acquisition failed, so the token really is dead and refresh() says so.
+        assertFalse(user.refresh());
+        assertEquals(1, acquisitions.get(), "an expired access token must not be given up on without asking MSAL4J");
+    }
+
+    @Test
+    public void test_refresh_recoversASessionWhoseTokenExpired() {
+        // The user was idle across the expiry -- with REFRESH_MARGIN in place their last request
+        // can easily have fallen before the renewal window -- and comes back. The cached refresh
+        // token is still good, so the session carries on with a live token and re-read groups.
+        final AtomicLong clock = new AtomicLong(1_700_000_000_000L);
+        registerClock(clock);
+        final AtomicInteger memberOfCalls = new AtomicInteger();
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void scheduleUpdateMemberOf(final EntraIdUser user) {
+                // The renewal schedules the re-resolution rather than running it: refresh() is on
+                // a request thread and updateMemberOf reaches Microsoft Graph. Counting the
+                // scheduling is what pins that the re-read is requested at all.
+                memberOfCalls.incrementAndGet();
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                return authResult(new Date(clock.get() + 60 * 60 * 1000L), "renewed-access-token");
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+
+        final EntraIdUser user = new EntraIdUser(authResult(new Date(clock.get() - 1L), "expired-access-token"));
+        // The constructor schedules the first resolution; only what refresh() adds is under test.
+        memberOfCalls.set(0);
+
+        assertTrue(user.refresh());
+        assertEquals("renewed-access-token", user.getAuthenticationResult().accessToken());
+        assertEquals(1, memberOfCalls.get(), "a recovered session must re-read its group memberships");
+    }
+
+    @Test
+    public void test_refresh_holdsOffAFailingRenewalUntilTheThrottleLapses() {
+        // A revoked refresh token, a disabled account, and an account a logout on another session
+        // evicted from the shared MSAL4J cache all fail for good, and refresh() runs on every
+        // action request. Retrying unconditionally would put back exactly the per-request round
+        // trip REFRESH_MARGIN was introduced to remove.
+        final AtomicLong clock = new AtomicLong(1_700_000_000_000L);
+        registerClock(clock);
+        final AtomicInteger acquisitions = new AtomicInteger();
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void scheduleUpdateMemberOf(final EntraIdUser user) {
+                // the constructor must not reach Microsoft Graph. Overriding the scheduling and
+                // not updateMemberOf: the base implementation hands a real task to TimeoutManager,
+                // so overriding only the body still leaves a timer thread racing this test.
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                acquisitions.incrementAndGet();
+                return null;
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+
+        final EntraIdUser user = new EntraIdUser(authResult(new Date(clock.get() - 1L), "expired-access-token"));
+
+        assertFalse(user.refresh());
+        assertEquals(1, acquisitions.get(), "the first request after the expiry must attempt a renewal");
+
+        // The rest of the requests this session makes inside the interval.
+        assertFalse(user.refresh());
+        clock.addAndGet(EntraIdUser.RENEWAL_THROTTLE_INTERVAL - 1L);
+        assertFalse(user.refresh());
+        assertEquals(1, acquisitions.get(), "a renewal that failed must not be retried on every request");
+
+        // ... and the first one after it.
+        clock.addAndGet(1L);
+        assertFalse(user.refresh());
+        assertEquals(2, acquisitions.get(), "the throttle must lapse rather than give up for good");
+    }
+
+    @Test
+    public void test_refresh_doesNotStampedeWhenConcurrentRequestsFindAnExpiredToken() throws Exception {
+        // The concurrency guard has to cover the expired token as well, not just the renewal
+        // window: godHandPrologue calls refresh() on every action request, so the requests a
+        // session has in flight when it comes back after the expiry arrive here together, and
+        // each of them would otherwise run its own acquisition and its own synchronous Microsoft
+        // Graph call behind updateMemberOf.
+        final AtomicLong clock = new AtomicLong(1_700_000_000_000L);
+        registerClock(clock);
+        final AtomicInteger acquisitions = new AtomicInteger();
+        final AtomicInteger memberOfCalls = new AtomicInteger();
+        final CountDownLatch winnerIsAcquiring = new CountDownLatch(1);
+        final CountDownLatch loserIsDone = new CountDownLatch(1);
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void scheduleUpdateMemberOf(final EntraIdUser user) {
+                // The scheduling is what refresh() does -- it runs on a request thread and
+                // updateMemberOf reaches Microsoft Graph. Counting the base implementation's
+                // TimeoutManager task instead would race this assertion.
+                memberOfCalls.incrementAndGet();
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                acquisitions.incrementAndGet();
+                // Hold the acquisition open the way a real MSAL4J round trip does, so the second
+                // request reaches refresh() while this one is still inside it.
+                winnerIsAcquiring.countDown();
+                try {
+                    loserIsDone.await(10L, TimeUnit.SECONDS);
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return authResult(new Date(clock.get() + 60 * 60 * 1000L), "renewed-access-token");
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+
+        final EntraIdUser user = new EntraIdUser(authResult(new Date(clock.get() - 1L), "expired-access-token"));
+        memberOfCalls.set(0);
+
+        final AtomicBoolean winnerResult = new AtomicBoolean();
+        final Thread winner = new Thread(() -> winnerResult.set(user.refresh()));
+        winner.start();
+        assertTrue(winnerIsAcquiring.await(10L, TimeUnit.SECONDS));
+
+        // The session's second concurrent request. It holds nothing valid, so it reports that,
+        // but it must not start a second acquisition of its own.
+        assertFalse(user.refresh());
+        assertEquals(1, acquisitions.get(), "a concurrent refresh must not start a second silent acquisition");
+        loserIsDone.countDown();
+        winner.join(10000L);
+
+        assertTrue(winnerResult.get());
+        assertEquals(1, memberOfCalls.get(), "a concurrent refresh must not make a second Microsoft Graph round trip");
+        assertEquals("renewed-access-token", user.getAuthenticationResult().accessToken());
+    }
+
+    @Test
+    public void test_refresh_holdsOffAfterAnExceptionToo() {
+        // The exception path has to back off as well, otherwise the failure it now reports at
+        // WARN -- refreshTokenSilently swallows its own, so in production this is updateMemberOf
+        // or the component lookup throwing -- is written once per request rather than once per
+        // interval, which is exactly the noise the throttle is there to prevent.
+        final AtomicLong clock = new AtomicLong(1_700_000_000_000L);
+        registerClock(clock);
+        final AtomicInteger acquisitions = new AtomicInteger();
+        ComponentUtil.register(new EntraIdAuthenticator() {
+            @Override
+            public void scheduleUpdateMemberOf(final EntraIdUser user) {
+                // the constructor must not reach Microsoft Graph. Overriding the scheduling and
+                // not updateMemberOf: the base implementation hands a real task to TimeoutManager,
+                // so overriding only the body still leaves a timer thread racing this test.
+            }
+
+            @Override
+            public IAuthenticationResult refreshTokenSilently(final EntraIdUser user) {
+                acquisitions.incrementAndGet();
+                throw new IllegalStateException("the directory could not be reached");
+            }
+        }, EntraIdAuthenticator.class.getCanonicalName());
+
+        final EntraIdUser user = new EntraIdUser(authResult(new Date(clock.get() - 1L), "expired-access-token"));
+
+        assertFalse(user.refresh());
+        assertFalse(user.refresh());
+        assertEquals(1, acquisitions.get(), "a renewal that threw must not be retried on every request");
+
+        clock.addAndGet(EntraIdUser.RENEWAL_THROTTLE_INTERVAL);
+        assertFalse(user.refresh());
+        assertEquals(2, acquisitions.get(), "the throttle must lapse rather than give up for good");
     }
 }


### PR DESCRIPTION

## Problem

`refresh()` gave up the moment the access token was past its expiry:

```java
if (tokenExpiryTime < currentTime) {
    return false;
}
```

`FessBaseAction.godHandPrologue` is the only caller of `FessUser.refresh()` in the whole tree — `refresh()` is declared on Fess's own `org.codelibs.fess.entity.FessUser`, so LastaFlute cannot call it — and it assigns the result to a local that is only debug-logged. So `false` never logged anyone out. The session simply kept a dead access token, and because every later request took the same early exit, no further silent acquisition was ever attempted and the user's group memberships stopped being re-read for the rest of the session.

That early exit is byte-identical to 15.7, so it is not itself new. What changed is how easy it is to reach. 15.7 ran a silent acquisition on **every** request, so any request before expiry renewed the token. Since #3243 one is attempted only inside the last five minutes, which is the right fix for the per-request Graph call it removed, but it means a user idle across that margin now lands in the dead state 15.7 kept them out of.

## Change

An expired access token goes through the acquisition instead of straight out. MSAL4J's silent flow spends the cached refresh token, which outlives the access token by hours, so the session is usually recoverable.

Attempting it unconditionally would put the per-request round trip straight back, because several failures are permanent: a revoked refresh token, a disabled account, and an account a `logout()` on another session evicted from the shared MSAL4J cache. One failure therefore holds the next attempt off for a minute — the same interval `EntraIdAuthenticator` uses for a throttled Microsoft Graph, and short enough that a failure early in the five-minute margin still leaves four more attempts before the token actually expires.

The return value is deliberately conservative: every path that used to return `true` still returns `true`, and every path that used to return `false` still returns `false`. Only "expired, then successfully renewed" changes. That is expressed as `return !expired` at the three exits, so the CAS loser and the post-failure exit report what this thread can actually vouch for rather than what the winner might achieve.

A silent result whose own expiry is already past is treated as a failure, so no path can leave the session holding a dead token without also recording the backoff.

## Logging

Both failure paths now log at WARN. This is the anti-pattern #3218 removed from `getLoginCredential`, where a failure was invisible unless debug logging happened to be on.

It is worth being precise about which path mattered: `refreshTokenSilently` catches `Exception` itself and returns `null`, so the dominant failure mode never reached the `catch` clause at all and fell through to `return true` with **no** logging at any level. Raising only the `catch` would have left the real failure invisible, so both are raised. The backoff is what keeps a permanently failing session to one line per minute instead of one per request.

One intended side effect: an in-margin acquisition failure now also logs, where it previously logged nothing. `expired=` in the message distinguishes the two.

## Verification

```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0 -- EntraIdUserPermissionTest (3 before)
Tests run: 94, Failures: 0, Errors: 0, Skipped: 0 -- sso.entraid
```

Each new test was checked against the unfixed class first (restored from `HEAD`) and fails there with the symptom it describes:

- `attemptsARenewalWhenTheTokenHasExpired` — `an expired access token must not be given up on without asking MSAL4J ==> expected: <1> but was: <0>`
- `recoversASessionWhoseTokenExpired` — `expected: <true> but was: <false>`
- `holdsOffAFailingRenewalUntilTheThrottleLapses` — `expected: <1> but was: <0>`
- `doesNotStampedeWhenConcurrentRequestsFindAnExpiredToken` — the latch timed out because the winner never entered the acquisition

Because the unfixed code never attempts a renewal at all, those failures alone would not prove the throttle and the CAS guard are load-bearing, so each was also mutation-tested against the fixed code: disabling the throttle check gives `expected: <1> but was: <3>`; disabling the CAS guard fails the stampede test; removing the throttle from the `catch` alone gives `expected: <1> but was: <2>`. All mutations were reverted.

The WARN was confirmed to render in `target/logs/fess.log`, where `org.codelibs` logs: `Silent authentication returned no usable access token for ... expired=true. Next attempt in 60 seconds.`

`mvn formatter:format` and `license:format` report no changes.

## Follow-ups not in this PR

- `EntraIdAuthenticator.refreshTokenSilently` swallows every exception into `null` and a DEBUG line, which is why the new WARN can only say "no usable token" and never why — revoked, network, or timeout. Letting it throw, or logging the MSAL error code there, would make this message actionable.
- `godHandPrologue` still discards the boolean. Acting on `false` is a behaviour change that needs its own decision, and this PR deliberately does not make it.

