### PR TITLE
fix(sso): bound the Entra ID parent group walk when Microsoft Graph stops answering

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -311,6 +311,24 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     protected int maxGroupDepth = 10;
 
     /**
+     * How many consecutive parent group lookups Microsoft Graph may fail to answer before
+     * {@link #updateMemberOf} stops walking the rest of the user's direct groups.
+     *
+     * <p>The walk costs one {@code POST /groups/{id}/getMemberGroups} per direct group. A 429 or a
+     * 503 records a tenant-wide backoff, so the rest of that walk is skipped without reaching
+     * Graph at all; a 500/502/504 or a transport failure -- DNS, connection refused, or the
+     * {@link #graphConnectTimeout} / {@link #graphReadTimeout} expiring -- records nothing, so
+     * without this bound every direct group costs a full request and a stack trace, on every
+     * login, each waiting out the timeouts. That runs on corelib's shared {@code TimeoutManager}
+     * pool, whose {@code CallerRunsPolicy} pushes the overflow onto the timer thread itself.
+     *
+     * <p>Consecutive rather than total is deliberate: one permanently broken group id must not
+     * stop the rest of the walk, while a Graph that has stopped answering trips the bound
+     * immediately.
+     */
+    protected int maxConsecutiveGroupLookupFailures = 3;
+
+    /**
      * Connection timeout for Microsoft Graph requests in milliseconds. curl4j leaves this unset,
      * which means an unbounded wait, and the direct-membership lookup runs on the login thread.
      */
@@ -1055,11 +1073,33 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         }
 
         // Every direct group is still walked after one of them fails: a partial parent set is worth
-        // more than none, so the failures are collected rather than short-circuited.
+        // more than none, so the failures are collected rather than short-circuited. What does end
+        // the walk early is maxConsecutiveGroupLookupFailures answers in a row that Graph did not
+        // give -- past that point the tenant is unreachable rather than one group being broken,
+        // and continuing only buys one request, one timeout and one stack trace per remaining
+        // group. Whatever was collected before that is still applied below.
         boolean parentsResolved = true;
+        int walkedCount = 0;
+        int consecutiveFailures = 0;
         for (final String groupId : groupIdsForParentLookup) {
-            if (!processParentGroup(user, groupList, roleList, groupId)) {
-                parentsResolved = false;
+            ++walkedCount;
+            if (processParentGroup(user, groupList, roleList, groupId)) {
+                consecutiveFailures = 0;
+                continue;
+            }
+            parentsResolved = false;
+            if (isGraphThrottled()) {
+                // A lookup skipped for the backoff never reached Graph: it costs nothing, and the
+                // backoff already bounds the tenant. Counting it would end the walk -- and log the
+                // WARN below -- on every login for as long as the throttle lasts, for no saving.
+                continue;
+            }
+            if (++consecutiveFailures >= maxConsecutiveGroupLookupFailures) {
+                logger.warn(
+                        "Stopped resolving the nested groups of {} after {} consecutive Microsoft Graph failures."
+                                + " {} of {} direct groups were not walked.",
+                        user.getName(), consecutiveFailures, groupIdsForParentLookup.size() - walkedCount, groupIdsForParentLookup.size());
+                break;
             }
         }
 
@@ -1999,6 +2039,14 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      */
     public void setMaxGroupDepth(final int maxGroupDepth) {
         this.maxGroupDepth = maxGroupDepth;
+    }
+
+    /**
+     * Sets how many consecutive unanswered parent group lookups end the walk.
+     * @param maxConsecutiveGroupLookupFailures The maximum number of consecutive failures.
+     */
+    public void setMaxConsecutiveGroupLookupFailures(final int maxConsecutiveGroupLookupFailures) {
+        this.maxConsecutiveGroupLookupFailures = maxConsecutiveGroupLookupFailures;
     }
 
     @Override

--- a/src/main/resources/fess_sso++.xml
+++ b/src/main/resources/fess_sso++.xml
@@ -11,6 +11,7 @@
 		<property name="groupCacheExpiry">600</property>
 		<property name="maxGroupCacheSize">10000</property>
 		<property name="maxGroupDepth">10</property>
+		<property name="maxConsecutiveGroupLookupFailures">3</property>
 		<property name="maxCachedAccounts">10000</property>
 		-->
 	</component>

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -2911,4 +2911,112 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
             fessConfig.setSystemProperty("entraid.reply.url", "");
         }
     }
