### PR TITLE
fix(sso): record the Entra ID Graph backoff from the group lookup too

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -1532,14 +1532,35 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @param id The group ID to process.
      */
     protected void processGroup(final EntraIdUser user, final List<String> groupList, final List<String> roleList, final String id) {
+        processGroup(user, groupList, roleList, id, "https://graph.microsoft.com/v1.0/groups/" + id);
+    }
+
+    /**
+     * Processes individual group information read from the specified URL. The URL is a parameter
+     * so that this, like {@link #processDirectMemberOf}, can be pointed at a stub rather than at
+     * Microsoft Graph.
+     *
+     * @param user The Entra ID user.
+     * @param groupList The list to add group names to.
+     * @param roleList The list to add role names to.
+     * @param id The group ID to process.
+     * @param url The Microsoft Graph URL to read the group from.
+     */
+    protected void processGroup(final EntraIdUser user, final List<String> groupList, final List<String> roleList, final String id,
+            final String url) {
         if (logger.isDebugEnabled()) {
-            logger.debug("[processGroup] Processing group info for id: {}", id);
-        }
-        final String url = "https://graph.microsoft.com/v1.0/groups/" + id;
-        if (logger.isDebugEnabled()) {
-            logger.debug("[processGroup] Fetching from url: {}", url);
+            logger.debug("[processGroup] Processing group info for id: {} from url: {}", id, url);
         }
         try (CurlResponse response = createGraphRequest(Curl.get(url), user.getAuthenticationResult().accessToken()).execute()) {
+            // Before the body, for the same reason as in getMemberGroupIds and
+            // processDirectMemberOf: a throttled reply is not required to be JSON, and the parser
+            // throws CurlException when it is not. This was the one Graph call in the class that
+            // did not record the backoff, and it is the one most likely to meet a 429 first: the
+            // parent group walk calls it once per member id, whereas getMemberGroupIds is called
+            // once per group. Worse, a 429 whose body *is* JSON leaves the walk believing it had
+            // an answer -- groupList.add(id) below runs on every non-throwing path -- so nothing
+            // else on that path ever reached Graph to notice the throttling.
+            applyGraphThrottle(response);
             final Map<String, Object> contentMap = response.getContent(OpenSearchCurl.jsonParser());
             if (logger.isDebugEnabled()) {
                 logger.debug("[processGroup] Response for id {}: {}", id, contentMap);

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -1723,6 +1723,46 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_processGroup_recordsTheBackoffAThrottledGraphAskedFor() throws Exception {
+        // processGroup was the one Microsoft Graph call in this class that never recorded the
+        // backoff, and it is the call most likely to meet a 429 first: the parent group walk
+        // issues one per member id, against one getMemberGroupIds per group. The gap did not
+        // close by itself either -- a 429 whose body is JSON parses, so groupList.add(id) runs
+        // and the `!groupList.contains(value)` guard in loadParentGroup then skips the recursion,
+        // which is the only other thing on that path that would have reached Graph.
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final EntraIdUser user = newUserWithoutGraph();
+        final List<String> groupList = new ArrayList<>();
+
+        try (GraphStub graph = new GraphStub(429, Map.of("Retry-After", "120"), "{\"error\":{\"code\":\"TooManyRequests\"}}")) {
+            authenticator.processGroup(user, groupList, new ArrayList<>(), "group-a", graph.url());
+        }
+
+        assertEquals(clock.get() + 120_000L, authenticator.graphThrottledUntil);
+        assertTrue(authenticator.isGraphThrottled());
+        // The membership itself is unaffected: the id came from getMemberGroups, which is
+        // authoritative, and only the permission fields are missing from this degraded answer.
+        assertEquals(List.of("group-a"), groupList);
+    }
+
+    @Test
+    public void test_processGroup_leavesTheBackoffAloneOnAnOrdinaryAnswer() throws Exception {
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithControlledClock();
+        final EntraIdUser user = newUserWithoutGraph();
+        final List<String> groupList = new ArrayList<>();
+
+        try (GraphStub graph = new GraphStub(200, Map.of(), "{\"id\":\"group-a\",\"mail\":\"group-a@example.com\"}")) {
+            authenticator.processGroup(user, groupList, new ArrayList<>(), "group-a", graph.url());
+        }
+
+        assertEquals(0L, authenticator.graphThrottledUntil);
+        assertFalse(authenticator.isGraphThrottled());
+        // Not asserting the permission fields here: entraid.permission.fields is a system
+        // property, and those live for the whole JVM, so a sibling test could decide it.
+        assertEquals("group-a", groupList.get(0));
+    }
+
+    @Test
     public void test_processDirectMemberOf_stillAsksWhileGraphIsThrottling() throws Exception {
         // The backoff keeps the asynchronous parent group walk off a throttled Graph. A login has
         // no such luxury: skipping the lookup would hand out the configured defaults alone for the


### PR DESCRIPTION
## Problem

`processGroup` was the only Microsoft Graph call in the Entra ID authenticator that did not pass its response through `applyGraphThrottle`, so a `429` or `503` answered to `GET /groups/{id}` was neither recorded nor honoured.

That call site is the one most likely to meet a throttled Graph first: the asynchronous parent group walk issues one request per member id, whereas `getMemberGroupIds` is issued once per group.

The gap did not close by itself:

- Microsoft Graph answers a `429` with a JSON body, so `getContent` succeeds and `groupList.add(id)` runs -- it sits on every non-throwing path, ahead of the error check.
- Back in `loadParentGroup`, the `!groupList.contains(value)` guard is therefore false and the recursion is skipped.
- That recursion is the only other thing on the path that would have reached Graph and noticed the throttling.

So the walk carried on issuing one request per member id against a Graph that had already asked it to wait.

## Change

- Call `applyGraphThrottle(response)` before reading the body, for the same reason as the two existing call sites: a throttled reply is not required to be JSON and the parser throws on it.
- Add a `processGroup` overload that takes the URL, mirroring `processDirectMemberOf`, so the behaviour can be driven against a local stub. The four-argument method keeps its signature and builds the same URL as before.

The membership itself is unaffected: the id comes from `getMemberGroups`, which is authoritative, and only the permission fields are missing from a degraded answer.

## Tests

Two tests added to the authenticator test class: a `429` carrying `Retry-After` arms the backoff from this call site, and an ordinary `200` leaves it alone.

Mutation-checked: with `applyGraphThrottle(response)` removed, the first test fails with `expected: <1120000> but was: <0>`; restored, it passes.

```
mvn -o clean test -Dtest='org.codelibs.fess.sso.**'
  Tests run: 245, Failures: 0, Errors: 0, Skipped: 0   (Entra ID: 96 -> 98)
mvn -o clean javadoc:jar
  BUILD SUCCESS
```
