### PR TITLE
fix(sso): join the Entra ID authority and tenant with a single separator

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -1872,10 +1872,37 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     /**
      * Builds the tenant's authority URL, the prefix every Entra ID endpoint is hung off.
      *
+     * <p>The authority and the tenant are joined with exactly one {@code /}. This used to be a
+     * raw concatenation, and the only guard on {@link #getAuthority()} maps a <em>blank</em> value
+     * onto {@link #DEFAULT_AUTHORITY}, which already carries a trailing slash -- a non-blank value
+     * without one was passed through untouched. So
+     * {@code entraid.authority=https://login.microsoftonline.com} plus
+     * {@code entraid.tenant=contoso.onmicrosoft.com} produced
+     * {@code https://login.microsoftonline.comcontoso.onmicrosoft.com/}: the host and the tenant
+     * fuse into a single bogus hostname, the browser gets NXDOMAIN, and because the authorization
+     * URL is only logged at debug level nothing points back at the setting.
+     * {@code https://login.microsoftonline.com} is how the endpoint is written wherever it is
+     * documented, so omitting the trailing slash is the expected mistake rather than an exotic one.
+     *
+     * <p>A tenant that already starts with a slash joins correctly against a slashless authority,
+     * so the separator is inserted only when neither side supplies one and a doubled separator is
+     * collapsed; a naive "always append a slash to the authority" fix would break that working
+     * configuration. Nothing is lowercased or trimmed, and the value still carries at least one
+     * path segment, which msal4j's {@code Authority.detectAuthorityType} requires.
+     *
      * @return The authority URL, with a trailing slash.
      */
     protected String getAuthorityUrl() {
-        return getAuthority() + getTenant() + "/";
+        final String authority = getAuthority();
+        final String tenant = getTenant();
+        if (StringUtil.isEmpty(tenant)) {
+            // Left byte-identical to what a blank tenant produced before. validateConfiguration
+            // refuses one on the login path, and the doubled slash it leaves behind is quoted in
+            // that method's own javadoc as the symptom an unconfigured server shows.
+            return authority + "/";
+        }
+        final String base = authority.endsWith("/") ? authority : authority + "/";
+        return base + (tenant.startsWith("/") ? tenant.substring(1) : tenant) + "/";
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -2813,5 +2814,101 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         }
 
         assertEquals(FessUser.PermissionState.FAILED, user.getPermissionState());
+    }
+
+    /**
+     * Sets the authority and the tenant, reads the joined value and restores both. Both keys are
+     * written back as "" rather than removed because getSystemProperty keeps them for the life of
+     * the container; the class asks for a one-time container so that stays inside this class.
+     */
+    private String authorityUrlOf(final String authority, final String tenant) {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        try {
+            fessConfig.setSystemProperty("entraid.authority", authority);
+            fessConfig.setSystemProperty("entraid.tenant", tenant);
+            return authenticator.getAuthorityUrl();
+        } finally {
+            fessConfig.setSystemProperty("entraid.authority", "");
+            fessConfig.setSystemProperty("entraid.tenant", "");
+        }
+    }
+
+    @Test
+    public void test_getAuthorityUrl_keepsASlashTerminatedAuthorityByteIdentical() {
+        // The normal case, and the shape DEFAULT_AUTHORITY has. It must not move.
+        assertEquals("https://login.microsoftonline.com/contoso.onmicrosoft.com/",
+                authorityUrlOf("https://login.microsoftonline.com/", "contoso.onmicrosoft.com"));
+    }
+
+    @Test
+    public void test_getAuthorityUrl_insertsTheMissingSeparator() {
+        // https://login.microsoftonline.com is how the endpoint is written everywhere it is
+        // documented, so an admin typing it without the trailing slash is the expected mistake.
+        // Concatenated raw it produced login.microsoftonline.comcontoso.onmicrosoft.com -- one
+        // bogus hostname -- and the browser got NXDOMAIN.
+        assertEquals("https://login.microsoftonline.com/contoso.onmicrosoft.com/",
+                authorityUrlOf("https://login.microsoftonline.com", "contoso.onmicrosoft.com"));
+    }
+
+    @Test
+    public void test_getAuthorityUrl_leavesASlashPrefixedTenantAlone() {
+        // A slashless authority plus a slash-prefixed tenant already joins correctly today. A fix
+        // that always appends a slash to the authority would break this working configuration.
+        assertEquals("https://login.microsoftonline.com/contoso.onmicrosoft.com/",
+                authorityUrlOf("https://login.microsoftonline.com", "/contoso.onmicrosoft.com"));
+    }
+
+    @Test
+    public void test_getAuthorityUrl_collapsesADoubledSeparator() {
+        assertEquals("https://login.microsoftonline.com/contoso.onmicrosoft.com/",
+                authorityUrlOf("https://login.microsoftonline.com/", "/contoso.onmicrosoft.com"));
+    }
+
+    @Test
+    public void test_getAuthorityUrl_leavesABlankTenantByteIdentical() {
+        // validateConfiguration refuses a blank tenant before any of this is reached on the login
+        // path, and the doubled slash below is the symptom its own javadoc quotes. Normalising it
+        // here would only change a URL an operator has already been told about.
+        assertEquals("https://login.microsoftonline.com//", authorityUrlOf("https://login.microsoftonline.com/", ""));
+        assertEquals("https://login.microsoftonline.com/", authorityUrlOf("https://login.microsoftonline.com", ""));
+    }
+
+    @Test
+    public void test_getAuthorityUrl_doesNotLowercaseTheAuthority() {
+        assertEquals("https://Login.MicrosoftOnline.com/Contoso.onmicrosoft.com/",
+                authorityUrlOf("https://Login.MicrosoftOnline.com", "Contoso.onmicrosoft.com"));
+    }
+
+    @Test
+    public void test_getAuthUrl_separatesASlashlessAuthorityFromTheTenant() {
+        // Pins the whole authorization URL, not just the join: the failure was silent because the
+        // URL is only logged at debug level, so the browser was the first thing to see it.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        try {
+            fessConfig.setSystemProperty("entraid.authority", "https://login.microsoftonline.com");
+            fessConfig.setSystemProperty("entraid.tenant", "contoso.onmicrosoft.com");
+            fessConfig.setSystemProperty("entraid.client.id", "11111111-1111-1111-1111-111111111111");
+            fessConfig.setSystemProperty("entraid.reply.url", "https://fess.example.com/sso/");
+
+            final String authUrl = authenticator.getAuthUrl(newAuthUrlRequest());
+
+            final String expected =
+                    "https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/authorize" + "?response_type=code&scope="
+                            + URLEncoder.encode("openid profile offline_access https://graph.microsoft.com/.default",
+                                    StandardCharsets.UTF_8)
+                            + "&response_mode=query&redirect_uri="
+                            + URLEncoder.encode("https://fess.example.com/sso/", StandardCharsets.UTF_8)
+                            + "&client_id=11111111-1111-1111-1111-111111111111";
+            // state and nonce are random per call; everything before them is fixed.
+            assertEquals(expected, authUrl.replaceFirst("&state=.*$", ""));
+        } finally {
+            fessConfig.setSystemProperty("entraid.authority", "");
+            fessConfig.setSystemProperty("entraid.tenant", "");
+            fessConfig.setSystemProperty("entraid.client.id", "");
+            fessConfig.setSystemProperty("entraid.reply.url", "");
+        }
     }
 }


