### PR TITLE
fix(sso): refuse a SAML LogoutRequest that names another user

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -34,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
+import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist.LoginCredentialResolver;
 import org.codelibs.fess.app.web.base.login.SamlCredential;
 import org.codelibs.fess.app.web.base.login.SamlCredential.SamlUser;
@@ -50,12 +52,16 @@ import org.codelibs.saml2.Auth;
 import org.codelibs.saml2.core.authn.AuthnRequestParams;
 import org.codelibs.saml2.core.exception.SAMLException;
 import org.codelibs.saml2.core.exception.ValidationException;
+import org.codelibs.saml2.core.logout.LogoutRequest;
 import org.codelibs.saml2.core.logout.LogoutRequestParams;
 import org.codelibs.saml2.core.replay.InMemoryReplayCache;
 import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
+import org.codelibs.saml2.core.util.Util;
+import org.codelibs.saml2.servlet.ServletUtils;
 import org.dbflute.optional.OptionalEntity;
+import org.dbflute.optional.OptionalThing;
 import org.lastaflute.core.message.UserMessages;
 import org.lastaflute.web.login.credential.LoginCredential;
 import org.lastaflute.web.response.ActionResponse;
@@ -63,6 +69,7 @@ import org.lastaflute.web.response.HtmlResponse;
 import org.lastaflute.web.response.StreamResponse;
 import org.lastaflute.web.util.LaRequestUtil;
 import org.lastaflute.web.util.LaResponseUtil;
+import org.w3c.dom.Document;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
@@ -152,11 +159,14 @@ import jakarta.servlet.http.HttpSession;
  * <p>{@code saml.security.want_messages_signed} matters in particular once
  * {@code saml.idp.single_logout_service.url} is configured. It defaults to {@code false} because
  * not every IdP signs its LogoutRequest, but while it is {@code false} the single logout service
