### PR TITLE
fix(sso/spnego): stop a rejected Authorization header logging a stack trace

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -259,7 +259,21 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 // The library reports why the handshake failed; keep it, but not every exception
                 // carries a message and "null <msg>" helps nobody diagnose an SSO failure.
                 final String detail = e.getMessage();
-                throw new SsoLoginException(detail == null ? msg : detail + " " + msg, e);
+                final String reason = detail == null ? msg : detail + " " + msg;
+                if (e instanceof UnsupportedOperationException) {
+                    // The library raises this type only for a header it refuses to even try: a
+                    // scheme that is neither Negotiate nor Basic, a Basic header carrying no token,
+                    // Basic while basic authentication is not supported, or an NTLM token it cannot
+                    // downgrade. The client decides every one of those, and /sso is anonymous, so a
+                    // stack trace per attempt would let an unauthenticated client fill the log. It
+                    // is not only an abuse path either: basic support is off unless the request is
+                    // secure, so a TLS-terminating proxy that leaves isSecure() false sends
+                    // ordinary browser traffic down here. An initialization fault cannot arrive as
+                    // this type, because getAuthenticator() wraps every one of them in a plain
+                    // SsoLoginException, which keeps its stack trace.
+                    throw new SsoStateException(reason, e);
+                }
+                throw new SsoLoginException(reason, e);
             }
 
             // context/auth loop not yet complete
@@ -380,7 +394,14 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
         final String user = colon < 0 ? credentials : credentials.substring(0, colon);
         // The library drops a NetBIOS "DOMAIN\" prefix before authenticating, so mirror it here.
         final String name = user.substring(user.indexOf('\\') + 1);
