### PR TITLE
docs(sso): correct the SAML single logout warning and surface the AuthnRequest cap

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -141,7 +141,10 @@ import jakarta.servlet.http.HttpSession;
  * {@code saml.idp.single_logout_service.url} is configured. It defaults to {@code false} because
  * not every IdP signs its LogoutRequest, but while it is {@code false} the single logout service
  * accepts an unsigned LogoutRequest and does not compare its NameID with the session user, so
- * anyone who knows the IdP entity ID can end an authenticated session. This is reported once as
+ * anyone who can lure a logged-in user to a crafted URL can end that session. The IdP entity ID
+ * is not needed either: {@code Issuer} is optional in the SAML protocol schema and java-saml
+ * compares it only when the element is present, so a LogoutRequest that omits it skips the
+ * comparison altogether. The impact is a forced logout, not account takeover. This is reported as
  * {@code unsigned_logoutrequest_accepted} in the insecure-settings warning.</p>
  *
  * <h2>Session Cookie Settings (Required)</h2>
@@ -427,8 +430,9 @@ public class SamlAuthenticator implements SsoAuthenticator {
         final List<String> warnings = new ArrayList<>(settings.getSecurityWarnings());
         if (settings.getIdpSingleLogoutServiceResponseUrl() != null && !settings.getWantMessagesSigned()) {
             // /sso/logout accepts a LogoutRequest that is not signed, and the NameID it carries is
-            // never compared with the session user, so anyone who knows the IdP entity ID can end
-            // an authenticated session by luring the user to a crafted URL.
+            // never compared with the session user, so anyone can end an authenticated session by
+            // luring the user to a crafted URL. Not even the IdP entity ID is needed: Issuer is
+            // optional in the protocol schema and java-saml compares it only when it is present.
             warnings.add("unsigned_logoutrequest_accepted");
         }
         if (!warnings.equals(loggedSecurityWarnings.getAndSet(warnings)) && !warnings.isEmpty()) {

--- a/src/main/resources/fess_sso++.xml
+++ b/src/main/resources/fess_sso++.xml
@@ -16,6 +16,10 @@
 	<component name="oicAuthenticator" class="org.codelibs.fess.sso.oic.OpenIdConnectAuthenticator">
 	</component>
 	<component name="samlAuthenticator" class="org.codelibs.fess.sso.saml.SamlAuthenticator">
+		<!-- Tunable with no saml.* configuration key. Uncomment to override the default.
+		     How long an unanswered AuthnRequest ID stays usable is saml.request.id.ttl instead.
+		<property name="maxRequestIds">10</property>
+		-->
 	</component>
 	<component name="spnegoAuthenticator" class="org.codelibs.fess.sso.spnego.SpnegoAuthenticator">
 	</component>


### PR DESCRIPTION
## Summary

Two comment-only corrections to the SAML SSO surface. No behaviour change.

### 1. The single logout warning understated the exposure

The class javadoc and the comment next to the `unsigned_logoutrequest_accepted`
warning both said that an attacker needs to know the IdP entity ID in order to
end an authenticated session with an unsigned `LogoutRequest`.

That is not the case. `Issuer` is declared `minOccurs="0"` in
`saml-schema-protocol-2.0.xsd`, so a `LogoutRequest` that omits it still passes
XML schema validation. `LogoutRequest.getIssuer()` returns `null` when the
element is absent, and the check is guarded by `if (issuer != null && ...)`, so
omitting `Issuer` skips the entity ID comparison altogether. The same applies to
`NotOnOrAfter` and `Destination`, which are guarded by `hasAttribute`.

The comments now say that no knowledge of the IdP entity ID is needed, and that
the impact is a forced logout rather than account takeover.

The mitigation is unchanged and already documented:
`saml.security.want_messages_signed=true`.

### 2. `maxRequestIds` had no discoverable knob

`samlAuthenticator` gets the commented-out tunable block that
`entraidAuthenticator` already carries in the same file. `maxRequestIds`
(default 10, the per-session cap on unanswered AuthnRequest IDs) is a LastaDi
setter with no `saml.*` configuration key, so without this it is invisible to
anyone reading the DI file. The comment also points at `saml.request.id.ttl`,
which is a real configuration key and is easy to confuse with it.

## Verification

- `mvn -o formatter:format license:format javadoc:jar` in a clean worktree:
  BUILD SUCCESS. The single remaining javadoc warning is pre-existing and
  unrelated (`ChunkBoundaryFinder.java:882`).
- `xmllint --noout` on `fess_sso++.xml`: well-formed.
- `formatter:format` and `license:format` produced no further changes.