- * accepts an unsigned LogoutRequest and does not compare its NameID with the session user, so
- * anyone who can lure a logged-in user to a crafted URL can end that session. The IdP entity ID
- * is not needed either: {@code Issuer} is optional in the SAML protocol schema and java-saml
- * compares it only when the element is present, so a LogoutRequest that omits it skips the
- * comparison altogether. The impact is a forced logout, not account takeover. This is reported as
+ * accepts a LogoutRequest that nobody authenticated, and reaching it needs no knowledge of the
+ * deployment: {@code Issuer} is optional in the SAML protocol schema and java-saml compares it
+ * only when the element is present, so a LogoutRequest that omits it is never matched against the
+ * IdP entity ID. A session logged in through SAML is protected by
+ * {@link #isLogoutRequestForAnotherUser}, which refuses to end a session the LogoutRequest does
+ * not name; what remains exposed is a session whose NameID the sender already knows, and any
+ * session that did not come from SAML at all, because there is then no NameID to compare. The
+ * impact is a forced logout, not account takeover. This is reported once as
  * {@code unsigned_logoutrequest_accepted} in the insecure-settings warning.</p>
  *
  * <h2>Session Cookie Settings (Required)</h2>
@@ -207,6 +217,16 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * The property key for the SAML SP base URL.
      */
     protected static final String SAML_SP_BASE_URL = "saml.sp.base.url";
+
+    /** Upper bound on the length of a sender-supplied NameID embedded in a log message. */
+    protected static final int MAX_LOGGED_NAME_ID_LENGTH = 64;
+
+    /**
+     * Characters that must not be copied verbatim into a log message. {@code \p{Cntrl}} alone is
+     * ASCII-only, so the Unicode break characters a log viewer still renders as a new line are
+     * listed explicitly.
+     */
+    private static final Pattern LOG_UNSAFE_PATTERN = Pattern.compile("[\\p{Cntrl}\\u0085\\u2028\\u2029]");
 
     /**
      * The property key for how long, in seconds, an unanswered AuthnRequest ID stays usable. Only
@@ -452,10 +472,13 @@ public class SamlAuthenticator implements SsoAuthenticator {
     protected void logSecurityWarnings(final Saml2Settings settings) {
         final List<String> warnings = new ArrayList<>(settings.getSecurityWarnings());
         if (settings.getIdpSingleLogoutServiceResponseUrl() != null && !settings.getWantMessagesSigned()) {
-            // /sso/logout accepts a LogoutRequest that is not signed, and the NameID it carries is
-            // never compared with the session user, so anyone can end an authenticated session by
-            // luring the user to a crafted URL. Not even the IdP entity ID is needed: Issuer is
-            // optional in the protocol schema and java-saml compares it only when it is present.
+            // /sso/logout accepts a LogoutRequest that is not signed, so anyone who can lure a
+            // logged-in user to a crafted URL can reach it; not even the IdP entity ID is needed,
+            // since Issuer is optional in the protocol schema and java-saml compares it only when
+            // it is present. isLogoutRequestForAnotherUser() keeps such a request from ending a
+            // SAML session it does not name, but a session whose NameID the sender already knows,
+            // and a session that did not come from SAML and therefore has no NameID to compare,
+            // are still ended by it.
             warnings.add("unsigned_logoutrequest_accepted");
         }
         if (!warnings.equals(loggedSecurityWarnings.getAndSet(warnings)) && !warnings.isEmpty()) {
@@ -1207,8 +1230,13 @@ public class SamlAuthenticator implements SsoAuthenticator {
                     throw processFailure("Failed to log out.", msg);
                 }
                 final Auth auth = new Auth(settings, request, response);
+                // A LogoutRequest that names somebody else must not take this session with it, but
+                // it is still answered with an ordinary LogoutResponse: an error would tell an
+                // unauthenticated sender whether it guessed a live session, and would leave a
+                // confused-but-legitimate IdP with no way of finishing its own logout.
+                final boolean keepLocalSession = isLogoutRequestForAnotherUser(request, settings);
                 // stay=true keeps java-saml from committing the servlet response itself
-                final String redirectUrl = auth.processSLO(false, null, true);
+                final String redirectUrl = auth.processSLO(keepLocalSession, null, true);
                 final List<String> errors = auth.getErrors();
                 if (!errors.isEmpty()) {
                     final String msg = String.join(", ", errors);
@@ -1225,5 +1253,178 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 throw processFailure("Failed to log out.", e.getMessage(), e);
             }
         }).orElseThrow(() -> processFailure("Failed to log out.", "Invalid state."));
+    }
+
+    /**
+     * Returns whether an IdP-initiated LogoutRequest names somebody other than the user this
+     * session is logged in as, in which case the session must survive it.
+     *
+     * <p>{@code /sso/logout} is anonymous and, because SAML requires {@code SameSite=none}, is
+     * reachable cross-site with the victim's session cookie attached. With the shipped default
+     * {@code saml.security.want_messages_signed=false} java-saml accepts a LogoutRequest that
+     * carries no signature, and every other check it makes is conditional on an attribute the
+     * sender simply omits -- {@code NotOnOrAfter}, {@code Destination}, and even {@code Issuer},
+     * which the protocol schema declares optional and whose absence therefore skips the entity ID
+     * comparison as well. The NameID is the one element java-saml insists on, so it is the one
+     * thing left worth checking, and comparing it with the session costs an attacker the guess.</p>
+     *
+     * <p>A LogoutResponse the IdP is answering ({@code SAMLResponse}) is left alone: it is the
+     * reply to a LogoutRequest this SP itself sent, so it carries no NameID to compare, and
+     * constructing a {@link LogoutRequest} from such a request would silently build a fresh
+     * outgoing message rather than parse anything.</p>
+     *
+     * <p>Anything that is not a clear mismatch keeps the previous behaviour of ending the session:
+     * no user logged in, a user who did not come from SAML, a NameID that cannot be read. Failing
+     * the other way would let an unreadable NameID keep sessions alive, which is the failure mode
+     * this method exists to avoid making worse.</p>
+     *
+     * @param request The HTTP request carrying the SAML logout message.
+     * @param settings The SAML settings, used to parse the LogoutRequest the way java-saml
+     *            itself parses it a moment later.
+     * @return true if the session must be kept because the LogoutRequest names another user.
+     */
+    protected boolean isLogoutRequestForAnotherUser(final HttpServletRequest request, final Saml2Settings settings) {
+        if (StringUtil.isBlank(request.getParameter("SAMLRequest"))) {
+            return false;
+        }
+        final String sessionNameId = getSessionSamlNameId();
+        if (StringUtil.isBlank(sessionNameId)) {
+            return false;
+        }
+        final String logoutRequestNameId = getLogoutRequestNameId(request, settings);
+        if (StringUtil.isBlank(logoutRequestNameId)) {
+            return false;
+        }
+        if (isSameNameId(sessionNameId, logoutRequestNameId)) {
+            return false;
+        }
+        logger.warn("The LogoutRequest names '{}' but this session is logged in as '{}', so it is answered without ending the session."
+                + " If a legitimate single logout stopped working, compare the NameID the IdP puts in its assertion with the one it puts"
+                + " in its LogoutRequest.", sanitizeForLog(logoutRequestNameId), sanitizeForLog(sessionNameId));
+        return true;
+    }
+
+    /**
+     * Bounds a NameID and strips its control characters so that it can be embedded in a log
+     * message.
+     *
+     * <p>The NameID of the LogoutRequest reaches this log before anything has authenticated the
+     * message -- that is the whole point of the check that reports it -- so a raw newline in it
+     * would let an unauthenticated sender forge log lines. It is XML text content, so it can hold
+     * one. {@code SpnegoAuthenticator} bounds the realm it logs for the same reason and in the
+     * same way.</p>
+     *
+     * @param value The NameID to embed in a log message.
+     * @return A value safe to embed in a log message.
+     */
+    protected static String sanitizeForLog(final String value) {
+        final String bounded = value.length() > MAX_LOGGED_NAME_ID_LENGTH ? value.substring(0, MAX_LOGGED_NAME_ID_LENGTH) + "..." : value;
+        return LOG_UNSAFE_PATTERN.matcher(bounded).replaceAll("?");
+    }
+
+    /**
+     * Returns the NameID this session was logged in with, or null when it did not come from SAML.
+     *
+     * <p>{@code SamlUser.getName()} is that NameID rather than a display name: it is what
+     * {@link #logout(FessUserBean)} passes as the {@code nameId} of the LogoutRequest it sends,
+     * so the IdP is expected to name the same value when the logout starts at its end.</p>
+     *
+     * @return The NameID of the session user, or null when nobody is logged in, when the user did
+     *         not authenticate through SAML, or when the session cannot be reached at all.
+     */
+    protected String getSessionSamlNameId() {
+        try {
+            final FessUserBean userBean = getSavedUserBean().orElse(null);
+            if (userBean != null && userBean.getFessUser() instanceof final SamlUser samlUser) {
+                return samlUser.getName();
+            }
+        } catch (final Exception e) {
+            // this endpoint has to keep working for a request that reaches it outside a login
+            // scope, so being unable to look at the session means "cannot tell", not "fail"
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to read the session user.", e);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the user bean held by the session.
+     *
+     * <p>Separate from {@link #getSessionSamlNameId()} so that a test can decide who is logged in
+     * without standing up a login scope; {@code /api/v2} does the same with its own handlers.</p>
+     *
+     * @return The user bean of the session, empty when nobody is logged in.
+     */
+    protected OptionalThing<FessUserBean> getSavedUserBean() {
+        return ComponentUtil.getComponent(FessLoginAssist.class).getSavedUserBean();
+    }
+
+    /**
+     * Returns the NameID carried by the incoming LogoutRequest, or null when it cannot be read.
+     *
+     * <p>The message is parsed with java-saml rather than by hand. {@code /sso/logout} is
+     * anonymous, so hand-parsing the base64 {@code SAMLRequest} here would put an XML parser --
+     * and therefore an XXE surface -- in front of an unauthenticated sender, whereas
+     * {@link LogoutRequest} decodes and loads it through the hardened path the library already
+     * uses. The arguments mirror {@code LogoutRequest.isValid()} exactly, including the allowed
+     * key transport algorithms, so an encrypted NameID is read here under the same restrictions it
+     * would be read under a moment later and this adds no decryption the message was not going to
+     * get anyway.</p>
+     *
+     * <p>Nothing here is allowed to abort the logout. A malformed message, an {@code EncryptedID}
+     * with no SP private key configured to open it, an unreadable NameID: all of them mean "cannot
+     * tell", which {@link #isLogoutRequestForAnotherUser} turns back into the previous behaviour.
+     * Constructing the {@link LogoutRequest} touches no replay cache -- only {@code isValid()}
+     * registers a message ID -- so parsing it twice does not make java-saml reject its own copy as
+     * a replay.</p>
+     *
+     * @param request The HTTP request carrying the LogoutRequest.
+     * @param settings The SAML settings.
+     * @return The NameID of the LogoutRequest, or null when it cannot be read.
+     */
+    protected String getLogoutRequestNameId(final HttpServletRequest request, final Saml2Settings settings) {
+        try {
+            final LogoutRequest logoutRequest = new LogoutRequest(settings, ServletUtils.makeHttpRequest(request));
+            final Document document = Util.loadXML(logoutRequest.getLogoutRequestXml());
+            if (document == null) {
+                // Util.loadXML answers unparsable XML, and anything holding an ENTITY, with null
+                return null;
+            }
+            return LogoutRequest.getNameId(document, settings.getSPkey(), settings.isTrimNameIds(),
+                    settings.getAllowedKeyTransportAlgorithms());
+        } catch (final Exception e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to read the NameID of the LogoutRequest.", e);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Returns whether two NameIDs identify the same user.
+     *
+     * <p>Deliberately more forgiving than {@code equals}, because the damage of the two comparisons
+     * is not symmetric: a false match only leaves today's behaviour in place, while a false
+     * mismatch breaks a legitimate single logout, which is silent and looks like the session simply
+     * refusing to end.</p>
+     *
+     * <p>Both sides are trimmed. The NameID stored at login and the NameID of the LogoutRequest
+     * are read from the text content of two different XML documents, and java-saml trims neither
+     * unless {@code saml.parsing.trim_name_ids} is turned on, which Fess leaves off; an IdP that
+     * pretty-prints one message and not the other would otherwise look like a different user.</p>
+     *
+     * <p>The comparison also ignores case. NameIDs that differ only in case are the same account
+     * at every IdP that produces them -- an email address or a UPN -- and an IdP that normalises
+     * case differently between its assertion and its LogoutRequest is a real deployment, not a
+     * hypothetical one. It costs nothing to defend against: a sender who does not know the NameID
+     * fails whatever the case, and one who does gains nothing from being allowed to change it.</p>
+     *
+     * @param sessionNameId The NameID this session was logged in with, not blank.
+     * @param logoutRequestNameId The NameID carried by the LogoutRequest, not blank.
+     * @return true if both name the same user.
+     */
+    protected boolean isSameNameId(final String sessionNameId, final String logoutRequestNameId) {
+        return sessionNameId.trim().equalsIgnoreCase(logoutRequestNameId.trim());
     }
 }

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -33,9 +33,12 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
+import org.codelibs.fess.app.web.base.login.SamlCredential.SamlUser;
+import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.exception.SsoMessageException;
 import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
@@ -44,6 +47,7 @@ import org.codelibs.saml2.core.exception.SAMLException;
 import org.codelibs.saml2.core.exception.ValidationException;
 import org.codelibs.saml2.core.exception.XMLParsingException;
 import org.codelibs.saml2.core.settings.Saml2Settings;
+import org.dbflute.optional.OptionalThing;
 import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -1345,6 +1349,262 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
         }
     }
 
+    // ===================================================================================
+    //                                                                Single Logout Service
+    //                                                                =====================
+
+    /** The session attribute a test watches to tell an invalidated session from a kept one. */
+    private static final String SESSION_MARKER = "SLO_TEST_MARKER";
+
+    /** IdP settings that also make the single logout service reachable. */
+    private void setUpSlo(final DynamicProperties systemProperties) {
+        setUpIdp(systemProperties);
+        systemProperties.setProperty("saml.idp.single_logout_service.url", "https://idp.example.com/slo");
+    }
+
+    private void tearDownSlo(final DynamicProperties systemProperties) {
+        systemProperties.remove("saml.idp.single_logout_service.url");
+        tearDownIdp(systemProperties);
+    }
+
+    /**
+     * Builds an authenticator that reports the given user as logged in. The real
+     * {@code FessLoginAssist} cannot be resolved here because it injects the user index, which is
+     * exactly why reading the session user sits behind an overridable method.
+     */
+    private SamlAuthenticator createAuthenticatorLoggedInAs(final OptionalThing<FessUserBean> userBean) throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator() {
+            @Override
+            protected OptionalThing<FessUserBean> getSavedUserBean() {
+                return userBean;
+            }
+        };
+        final Field field = SamlAuthenticator.class.getDeclaredField("defaultSettings");
+        field.setAccessible(true);
+        field.set(authenticator, authenticator.createDefaultSettings());
+        return authenticator;
+    }
+
+    /** The session bean a SAML login leaves behind; SamlUser.getName() is the NameID. */
+    private OptionalThing<FessUserBean> samlUserBean(final String nameId) {
+        return OptionalThing.of(new FessUserBean(new SamlUser(nameId, "_sessionIndex", null, null, null, new String[0], new String[0])));
+    }
+
+    /**
+     * Puts an IdP-initiated LogoutRequest on the request, shaped the way one that nobody
+     * authenticated looks: no signature, and neither {@code NotOnOrAfter} nor {@code Destination},
+     * both of which java-saml checks only when the attribute is present.
+     *
+     * @param request The request the IdP is pretending to send.
+     * @param id The LogoutRequest ID, which the replay cache keys on.
+     * @param nameId The NameID the LogoutRequest asks to log out.
+     */
+    private void sendLogoutRequest(final MockletHttpServletRequest request, final String id, final String nameId) {
+        final String xml = "<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\""
+                + " xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + id + "\" Version=\"2.0\""
+                + " IssueInstant=\"2026-01-01T00:00:00Z\">" + "<saml:Issuer>https://idp.example.com/metadata</saml:Issuer>"
+                + "<saml:NameID>" + nameId + "</saml:NameID></samlp:LogoutRequest>";
+        request.setParameter("SAMLRequest", Base64.getEncoder().encodeToString(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void test_getLogoutResponse_keepsTheSessionWhenTheLogoutRequestNamesAnotherUser() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorLoggedInAs(samlUserBean("victim@example.com"));
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpSlo(systemProperties);
+            // /sso/logout is anonymous and SAML forces SameSite=none, so this request reaches the
+            // endpoint cross-site with the victim's session cookie on it
+            final MockletHttpServletRequest request = getMockRequest();
+            request.getSession().setAttribute(SESSION_MARKER, "kept");
+            sendLogoutRequest(request, "_crafted", "attacker@example.com");
+            // primed so that the insecure-settings warning is not one of the lines asserted below
+            authenticator.getSettings();
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                final ActionResponse response = authenticator.getResponse(SsoResponseType.LOGOUT);
+
+                assertEquals("kept", request.getSession(false).getAttribute(SESSION_MARKER));
+                // the IdP still gets an ordinary LogoutResponse: an error would tell the sender
+                // whether it guessed a live session, and would strand a confused-but-real IdP
+                assertTrue(String.valueOf(response), String.valueOf(response).contains("https://idp.example.com/slo?SAMLResponse="));
+                assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("attacker@example.com"));
+                assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("victim@example.com"));
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownSlo(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLogoutResponse_endsTheSessionWhenTheLogoutRequestNamesTheSessionUser() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorLoggedInAs(samlUserBean("victim@example.com"));
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpSlo(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+            request.getSession().setAttribute(SESSION_MARKER, "kept");
+            sendLogoutRequest(request, "_slo", "victim@example.com");
+            authenticator.getSettings();
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                final ActionResponse response = authenticator.getResponse(SsoResponseType.LOGOUT);
+
+                // the whole point of single logout: the IdP says so, so the session ends
+                assertNull(request.getSession(false).getAttribute(SESSION_MARKER), "the session must not survive its own logout");
+                assertTrue(String.valueOf(response), String.valueOf(response).contains("https://idp.example.com/slo?SAMLResponse="));
+                assertTrue(String.valueOf(appender.warnings()), appender.warnings().isEmpty());
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownSlo(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLogoutResponse_endsTheSessionWhenTheNameIdDiffersOnlyInFormatting() throws Exception {
+        // The two NameIDs are read from the text content of two different XML documents, and
+        // java-saml trims neither unless saml.parsing.trim_name_ids is turned on, which Fess
+        // leaves off. An IdP that pretty-prints its LogoutRequest but not its assertion, or that
+        // normalises the case of a UPN in one and not the other, must not end up unable to log
+        // anyone out -- that failure is silent and looks like the session refusing to die.
+        final SamlAuthenticator authenticator = createAuthenticatorLoggedInAs(samlUserBean("Victim@Example.com"));
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpSlo(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+            request.getSession().setAttribute(SESSION_MARKER, "kept");
+            sendLogoutRequest(request, "_formatted", "\n            victim@example.com\n        ");
+            authenticator.getSettings();
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                authenticator.getResponse(SsoResponseType.LOGOUT);
+
+                assertNull(request.getSession(false).getAttribute(SESSION_MARKER), "a reformatted NameID is still the same user");
+                assertTrue(String.valueOf(appender.warnings()), appender.warnings().isEmpty());
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownSlo(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLogoutResponse_endsTheSessionWhenNobodyIsLoggedIn() throws Exception {
+        // With no session user there is no NameID to compare against, so the LogoutRequest keeps
+        // the effect it always had rather than being refused on a comparison that cannot be made.
+        final SamlAuthenticator authenticator = createAuthenticatorLoggedInAs(OptionalThing.empty());
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpSlo(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+            request.getSession().setAttribute(SESSION_MARKER, "kept");
+            sendLogoutRequest(request, "_anonymous", "someone@example.com");
+
+            final ActionResponse response = authenticator.getResponse(SsoResponseType.LOGOUT);
+
+            assertNull(request.getSession(false).getAttribute(SESSION_MARKER), "the session must still be invalidated");
+            assertTrue(String.valueOf(response), String.valueOf(response).contains("https://idp.example.com/slo?SAMLResponse="));
+        } finally {
+            tearDownSlo(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_isLogoutRequestForAnotherUser_leavesALogoutResponseAlone() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorLoggedInAs(samlUserBean("victim@example.com"));
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpSlo(systemProperties);
+            // the IdP answering a LogoutRequest this SP sent. Handing such a request to the
+            // LogoutRequest parser would not parse anything: with no SAMLRequest parameter it
+            // builds a fresh outgoing message instead, whose NameID defaults to the IdP entity ID
+            // and therefore never matches the session user, leaving every SP-initiated logout with
+            // a session that refuses to end.
+            final MockletHttpServletRequest request = getMockRequest();
+            request.setParameter("SAMLResponse", "PHNhbWxwOkxvZ291dFJlc3BvbnNlIC8+");
+
+            assertFalse(authenticator.isLogoutRequestForAnotherUser(request, authenticator.getSettings()));
+        } finally {
+            tearDownSlo(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLogoutRequestNameId_returnsNullWhenTheNameIdCannotBeRead() throws Exception {
+        // A NameID this check cannot read must mean "cannot tell", which leaves the previous
+        // behaviour in place; throwing here would turn an unreadable message into a broken logout.
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpSlo(systemProperties);
+            final Saml2Settings settings = authenticator.getSettings();
+
+            final MockletHttpServletRequest wellFormed = getMockRequest();
+            sendLogoutRequest(wellFormed, "_readable", "victim@example.com");
+            assertEquals("victim@example.com", authenticator.getLogoutRequestNameId(wellFormed, settings));
+
+            final MockletHttpServletRequest notXml = getMockRequest();
+            notXml.setParameter("SAMLRequest", "................");
+            assertNull(authenticator.getLogoutRequestNameId(notXml, settings), "an undecodable message has no NameID");
+
+            final MockletHttpServletRequest withoutNameId = getMockRequest();
+            final String xml = "<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\""
+                    + " xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_bare\" Version=\"2.0\""
+                    + " IssueInstant=\"2026-01-01T00:00:00Z\"/>";
+            withoutNameId.setParameter("SAMLRequest", Base64.getEncoder().encodeToString(xml.getBytes(StandardCharsets.UTF_8)));
+            assertNull(authenticator.getLogoutRequestNameId(withoutNameId, settings), "java-saml rejects this one on its own later");
+        } finally {
+            tearDownSlo(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getSessionSamlNameId_ignoresAUserThatDidNotComeFromSaml() throws Exception {
+        // A local or LDAP login carries a user name, not a NameID, and comparing the two would
+        // reject every legitimate single logout on a mixed-authentication deployment.
+        assertEquals("victim@example.com", createAuthenticatorLoggedInAs(samlUserBean("victim@example.com")).getSessionSamlNameId());
+        assertNull(createAuthenticatorLoggedInAs(OptionalThing.of(new FessUserBean(new LocalUser("victim@example.com"))))
+                .getSessionSamlNameId(), "a non-SAML user has no NameID to compare");
+        assertNull(createAuthenticatorLoggedInAs(OptionalThing.empty()).getSessionSamlNameId(), "nobody is logged in");
+    }
+
+    @Test
+    public void test_isSameNameId_toleratesFormattingButNotADifferentUser() throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+
+        // the two sides come from different XML documents, which the IdP may format differently
+        assertTrue(authenticator.isSameNameId("victim@example.com", "  victim@example.com\n"));
+        // an IdP that normalises the case of a UPN in one message and not the other is a real
+        // deployment; a sender that does not know the NameID fails whatever case it picks
+        assertTrue(authenticator.isSameNameId("Victim@Example.com", "victim@example.com"));
+        assertFalse(authenticator.isSameNameId("victim@example.com", "attacker@example.com"));
+    }
+
+    @Test
+    public void test_sanitizeForLog_keepsAnUnauthenticatedNameIdFromForgingLogLines() throws Exception {
+        // the NameID of the LogoutRequest is written to the log before anything has authenticated
+        // the message, and it is XML text content, so it can carry a line break
+        assertEquals("victim@example.com? ERROR forged", SamlAuthenticator.sanitizeForLog("victim@example.com\n ERROR forged"));
+        assertEquals("victim@example.com? ERROR forged", SamlAuthenticator.sanitizeForLog("victim@example.com\r ERROR forged"));
+        // \p{Cntrl} is ASCII-only, so the Unicode break characters a log viewer still renders as
+        // a new line have to be covered separately
+        assertEquals("a?b?c", SamlAuthenticator.sanitizeForLog("a\u0085b\u2028c"));
+
+        final int max = SamlAuthenticator.MAX_LOGGED_NAME_ID_LENGTH;
+        assertEquals("x".repeat(max) + "...", SamlAuthenticator.sanitizeForLog("x".repeat(max + 10)));
+        // an ordinary NameID is passed through untouched
+        assertEquals("victim@example.com", SamlAuthenticator.sanitizeForLog("victim@example.com"));
+    }
+
     @Test
     public void test_buildDefaultUrl_withDefaultBaseUrl() throws Exception {
         assertEquals("http://localhost:8080/sso/metadata", new SamlAuthenticator().buildDefaultUrl("/sso/metadata"));
@@ -1386,6 +1646,38 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertEquals("http://localhost:8080/sso/logout", authenticator.buildDefaultUrl("/sso/logout"));
         } finally {
             systemProperties.remove(BASE_URL_KEY);
+        }
+    }
+
+    /** A user that did not authenticate through SAML, as a local or LDAP login leaves behind. */
+    private static class LocalUser implements FessUser {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        LocalUser(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String[] getRoleNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getGroupNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getPermissions() {
+            return new String[0];
         }
     }
 }


### PR DESCRIPTION
## The problem

`/sso/logout` is anonymous and, because SAML requires `tomcat.sameSiteCookies=none`,
is reachable cross-site with the victim's session cookie attached. With the
shipped default `saml.security.want_messages_signed=false`, java-saml accepts a
LogoutRequest that carries no signature, and every other check it makes is
conditional on an attribute the sender simply omits:

| check | why it does not fire |
|---|---|
| signature | `LogoutRequest.java:479` — only when `getWantMessagesSigned()` |
| `NotOnOrAfter` | `:452` — guarded by `hasAttribute` |
| `Destination` | `:462` — guarded by `hasAttribute` |
| `Issuer` vs `saml.idp.entityid` | `:474` — `if (issuer != null && …)`, and `getIssuer()` returns `null` when the element is absent (`:905-917`). `saml-schema-protocol-2.0.xsd:31` declares `<element ref="saml:Issuer" minOccurs="0"/>`, so omitting it still passes XML validation |

The NameID is the one element java-saml insists on (`:694-696` throws `NO_NAMEID`),
and its **value was never compared with anything**. So ending an authenticated
session required no knowledge of the deployment at all — not even the IdP entity
ID. `Auth.processSLO(false, …)` then invalidates the session at `Auth.java:1242`.

Impact is a forced logout (denial of service), not account takeover.

## The change

`getLogoutResponse()` now compares the LogoutRequest's NameID with the session
user's before letting java-saml invalidate the session. On a mismatch the
session is kept and the IdP still gets an ordinary LogoutResponse — an error
would tell an unauthenticated sender whether it guessed a live session, and
would leave a confused-but-legitimate IdP unable to finish its own logout.

`SamlUser.getName()` is the NameID: it is what `logout(FessUserBean)` already
passes as the `nameId` of the LogoutRequest Fess sends.

The `SAMLResponse` branch is untouched.

### Why the comparison is not `equals`

The risk is asymmetric — a false *match* only restores the previous behaviour,
while a false *mismatch* silently breaks a working single logout.

- **Both sides are trimmed.** They are read from the text content of two
  different XML documents, and java-saml trims neither unless
  `saml.parsing.trim_name_ids` is on, which Fess leaves off. An IdP that
  pretty-prints its LogoutRequest but not its assertion would otherwise look
  like a different user on every logout.
- **Case is ignored.** An IdP that normalises an email or UPN differently
  between its assertion and its LogoutRequest is a real deployment. It costs
  nothing: a sender who does not know the NameID fails at any case, and one who
  does gains nothing from changing it.

### Fail-open by design

Nothing short of a clear mismatch changes behaviour: nobody logged in, a user
who did not come from SAML, a malformed message, an `EncryptedID` with no SP key
to open it. All of them mean "cannot tell", which keeps today's behaviour.

The message is parsed through `new LogoutRequest(settings, ServletUtils.makeHttpRequest(request))`
with the same argument list `LogoutRequest.isValid()` uses, not by hand — hand
parsing would put an XML parser, and therefore an XXE surface, in front of an
unauthenticated sender. Constructing a `LogoutRequest` touches no replay cache
(only `isValid()` registers an ID), so parsing twice does not make java-saml
reject its own copy.

The NameID is bounded to 64 characters and stripped of control characters before
it reaches the log, the way `SpnegoAuthenticator.sanitizeForLog` already treats a
client-supplied realm — it is written **before** anything authenticated the
message, and it is XML text content, so it can carry a newline.

## What this does NOT fix

This narrows the exposure, it does not close it. Still ended by a crafted
request:

- a SAML session whose NameID the sender already knows (with the default
  `emailAddress` format, that may just be the victim's email address)
- any session that did not come from SAML (local admin, LDAP), since there is no
  NameID to compare

`saml.security.want_messages_signed=true` remains the real fix. The class javadoc
and the `unsigned_logoutrequest_accepted` comment are updated to say exactly
this, since both previously asserted that the NameID is never compared.

## Verification

- `mvn -o clean test -Dtest=SamlAuthenticatorTest` → `Tests run: 45, Failures: 0, Errors: 0, Skipped: 0` (was 36)
- `mvn -o test -Dtest='*Sso*,*Saml*'` → `Tests run: 167, Failures: 0, Errors: 0, Skipped: 0`
- `mvn -o javadoc:jar` → BUILD SUCCESS (the one remaining warning is the pre-existing, unrelated `ChunkBoundaryFinder.java:882`)
- `mvn -o formatter:format license:format` → no further changes

12 mutations were applied to the production code and each was confirmed to fail a
test before being restored: restoring `processSLO(false, …)`, dropping the
`SAMLRequest` guard, dropping `.trim()`, `equalsIgnoreCase` → `equals`, dropping
the `instanceof SamlUser` check, removing the exception swallowing, dropping the
blank-NameID guards, removing the WARN, inverting the comparison, forcing the
NameID reader to null, and making `sanitizeForLog` return its input unchanged.
None passed.

## Worth knowing before merge

- **The check applies to signed LogoutRequests too.** With
  `want_messages_signed=true` the message is authenticated, yet a NameID mismatch
  still keeps the session. That is deliberate — honouring it would log out the
  wrong user — but it means a correctly-secured deployment is also exposed to the
  false-mismatch failure mode. There is no kill switch; a mismatch is at least
  no longer silent, since the WARN names both values.
- **The production wiring of `getSavedUserBean()` is not covered by a test.** In
  the unit container `FessLoginAssist` resolves as a component def but fails to
  auto-inject its `@Resource UserBhv` (no user index), so the tests override a
  `protected` seam — the same idiom `MeHandlerTest` uses. `ViewHelper` and
  `MeHandler` rely on the same call in production. One manual SLO round trip
  against a real IdP before release would be worth it.

## Related

- codelibs/fess#3257 and codelibs/fess-docs#487 correct the comments and docs that understated this exposure (different regions of the same file; merges cleanly).