-        final int at = name.indexOf('@');
+        // Kerberos reads the realm after the last '@', not the first: KerberosPrincipal collapses
+        // "alice@a@PARTNER.EXAMPLE" to name "alice@PARTNER.EXAMPLE" in realm "PARTNER.EXAMPLE", and
+        // the library hands the typed name straight to the login module, so PARTNER.EXAMPLE is the
+        // realm an AS-REQ would actually reach. Splitting on the first '@' names a realm that
+        // exists nowhere and that the allow list can therefore only refuse.
+        final int at = name.lastIndexOf('@');
+        // A name ending in '@' names an empty realm, which KerberosPrincipal rejects outright, so
+        // there is nothing here for the allow list to decide.
         if (at < 0 || at == name.length() - 1) {
             return null;
         }

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
@@ -97,6 +97,19 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getBasicRealm_realmFollowsTheLastAtSign() {
+        // Kerberos takes the realm after the LAST '@': KerberosPrincipal("alice@a@PARTNER.EXAMPLE")
+        // normalizes to name "alice@PARTNER.EXAMPLE" and realm "PARTNER.EXAMPLE", and the library
+        // hands the typed name straight to the login module, so that is the realm an AS-REQ would
+        // reach. Reading the first '@' instead names a realm that exists nowhere, which the allow
+        // list can only ever refuse. Built literally so the header is visible at the call site.
+        assertEquals("PARTNER.EXAMPLE", SpnegoAuthenticator.getBasicRealm("Basic " + token("alice@a@PARTNER.EXAMPLE:secret")));
+        // A name ending in '@' names an empty realm, which KerberosPrincipal rejects outright, so
+        // there is nothing for the allow list to decide.
+        assertNull(SpnegoAuthenticator.getBasicRealm("Basic " + token("alice@a@:secret")));
+    }
+
+    @Test
     public void test_getBasicRealm_separatorMatchesLibraryParsing() {
         // SpnegoProvider#parseAuthHeader matches the scheme case-insensitively and then skips a run
         // of any whitespace, possibly empty. Every header below is authenticated by the library, so
@@ -194,6 +207,44 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
         authenticator.rejectDisallowedBasicRealm(requestWithAuthz("Negotiate YIIFoAYGKwYBBQUCoIIF"));
         authenticator.rejectDisallowedBasicRealm(requestWithAuthz(basic("alice:secret")));
         authenticator.rejectDisallowedBasicRealm(requestWithAuthz(basic("CORP\\alice:secret")));
+    }
+
+    @Test
+    public void test_getLoginCredential_rejectedAuthorizationHeaderIsAStateException() {
+        // "Negotiate or Basic Only" is what SpnegoProvider#getAuthScheme raises for a header whose
+        // scheme is neither Negotiate nor Basic, and for a Basic header carrying no token. The
+        // library also raises UnsupportedOperationException for Basic once basicSupported is false
+        // and for an NTLM token it cannot downgrade. All three are decided by the client, and /sso
+        // is anonymous, so a stack trace per attempt would let an unauthenticated client fill the
+        // log -- SsoStateException, which SsoAction logs message-only.
+        addMockRequestHeader(Constants.AUTHZ_HEADER, "Bearer " + token("alice@PARTNER.EXAMPLE"));
+        final SpnegoAuthenticator authenticator = new SpnegoAuthenticator() {
+            @Override
+            protected org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
+                throw new UnsupportedOperationException("Negotiate or Basic Only");
+            }
+        };
+        final SsoStateException e = assertThrows(SsoStateException.class, authenticator::getLoginCredential);
+        assertTrue(e.getMessage().contains("Negotiate or Basic Only"));
+        // The header is echoed masked, so the scheme survives and the credential does not.
+        assertTrue(e.getMessage().contains("Bearer ***"));
+        assertFalse(e.getMessage().contains(token("alice@PARTNER.EXAMPLE")));
+    }
+
+    @Test
+    public void test_getLoginCredential_serverFaultKeepsItsStackTrace() {
+        // The counterpart of the case above: getAuthenticator() wraps every initialization failure
+        // in a plain SsoLoginException, and that must not be downgraded to a rejected request --
+        // an unreadable keytab or an unreachable KDC is a fault the operator needs the trace for.
+        addMockRequestHeader(Constants.AUTHZ_HEADER, "Negotiate YIIFoAYGKwYBBQUCoIIF");
+        final SpnegoAuthenticator authenticator = new SpnegoAuthenticator() {
+            @Override
+            protected org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
+                throw new SsoLoginException("Failed to initialize SPNEGO.", new java.io.FileNotFoundException("krb5.conf"));
+            }
+        };
+        final SsoLoginException e = assertThrows(SsoLoginException.class, authenticator::getLoginCredential);
+        assertFalse(e instanceof SsoStateException);
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
@@ -232,15 +232,21 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_getLoginCredential_serverFaultKeepsItsStackTrace() {
-        // The counterpart of the case above: getAuthenticator() wraps every initialization failure
-        // in a plain SsoLoginException, and that must not be downgraded to a rejected request --
-        // an unreadable keytab or an unreachable KDC is a fault the operator needs the trace for.
+    public void test_getLoginCredential_initializationFaultKeepsItsStackTrace() {
+        // The boundary the case above must not cross, and the reason it tests the thrown type
+        // rather than the cause chain. SpnegoFilterConfig raises UnsupportedOperationException for
+        // an invalid login module too -- no storeKey, a login module class it does not support, a
+        // control flag other than REQUIRED -- and those are server-side faults the operator needs
+        // the trace for. They are harmless here only because getAuthenticator() has already wrapped
+        // them in a plain SsoLoginException, so the thrown type is no longer the one being matched.
+        // Matching on the cause instead would find the nested UnsupportedOperationException and
+        // silently demote every initialization failure to a message-only log; this goes red first.
         addMockRequestHeader(Constants.AUTHZ_HEADER, "Negotiate YIIFoAYGKwYBBQUCoIIF");
         final SpnegoAuthenticator authenticator = new SpnegoAuthenticator() {
             @Override
             protected org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
-                throw new SsoLoginException("Failed to initialize SPNEGO.", new java.io.FileNotFoundException("krb5.conf"));
+                throw new SsoLoginException("Failed to initialize SPNEGO.",
+                        new UnsupportedOperationException("Login Module for server does not have the storeKey option."));
             }
         };
         final SsoLoginException e = assertThrows(SsoLoginException.class, authenticator::getLoginCredential);


### PR DESCRIPTION
Two defects in the SPNEGO authenticator, both in `SpnegoAuthenticator`.

Neither is a 15.7 regression in the strict sense — 15.7's `SsoAction` had no `catch` at all, so both surfaced as HTTP 500 — but the hardened `spnego.allow.unsecure.basic=false` default introduced in 15.8 makes the first one fire on ordinary traffic rather than only on crafted requests.

## 1. An unsupported Authorization scheme logs a full stack trace on an anonymous endpoint

**Trigger.** The spnego library raises `UnsupportedOperationException` for a header it refuses to even attempt:

- `SpnegoProvider#getAuthScheme` — `"Negotiate or Basic Only"` — when the scheme is neither `Negotiate` nor `Basic`, and also for a `Basic` header with no token or an empty token, since `parseAuthHeader` returns null for both schemes in that case.
- the library's `SpnegoAuthenticator#authenticate` — `"Basic Auth not allowed or SSL required."` — when `basicSupported` is false.
- the NTLM-token-cannot-be-downgraded case.

Verified against the shipping spnego 1.2.2 sources; `Bearer <b64>`, bare `Basic`, and `Basic ` (empty token) each reach the first of those.

**Consequence.** Fess wrapped all of them in a plain `SsoLoginException`, and `SsoAction` logs anything that is not an `SsoStateException` with `logger.warn(msg, e)` — a full stack trace. `/sso` is anonymous, so one crafted header per request produced one stack trace.

It is not only an abuse vector. The library computes `basicSupported = allowBasic && (allowUnsecure || req.isSecure())`. With `spnego.allow.unsecure.basic` now defaulting to false, an instance behind a TLS-terminating reverse proxy that does not set `tomcat.secure=true` leaves `req.isSecure()` false, so every browser request still carrying a `Basic` header takes this path.

**Fix.** Throw `SsoStateException` — which already extends `SsoLoginException` — when the caught exception is an `UnsupportedOperationException`, so the existing `SsoAction` branch logs the reason without the trace. The `logger.debug(msg)` in the same block is untouched, so the detail is still reachable at DEBUG.

The test is deliberately on the **thrown** type, not the cause chain. `SpnegoFilterConfig` also raises `UnsupportedOperationException` during initialization (no `storeKey`, an unsupported login module class, a control flag other than `REQUIRED`), and those are server-side faults that must keep their stack trace. They cannot be downgraded here because `getAuthenticator()` wraps every initialization failure in `SsoLoginException("Failed to initialize SPNEGO.", e)` inside its own `try`/`catch (Exception)` before it can reach this block — but a cause-chain walk would find the nested `UnsupportedOperationException` and silently demote all of them. A test pins that boundary.

## 2. `getBasicRealm` splits the user name on the first `@`; Kerberos uses the last

**Trigger.** A Basic user name containing more than one `@`, e.g. `alice@a@PARTNER.EXAMPLE`.

**Consequence.** Kerberos takes the realm after the *last* `@`: `new KerberosPrincipal("alice@a@PARTNER.EXAMPLE")` normalizes to name `alice@PARTNER.EXAMPLE`, realm `PARTNER.EXAMPLE` (verified on JDK 21), and the library passes the typed name straight to the login module, so that is the realm an AS-REQ would reach. Fess read `a@PARTNER.EXAMPLE` instead.

This is not a bypass — the direction is fail-closed, because a configured `spnego.allowed.realms` entry can never contain `@`, so such a name can only ever be over-rejected. It is fixed so the check matches Kerberos semantics exactly.

**Fix.** `indexOf('@')` becomes `lastIndexOf('@')`. The guard rejecting a name that ends in `@` stays: such a name makes `KerberosPrincipal` throw `empty realm part not allowed`, so the library cannot authenticate it either. The NetBIOS-prefix strip on the line above stays `indexOf`, mirroring the library's own `basicData[0].substring(basicData[0].indexOf('\\') + 1)`.

## Tests

Both new tests were confirmed to fail against the unmodified branch first:

- `test_getLoginCredential_rejectedAuthorizationHeaderIsAStateException` — `expected: <SsoStateException> but was: <SsoLoginException>`. Drives the real `getLoginCredential()` through the UTFlute mock request with a `Bearer` header, overriding only `getAuthenticator()` so the library raises at the same call site; also asserts the header is echoed masked.
- `test_getBasicRealm_realmFollowsTheLastAtSign` — `expected: <PARTNER.EXAMPLE> but was: <a@PARTNER.EXAMPLE>`.
- `test_getLoginCredential_initializationFaultKeepsItsStackTrace` — the boundary guard: an `SsoLoginException` from `getAuthenticator()` whose cause *is* an `UnsupportedOperationException` must not become an `SsoStateException`. Green before and after this change by design; confirmed falsifiable by temporarily switching the implementation to a cause-chain walk, which turns it red.

`SpnegoAuthenticatorTest`, `SpnegoFilterConfigBoundaryTest` and `SsoActionTest`: 38 tests, 0 failures.
