### PR TITLE
fix(sso): refuse a non-positive SAML AuthnRequest TTL and stop blaming the cookie

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -195,15 +195,16 @@ public class SamlAuthenticator implements SsoAuthenticator {
     protected static final String SAML_SP_BASE_URL = "saml.sp.base.url";
 
     /**
-     * The property key for how long, in seconds, an unanswered AuthnRequest ID stays usable.
+     * The property key for how long, in seconds, an unanswered AuthnRequest ID stays usable. Only
+     * a positive value is honoured; see {@link #getRequestIdTtl()}.
      */
     protected static final String SAML_REQUEST_ID_TTL = "saml.request.id.ttl";
 
     /**
      * The time-to-live applied to an unanswered AuthnRequest ID when
-     * {@link #SAML_REQUEST_ID_TTL} is absent, blank or not a number. One hour, the same default
-     * {@code EntraIdAuthenticator} uses for an OpenID Connect state, and comfortably longer than
-     * any interactive login at an IdP.
+     * {@link #SAML_REQUEST_ID_TTL} is absent, blank, not a number, or not positive. One hour, the
+     * same default {@code EntraIdAuthenticator} uses for an OpenID Connect state, and comfortably
+     * longer than any interactive login at an IdP.
      */
     protected static final String DEFAULT_REQUEST_ID_TTL = "3600";
 
@@ -448,8 +449,12 @@ public class SamlAuthenticator implements SsoAuthenticator {
 
             if (containsSamlResponse(request)) {
                 final HttpSession session = request.getSession(false);
+                // counted here rather than inside removeExpiredRequestIds so that the pruning
+                // itself keeps the signature it ships with; see logUnmatchedSamlResponseAfterExpiry
+                int expiredCount = 0;
                 if (session != null) {
                     final Map<String, Long> requestIdMap = getRequestIdMap(session);
+                    final int pendingCount = requestIdMap.size();
                     removeExpiredRequestIds(requestIdMap);
                     if (!requestIdMap.isEmpty()) {
                         try {
@@ -459,11 +464,21 @@ public class SamlAuthenticator implements SsoAuthenticator {
                             return null;
                         }
                     }
+                    // pruning is the only thing this thread removed, so an emptied map that was not
+                    // empty a moment ago says how many logins ran out of time. A concurrent request
+                    // of the same session can consume or evict an entry too, which would make this
+                    // an over-count; it only shapes a log line, and the response was unanswerable
+                    // by this thread either way.
+                    expiredCount = pendingCount;
                 }
                 // No session at all, or one that holds nothing still answerable: the assertion
                 // cannot be tied to an AuthnRequest this server sent, so it is refused rather
                 // than answered with another one.
-                logUnmatchedSamlResponse(0);
+                if (expiredCount > 0) {
+                    logUnmatchedSamlResponseAfterExpiry(expiredCount);
+                } else {
+                    logUnmatchedSamlResponse(0);
+                }
                 return null;
             }
 
@@ -604,6 +619,12 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * authenticated, which posts the same kind of unmatched assertion straight back, and the
      * loop only ends when the browser gives up.</p>
      *
+     * <p>The SameSite guidance below is what this case usually is, but only because the case
+     * where the session was found and its AuthnRequest IDs had merely run out of time is reported
+     * by {@link #logUnmatchedSamlResponseAfterExpiry(int)} instead. Without that split every
+     * expired login would read as a cookie misconfiguration, since the pruning happens before
+     * this is reached and therefore reports a pending count of zero as well.</p>
+     *
      * @param pendingCount How many pending AuthnRequest IDs the session held, so that a log can
      *            tell a missing session cookie apart from a response that simply matched none of
      *            several live logins.
@@ -613,6 +634,36 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 + " The assertion consumer service is a cross-site POST, which does not carry a SameSite=Lax cookie;"
                 + " see tomcat.sameSiteCookies in tomcat_config.properties."
                 + " An IdP-initiated (unsolicited) response is rejected for the same reason.", pendingCount);
+    }
+
+    /**
+     * Logs the one line reported when a SAML response arrives after every AuthnRequest ID its
+     * session held had passed {@link #SAML_REQUEST_ID_TTL}.
+     *
+     * <p>Kept apart from {@link #logUnmatchedSamlResponse(int)} because that line names
+     * {@code tomcat.sameSiteCookies} as the cause, and here the session cookie demonstrably did
+     * arrive: the session was found and it did hold pending IDs until this request pruned them.
+     * Sending an operator whose cookie settings are already correct off to change them is what
+     * the split avoids; the only line that told the two apart was the {@code debug} one in
+     * {@link #removeExpiredRequestIds(Map)}, which is below the level a shipped Fess logs at.</p>
+     *
+     * <p>This is an ordinary event rather than a misconfiguration -- a user who starts a login and
+     * finishes it at the IdP later than the TTL allows reaches it, and simply starting the login
+     * again succeeds -- so it is worth telling apart from the cases that need an administrator.</p>
+     *
+     * <p>An extension that overrides {@link #logUnmatchedSamlResponse(int)} to reshape or suppress
+     * that warning wants to override this one as well: until this method existed, the expiry case
+     * was reported by that one with a pending count of zero.</p>
+     *
+     * @param expiredCount How many pending AuthnRequest IDs had expired, that is, how many logins
+     *            the session still had in flight before the TTL removed them.
+     */
+    protected void logUnmatchedSamlResponseAfterExpiry(final int expiredCount) {
+        logger.warn(
+                "Received a SAML response after all {} pending AuthnRequest ID(s) of the session had expired."
+                        + " The session cookie did reach this server, so this is not the SameSite case:"
+                        + " the login took longer to finish at the IdP than {} allows, and starting it again resolves it.",
+                expiredCount, SAML_REQUEST_ID_TTL);
     }
 
     /**
@@ -729,20 +780,37 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * alternative is a login that dies with a {@code NumberFormatException} nobody can act
      * on.</p>
      *
-     * @return The TTL in seconds. {@link #removeExpiredRequestIds} compares it against an elapsed
-     *         time that has already been divided by 1000.
+     * <p>A value that is not positive is treated the same way, and for the same reason. It parses,
+     * so nothing would fail here, but {@link #removeExpiredRequestIds} compares
+     * {@code (now - created) / 1000} against it: {@code 0} drops an AuthnRequest ID one second
+     * after it was issued and a negative value drops it at once, so no IdP round trip could ever
+     * complete and every SAML login in the deployment would fail. {@code 0} is not a far-fetched
+     * value to write either -- it reads as "no expiry", and elsewhere in Fess that is what it
+     * means -- which is why it falls back rather than being taken literally. The warning names the
+     * property and the value, and is worded differently from the one above so that a log says
+     * which of the two mistakes was made.</p>
+     *
+     * @return The TTL in seconds, always positive. {@link #removeExpiredRequestIds} compares it
+     *         against an elapsed time that has already been divided by 1000.
      */
     protected long getRequestIdTtl() {
         final String value = ComponentUtil.getFessConfig().getSystemProperty(SAML_REQUEST_ID_TTL);
         if (StringUtil.isBlank(value)) {
             return Long.parseLong(DEFAULT_REQUEST_ID_TTL);
         }
+        final long requestIdTtl;
         try {
-            return Long.parseLong(value.trim());
+            requestIdTtl = Long.parseLong(value.trim());
         } catch (final NumberFormatException e) {
             logger.warn("Invalid {}: {}. Using {} seconds.", SAML_REQUEST_ID_TTL, value, DEFAULT_REQUEST_ID_TTL);
             return Long.parseLong(DEFAULT_REQUEST_ID_TTL);
         }
+        if (requestIdTtl <= 0) {
+            logger.warn("{} must be a positive number of seconds: {}. Using {} seconds.", SAML_REQUEST_ID_TTL, value,
+                    DEFAULT_REQUEST_ID_TTL);
+            return Long.parseLong(DEFAULT_REQUEST_ID_TTL);
+        }
+        return requestIdTtl;
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -423,6 +423,9 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertNull(authenticator.getLoginCredential());
             assertEquals(1, appender.warnings().size());
             assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("no matching AuthnRequest ID"));
+            // there is no session at all, which is the one situation the cookie really explains,
+            // so this is where that guidance has to stay
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("tomcat.sameSiteCookies"));
         } finally {
             tearDownIdp(systemProperties);
             appender.detach();
@@ -565,8 +568,14 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
 
                 assertNull(authenticator.getLoginCredential());
                 assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
-                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("no matching AuthnRequest ID"));
-                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("(0 pending)"));
+                // The session was found and it did hold the ID until this very request pruned it,
+                // so the cookie demonstrably arrived. Reporting this as the SameSite case sends an
+                // operator whose cookie settings are already right off to change them, and this is
+                // the ordinary outcome of a user who walks away mid-login.
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("had expired"));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("all 1 pending"));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("saml.request.id.ttl"));
+                assertFalse(appender.warnings().get(0), appender.warnings().get(0).contains("tomcat.sameSiteCookies"));
                 assertTrue(pendingRequestIds(request.getSession(false)).toString(), pendingRequestIds(request.getSession(false)).isEmpty());
             } finally {
                 appender.detach();
@@ -688,6 +697,116 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertTrue(String.valueOf(appender.warnings()), appender.warnings().isEmpty());
         } finally {
             ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "");
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getRequestIdTtl_fallsBackWhenTheConfiguredValueIsNotPositive() throws Exception {
+        // Both values parse, so nothing fails here, but removeExpiredRequestIds compares
+        // (now - created) / 1000 against the result: 0 drops the AuthnRequest ID one second after
+        // the IdP was sent to, and -1 drops it at once, so every SAML login in the deployment
+        // fails. 0 is not a far-fetched thing to write, either: it reads as "no expiry".
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "0");
+            assertEquals(3600L, new SamlAuthenticator().getRequestIdTtl());
+
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "-1");
+            assertEquals(3600L, new SamlAuthenticator().getRequestIdTtl());
+
+            assertEquals(2, appender.warnings().size(), String.valueOf(appender.warnings()));
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("saml.request.id.ttl"));
+            // the value that was configured, not only the default that replaced it
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains(": 0."));
+            assertTrue(appender.warnings().get(1), appender.warnings().get(1).contains(": -1."));
+        } finally {
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "");
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getRequestIdTtl_reportsANonPositiveValueDifferentlyFromANonNumericOne() throws Exception {
+        // The two mistakes need different corrections, and 0 is a number, so reporting it as
+        // invalid would send an administrator hunting for a typo that is not there.
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "0");
+            new SamlAuthenticator().getRequestIdTtl();
+
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "one hour");
+            new SamlAuthenticator().getRequestIdTtl();
+
+            assertEquals(2, appender.warnings().size(), String.valueOf(appender.warnings()));
+            final String nonPositive = appender.warnings().get(0);
+            final String nonNumeric = appender.warnings().get(1);
+            assertTrue(nonPositive, nonPositive.contains("positive"));
+            assertFalse(nonPositive, nonPositive.contains("Invalid"));
+            assertTrue(nonNumeric, nonNumeric.contains("Invalid"));
+            assertFalse(nonNumeric, nonNumeric.contains("positive"));
+        } finally {
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "");
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_nonPositiveRequestIdTtlStillAnswersAResponse() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            // Taken literally, this expires the AuthnRequest ID one second after the browser was
+            // sent to the IdP, which no round trip can beat: the deployment would answer every
+            // login attempt with a warning and no session would ever be created.
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "0");
+            final MockletHttpServletRequest request = getMockRequest();
+            authenticator.getLoginCredential();
+            final String requestId = pendingRequestIds(request.getSession(false)).iterator().next();
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                clock.addAndGet(1000L);
+                postSamlResponse(request, requestId);
+
+                // The response is unsigned, so it cannot authenticate; what this pins is that it
+                // was compared with the pending ID at all rather than finding it already pruned.
+                assertNull(authenticator.getLoginCredential());
+                final List<String> warnings = appender.warnings();
+                assertTrue(String.valueOf(warnings), warnings.stream().anyMatch(w -> w.startsWith("Authentication Failure:")));
+                assertTrue(String.valueOf(warnings), warnings.stream().noneMatch(w -> w.contains("had expired")));
+                assertTrue(String.valueOf(warnings), warnings.stream().noneMatch(w -> w.contains("no matching AuthnRequest ID")));
+                // and a rejected response does not consume the ID, so the login is still live
+                final Set<String> pending = pendingRequestIds(request.getSession(false));
+                assertTrue(String.valueOf(pending), pending.contains(requestId));
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            ComponentUtil.getFessConfig().setSystemProperty("saml.request.id.ttl", "");
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_logUnmatchedSamlResponse_separatesAnExpiredLoginFromAMissingSessionCookie() throws Exception {
+        // Both situations reach the log with nothing pending, so the text is the only thing that
+        // can tell them apart, and only one of them is a misconfiguration.
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            authenticator.logUnmatchedSamlResponse(0);
+            authenticator.logUnmatchedSamlResponseAfterExpiry(1);
+
+            assertEquals(2, appender.warnings().size(), String.valueOf(appender.warnings()));
+            final String missingCookie = appender.warnings().get(0);
+            final String expired = appender.warnings().get(1);
+            assertTrue(missingCookie, missingCookie.contains("tomcat.sameSiteCookies"));
+            assertFalse(missingCookie, missingCookie.contains("saml.request.id.ttl"));
+            assertTrue(expired, expired.contains("saml.request.id.ttl"));
+            assertFalse(expired, expired.contains("tomcat.sameSiteCookies"));
+        } finally {
             appender.detach();
         }
     }


