### PR TITLE
fix(sso): bound the accounts kept in the shared Entra ID token cache

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -343,6 +343,37 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     protected volatile ClientApplicationHolder clientApplicationHolder;
 
     /**
+     * The accounts whose tokens are in the shared application's cache, in least-recently-acquired
+     * order. See {@link #maxCachedAccounts} for why this exists; access order rather than
+     * insertion order because the entry worth evicting is the one whose tokens have gone longest
+     * without being used, not the one that logged in first -- a session that has been alive for
+     * days is the last one to throw away.
+     *
+     * <p>Guarded by its own monitor. It is only ever touched after an acquisition or a logout,
+     * so contention is a fraction of what the login path already serialises on.
+     */
+    protected final Map<String, IAccount> cachedAccounts = new LinkedHashMap<>(16, 0.75f, true);
+
+    /**
+     * Maximum number of accounts kept in the shared application's token cache.
+     *
+     * <p>MSAL4J's {@code TokenCache} is five plain maps with no size bound and no expiry, and
+     * {@code removeAccount} is the only thing that takes anything out of them. While the
+     * application was rebuilt per call there was nothing to accumulate; now that one instance is
+     * shared so that silent refresh can work at all, every account that logged in and never
+     * pressed Logout keeps an access token, a refresh token and an ID token resident until the
+     * JVM restarts. The keys are account-scoped, so a user who logs in repeatedly overwrites
+     * their own entry -- the bound is distinct accounts, not logins -- but a large tenant still
+     * reaches a size worth capping, and a refresh token is good for up to 90 days.
+     *
+     * <p>The default is high enough that an ordinary deployment never reaches it. When it is
+     * reached, the cost of evicting a live session is one silent re-authentication: a failed
+     * silent acquisition leaves {@code refresh()} returning true until the access token actually
+     * expires, and the re-login that follows goes through an unexpired Entra ID session.
+     */
+    protected int maxCachedAccounts = 10000;
+
+    /**
      * Initializes the Entra ID authenticator.
      * Registers this authenticator with the SSO manager and sets up group cache.
      */
@@ -800,6 +831,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             if (result == null) {
                 throw new SsoLoginException("authentication result was null");
             }
