### PR TITLE
fix(sso): let a SAML session answer any AuthnRequest still in flight

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -18,9 +18,11 @@ package org.codelibs.fess.sso.saml;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -43,6 +45,7 @@ import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.saml2.Auth;
 import org.codelibs.saml2.core.authn.AuthnRequestParams;
+import org.codelibs.saml2.core.exception.ValidationException;
 import org.codelibs.saml2.core.logout.LogoutRequestParams;
 import org.codelibs.saml2.core.replay.InMemoryReplayCache;
 import org.codelibs.saml2.core.replay.ReplayCache;
@@ -170,8 +173,19 @@ public class SamlAuthenticator implements SsoAuthenticator {
     protected static final String SAML_PREFIX = "saml.";
 
     /**
-     * The session key holding the ID of the AuthnRequest sent to the IdP.
-     * The value is compared with the InResponseTo of the SAML response.
+     * The session key holding the IDs of the AuthnRequests sent to the IdP that have not been
+     * answered yet. Each ID is compared with the InResponseTo of the SAML response.
+     *
+     * <p>The value is a {@code Map<String, Long>} of AuthnRequest ID to the time it was created,
+     * not a single ID: a browser with several tabs open sends one AuthnRequest per tab, and a
+     * single slot means the second overwrites the first, after which the first assertion to come
+     * back consumes the slot, fails the InResponseTo comparison and takes both logins down with
+     * it. {@code FessSearchAction} redirects every unauthenticated page hit to {@code /sso/}, so
+     * that happens as soon as a session expires with more than one tab open.</p>
+     *
+     * <p>The key is unchanged from the release that stored a bare {@link String} here, so that an
+     * existing session keeps working across an upgrade; see {@link #getRequestIdMap(HttpSession)}
+     * for how such a value is migrated.</p>
      */
     protected static final String SAML_STATE = "SAML_STATE";
 
@@ -179,6 +193,28 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * The property key for the SAML SP base URL.
      */
     protected static final String SAML_SP_BASE_URL = "saml.sp.base.url";
+
+    /**
+     * The property key for how long, in seconds, an unanswered AuthnRequest ID stays usable.
+     */
+    protected static final String SAML_REQUEST_ID_TTL = "saml.request.id.ttl";
+
+    /**
+     * The time-to-live applied to an unanswered AuthnRequest ID when
+     * {@link #SAML_REQUEST_ID_TTL} is absent, blank or not a number. One hour, the same default
+     * {@code EntraIdAuthenticator} uses for an OpenID Connect state, and comfortably longer than
+     * any interactive login at an IdP.
+     */
+    protected static final String DEFAULT_REQUEST_ID_TTL = "3600";
+
+    /**
+     * Maximum number of unanswered AuthnRequest IDs kept per session. Every visit to
+     * {@code /sso/} without a SAML response stores one, and {@code /sso/} is anonymous and
+     * answers GET, so without a cap a page that embeds it as a sub-resource would grow the
+     * session attribute without bound. It also bounds the number of candidates
+     * {@link #processSamlResponse} tries.
+     */
+    protected int maxRequestIds = 10;
 
     private Map<String, Object> defaultSettings;
 
@@ -412,36 +448,22 @@ public class SamlAuthenticator implements SsoAuthenticator {
 
             if (containsSamlResponse(request)) {
                 final HttpSession session = request.getSession(false);
-                final String requestId = session == null ? null : (String) session.getAttribute(SAML_STATE);
-                if (StringUtil.isNotBlank(requestId)) {
-                    session.removeAttribute(SAML_STATE);
-                    try {
-                        final Auth auth = new Auth(getSettings(), request, response);
-                        auth.processResponse(requestId);
-
-                        if (!auth.isAuthenticated()) {
-                            final String errors = auth.getErrors().stream().collect(Collectors.joining(", "));
-                            if (auth.isDebugActive() && StringUtil.isNotBlank(auth.getLastErrorReason())) {
-                                logger.warn("Authentication Failure: {} - Reason: {}", errors, auth.getLastErrorReason());
-                            } else {
-                                logger.warn("Authentication Failure: {}", errors);
-                            }
+                if (session != null) {
+                    final Map<String, Long> requestIdMap = getRequestIdMap(session);
+                    removeExpiredRequestIds(requestIdMap);
+                    if (!requestIdMap.isEmpty()) {
+                        try {
+                            return processSamlResponse(request, response, requestIdMap);
+                        } catch (final Exception e) {
+                            logger.warn("Authentication failed.", e);
                             return null;
                         }
-
-                        return createLoginCredential(request, response, auth);
-                    } catch (final Exception e) {
-                        logger.warn("Authentication failed.", e);
-                        return null;
                     }
                 }
-                // The assertion arrived but the matching AuthnRequest ID is unreachable. Sending
-                // another AuthnRequest would come straight back here in the same state, looping
-                // forever, so fail once instead.
-                logger.warn("Received a SAML response with no matching AuthnRequest ID in the session."
-                        + " The assertion consumer service is a cross-site POST, which does not carry a SameSite=Lax cookie;"
-                        + " see tomcat.sameSiteCookies in tomcat_config.properties."
-                        + " An IdP-initiated (unsolicited) response is rejected for the same reason.");
+                // No session at all, or one that holds nothing still answerable: the assertion
+                // cannot be tied to an AuthnRequest this server sent, so it is refused rather
+                // than answered with another one.
+                logUnmatchedSamlResponse(0);
                 return null;
             }
 
@@ -449,13 +471,278 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 final Auth auth = new Auth(getSettings(), request, response);
                 final AuthnRequestParams authnRequestParams = new AuthnRequestParams(false, false, true);
                 final String loginUrl = auth.login(null, authnRequestParams, true);
-                request.getSession().setAttribute(SAML_STATE, auth.getLastRequestId());
+                storeRequestIdInSession(request.getSession(), auth.getLastRequestId());
                 return new ActionResponseCredential(() -> HtmlResponse.fromRedirectPathAsIs(loginUrl));
             } catch (final Exception e) {
                 throw new SsoLoginException("Invalid SAML redirect URL.", e);
             }
 
         }).orElse(null);
+    }
+
+    /**
+     * Answers a SAML response with the pending AuthnRequest it names.
+     *
+     * <p>{@code Auth.processResponse} takes exactly one AuthnRequest ID and compares it with the
+     * InResponseTo of the response, and java-saml 3.1.1 exposes no supported way of reading that
+     * InResponseTo beforehand: {@code SamlResponse} has no getter for it, and the only other
+     * route would be to base64-decode and parse the {@code SAMLResponse} parameter here, which
+     * would add an XML parsing surface -- and therefore an XXE surface -- to an endpoint that is
+     * anonymous by design. So the candidates are tried one at a time instead.</p>
+     *
+     * <p>That is cheap and, more importantly, safe, because of where the comparison sits in
+     * {@code SamlResponse.isValid}: it runs before signature validation and before the assertion
+     * ID is registered with the replay cache, so a candidate the response does not name fails
+     * fast and leaves no trace behind. A candidate that fails for any other reason has already
+     * passed the comparison, so there is nothing left to try and the loop stops there; that is
+     * also what keeps the reported error the real one rather than the InResponseTo mismatch of
+     * whichever candidate happened to be tried last.</p>
+     *
+     * <p>Only a response that authenticates consumes its AuthnRequest ID. Consuming it on failure
+     * as well would look tidier, but telling "named this ID and was then rejected" apart from
+     * "was rejected before the ID was even looked at" means enumerating java-saml's internal
+     * ordering of checks, and getting that wrong hands anyone who can reach the assertion
+     * consumer service -- a cross-site POST, since SAML requires {@code SameSite=none} -- a way
+     * to burn a pending login per request. The TTL and {@link #maxRequestIds} bound the map
+     * instead.</p>
+     *
+     * <p>With {@code saml.strict=false} the library skips the InResponseTo comparison entirely,
+     * so the first candidate either authenticates or fails for a real reason and no further
+     * candidate is tried. That matches the library's contract: without strict mode there is no
+     * InResponseTo binding to match against.</p>
+     *
+     * @param request The HTTP request carrying the SAML response.
+     * @param response The HTTP response.
+     * @param requestIdMap The pending AuthnRequest IDs of the session, already pruned of expired
+     *            entries. The matching entry is removed from it on success.
+     * @return The login credential, or null when the response is not accepted.
+     */
+    protected LoginCredential processSamlResponse(final HttpServletRequest request, final HttpServletResponse response,
+            final Map<String, Long> requestIdMap) {
+        Auth lastAuth = null;
+        for (final String requestId : getCandidateRequestIds(requestIdMap)) {
+            final Auth auth = createAuth(request, response);
+            auth.processResponse(requestId);
+            if (auth.isAuthenticated()) {
+                requestIdMap.remove(requestId);
+                return createLoginCredential(request, response, auth);
+            }
+            lastAuth = auth;
+            if (!isInResponseToMismatch(auth)) {
+                break;
+            }
+        }
+        if (lastAuth == null || isInResponseToMismatch(lastAuth)) {
+            logUnmatchedSamlResponse(requestIdMap.size());
+            return null;
+        }
+        final String errors = lastAuth.getErrors().stream().collect(Collectors.joining(", "));
+        if (lastAuth.isDebugActive() && StringUtil.isNotBlank(lastAuth.getLastErrorReason())) {
+            logger.warn("Authentication Failure: {} - Reason: {}", errors, lastAuth.getLastErrorReason());
+        } else {
+            logger.warn("Authentication Failure: {}", errors);
+        }
+        return null;
+    }
+
+    /**
+     * Creates the {@link Auth} that processes one candidate AuthnRequest ID.
+     *
+     * <p>A fresh instance per candidate is required, not an optimisation left undone:
+     * {@code Auth} accumulates its errors, its authenticated flag and its last validation
+     * exception across calls, so reusing one would report the first candidate's InResponseTo
+     * mismatch alongside whatever the matching candidate produced.</p>
+     *
+     * @param request The HTTP request.
+     * @param response The HTTP response.
+     * @return A new SAML authentication object.
+     */
+    protected Auth createAuth(final HttpServletRequest request, final HttpServletResponse response) {
+        return new Auth(getSettings(), request, response);
+    }
+
+    /**
+     * Returns the pending AuthnRequest IDs to try, most recently created first.
+     *
+     * <p>Most recent first because the overwhelmingly common case is a single login, whose ID is
+     * the newest one; every earlier entry is a tab or a visit the user abandoned. The list is
+     * capped at {@link #maxRequestIds} even though the map is already bounded on write, so that
+     * lowering the cap at runtime takes effect on the very next response rather than only once
+     * the surplus entries have been evicted.</p>
+     *
+     * @param requestIdMap The pending AuthnRequest IDs of the session.
+     * @return The AuthnRequest IDs to try, in the order they are tried.
+     */
+    protected List<String> getCandidateRequestIds(final Map<String, Long> requestIdMap) {
+        return requestIdMap.entrySet()
+                .stream()
+                .sorted(Comparator.comparingLong((final Map.Entry<String, Long> e) -> e.getValue()).reversed())
+                .limit(maxRequestIds)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns whether the given attempt failed only because the response names a different
+     * AuthnRequest, which is the one failure that says nothing about the response itself and is
+     * therefore worth retrying with the next candidate.
+     *
+     * @param auth The attempt that did not authenticate.
+     * @return true if the response's InResponseTo did not match the candidate that was tried.
+     */
+    protected boolean isInResponseToMismatch(final Auth auth) {
+        return auth.getLastValidationException() instanceof final ValidationException e
+                && e.getErrorCode() == ValidationException.WRONG_INRESPONSETO;
+    }
+
+    /**
+     * Logs the one line reported when a SAML response cannot be tied to an AuthnRequest this
+     * server sent.
+     *
+     * <p>It is a warning and not a redirect back to the IdP on purpose: answering an unmatched
+     * assertion with a fresh AuthnRequest sends the browser to an IdP that is already
+     * authenticated, which posts the same kind of unmatched assertion straight back, and the
+     * loop only ends when the browser gives up.</p>
+     *
+     * @param pendingCount How many pending AuthnRequest IDs the session held, so that a log can
+     *            tell a missing session cookie apart from a response that simply matched none of
+     *            several live logins.
+     */
+    protected void logUnmatchedSamlResponse(final int pendingCount) {
+        logger.warn("Received a SAML response with no matching AuthnRequest ID in the session ({} pending)."
+                + " The assertion consumer service is a cross-site POST, which does not carry a SameSite=Lax cookie;"
+                + " see tomcat.sameSiteCookies in tomcat_config.properties."
+                + " An IdP-initiated (unsolicited) response is rejected for the same reason.", pendingCount);
+    }
+
+    /**
+     * Records the ID of an AuthnRequest that has just been sent to the IdP, pruning the entries
+     * that can no longer be answered first.
+     *
+     * @param session The HTTP session.
+     * @param requestId The ID of the AuthnRequest sent to the IdP.
+     */
+    protected void storeRequestIdInSession(final HttpSession session, final String requestId) {
+        final Map<String, Long> requestIdMap = getRequestIdMap(session);
+        removeExpiredRequestIds(requestIdMap);
+        removeOldestRequestIds(requestIdMap, maxRequestIds - 1);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Storing AuthnRequest ID in session: {}", requestId);
+        }
+        requestIdMap.put(requestId, ComponentUtil.getSystemHelper().getCurrentTimeAsLong());
+    }
+
+    /**
+     * Returns the per-session map of unanswered AuthnRequest IDs, creating it if needed.
+     *
+     * <p>The map is concurrent, and the create is synchronized on the session, because the tabs
+     * that make several logins possible in the first place can also start them at the same
+     * moment: a plain {@code HashMap} created twice loses the ID one of them has to match
+     * later.</p>
+     *
+     * <p>Anything else found under the key is replaced rather than cast. A session that predates
+     * this change holds a bare {@link String} there, and blindly casting it would end the login
+     * with a {@link ClassCastException} rather than a message; that single ID is carried over so
+     * a login already in flight across the upgrade can still complete.</p>
+     *
+     * @param session The HTTP session.
+     * @return The AuthnRequest ID map held by the session, keyed by ID and valued with the time
+     *         the ID was created.
+     */
+    protected Map<String, Long> getRequestIdMap(final HttpSession session) {
+        synchronized (session) {
+            final Object stored = session.getAttribute(SAML_STATE);
+            if (stored instanceof ConcurrentHashMap) {
+                @SuppressWarnings("unchecked")
+                final Map<String, Long> requestIdMap = (Map<String, Long>) stored;
+                return requestIdMap;
+            }
+            final Map<String, Long> concurrentMap = new ConcurrentHashMap<>();
+            if (stored instanceof final String requestId && StringUtil.isNotBlank(requestId)) {
+                concurrentMap.put(requestId, ComponentUtil.getSystemHelper().getCurrentTimeAsLong());
+            }
+            session.setAttribute(SAML_STATE, concurrentMap);
+            return concurrentMap;
+        }
+    }
+
+    /**
+     * Drops the AuthnRequest IDs that are older than the configured TTL.
+     *
+     * @param requestIdMap The AuthnRequest ID map to prune.
+     */
+    protected void removeExpiredRequestIds(final Map<String, Long> requestIdMap) {
+        final long now = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
+        final long requestIdTtl = getRequestIdTtl();
+        requestIdMap.entrySet()
+                .stream()
+                .filter(e -> (now - e.getValue()) / 1000L > requestIdTtl)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList())
+                .forEach(requestId -> {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Removing expired AuthnRequest ID: {}", requestId);
+                    }
+                    requestIdMap.remove(requestId);
+                });
+    }
+
+    /**
+     * Drops the least recently created AuthnRequest IDs until at most {@code limit} remain. An
+     * AuthnRequest that is never answered does not expire before the TTL, so this is what bounds
+     * the map for a client that keeps starting logins.
+     *
+     * @param requestIdMap The AuthnRequest ID map to prune.
+     * @param limit The number of AuthnRequest IDs to keep.
+     */
+    protected void removeOldestRequestIds(final Map<String, Long> requestIdMap, final int limit) {
+        if (requestIdMap.size() <= limit) {
+            return;
+        }
+        requestIdMap.entrySet()
+                .stream()
+                .sorted(Comparator.comparingLong(Map.Entry::getValue))
+                .limit((long) requestIdMap.size() - limit)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList())
+                .forEach(requestId -> {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Removing surplus AuthnRequest ID: {}", requestId);
+                    }
+                    requestIdMap.remove(requestId);
+                });
+    }
+
+    /**
+     * Sets the maximum number of unanswered AuthnRequest IDs kept per session.
+     *
+     * @param maxRequestIds The maximum number of AuthnRequest IDs.
+     */
+    public void setMaxRequestIds(final int maxRequestIds) {
+        this.maxRequestIds = maxRequestIds;
+    }
+
+    /**
+     * Gets how long an unanswered AuthnRequest ID stays usable.
+     *
+     * <p>A value that is not a number is reported once per read rather than thrown, because the
+     * alternative is a login that dies with a {@code NumberFormatException} nobody can act
+     * on.</p>
+     *
+     * @return The TTL in seconds. {@link #removeExpiredRequestIds} compares it against an elapsed
+     *         time that has already been divided by 1000.
+     */
+    protected long getRequestIdTtl() {
+        final String value = ComponentUtil.getFessConfig().getSystemProperty(SAML_REQUEST_ID_TTL);
+        if (StringUtil.isBlank(value)) {
+            return Long.parseLong(DEFAULT_REQUEST_ID_TTL);
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (final NumberFormatException e) {
+            logger.warn("Invalid {}: {}. Using {} seconds.", SAML_REQUEST_ID_TTL, value, DEFAULT_REQUEST_ID_TTL);
+            return Long.parseLong(DEFAULT_REQUEST_ID_TTL);
+        }
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -16,13 +16,23 @@
 package org.codelibs.fess.sso.saml;
 
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.exception.SsoMessageException;
 import org.codelibs.fess.exception.SsoStateException;
+import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
@@ -34,6 +44,8 @@ import org.junit.jupiter.api.Test;
 import org.lastaflute.web.login.credential.LoginCredential;
 import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.response.StreamResponse;
+
+import jakarta.servlet.http.HttpSession;
 
 public class SamlAuthenticatorTest extends UnitFessTestCase {
 
@@ -265,12 +277,23 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     @Test
     public void test_getSettings_sharesReplayCacheAcrossRequests() throws Exception {
         final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            // the properties have to change between the two calls, otherwise the settings cache
+            // hands back the same instance and comparing its replay cache with itself asserts
+            // nothing. What matters is that the cache survives a *rebuild*: it is the only thing
+            // that would otherwise be discarded, letting an assertion already seen be replayed
+            // whenever an administrator saves a SAML setting.
+            final Saml2Settings first = authenticator.getSettings();
+            systemProperties.setProperty("saml.security.want_assertions_signed", "true");
+            final Saml2Settings second = authenticator.getSettings();
 
-        final Saml2Settings first = authenticator.getSettings();
-        final Saml2Settings second = authenticator.getSettings();
-
-        assertNotNull(first.getReplayCache());
-        assertSame(first.getReplayCache(), second.getReplayCache());
+            Assertions.assertNotSame(first, second);
+            assertNotNull(first.getReplayCache());
+            assertSame(first.getReplayCache(), second.getReplayCache());
+        } finally {
+            systemProperties.remove("saml.security.want_assertions_signed");
+        }
     }
 
     @Test
@@ -319,6 +342,55 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
         systemProperties.remove("saml.idp.certfingerprint");
     }
 
+    /** Lets a test move the clock that pending AuthnRequest ID expiry is measured against. */
+    private final AtomicLong clock = new AtomicLong(1_000_000L);
+
+    private SamlAuthenticator createAuthenticatorWithControlledClock() throws Exception {
+        ComponentUtil.register(new SystemHelper() {
+            @Override
+            public long getCurrentTimeAsLong() {
+                return clock.get();
+            }
+        }, "systemHelper");
+        return createAuthenticator();
+    }
+
+    /**
+     * Reads the pending AuthnRequest IDs out of the session without assuming the shape of the
+     * attribute, so that the same assertion can be run against the build that stored a single ID
+     * as a bare String.
+     */
+    private Set<String> pendingRequestIds(final HttpSession session) {
+        final Object value = session == null ? null : session.getAttribute("SAML_STATE");
+        if (value instanceof final Map<?, ?> requestIdMap) {
+            return requestIdMap.keySet().stream().map(String::valueOf).collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+        if (value instanceof final String requestId) {
+            return new LinkedHashSet<>(List.of(requestId));
+        }
+        return new LinkedHashSet<>();
+    }
+
+    /**
+     * Puts a SAML response on the request that is well formed enough to reach the InResponseTo
+     * comparison and is rejected right after it. It carries no signature, so it can never
+     * authenticate; what it makes observable is which pending AuthnRequest ID it was compared
+     * with, without a test having to sign an assertion.
+     *
+     * @param request The request the IdP is pretending to post to.
+     * @param inResponseTo The AuthnRequest ID the response claims to answer.
+     */
+    private void postSamlResponse(final MockletHttpServletRequest request, final String inResponseTo) {
+        final String xml = "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\""
+                + " xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_response\" Version=\"2.0\""
+                + " IssueInstant=\"2026-01-01T00:00:00Z\" InResponseTo=\"" + inResponseTo + "\">"
+                + "<samlp:Status><samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/></samlp:Status>"
+                + "<saml:Assertion ID=\"_assertion\" Version=\"2.0\" IssueInstant=\"2026-01-01T00:00:00Z\">"
+                + "<saml:Issuer>https://idp.example.com/metadata</saml:Issuer></saml:Assertion></samlp:Response>";
+        request.setMethod("POST");
+        request.setParameter("SAMLResponse", Base64.getEncoder().encodeToString(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
     @Test
     public void test_containsSamlResponse() throws Exception {
         final SamlAuthenticator authenticator = new SamlAuthenticator();
@@ -359,7 +431,9 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
 
     @Test
     public void test_getLoginCredential_requestWithoutResponseStartsLogin() throws Exception {
-        final SamlAuthenticator authenticator = createAuthenticator();
+        // recording the AuthnRequest ID stamps it with SystemHelper's clock, which test_app.xml
+        // does not register on its own
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
         final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
         try {
             setUpIdp(systemProperties);
@@ -375,25 +449,246 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_getLoginCredential_requestWithoutResponseReplacesPendingRequestId() throws Exception {
-        final SamlAuthenticator authenticator = createAuthenticator();
+    public void test_getLoginCredential_requestWithoutResponseKeepsPendingRequestIds() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
         final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
         try {
             setUpIdp(systemProperties);
-            // a plain visit to /sso/ sends a fresh AuthnRequest and rebinds the session to its
-            // ID, so a login already in flight is abandoned: only one AuthnRequest per session
-            // can be answered, and the response to the older one is rejected as unmatched
+            // FessSearchAction redirects every unauthenticated page hit to /sso/, so a session
+            // that expires with two tabs open sends two AuthnRequests. A single slot made the
+            // second visit abandon the first login, and the first assertion back then consumed
+            // the slot, failed the InResponseTo comparison and took both tabs down with it.
             final MockletHttpServletRequest request = getMockRequest();
-            request.getSession().setAttribute("SAML_STATE", "ONELOGIN_pending");
 
             authenticator.getLoginCredential();
+            final Set<String> afterFirstVisit = pendingRequestIds(request.getSession(false));
+            clock.addAndGet(1000L);
+            authenticator.getLoginCredential();
+            final Set<String> afterSecondVisit = pendingRequestIds(request.getSession(false));
 
-            final Object requestId = request.getSession(false).getAttribute("SAML_STATE");
-            assertNotNull(requestId);
-            Assertions.assertNotEquals("ONELOGIN_pending", requestId);
-            assertTrue(String.valueOf(requestId), String.valueOf(requestId).startsWith("ONELOGIN_"));
+            assertEquals(1, afterFirstVisit.size(), String.valueOf(afterFirstVisit));
+            assertEquals(2, afterSecondVisit.size(), String.valueOf(afterSecondVisit));
+            assertTrue(String.valueOf(afterSecondVisit), afterSecondVisit.containsAll(afterFirstVisit));
+            afterSecondVisit.forEach(requestId -> assertTrue(requestId, requestId.startsWith("ONELOGIN_")));
         } finally {
             tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_requestWithoutResponseCarriesOverALegacyRequestId() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            // A session created before this change holds the single pending ID as a bare String.
+            // Casting it to the map would end the login with a ClassCastException, and dropping
+            // it would abandon a login that was already in flight over the upgrade.
+            final MockletHttpServletRequest request = getMockRequest();
+            request.getSession().setAttribute("SAML_STATE", "ONELOGIN_legacy");
+
+            final LoginCredential credential = authenticator.getLoginCredential();
+
+            assertTrue(String.valueOf(credential), credential instanceof ActionResponseCredential);
+            final Set<String> pending = pendingRequestIds(request.getSession(false));
+            assertEquals(2, pending.size(), String.valueOf(pending));
+            assertTrue(String.valueOf(pending), pending.contains("ONELOGIN_legacy"));
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getRequestIdMap_replacesAnUnusableSessionValue() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final HttpSession session = getMockRequest().getSession();
+        session.setAttribute("SAML_STATE", Integer.valueOf(42));
+
+        final Map<String, Long> requestIdMap = authenticator.getRequestIdMap(session);
+
+        // Anything that is not a live map and not a legacy ID is discarded rather than cast.
+        assertTrue(requestIdMap.toString(), requestIdMap.isEmpty());
+        assertTrue(String.valueOf(requestIdMap), requestIdMap instanceof ConcurrentHashMap);
+        // The map that was handed out is the one stored back, so later writes are not lost.
+        assertSame(requestIdMap, session.getAttribute("SAML_STATE"));
+    }
+
+    @Test
+    public void test_getLoginCredential_capsThePendingRequestIds() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            // /sso/ is anonymous and answers GET, so a page embedding it as a sub-resource would
+            // otherwise grow the session attribute for as long as the session lives.
+            final MockletHttpServletRequest request = getMockRequest();
+            final List<String> issuedRequestIds = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                clock.addAndGet(1000L);
+                authenticator.getLoginCredential();
+                pendingRequestIds(request.getSession(false)).stream()
+                        .filter(requestId -> !issuedRequestIds.contains(requestId))
+                        .forEach(issuedRequestIds::add);
+            }
+
+            final Set<String> pending = pendingRequestIds(request.getSession(false));
+
+            assertEquals(12, issuedRequestIds.size(), String.valueOf(issuedRequestIds));
+            assertEquals(10, pending.size(), String.valueOf(pending));
+            // The two oldest were evicted; the most recent are the ones a user can still finish.
+            assertFalse(String.valueOf(pending), pending.contains(issuedRequestIds.get(0)));
+            assertFalse(String.valueOf(pending), pending.contains(issuedRequestIds.get(1)));
+            assertTrue(String.valueOf(pending), pending.contains(issuedRequestIds.get(2)));
+            assertTrue(String.valueOf(pending), pending.contains(issuedRequestIds.get(11)));
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_expiredRequestIdCannotBeAnswered() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+            authenticator.getLoginCredential();
+            final String requestId = pendingRequestIds(request.getSession(false)).iterator().next();
+
+            // attached only now, so that the insecure-settings warning the first getSettings()
+            // emits is not one of the messages asserted on below
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                // getRequestIdTtl() defaults to 3600 and is compared in seconds
+                clock.addAndGet(3601L * 1000L);
+                postSamlResponse(request, requestId);
+
+                assertNull(authenticator.getLoginCredential());
+                assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("no matching AuthnRequest ID"));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("(0 pending)"));
+                assertTrue(pendingRequestIds(request.getSession(false)).toString(), pendingRequestIds(request.getSession(false)).isEmpty());
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_responseMatchingNoPendingRequestIdFails() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+            authenticator.getLoginCredential();
+            final Set<String> pending = pendingRequestIds(request.getSession(false));
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                postSamlResponse(request, "ONELOGIN_never-sent");
+
+                // Answering it with a fresh AuthnRequest would bounce off an IdP that is already
+                // authenticated and come straight back here, forever.
+                assertNull(authenticator.getLoginCredential());
+                assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("no matching AuthnRequest ID"));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("(1 pending)"));
+                // A response nobody asked for must not be able to burn a login that is in flight:
+                // the assertion consumer service is reachable cross-site, since SAML needs
+                // SameSite=none, so consuming an ID here would be a denial of service per request.
+                Assertions.assertEquals(pending, pendingRequestIds(request.getSession(false)));
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_answersTheOlderOfTwoPendingRequestIds() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            // schema validation is not what this test is about, and switching it off keeps the
+            // response below down to the elements the InResponseTo comparison needs
+            systemProperties.setProperty("saml.security.want_xml_validation", "false");
+            final MockletHttpServletRequest request = getMockRequest();
+            authenticator.getLoginCredential();
+            final String olderRequestId = pendingRequestIds(request.getSession(false)).iterator().next();
+            clock.addAndGet(1000L);
+            authenticator.getLoginCredential();
+            final Set<String> pending = pendingRequestIds(request.getSession(false));
+            assertEquals(2, pending.size(), String.valueOf(pending));
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            // java-saml reports each rejected candidate itself, which is how a test can see that
+            // the response was tried against more than the newest pending ID
+            final LogCapturingAppender samlAppender = LogCapturingAppender.attach("org.codelibs.saml2.core.authn.SamlResponse");
+            try {
+                // the first tab's assertion comes back while the second tab's AuthnRequest is the
+                // most recent one, which is the case that used to fail both logins
+                postSamlResponse(request, olderRequestId);
+                assertNull(authenticator.getLoginCredential());
+
+                final List<String> samlWarnings = samlAppender.warnings();
+                assertEquals(2, samlWarnings.size(), String.valueOf(samlWarnings));
+                // the newest ID is tried first and rejected on InResponseTo alone
+                assertTrue(samlWarnings.get(0), samlWarnings.get(0).contains("does not match the ID of the AuthNRequest"));
+                assertTrue(samlWarnings.get(0), samlWarnings.get(0).contains(olderRequestId));
+                // the older ID then matched, so the response was rejected on its own merits, which
+                // is as far as an unsigned response can get
+                assertFalse(samlWarnings.get(1), samlWarnings.get(1).contains("does not match the ID of the AuthNRequest"));
+                assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+                assertFalse(appender.warnings().get(0), appender.warnings().get(0).contains("no matching AuthnRequest ID"));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).startsWith("Authentication Failure:"));
+            } finally {
+                samlAppender.detach();
+                appender.detach();
+            }
+        } finally {
+            systemProperties.remove("saml.security.want_xml_validation");
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getRequestIdTtl_defaultsToOneHourInSeconds() throws Exception {
+        // removeExpiredRequestIds compares (now - created) / 1000 against this value
+        assertEquals(3600L, new SamlAuthenticator().getRequestIdTtl());
+    }
+
+    @Test
+    public void test_getRequestIdTtl_fallsBackWhenTheConfiguredValueIsNotANumber() throws Exception {
+        // A typo in conf/system.properties must not fail every login with a
+        // NumberFormatException nobody can act on.
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "one hour");
+        try {
+            assertEquals(3600L, new SamlAuthenticator().getRequestIdTtl());
+            assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("saml.request.id.ttl"));
+        } finally {
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "");
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getRequestIdTtl_blankValueIsNotReportedAsInvalid() throws Exception {
+        // A blank property means "unset" everywhere else in this class, so it must not warn.
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", " ");
+        try {
+            assertEquals(3600L, new SamlAuthenticator().getRequestIdTtl());
+            assertTrue(String.valueOf(appender.warnings()), appender.warnings().isEmpty());
+        } finally {
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "");
+            appender.detach();
         }
     }
 