### PR DESCRIPTION
## Summary

Two fixes around `saml.request.id.ttl`, which is new in 15.8. Neither changes
behaviour for any deployment that is currently working.

### 1. A non-positive TTL silently breaks every SAML login

`getRequestIdTtl()` validated only that the value parses as a number. It is
compared in `removeExpiredRequestIds()` as `(now - created) / 1000L > ttl`, so:

| value | effect |
|---|---|
| `0` | the AuthnRequest ID is pruned 1 second after the browser is sent to the IdP |
| `-1` | pruned immediately |

Either way no IdP round trip can complete and **every** SAML login in the
deployment fails. `0` is not a far-fetched thing to write: it reads as
"no expiry", and elsewhere in Fess that is what it means.

Any non-positive value now falls back to the default, with a warning worded
differently from the non-numeric one (`must be a positive number of seconds`
vs `Invalid`) so that a log says which of the two mistakes was made. `0` is a
number, so reporting it as invalid would send an administrator hunting for a
typo that is not there.

### 2. The warning blamed the wrong setting

Three situations reach the "no matching AuthnRequest ID" warning, and two of
them report a pending count of zero:

1. no session at all — genuinely the `SameSite=Lax` cookie case
2. **a session whose AuthnRequest IDs this very request pruned** — reports zero
   too, because `removeExpiredRequestIds` runs before the check