+            trackAccount(result);
             return result;
         } catch (final Exception e) {
             throw new SsoLoginException("Failed to get a token.", e);
@@ -829,6 +861,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             if (result == null) {
                 throw new SsoLoginException("authentication result was null");
             }
+            trackAccount(result);
             return result;
         } catch (final Exception e) {
             throw new SsoLoginException("Failed to get a token.", e);
@@ -851,6 +884,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             if (logger.isDebugEnabled()) {
                 logger.debug("Silent token acquisition successful");
             }
+            trackAccount(result);
             return result;
         } catch (final Exception e) {
             if (logger.isDebugEnabled()) {
@@ -1957,11 +1991,53 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Records that an acquisition put tokens in the shared cache, and evicts the accounts that
+     * pushes past {@link #maxCachedAccounts}.
+     *
+     * <p>The eviction runs outside the monitor: {@link #removeAccount} joins on MSAL4J's future,
+     * and holding the map while it does that would put every other acquisition behind it.
+     *
+     * @param result The acquisition result, which may be null.
+     */
+    protected void trackAccount(final IAuthenticationResult result) {
+        if (result == null || result.account() == null || StringUtil.isBlank(result.account().homeAccountId())) {
+            return;
+        }
+        final List<IAccount> evicted = new ArrayList<>();
+        synchronized (cachedAccounts) {
+            cachedAccounts.put(result.account().homeAccountId(), result.account());
+            while (cachedAccounts.size() > maxCachedAccounts) {
+                final Map.Entry<String, IAccount> eldest = cachedAccounts.entrySet().iterator().next();
+                cachedAccounts.remove(eldest.getKey());
+                evicted.add(eldest.getValue());
+            }
+        }
+        if (!evicted.isEmpty()) {
+            logger.warn("The Entra ID token cache reached {} accounts. Evicting {} that went longest without acquiring a token.",
+                    maxCachedAccounts, evicted.size());
+            evicted.forEach(this::removeAccount);
+        }
+    }
+
+    /**
+     * Sets the maximum number of accounts kept in the shared application's token cache.
+     * @param maxCachedAccounts The maximum number of accounts.
+     */
+    public void setMaxCachedAccounts(final int maxCachedAccounts) {
+        this.maxCachedAccounts = maxCachedAccounts;
+    }
+
+    /**
      * Drops an account's tokens from the shared client application's cache.
      *
      * @param account The account to evict.
      */
     protected void removeAccount(final IAccount account) {
+        // Unconditional, and ahead of the join below: an eviction has already taken the entry out,
+        // and a logout has to take it out whether or not MSAL4J manages to prune its own cache.
+        synchronized (cachedAccounts) {
+            cachedAccounts.remove(account.homeAccountId());
+        }
         try {
             getClientApplication().removeAccount(account).join();
             if (logger.isDebugEnabled()) {

--- a/src/main/resources/fess_sso++.xml
+++ b/src/main/resources/fess_sso++.xml
@@ -11,6 +11,7 @@
 		<property name="groupCacheExpiry">600</property>
 		<property name="maxGroupCacheSize">10000</property>
 		<property name="maxGroupDepth">10</property>
+		<property name="maxCachedAccounts">10000</property>
 		-->
 	</component>
 	<component name="oicAuthenticator" class="org.codelibs.fess.sso.oic.OpenIdConnectAuthenticator">

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -183,6 +183,100 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         assertSame(account, removed.get(0));
     }
 
+    /** An authenticator that records the evictions instead of reaching MSAL4J for them. */
+    private EntraIdAuthenticator newAuthenticatorRecordingEvictions(final List<IAccount> evicted, final int maxCachedAccounts) {
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator() {
+            @Override
+            protected void removeAccount(final IAccount account) {
+                synchronized (cachedAccounts) {
+                    cachedAccounts.remove(account.homeAccountId());
+                }
+                evicted.add(account);
+            }
+        };
+        authenticator.setMaxCachedAccounts(maxCachedAccounts);
+        return authenticator;
+    }
+
+    @Test
+    public void test_trackAccount_overwritesRatherThanGrowingForTheSameAccount() {
+        // MSAL4J keys its cache by home account id, so a user who logs in repeatedly replaces
+        // their own tokens. The bound is distinct accounts, not logins, and this is what says so.
+        final EntraIdAuthenticator authenticator = newAuthenticatorRecordingEvictions(new ArrayList<>(), 10);
+        final TestAccount account = new TestAccount("account-a");
+
+        for (int i = 0; i < 100; i++) {
+            authenticator.trackAccount(new TestAuthenticationResult(account));
+        }
+
+        assertEquals(1, authenticator.cachedAccounts.size());
+    }
+
+    @Test
+    public void test_trackAccount_evictsTheAccountThatWentLongestWithoutAToken() {
+        // Nothing leaves MSAL4J's cache on its own -- no size bound, no expiry, and an expired
+        // access token is filtered on read rather than removed -- so without this a server that
+        // never sees a Logout keeps every account resident until it restarts.
+        final List<IAccount> evicted = new ArrayList<>();
+        final EntraIdAuthenticator authenticator = newAuthenticatorRecordingEvictions(evicted, 2);
+
+        authenticator.trackAccount(new TestAuthenticationResult(new TestAccount("account-a")));
+        authenticator.trackAccount(new TestAuthenticationResult(new TestAccount("account-b")));
+        authenticator.trackAccount(new TestAuthenticationResult(new TestAccount("account-c")));
+
+        assertEquals(1, evicted.size());
+        assertEquals("account-a", evicted.get(0).homeAccountId());
+        assertEquals(Set.of("account-b", "account-c"), authenticator.cachedAccounts.keySet());
+    }
+
+    @Test
+    public void test_trackAccount_keepsTheAccountThatIsStillAcquiring() {
+        // Access order, not insertion order. A session that has been alive for days keeps
+        // acquiring, and evicting it first -- which is what insertion order would do -- would
+        // throw away exactly the account most likely to still be in use.
+        final List<IAccount> evicted = new ArrayList<>();
+        final EntraIdAuthenticator authenticator = newAuthenticatorRecordingEvictions(evicted, 2);
+
+        final TestAccount oldest = new TestAccount("account-a");
+        authenticator.trackAccount(new TestAuthenticationResult(oldest));
+        authenticator.trackAccount(new TestAuthenticationResult(new TestAccount("account-b")));
+        authenticator.trackAccount(new TestAuthenticationResult(oldest));
+        authenticator.trackAccount(new TestAuthenticationResult(new TestAccount("account-c")));
+
+        assertEquals(1, evicted.size());
+        assertEquals("account-b", evicted.get(0).homeAccountId());
+        assertEquals(Set.of("account-a", "account-c"), authenticator.cachedAccounts.keySet());
+    }
+
+    @Test
+    public void test_trackAccount_ignoresAnAcquisitionWithNothingToTrack() {
+        final EntraIdAuthenticator authenticator = newAuthenticatorRecordingEvictions(new ArrayList<>(), 2);
+
+        authenticator.trackAccount(null);
+        authenticator.trackAccount(new TestAuthenticationResult(null));
+        authenticator.trackAccount(new TestAuthenticationResult(new TestAccount("")));
+
+        assertTrue(authenticator.cachedAccounts.isEmpty());
+    }
+
+    @Test
+    public void test_removeAccount_freesTheSlotSoALogoutIsNotJustAnMsalCall() {
+        // A user who logs out must stop counting against the bound, otherwise a server with a
+        // steady turnover evicts live sessions to make room for accounts that already left.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        authenticator.setMaxCachedAccounts(2);
+        final TestAccount account = new TestAccount("account-a");
+        authenticator.trackAccount(new TestAuthenticationResult(account));
+        assertEquals(1, authenticator.cachedAccounts.size());
+
+        // Entra ID is unconfigured here, so the MSAL4J call behind this fails and is swallowed.
+        // The slot has to be freed regardless of whether that call got anywhere.
+        setEntraIdConfig("", "", "");
+        authenticator.removeAccount(account);
+
+        assertTrue(authenticator.cachedAccounts.isEmpty());
+    }
+
     @Test
     public void test_logout_ignoresAUserThatIsNotAnEntraIdUser() {
         // SPNEGO, SAML and LDAP users reach the same logout hook.
@@ -225,10 +319,19 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
     private static class TestAccount implements IAccount {
         private static final long serialVersionUID = 1L;
+        private final String homeAccountId;
+
+        TestAccount() {
+            this("home-account-id");
+        }
+
+        TestAccount(final String homeAccountId) {
+            this.homeAccountId = homeAccountId;
+        }
 
         @Override
         public String homeAccountId() {
-            return "home-account-id";
+            return homeAccountId;
         }
 
         @Override


### PR DESCRIPTION
## Problem

MSAL4J's `TokenCache` is five plain maps with no size bound and no expiry. `removeAccount` is the only thing that takes anything out of them — the `expiresOn` comparison is a read filter, not a sweep, so an expired access token is never removed, it just stops being served.

While the client application was rebuilt on every call this was harmless: nothing survived the call. #3227 shares one instance for the whole server so that silent refresh can work at all — a fresh application starts with an empty cache and `acquireTokenSilently` throws `NO_TOKEN_IN_CACHE` on a miss — and that cache now lives as long as the JVM.

`logout()` prunes the account it is given, and that is the only trigger there is. There is no session listener, so a user who lets their session time out, or just closes the browser, keeps an access token, a refresh token and an ID token resident until the server restarts. A refresh token is good for up to 90 days.

**The growth is smaller than it first looks.** Every cache key is composed from the home account id, environment, credential type, client id, realm and target, with no per-login component — and the `extCacheKeyHash` that would add one is only non-blank for client-credential requests, which none of the three paths here use. So a user who logs in repeatedly overwrites their own entry: the bound is **distinct accounts, not logins**. A large tenant still reaches a size worth capping.

## Change

Accounts are tracked in a small access-ordered map keyed by home account id, and the account that went longest without acquiring a token is evicted once `maxCachedAccounts` is passed, via the existing `removeAccount` path.

**Access order, not insertion order.** A session that has been alive for days keeps acquiring; insertion order would evict exactly the account most likely to still be in use.

**`removeAccount` frees the slot unconditionally and before the MSAL4J call**, so a logout stops counting against the bound whether or not that call gets anywhere. Otherwise a server with a steady turnover would evict live sessions to make room for accounts that had already left.

**The eviction runs outside the monitor**, because `removeAccount` joins on MSAL4J's future and holding the map across that would queue every other acquisition behind it.

## Risk

The default of 10000 is out of reach for an ordinary deployment, so behaviour is unchanged for essentially everyone; it is exposed as a commented `<property>` in `fess_sso++.xml` alongside `maxGroupCacheSize`, which has the same shape and the same default.

When the bound *is* reached, the cost of evicting a live session is one silent re-authentication: a failed silent acquisition is caught and `refresh()` still returns `true` until the access token really expires, and the login that follows goes through an unexpired Entra ID session.

Targeted at 15.9.0 rather than 15.8.0 — this adds state to a path that was hardened repeatedly during the 15.8 cycle, and the condition it addresses is a slow accumulation rather than a fault.

## Not done here

The complete fix is a session-backed token cache via `ITokenCacheAccessAspect`, which is the pattern MSAL4J is designed for and which would let Tomcat's own session expiry do the eviction. `deserialize()` replaces the cache maps wholesale under the write lock, so that means one application per user session — a redesign of `getClientApplication()`, not a patch-release change.

## Verification

`mvn test` over the SSO, logout and admin surface → 236/236 (`EntraIdAuthenticator*` 103, up from 98; `EntraIdUserPermission*` 3, `LogoutHandler*` 9, `AdminGeneralAction*` 17, `AdminSysteminfoAction*` 6, `SamlAuthenticator*` 40, `OpenIdConnectAuthenticator*` 26, `SpnegoAuthenticator*` 32).

Each new test was checked against a mutant:

| mutation | reddens |
|---|---|
| insertion order instead of access order | `keepsTheAccountThatIsStillAcquiring` |
| `removeAccount` no longer frees the slot | `freesTheSlotSoALogoutIsNotJustAnMsalCall` |
| eviction loop removed | `evictsTheAccountThatWentLongestWithoutAToken` |