### PR DESCRIPTION
Regression against 15.7, found reviewing `src/main/java/org/codelibs/fess/sso/saml` for the 15.8 release.

## The bug

`SAML_STATE` held a single AuthnRequest ID, so a session could only ever answer the *last* AuthnRequest it sent. `FessSearchAction` redirects every unauthenticated page hit to `/sso/`, so a session that expires with two tabs open sends two AuthnRequests:

1. tab A sends its AuthnRequest, session holds `idA`
2. tab B sends its AuthnRequest, session now holds `idB` -- `idA` is gone
3. tab A's assertion arrives, `removeAttribute` consumes `idB`, the InResponseTo comparison fails -> tab A fails
4. tab B's assertion arrives, the session holds nothing -> tab B fails

Both tabs end on the login page with "SSO login process failed". The overwrite is pinned by the current `test_getLoginCredential_requestWithoutResponseReplacesPendingRequestId`, whose comment says "a login already in flight is abandoned".

15.7 completed one of the two. Not because it did this better -- it dispatched on session-state presence rather than on `SAMLResponse` presence, so tab B's plain `/sso/` visit entered the response branch, consumed the slot and died on a `SAMLSevereException` without ever reaching the IdP, while tab A recovered by falling through to a fresh AuthnRequest whose response was then accepted with **no** InResponseTo check at all. So the delta is 1-of-2 -> 0-of-2, and 15.7's one success came out of the very gap #3214 closed. Restoring it by relaxing the binding is not an option; the fix has to be multi-slot state.