3. a session with live IDs, none of which the response names — non-zero count

Case 2 is the ordinary real-world outcome: a user starts a login, walks away
past the TTL, and comes back. But the single warning names
`tomcat.sameSiteCookies` as the cause, so operators whose cookie configuration
is already correct were sent to change it. The only line that distinguished the
two is the `logger.debug("Removing expired AuthnRequest ID…")`, which is below
the level a shipped Fess logs at (`FESS_LOG_LEVEL=warn`).

Case 2 now reports through `logUnmatchedSamlResponseAfterExpiry(int)`, which
says the session cookie did arrive, names `saml.request.id.ttl`, and says that
starting the login again resolves it. Cases 1 and 3 keep the SameSite guidance.

`logUnmatchedSamlResponse(int)` keeps its signature and body. The one
consequence for an extension overriding it is that the expiry case no longer
reaches it; its javadoc now records that.

## Verification

- `mvn -o clean test -Dtest=SamlAuthenticatorTest` → `Tests run: 40, Failures: 0, Errors: 0, Skipped: 0` (was 36)
- whole SSO package → `Tests run: 247, Failures: 0, Errors: 0, Skipped: 0`
- `mvn -o javadoc:jar` → BUILD SUCCESS (the one remaining warning is the pre-existing, unrelated `ChunkBoundaryFinder.java:882`)
- `mvn -o formatter:format license:format` → no further changes

Every new test was mutation-checked — the production code was broken on purpose
and the test confirmed to fail, then restored. Seven mutations were tried,
including weakening the guard to `< 0` (to pin the `0` boundary), giving the new
warning the old wording, making the new log method delegate to the old one, and
dropping `tomcat.sameSiteCookies` from the unmatched message. None passed.

Note that `test_getLoginCredential_expiredRequestIdCannotBeAnswered` was
rewritten rather than extended: it asserted `(0 pending)` and the SameSite
wording, so it was the pin holding the old behaviour in place.

## Related

- codelibs/fess#3257 — corrects the misleading comments in the same file (different regions; merges cleanly)
- codelibs/fess-docs#487 — documents `saml.request.id.ttl`. If both land, that page is worth a follow-up line saying the value must be positive.