+
+    /**
+     * An authenticator whose direct membership lookup hands back a fixed set of group ids without
+     * reaching Microsoft Graph, and whose parent group walk is scripted by {@code walkResult}.
+     * Every id the walk is asked for is appended to {@code walked}, so a test can tell how far the
+     * walk got as well as what it produced.
+     */
+    private EntraIdAuthenticator newAuthenticatorWithScriptedWalk(final List<String> groupIds, final List<String> walked,
+            final java.util.function.Predicate<String> walkResult, final boolean throttled) {
+        return new EntraIdAuthenticator() {
+            @Override
+            protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
+                    final List<String> groupIdsForParentLookup, final String url) {
+                groupIdsForParentLookup.addAll(groupIds);
+                groupList.add("direct-group");
+                return true;
+            }
+
+            @Override
+            protected boolean processParentGroup(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
+                    final String id) {
+                walked.add(id);
+                if (walkResult.test(id)) {
+                    groupList.add("parent-of-" + id);
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            protected boolean isGraphThrottled() {
+                return throttled;
+            }
+        };
+    }
+
+    @Test
+    public void test_updateMemberOf_stopsTheWalkAfterConsecutiveGraphFailures() {
+        // Graph answers /me/memberOf and then fails every getMemberGroups with something that
+        // records no backoff -- a 500/502/504, or a transport failure such as DNS, connection
+        // refused or the graphConnectTimeout/graphReadTimeout expiring. Without the bound that is
+        // one request, one waited-out timeout and one stack trace per direct group, on every
+        // login, on the shared TimeoutManager pool.
+        final List<String> walked = new ArrayList<>();
+        final EntraIdAuthenticator authenticator =
+                newAuthenticatorWithScriptedWalk(List.of("g1", "g2", "g3", "g4", "g5", "g6"), walked, id -> false, false);
+        final EntraIdUser user = newUserWithoutGraph();
+        final int before = permissionChangedCount.get();
+
+        authenticator.updateMemberOf(user);
+
+        assertEquals(3, walked.size(), "the walk has to stop at maxConsecutiveGroupLookupFailures");
+        assertEquals(List.of("g1", "g2", "g3"), walked);
+        // Still applied, and still announced: a partial parent set is worth more than none, and
+        // FAILED is what tells the user their permissions fell short.
+        assertTrue(List.of(user.getGroupNames()).contains("direct-group"));
+        assertEquals(FessUser.PermissionState.FAILED, user.getPermissionState());
+        assertEquals(before + 1, permissionChangedCount.get());
+    }
+
+    @Test
+    public void test_updateMemberOf_letsASuccessResetTheFailureCounter() {
+        // Consecutive, not total: one group id that is permanently broken -- deleted, or one the
+        // application has no permission for -- must not stop the rest of the walk.
+        final List<String> walked = new ArrayList<>();
+        final EntraIdAuthenticator authenticator = newAuthenticatorWithScriptedWalk(List.of("g1", "g2", "g3", "g4", "g5", "g6"), walked,
+                id -> "g3".equals(id) || "g6".equals(id), false);
+        final EntraIdUser user = newUserWithoutGraph();
+
+        authenticator.updateMemberOf(user);
+
+        assertEquals(6, walked.size(), "a success between failures has to clear the counter");
+        assertTrue(List.of(user.getGroupNames()).contains("parent-of-g3"));
+        assertTrue(List.of(user.getGroupNames()).contains("parent-of-g6"));
+        // Some parents were still missed, so the user is not fully resolved.
+        assertEquals(FessUser.PermissionState.FAILED, user.getPermissionState());
+    }
+
+    @Test
+    public void test_updateMemberOf_doesNotCountAThrottledSkipTowardsTheBound() {
+        // A lookup skipped for the tenant-wide backoff never reaches Graph, so it costs nothing
+        // and the backoff already bounds it. Counting it would end the walk -- and log the WARN --
+        // on every login for as long as the throttle lasts, buying nothing.
+        final List<String> walked = new ArrayList<>();
+        final EntraIdAuthenticator authenticator =
+                newAuthenticatorWithScriptedWalk(List.of("g1", "g2", "g3", "g4", "g5", "g6"), walked, id -> false, true);
+        final EntraIdUser user = newUserWithoutGraph();
+
+        authenticator.updateMemberOf(user);
+
+        assertEquals(6, walked.size(), "a throttled skip must not consume the bound");
+        assertEquals(FessUser.PermissionState.FAILED, user.getPermissionState());
+    }
+
+    @Test
+    public void test_updateMemberOf_honoursAConfiguredFailureBound() {
+        // The bound is a fess_sso++.xml property, so an operator can widen it for a tenant whose
+        // groups genuinely fail one by one, or narrow it to 1 to give up at the first failure.
+        final List<String> walked = new ArrayList<>();
+        final EntraIdAuthenticator authenticator =
+                newAuthenticatorWithScriptedWalk(List.of("g1", "g2", "g3", "g4", "g5", "g6"), walked, id -> false, false);
+        authenticator.setMaxConsecutiveGroupLookupFailures(1);
+        final EntraIdUser user = newUserWithoutGraph();
+
+        authenticator.updateMemberOf(user);
+
+        assertEquals(1, walked.size());
+    }
 }


### PR DESCRIPTION


## Problem

`updateMemberOf` walks every direct group id and calls `processParentGroup` for each one. A lookup that fails is recorded and the walk carries on:

```java
// Every direct group is still walked after one of them fails: a partial parent set is worth
// more than none, so the failures are collected rather than short-circuited.
boolean parentsResolved = true;
for (final String groupId : groupIdsForParentLookup) {
    if (!processParentGroup(user, groupList, roleList, groupId)) {
        parentsResolved = false;
    }
}
```