`/sso/` is anonymous, answers GET, and is the assertion consumer service as well as the login initiator, so step 2 does not need a second tab. Another origin can reach it with a link, `window.open`, or -- once `tomcat.sameSiteCookies` is `none`, which SAML requires -- a plain sub-resource such as `<img>`. `SsoAction.index()` only short-circuits for a user who is *already* logged in, and there is no CSRF token, filter or method restriction on the path. Impact is a denial of login: the AuthnRequest is issued into the victim's own session and only the victim's browser can complete it, so nothing is bypassed and the victim succeeds on retry. It is worth fixing anyway because 15.7 self-healed here (via the bounce) and 15.8, correctly, does not.

## The fix

`SAML_STATE` now holds a `Map<String, Long>` of AuthnRequest ID to creation time, bounded by `maxRequestIds` (10) and a TTL read from `saml.request.id.ttl` (default 3600s). This mirrors the state map `EntraIdAuthenticator` already keeps for OpenID Connect, down to the `getRequestIdMap`/`removeExpiredRequestIds`/`removeOldestRequestIds` shape, the `synchronized (session)` create and the same cap of 10, so the two authenticators read alike.

A response is matched against the pending IDs most-recent-first, and **only a response that authenticates consumes its ID**. Consuming on failure would look tidier, but telling "named this ID and was then rejected" apart from "was rejected before the ID was looked at" means enumerating java-saml's internal check ordering, and getting that wrong hands anyone who can reach the ACS a way to burn a pending login per request -- the exact class of problem this PR removes. The TTL and the cap bound the map instead.

