### PR TITLE
fix(sso): refuse a non-positive SAML AuthnRequest cap

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -212,13 +212,24 @@ public class SamlAuthenticator implements SsoAuthenticator {
     protected static final String DEFAULT_REQUEST_ID_TTL = "3600";
 
     /**
+     * The number of unanswered AuthnRequest IDs kept per session when {@code fess_sso++.xml}
+     * leaves the cap alone, and the value {@link #setMaxRequestIds} falls back to when the
+     * configured one is not positive. Ten abandoned logins in one session is already well past
+     * anything a person does by hand.
+     */
+    protected static final int DEFAULT_MAX_REQUEST_IDS = 10;
+
+    /**
      * Maximum number of unanswered AuthnRequest IDs kept per session. Every visit to
      * {@code /sso/} without a SAML response stores one, and {@code /sso/} is anonymous and
      * answers GET, so without a cap a page that embeds it as a sub-resource would grow the
      * session attribute without bound. It also bounds the number of candidates
      * {@link #processSamlResponse} tries.
+     *
+     * <p>Always positive when it is set through {@link #setMaxRequestIds}, which is the only path
+     * a configured value takes; a subclass that assigns the field directly is on its own.</p>
      */
-    protected int maxRequestIds = 10;
+    protected int maxRequestIds = DEFAULT_MAX_REQUEST_IDS;
 
     private Map<String, Object> defaultSettings;
 
@@ -771,9 +782,28 @@ public class SamlAuthenticator implements SsoAuthenticator {
     /**
      * Sets the maximum number of unanswered AuthnRequest IDs kept per session.
      *
-     * @param maxRequestIds The maximum number of AuthnRequest IDs.
+     * <p>A value that is not positive is reported and replaced by
+     * {@link #DEFAULT_MAX_REQUEST_IDS} rather than taken literally, for the same reason
+     * {@link #getRequestIdTtl()} refuses one. Nothing fails as it is applied, but
+     * {@link #getCandidateRequestIds} hands it to {@code limit()}: {@code 0} leaves
+     * {@link #processSamlResponse} no candidate to try, so every SAML login in the deployment
+     * fails and is reported by {@link #logUnmatchedSamlResponse} as the cookie problem it is not,
+     * and a negative value makes {@code limit()} throw an {@link IllegalArgumentException} that
+     * reaches the log only as "Authentication failed.". {@code 0} is not a far-fetched value to
+     * write either -- it reads as "no limit" -- which is why it falls back rather than being
+     * taken at its word. The warning names the property and the value. Refusing it here is
+     * enough because this setter is the only path a configured value takes; a subclass that
+     * assigns the field directly bypasses the check.</p>
+     *
+     * @param maxRequestIds The maximum number of AuthnRequest IDs. Only a positive value is
+     *                      honoured.
      */
     public void setMaxRequestIds(final int maxRequestIds) {
+        if (maxRequestIds <= 0) {
+            logger.warn("maxRequestIds must be a positive number: {}. Using {}.", maxRequestIds, DEFAULT_MAX_REQUEST_IDS);
+            this.maxRequestIds = DEFAULT_MAX_REQUEST_IDS;
+            return;
+        }
         this.maxRequestIds = maxRequestIds;
     }
 

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -752,6 +752,74 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_setMaxRequestIds_honoursAPositiveValue() throws Exception {
+        // fess_sso++.xml offers 10 as the line to uncomment, so that is what an untouched
+        // deployment has to be running with.
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        assertEquals(10, authenticator.maxRequestIds);
+
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            authenticator.setMaxRequestIds(1);
+            assertEquals(1, authenticator.maxRequestIds);
+
+            authenticator.setMaxRequestIds(50);
+            assertEquals(50, authenticator.maxRequestIds);
+
+            assertTrue(String.valueOf(appender.warnings()), appender.warnings().isEmpty());
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_setMaxRequestIds_fallsBackWhenTheValueIsNotPositive() throws Exception {
+        // Both values are applied without failing here, but getCandidateRequestIds hands the cap
+        // to limit(): 0 leaves processSamlResponse no candidate to try and -1 makes limit() throw,
+        // so either way every SAML login in the deployment fails. 0 is not a far-fetched thing to
+        // write, either: it reads as "no limit".
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            authenticator.setMaxRequestIds(0);
+            assertEquals(10, authenticator.maxRequestIds);
+
+            authenticator.setMaxRequestIds(-1);
+            assertEquals(10, authenticator.maxRequestIds);
+
+            assertEquals(2, appender.warnings().size(), String.valueOf(appender.warnings()));
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains("maxRequestIds"));
+            // the value that was configured, not only the default that replaced it
+            assertTrue(appender.warnings().get(0), appender.warnings().get(0).contains(": 0."));
+            assertTrue(appender.warnings().get(1), appender.warnings().get(1).contains(": -1."));
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getCandidateRequestIds_isNotEmptiedByANonPositiveCap() throws Exception {
+        // The end the guard protects. Taken literally, the cap discards the pending ID the
+        // session does hold before processSamlResponse ever sees it, and the login is then
+        // reported as a session cookie that never arrived.
+        final Map<String, Long> requestIdMap = new ConcurrentHashMap<>();
+        requestIdMap.put("_pending", 1000L);
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            authenticator.setMaxRequestIds(0);
+            Assertions.assertEquals(List.of("_pending"), authenticator.getCandidateRequestIds(requestIdMap));
+
+            // -1 does not merely return nothing: limit() throws, and processSamlResponse's caller
+            // logs that as "Authentication failed." with no hint of the cap.
+            authenticator.setMaxRequestIds(-1);
+            Assertions.assertEquals(List.of("_pending"), authenticator.getCandidateRequestIds(requestIdMap));
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
     public void test_getLoginCredential_nonPositiveRequestIdTtlStillAnswersAResponse() throws Exception {
         final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
         final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();


### PR DESCRIPTION
## The problem

`maxRequestIds` bounds the unanswered AuthnRequest IDs a session keeps. It has no
`saml.*` configuration key, so `fess_sso++.xml` documents it as a LastaDi property an
operator may uncomment, and the setter took whatever was written there.

`getCandidateRequestIds` hands it to `limit()`:

| value | what happens |
|---|---|
| `0` | no candidate at all, so `processSamlResponse` never compares the response against the ID the session is holding — **every SAML login in the deployment fails** |
| negative | `limit()` throws `IllegalArgumentException`, which reaches the log only as `Authentication failed.` |

`0` is not a far-fetched value to write: it reads as "no limit".

The zero case is also **misreported**. The ID is still stored, so the session is not
empty and the response does not look like one that arrived without its cookie — it
reaches `logUnmatchedSamlResponse`, which names `tomcat.sameSiteCookies` as the cause.
The operator is then sent to change a cookie setting that was already correct, for a
failure caused by the line they had just uncommented.

## The change

Fall back to the default for any non-positive value, with a warning naming the property
and the value. Any positive value takes exactly the path it took before.

A warning and a fallback rather than an exception, for the reason `getRequestIdTtl()`
chose the same: the value is applied while the container wires the component, so throwing
would turn a tunable with a perfectly good default into a component that cannot be
created, and the failure would surface far from the line that caused it.

The check lives in the setter because that is the only path a configured value takes. A
subclass assigning the protected field directly bypasses it, which the field's javadoc now
records; the read in `getCandidateRequestIds` is deliberately left alone rather than
clamped a second time.

## Scope

`EntraIdAuthenticator.maxStates` is documented the same way in the same file but is **not**
affected: it has no read-side `limit()`, only `removeOldestStates(stateMap, maxStates - 1)`,
so `0` degrades to a one-slot cap that still works. This is specific to the read side of
`getCandidateRequestIds`.

## Verification

- `SamlAuthenticatorTest` 40 -> 43, `org.codelibs.fess.sso.**` 252 -> 255, 0 failures
- `mvn -o clean javadoc:jar` passes
- Every new test was mutation-checked (5 mutations, all killed): removing the guard,
  dropping the warning, weakening `<= 0` to `< 0`, warning unconditionally, and changing
  the default each turn at least one new test red.