That is right for one broken group id. It is wrong for a Graph that has stopped answering.

A 429 or a 503 records a tenant-wide backoff (`applyGraphThrottle`), and `getParentGroup` then skips the rest of the walk without reaching Graph at all — that path is already bounded. **Nothing else is.** `toMemberGroupIds` throws `IOException` for any other error body, and curl4j raises `CurlException` for a transport failure, so a 500/502/504, DNS, connection refused, or the 10s connect / 30s read timeouts expiring all land in the `catch` in `getParentGroup`, which logs a full stack trace and returns an empty pair. The walk then costs **one request, one waited-out timeout and one stack trace per direct group, on every login**.

It runs on corelib's shared `TimeoutManager` pool: `availableProcessors()/2` threads, a `LinkedBlockingQueue` of the same size and `ThreadPoolExecutor.CallerRunsPolicy`. Once that overflows, the walk runs on the `TimeoutManager` timer thread itself and stalls every other Fess timed task. Since #3273 moved the whole resolution into the background, the direct membership lookup shares that pool too, so there is more of Fess behind it than there was.

15.7 was bounded here only by accident: `CurlException` is unchecked, Guava wraps it in `UncheckedExecutionException`, and 15.7 caught only `ExecutionException`, so the exception escaped and the task-level `catch (Exception)` aborted the whole walk at the first group. Widening that catch was correct, but it removed the bound.

## Fix

Stop the walk after `maxConsecutiveGroupLookupFailures` (default 3) **consecutive** lookups Graph did not answer, log one WARN naming how many direct groups were left unwalked, and still apply everything collected so far.

**Consecutive rather than total** is deliberate: one permanently broken group id — deleted, or one the application has no permission for — must not stop the rest of the walk, while an unreachable Graph trips the bound immediately.

**A throttled skip does not consume the bound.** It never reached Graph, so it costs nothing, and the backoff already bounds the tenant. Counting it would end the walk — and log the WARN — on every login for as long as the throttle lasts, buying nothing.

**What was already collected is still applied**, and the user is still marked `FAILED` and still announced through `permissionChanged`. A partial parent set is worth more than none, and `FAILED` is what tells the operator the permissions fell short.

`maxConsecutiveGroupLookupFailures` is listed in the commented `<property>` block of `fess_sso++.xml` alongside `maxGroupDepth`, and has a setter, so an operator can widen it for a tenant whose groups genuinely fail one by one or narrow it to `1` to give up at the first failure.

## Scope note vs. the original version of this PR

The original PR was written against a tree where the walk lived in `scheduleParentGroupLookup` and `getParentGroup` flattened every failure into an empty pair. It introduced a `ParentGroupLookupException` and a `boolean` return on `processParentGroup` so that "Graph did not answer" could be told apart from "this group has no parents".

`master` has since solved that half differently: #3273 moved the walk into `updateMemberOf`, and #3266 added the `AtomicBoolean failed` flag that `processParentGroup` already turns into its `boolean` result, feeding `PermissionState.FAILED`. Applying the original diff would have reverted both. It has therefore been rewritten against `master`: the exception and the signature changes are gone, and what is left is the bound itself — the one thing `master` still does not have.

The original PR also proposed logging only the *first* failure of a walk with a stack trace. That is **not** included here. With the bound in place the "Graph is down" case is capped at three traces, and threading a flag through `processParentGroup` / `getParentGroup` to cover the alternating-failure case would churn signatures that `master`'s tests exercise for a much smaller gain. It is a reasonable follow-up.

## Tests

Four tests in the `EntraIdAuthenticator` test class, driven through a scripted direct lookup and a scripted walk so no timer thread and no Graph are involved:

- the bound trips after N consecutive failures, exactly the first N ids are walked, what was collected before is still applied, the state is `FAILED` and `permissionChanged` still fires once;
- a success between failures resets the counter, so all six ids are walked;
- a throttled skip does not consume the bound, so all six ids are walked;
- the configured bound is honoured (`setMaxConsecutiveGroupLookupFailures(1)` stops at the first failure).

Mutation-checked against the fixed code:

| mutation | reddens |
|---|---|
| no bound (`>= Integer.MAX_VALUE`) | `stopsTheWalkAfterConsecutiveGraphFailures`, `honoursAConfiguredFailureBound` |
| counter never reset on success | `letsASuccessResetTheFailureCounter` (4 walked instead of 6) |
| a throttled skip consumes the bound | `doesNotCountAThrottledSkipTowardsTheBound` (3 walked instead of 6) |

## Verification

`mvn clean test -Dtest='org.codelibs.fess.sso.**,org.codelibs.fess.app.web.base.login.**'` at the top of the stack → 421 tests, 0 failures (136 of them in the `EntraIdAuthenticator` test class). `mvn clean javadoc:jar` → BUILD SUCCESS. `mvn formatter:format && mvn license:format` produced no changes.