### PR DESCRIPTION
## Problem

`getAuthorityUrl()` — the prefix every Entra ID endpoint is hung off — is a raw concatenation:

```java
protected String getAuthorityUrl() {
    return getAuthority() + getTenant() + "/";
}
```

The only guard on `getAuthority()` maps a *blank* value onto `DEFAULT_AUTHORITY`, which already carries a trailing slash. A non-blank value **without** one is passed through untouched, so with

```
entraid.authority=https://login.microsoftonline.com
entraid.tenant=contoso.onmicrosoft.com
```

the authorization URL becomes

```
https://login.microsoftonline.comcontoso.onmicrosoft.com/oauth2/v2.0/authorize?...
```

The host and the tenant fuse into a single bogus hostname. The browser gets NXDOMAIN, and because the URL is only logged at debug level nothing points back at the setting. `https://login.microsoftonline.com` is how the endpoint is written wherever it is documented, so omitting the trailing slash is the expected mistake rather than an exotic one.

`validateConfiguration()` does not catch it: it refuses a blank tenant, a blank client id and a blank client secret, and says nothing about the shape of the authority.

This is pre-existing and reproduces on 15.7.x as well; it is not a 15.8 regression.

## Fix

`getAuthorityUrl()` joins the two with exactly one `/`. Normalisation rules:

| authority ends `/` | tenant starts `/` | before | after |
|---|---|---|---|
| yes | no | `A/T/` | unchanged (the normal case, byte-identical) |
| no | no | `AT/` | `A/T/` — **the bug** |
| no | yes | `A/T/` | unchanged — already correct today |
| yes | yes | `A//T/` | `A/T/` — collapsed |

A tenant that already starts with a slash joins correctly against a slashless authority today, so a naive "always append a slash to the authority" fix would break a working configuration.

A **blank tenant is left byte-identical**, doubled slash and all: `validateConfiguration()` refuses one on the login path before any of this is reached, and that method's own javadoc quotes `https://login.microsoftonline.com//oauth2/v2.0/authorize?...` as the symptom an unconfigured server shows. Normalising it here would only change a URL an operator has already been told about.

`getAuthority()` itself is deliberately unchanged: it is a documented getter, and it is what the admin screen round-trips.

Nothing is lowercased or trimmed, and the shape handed to msal4j is unchanged — it still receives at least one path segment, which `Authority.detectAuthorityType` requires.

## Scope note vs. the original version of this PR

This PR originally added a separate `getTenantAuthority()` and routed `getAuthUrl`, `getClientApplication`, `buildClientApplicationKey()` and the two debug-log authorities in `getAccessToken` through it. #3279 has since collapsed all five of those call sites into `getAuthorityUrl()`, so the structural half of the change is already on `master` and only the normalisation is left. The diff is now one method plus its tests.

## Tests

Seven tests in the `EntraIdAuthenticator` test class:

- the four join cases in the table above, including the two that must stay **byte-identical**;
- a blank tenant against both a slash-terminated and a slashless authority, pinning that today's output does not move;
- the authority is not lowercased;
- `getAuthUrl` end to end, pinning the whole authorization URL rather than just the join — the failure was silent precisely because that URL is only logged at debug level, so the browser was the first thing to see it.

Mutation-checked: restoring `return getAuthority() + getTenant() + "/";` reddens exactly four of them, and the `getAuthUrl` failure prints the fused hostname:

```
expected: <https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/authorize?...>
but was:  <https://login.microsoftonline.comcontoso.onmicrosoft.com/oauth2/v2.0/authorize?...>
```

The three byte-identical cases correctly stay green under that mutation — they exist to pin the absence of a regression, not the fix.

## Verification

`mvn clean test -Dtest='org.codelibs.fess.sso.**,org.codelibs.fess.app.web.base.login.**'` at the top of the stack → 421 tests, 0 failures (136 of them in the `EntraIdAuthenticator` test class). `mvn clean javadoc:jar` → BUILD SUCCESS. `mvn formatter:format && mvn license:format` produced no changes.
