### PR TITLE
fix(sso/spnego): stop a malformed Authorization token logging a stack trace

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -260,17 +260,30 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 // carries a message and "null <msg>" helps nobody diagnose an SSO failure.
                 final String detail = e.getMessage();
                 final String reason = detail == null ? msg : detail + " " + msg;
-                if (e instanceof UnsupportedOperationException) {
-                    // The library raises this type only for a header it refuses to even try: a
-                    // scheme that is neither Negotiate nor Basic, a Basic header carrying no token,
-                    // Basic while basic authentication is not supported, or an NTLM token it cannot
-                    // downgrade. The client decides every one of those, and /sso is anonymous, so a
-                    // stack trace per attempt would let an unauthenticated client fill the log. It
-                    // is not only an abuse path either: basic support is off unless the request is
-                    // secure, so a TLS-terminating proxy that leaves isSecure() false sends
-                    // ordinary browser traffic down here. An initialization fault cannot arrive as
-                    // this type, because getAuthenticator() wraps every one of them in a plain
-                    // SsoLoginException, which keeps its stack trace.
+                if (e instanceof UnsupportedOperationException || e instanceof IllegalArgumentException) {
+                    // Both types describe a header the client got wrong, never a fault of this
+                    // server. UnsupportedOperationException is what the library raises for a header
+                    // it refuses to even try: a scheme that is neither Negotiate nor Basic, a Basic
+                    // header carrying no token, Basic while basic authentication is not supported,
+                    // or an NTLM token it cannot downgrade. IllegalArgumentException is what the
+                    // token itself raises: SpnegoProvider#parseAuthHeader does not validate the
+                    // token, so the strict Base64 decoder behind SpnegoAuthScheme#getToken rejects
+                    // it, and that decode runs at the top of SpnegoProvider#negotiate before any
+                    // scheme dispatch -- so "Negotiate ###" reaches it whatever the spnego.allow.*
+                    // settings say. A decoded Basic token with no ':' raises it from doBasicAuth
+                    // as well.
+                    //
+                    // The client decides every one of those, and /sso is anonymous, so a stack
+                    // trace per attempt would let an unauthenticated client fill the log. It is not
+                    // only an abuse path either: basic support is off unless the request is secure,
+                    // so a TLS-terminating proxy that leaves isSecure() false sends ordinary
+                    // browser traffic down here.
+                    //
+                    // A genuine server fault cannot arrive as either type. Initialization faults
+                    // are wrapped by getAuthenticator() in a plain SsoLoginException -- which is a
+                    // FessSystemException, so it is neither of these types -- and that keeps its
+                    // stack trace. A broken keytab, an unreachable KDC, clock skew or a wrong SPN
+                    // surface from authenticate() as GSSException, which also keeps its trace.
                     throw new SsoStateException(reason, e);
                 }
                 throw new SsoLoginException(reason, e);

--- a/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticatorTest.java
@@ -17,6 +17,8 @@ package org.codelibs.fess.sso.spnego;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -27,6 +29,7 @@ import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.spnego.SpnegoHttpFilter.Constants;
+import org.codelibs.spnego.SpnegoProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -247,6 +250,99 @@ public class SpnegoAuthenticatorTest extends UnitFessTestCase {
             protected org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
                 throw new SsoLoginException("Failed to initialize SPNEGO.",
                         new UnsupportedOperationException("Login Module for server does not have the storeKey option."));
+            }
+        };
+        final SsoLoginException e = assertThrows(SsoLoginException.class, authenticator::getLoginCredential);
+        assertFalse(e instanceof SsoStateException);
+    }
+
+    /**
+     * Drives the library's own header parser and token decoder, so the exception type the mapping
+     * below relies on is pinned against the shipping spnego jar rather than assumed.
+     *
+     * <p>
+     * {@code SpnegoProvider#getAuthScheme} is public, but the {@code SpnegoAuthScheme} it returns is
+     * a package-private final class whose {@code getToken()} is package private too, so both are
+     * reached by reflection. Library and Fess both load from the class path (the unnamed module),
+     * so {@code setAccessible(true)} succeeds without any {@code --add-opens}.
+     * </p>
+     *
+     * @param header the raw Authorization header value
+     * @throws Throwable whatever the library raises, unwrapped from the reflective call
+     */
+    private void decodeLibraryToken(final String header) throws Throwable {
+        final Method getAuthScheme = SpnegoProvider.class.getMethod("getAuthScheme", String.class);
+        final Object scheme;
+        try {
+            scheme = getAuthScheme.invoke(null, header);
+        } catch (final InvocationTargetException e) {
+            throw e.getCause();
+        }
+        assertNotNull(scheme);
+        final Method getToken = scheme.getClass().getDeclaredMethod("getToken");
+        getToken.setAccessible(true);
+        try {
+            getToken.invoke(scheme);
+        } catch (final InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test
+    public void test_libraryRaisesIllegalArgumentExceptionForAMalformedToken() {
+        // SpnegoProvider#parseAuthHeader does not validate the token -- it accepts any non-empty
+        // trimmed remainder -- so the strict decoder behind SpnegoAuthScheme#getToken is what
+        // rejects it. SpnegoProvider#negotiate evaluates that decode at the top of the method,
+        // before any scheme dispatch and before the 401 is written, so every shape below reaches it
+        // whatever the spnego.allow.* settings say. This is the contract the mapping in
+        // getLoginCredential depends on; if a library upgrade changed the type, this goes red
+        // first instead of the demotion silently ceasing to apply.
+        assertThrows(IllegalArgumentException.class, () -> decodeLibraryToken("Negotiate ###"));
+        assertThrows(IllegalArgumentException.class, () -> decodeLibraryToken("Basic ###"));
+        // Valid base64 alphabet, but not a valid length.
+        assertThrows(IllegalArgumentException.class, () -> decodeLibraryToken("Negotiate a"));
+        // The scheme is matched case-insensitively and the separator is any run of whitespace, so a
+        // lower-case scheme behind a tab decodes -- and fails -- exactly the same way.
+        assertThrows(IllegalArgumentException.class, () -> decodeLibraryToken("negotiate" + ch(0x09) + "###"));
+        // The control: a scheme the library refuses outright is the other family, and it is raised
+        // by getAuthScheme before any token exists. Both families are demoted, but keeping the
+        // distinction visible here documents why the mapping names two types rather than one.
+        assertThrows(UnsupportedOperationException.class, () -> decodeLibraryToken("Digest abc"));
+    }
+
+    @Test
+    public void test_getLoginCredential_malformedTokenIsAStateException() {
+        // The client chose the token, /sso is anonymous, and the header is echoed masked, so this
+        // is a rejected request rather than a fault: SsoStateException, which SsoAction logs
+        // message-only. Before this mapping existed the same request produced a full stack trace
+        // per attempt, which let an unauthenticated client fill the log.
+        addMockRequestHeader(Constants.AUTHZ_HEADER, "Negotiate ###");
+        final SpnegoAuthenticator authenticator = new SpnegoAuthenticator() {
+            @Override
+            protected org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
+                throw new IllegalArgumentException("Illegal base64 character 23");
+            }
+        };
+        final SsoStateException e = assertThrows(SsoStateException.class, authenticator::getLoginCredential);
+        assertTrue(e.getMessage().contains("Illegal base64 character 23"));
+        assertTrue(e.getMessage().contains("Negotiate ***"));
+    }
+
+    @Test
+    public void test_getLoginCredential_initializationFaultWithAnIllegalArgumentCauseKeepsItsStackTrace() {
+        // The same boundary as the UnsupportedOperationException case above, for the type added
+        // alongside it. SpnegoFilterConfig raises IllegalArgumentException for a missing
+        // spnego.krb5.conf, a missing spnego.login.conf and an exclude-dirs pattern it rejects, and
+        // those are server-side faults the operator needs the trace for. They are harmless here
+        // only because getAuthenticator() has already wrapped them in a plain SsoLoginException --
+        // a FessSystemException, so no longer the type being matched. Matching on the cause instead
+        // would find the nested IllegalArgumentException and silently demote every one of them.
+        addMockRequestHeader(Constants.AUTHZ_HEADER, "Negotiate YIIFoAYGKwYBBQUCoIIF");
+        final SpnegoAuthenticator authenticator = new SpnegoAuthenticator() {
+            @Override
+            protected org.codelibs.spnego.SpnegoAuthenticator getAuthenticator() {
+                throw new SsoLoginException("Failed to initialize SPNEGO.",
+                        new IllegalArgumentException("Must specify a username and password or a keyTab."));
             }
         };
         final SsoLoginException e = assertThrows(SsoLoginException.class, authenticator::getLoginCredential);


### PR DESCRIPTION
Completes #3263. That PR demoted the `UnsupportedOperationException` family so a rejected `Authorization` header no longer logs a stack trace on the anonymous `/sso` endpoint; the `IllegalArgumentException` family reaches the same call site and was missed.

## Trigger

`SpnegoProvider#parseAuthHeader` performs no validation on the token it extracts — it accepts any non-empty trimmed remainder — so the strict Base64 decoder behind `SpnegoAuthScheme#getToken` is what rejects a malformed one. Verified against the shipping spnego 1.2.2 sources by driving `SpnegoProvider#getAuthScheme` directly on JDK 21:

```
negotiate([Negotiate ###], basicSupported=false) -> IllegalArgumentException: Illegal base64 character 23
negotiate([Basic ###],     basicSupported=false) -> IllegalArgumentException: Illegal base64 character 23
negotiate([Negotiate a],   basicSupported=false) -> IllegalArgumentException: Input byte[] should at least have 2 bytes for base64 bytes
negotiate([negotiate<tab>###], basicSupported=false) -> IllegalArgumentException: Illegal base64 character 23
```

`SpnegoProvider#negotiate` evaluates that decode on line 113, inside `if (null == scheme || scheme.getToken().length == 0)` — **before** any scheme dispatch, **before** the NTLM check and **before** the 401 is written. So the trigger does not depend on configuration: `Basic ###` throws the identical exception even when `spnego.allow.basic` is effectively off, and disabling Basic is not a mitigation. The library's `authenticate()` has no `try`/`catch` and declares only `GSSException, IOException`, so the unchecked exception propagates.

A second, narrower path exists once Basic is supported: a decoded Basic token with no `:` raises `IllegalArgumentException("Username/Password may have contained an invalid character. basicData.length=1")` from `doBasicAuth`.

`rejectDisallowedBasicRealm` does not intercept either: it matches only the literal `Basic` prefix, and its own decode already catches `IllegalArgumentException` and returns null.

## Consequence

`getLoginCredential` matched only `UnsupportedOperationException`, so the decode failure became a plain `SsoLoginException`, and `SsoAction` logs anything that is not an `SsoStateException` with `logger.warn(msg, e)` — a full stack trace. Confirmed by running the real compiled classes through `SpnegoAuthenticator#getLoginCredential` under the project's own `log4j2.xml`:

```
2026-08-11 22:05:38,541 [main] WARN  Failed to process SSO login.
org.codelibs.fess.exception.SsoLoginException: Illegal base64 character 23 Failed to process Authorization Header: Negotiate ***
Caused by: java.lang.IllegalArgumentException: Illegal base64 character 23
```

`SsoManager#getLoginCredential` does not wrap, `ssoManager.available()` is `!"none".equals(ssoType)` and therefore true for `sso.type=spnego`, and `/sso` is anonymous — `SsoAction` never calls `isLoginRequired()`, and `FessLoginAssist#checkPermission` only restricts `FessAdminAction`. So one crafted header per request produced one stack trace, roughly 30-60 lines each against 1.

Not a 15.7 regression: 15.7's `SsoAction` had no `catch` around `getLoginCredential()` at all, so the same request surfaced as an HTTP 500 with a trace.

Not a disclosure issue: `maskAuthzHeader` already reduces the header to `Negotiate ***`, so no credential reaches the log either way. This is purely log volume.

## Fix

Match `IllegalArgumentException` alongside `UnsupportedOperationException`. The message is unchanged and still masked, and `SsoAction` still logs one WARN line per rejected request — the change removes the trace, not the record.

**Why a blanket `instanceof IllegalArgumentException` is safe here.** Every `IllegalArgumentException` reachable from `authenticate()` was enumerated against the 1.2.2 sources:

| Source | Reachable from `authenticate()`? | Decided by |
|---|---|---|
| `Base64.decode` (via `negotiate`, `doBasicAuth`, `doSpnegoAuth`) | yes | **client** |
| `doBasicAuth` — decoded Basic token has no `:` | yes, when `basicSupported` | **client** |
| `SpnegoAuthenticator(String, SpnegoFilterConfig)` ctor | no — Fess uses the other constructor | n/a |
| `new KerberosPrincipal(...)` via `SpnegoPrincipal` (3 sites) | reachable but cannot throw — see below | n/a |
| `SpnegoFilterConfig` (11 sites) | no — config is read into final fields in the constructor | initialization |
| `LdapAccessControl`, `SpnegoSOAPConnection`, `SpnegoHttpURLConnection` | no — Fess imports only `SpnegoHttpFilter.Constants` | n/a |

The `KerberosPrincipal` sites are where a real server fault could plausibly have hidden. Its `IllegalArgumentException`s are `empty realm part not allowed` (name ends in `@`), `KrbException: Cannot locate default realm` (name has **no** `@` — the genuine bad-`krb5.conf` case), `Empty nameString(s) not allowed` and `Illegal name type`. None is reachable: all three call sites append `'@' + this.serverPrincipal.getRealm()`, and `serverPrincipal` was constructed successfully at initialization, so its realm is non-empty and a realm-less name cannot occur.

Genuine server faults keep their stack traces:

- **Initialization** — `getAuthenticator()` wraps every failure in a plain `SsoLoginException`. That is a `FessSystemException extends RuntimeException`, so it is neither matched type and cannot be demoted here.
- **Runtime Kerberos faults** — an expired or broken keytab, an unreachable KDC, clock skew or a wrong SPN surface as `GSSException`, a checked exception declared by `authenticate()`.

`SpnegoProvider`'s `"HTTP Status already set."` is an `IllegalStateException`, not an `IllegalArgumentException`, and is unaffected.

## Tests

Confirmed red before the change:

```
SpnegoAuthenticatorTest.test_getLoginCredential_malformedTokenIsAStateException
  Unexpected exception type thrown, expected: <SsoStateException> but was: <SsoLoginException>
  Caused by: java.lang.IllegalArgumentException: Illegal base64 character 23
```

- `test_getLoginCredential_malformedTokenIsAStateException` — drives the real `getLoginCredential()` through the UTFlute mock request with a `Negotiate ###` header, overriding only `getAuthenticator()` so the library raises at the same call site; also asserts the header is still echoed masked.
- `test_libraryRaisesIllegalArgumentExceptionForAMalformedToken` — pins the exception type against the shipping spnego jar rather than assuming it, by driving `SpnegoProvider#getAuthScheme` and `SpnegoAuthScheme#getToken` reflectively (the returned class and that method are package private; both sides load from the class path, so `setAccessible(true)` needs no `--add-opens`). Covers the four shapes above plus `Digest abc` as the control that the two families stay distinct. If a library upgrade changed the type, this goes red instead of the demotion silently ceasing to apply.
- `test_getLoginCredential_initializationFaultWithAnIllegalArgumentCauseKeepsItsStackTrace` — the boundary guard, mirroring the existing one for `UnsupportedOperationException`. An `SsoLoginException` from `getAuthenticator()` whose *cause* is an `IllegalArgumentException` must not become an `SsoStateException`; matching on the cause chain instead would silently demote every initialization failure. Green before and after by design.

`SpnegoAuthenticatorTest`, `SpnegoFilterConfigBoundaryTest`, `SsoActionTest`, `AdminGeneralActionTest`: 58 tests, 0 failures. `mvn formatter:format` and `mvn license:format` applied.

## Out of scope

If SPNEGO initialization itself fails, `authenticator` stays null and is retried per login, so `getAuthenticator()` throws on every anonymous `/sso` hit and each one logs a trace. That is a genuine server fault an operator needs the trace for, and the boundary tests exist specifically to keep it that way, so it is deliberately left alone.
