### PR TITLE
docs(sso): describe what decides the fate of a failed Entra ID lookup

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -955,9 +955,11 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * #scheduleUpdateMemberOf} is what keeps it off the login thread -- so tests can call it
      * directly.
      *
-     * <p>When Microsoft Graph does not answer with a membership list, the memberships already on
-     * the user are kept; if there are none yet -- which is the case at login -- the login
-     * completes with whatever was collected plus the configured defaults.
+     * <p>When Microsoft Graph does not answer with a membership list, a re-resolution keeps the
+     * memberships it resolved earlier rather than replacing them. A first resolution has none of
+     * those to keep, so it writes whatever was collected on top of the configured defaults the
+     * lists were seeded with, and marks the user {@link PermissionState#FAILED} rather than
+     * leaving the session with no memberships at all.
      *
      * @param user The Entra ID user to update.
      */
@@ -1098,10 +1100,11 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @param groupIdsForParentLookup The list to collect group IDs for later parent lookup.
      * @param url The Microsoft Graph API URL.
      * @return True if Microsoft Graph answered with a membership list, false if it reported an
-     *         error or could not be read. When this is false the lists hold whatever was collected
-     *         before the failure, and {@link #updateMemberOf} keeps the memberships already on the
-     *         user, or, when there are none yet, writes what was collected plus the configured
-     *         defaults.
+     *         error or could not be read. When this is false the lists hold the configured
+     *         defaults they were seeded with plus whatever was collected before the failure, and
+     *         what {@link #updateMemberOf} does with them turns on whether a resolution has
+     *         completed for this user before: a re-resolution discards them and keeps the
+     *         memberships it resolved earlier, while a first resolution writes them.
      */
     protected boolean processDirectMemberOf(final EntraIdUser user, final List<String> groupList, final List<String> roleList,
             final List<String> groupIdsForParentLookup, final String url) {


### PR DESCRIPTION
## What changed since this PR was opened

This PR was opened against the `@return` tag on `processDirectMemberOf` while it still stated the
pre-#3254 contract. #3273 has since landed and rewrote that tag itself, so the original problem is
gone — and the fix this PR proposed can no longer be merged at all: it links
`{@link #isRequireMembership()}`, and #3273 removed `entraid.require.membership` together with that
method, so the javadoc build fails with `reference not found` (CI runs `javadoc:jar`).

The branch has therefore been rebased onto `master` and the change replaced with the correction the
passages need today.

## Problem

Both passages still say that what `updateMemberOf` does with a failed membership lookup turns on
whether the user has memberships **yet**:

> ... and `{@link #updateMemberOf}` keeps the memberships already on the user, or, **when there are
> none yet**, writes what was collected plus the configured defaults.

> ... the memberships already on the user are kept; **if there are none yet — which is the case at
> login** — the login completes with whatever was collected plus the configured defaults.

#3273 made that the wrong discriminator twice over:

1. The `EntraIdUser` constructor now calls `applyDefaultMemberships`, so a user **always** holds
   memberships — there is no "none yet", not even at login.
2. The decision is taken on the explicit `resolutionCompleted` flag: `firstResolution =
   !user.isResolutionCompleted()`.

| when the lookup fails | outcome |
|---|---|
| a resolution completed before (re-resolution) | early return — keeps the memberships resolved earlier |
| no resolution completed yet (first resolution) | writes the collected lists, marks the user `FAILED` |

## Why it matters

Inferring "first resolution" from the memberships being absent is the exact bug #3273 fixed, and the
code says so in three places — the comment inside `updateMemberOf`, the javadoc on the
`resolutionCompleted` field, and `test_updateMemberOf_keepsTheSeededDefaultsWhenTheFirstLookupFails`,
which spells out that with it inferred from `getGroupNames() == null` the seed makes a first
resolution look like a re-resolution, so the user stays `PENDING` for the rest of the session and is
never told their permissions are incomplete.

These two passages are what a reader meets before any of those, so they invite exactly that
restoration.

The class-level passage carries a second staleness: it says *the login* completes with what was
collected, which the paragraph directly above it already contradicts — since #3273 the resolution
runs off the login thread via `scheduleUpdateMemberOf`.

## Change

Documentation only. No behaviour change, no test change.