The session key is unchanged and a bare `String` left by an older build is carried over rather than cast, so a login already in flight across the upgrade still completes, and an unusable value is replaced instead of throwing `ClassCastException`.

Neither hardening this builds on is relaxed: an unmatched response is still refused rather than answered with a fresh AuthnRequest (#3239), and every response is still bound to an AuthnRequest ID this server sent (#3214).

### Why candidates are tried one at a time

`Auth.processResponse` takes exactly one ID, and java-saml 3.1.1 exposes no supported way to read a response's InResponseTo beforehand -- `SamlResponse` has no getter, and the alternative would be to base64-decode and parse the `SAMLResponse` parameter here, adding an XML parsing (and therefore XXE) surface to an endpoint that is anonymous by design.

Trying candidates is safe because of where the comparison sits in `SamlResponse.isValid`: InResponseTo is compared **before** signature validation and **before** the assertion ID is registered with the replay cache, so a candidate the response does not name fails fast and leaves no trace. A candidate that fails for any other reason has already passed the comparison, so the loop stops there -- which is also what keeps the logged error the real one rather than the InResponseTo mismatch of whichever candidate was tried last.

Cost: a malformed or unsigned-and-invalid response fails on the first candidate and stops, so the common bad case is one parse. A well-formed, schema-valid response naming none of the pending IDs is parsed once per pending ID, capped at 10. Reaching that ceiling means first filling your own session with 10 pending IDs, so it is a bounded, self-inflicted cost on an endpoint that already parses the response once; `maxRequestIds` is settable if a deployment wants it lower.

## Also in this PR

`test_getSettings_sharesReplayCacheAcrossRequests` called `getSettings()` twice with no property change in between. The settings cache returns the same instance for unchanged parameters -- `test_getSettings_cachedUntilPropertiesChange` asserts exactly that -- so the `assertSame` compared a replay cache with itself and could not fail. It now forces a rebuild, which is the case that matters: the replay cache surviving a settings rebuild is what stops an already-seen assertion being replayable whenever an administrator saves a SAML setting. Verified by mutation -- swapping in a fresh `InMemoryReplayCache` per rebuild passed before and fails now.

## Verification

`mvn -o clean test -Dtest='org.codelibs.fess.sso.**.*Test'` -- **236 tests, 0 failures** (SamlAuthenticatorTest 36). `mvn -o clean javadoc:jar` -- success. `mvn formatter:format && mvn license:format` -- no incidental changes.

Every new test was mutation-checked. Against the unmodified production code:

| Test | Failure before the fix |
| --- | --- |
| `…requestWithoutResponseKeepsPendingRequestIds` (rewrite of `…ReplacesPendingRequestId`) | `expected: <2> but was: <1>` |
| `…requestWithoutResponseCarriesOverALegacyRequestId` | `expected: <2> but was: <1>` |
| `…capsThePendingRequestIds` | `expected: <10> but was: <1>` |
| `…expiredRequestIdCannotBeAnswered` | "no matching AuthnRequest ID" assertion, `expected: <true> but was: <false>` |
| `…responseMatchingNoPendingRequestIdFails` | same |
| `…answersTheOlderOfTwoPendingRequestIds` | `expected: <2> but was: <1>` -- only one candidate was ever tried |

Tests covering only new methods were killed by targeted mutations instead: a blind cast in `getRequestIdMap` (`ClassCastException`), a changed TTL default, a removed blank-value guard, a removed WARN, evicting newest instead of oldest, and trying candidates oldest-first.
