### PR TITLE
fix(sso): tell an expired session apart from a blocked SAML cookie

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -480,6 +480,8 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 // than answered with another one.
                 if (expiredCount > 0) {
                     logUnmatchedSamlResponseAfterExpiry(expiredCount);
+                } else if (hasExpiredSession(request)) {
+                    logUnmatchedSamlResponseAfterSessionExpiry();
                 } else {
                     logUnmatchedSamlResponse(0);
                 }
@@ -623,11 +625,13 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * authenticated, which posts the same kind of unmatched assertion straight back, and the
      * loop only ends when the browser gives up.</p>
      *
-     * <p>The SameSite guidance below is what this case usually is, but only because the case
-     * where the session was found and its AuthnRequest IDs had merely run out of time is reported
-     * by {@link #logUnmatchedSamlResponseAfterExpiry(int)} instead. Without that split every
-     * expired login would read as a cookie misconfiguration, since the pruning happens before
-     * this is reached and therefore reports a pending count of zero as well.</p>
+     * <p>The SameSite guidance below is what this case usually is, but only because the two ways
+     * a login can instead have run out of time are reported elsewhere: an ID pruned by
+     * {@link #SAML_REQUEST_ID_TTL} by {@link #logUnmatchedSamlResponseAfterExpiry(int)}, and a
+     * session the container has already discarded by
+     * {@link #logUnmatchedSamlResponseAfterSessionExpiry()}. Without that split every expired
+     * login would read as a cookie misconfiguration, since neither leaves anything pending and
+     * both therefore reach this line with a pending count of zero as well.</p>
      *
      * @param pendingCount How many pending AuthnRequest IDs the session held, so that a log can
      *            tell a missing session cookie apart from a response that simply matched none of
@@ -668,6 +672,62 @@ public class SamlAuthenticator implements SsoAuthenticator {
                         + " The session cookie did reach this server, so this is not the SameSite case:"
                         + " the login took longer to finish at the IdP than {} allows, and starting it again resolves it.",
                 expiredCount, SAML_REQUEST_ID_TTL);
+    }
+
+    /**
+     * Logs the one line reported when a SAML response arrives with a session id the container no
+     * longer recognises, so the session that held the AuthnRequest ID is gone rather than merely
+     * empty.
+     *
+     * <p>This, not {@link #logUnmatchedSamlResponseAfterExpiry(int)}, is what a login left too
+     * long at the IdP actually reaches on a stock Fess, because the session runs out first: the
+     * AuthnRequest ID is kept for {@link #DEFAULT_REQUEST_ID_TTL} seconds, an hour, while
+     * {@code WEB-INF/web.xml} sets no {@code session-timeout} and nothing calls
+     * {@code setMaxInactiveInterval}, which leaves the servlet container's own default of thirty
+     * minutes. The session is therefore discarded, IDs and all, some half an hour before any of
+     * those IDs can expire, and the response comes back to a {@code getSession(false)} that
+     * returns null. Without this line that lands on {@link #logUnmatchedSamlResponse(int)} and is
+     * reported as a {@code SameSite} cookie problem -- the very misdiagnosis the expiry line was
+     * added to prevent, in the one case that occurs in practice.</p>
+     *
+     * <p>The two are told apart by {@link #hasExpiredSession(HttpServletRequest)}: a browser that
+     * is not sending the session cookie sends no session id at all, so a request that does carry
+     * one demonstrably kept the cookie and lost only the session behind it.</p>
+     *
+     * <p>Like the TTL case this is an ordinary event rather than a misconfiguration, and starting
+     * the login again resolves it. It names the container's session timeout instead of
+     * {@link #SAML_REQUEST_ID_TTL} on purpose, since raising the TTL cannot extend a session that
+     * is already the shorter of the two.</p>
+     *
+     * <p>An extension that overrides {@link #logUnmatchedSamlResponse(int)} to reshape or suppress
+     * that warning wants to override this one as well: until this method existed, this case was
+     * reported by that one with a pending count of zero.</p>
+     */
+    protected void logUnmatchedSamlResponseAfterSessionExpiry() {
+        logger.warn("Received a SAML response after the session it belongs to had expired."
+                + " The browser did return its session cookie, so this is not the SameSite case:"
+                + " the session, and with it the AuthnRequest ID it held, was discarded by the"
+                + " container's session timeout rather than by {}, so raising that value does not help."
+                + " Starting the login again resolves it.", SAML_REQUEST_ID_TTL);
+    }
+
+    /**
+     * Returns whether the request carries a session id that the container no longer recognises.
+     *
+     * <p>This is what tells an expired session apart from a browser that is not sending the
+     * cookie: a request with no session id at all cannot have lost one. Named after the
+     * {@code EntraIdAuthenticator} method that answers the same question, so that the two
+     * authenticators stay recognisable to each other.</p>
+     *
+     * <p>Unlike there, the answer only chooses a log line here. An unmatched SAML response is
+     * refused either way, because restarting the login by redirecting to an IdP that is already
+     * authenticated would only bring the same unmatched assertion straight back.</p>
+     *
+     * @param request The HTTP servlet request.
+     * @return True if a session id was sent and it is no longer valid.
+     */
+    protected boolean hasExpiredSession(final HttpServletRequest request) {
+        return request.getRequestedSessionId() != null && !request.isRequestedSessionIdValid();
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -45,6 +45,7 @@ import org.lastaflute.web.login.credential.LoginCredential;
 import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.response.StreamResponse;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpSession;
 
 public class SamlAuthenticatorTest extends UnitFessTestCase {
@@ -808,6 +809,123 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertFalse(expired, expired.contains("tomcat.sameSiteCookies"));
         } finally {
             appender.detach();
+        }
+    }
+
+    @Test
+    public void test_hasExpiredSession_needsASessionIdThatIsNoLongerValid() throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        // one request, walked through the three states, because getMockRequest() hands out the
+        // same instance for the whole test method
+        final MockletHttpServletRequest request = getMockRequest();
+
+        // a browser that is not sending the cookie sends no session id, so nothing was lost
+        assertNull(request.getRequestedSessionId());
+        assertFalse(authenticator.hasExpiredSession(request));
+
+        // an id that came back with nothing behind it is the case worth naming
+        request.addCookie(new Cookie("jsessionid", "AB1C2D3E4F5061728394A5B6C7D8E9F0"));
+        assertNotNull(request.getRequestedSessionId());
+        assertFalse(request.isRequestedSessionIdValid());
+        assertTrue(authenticator.hasExpiredSession(request));
+
+        // an id the container still knows is a live session, not an expired one
+        request.getSession();
+        assertTrue(request.isRequestedSessionIdValid());
+        assertFalse(authenticator.hasExpiredSession(request));
+    }
+
+    @Test
+    public void test_getLoginCredential_responseWithoutASessionIdBlamesTheCookie() throws Exception {
+        // Nothing came back at all, which really is what a SameSite=Lax cookie on a cross-site
+        // POST looks like, so this is the one case that keeps that guidance.
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+            request.setMethod("POST");
+            request.setParameter("SAMLResponse", "PHNhbWxwOlJlc3BvbnNlIC8+");
+            assertNull(request.getRequestedSessionId());
+
+            assertNull(authenticator.getLoginCredential());
+            assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+            final String warning = appender.warnings().get(0);
+            assertTrue(warning, warning.contains("tomcat.sameSiteCookies"));
+            assertFalse(warning, warning.contains("session it belongs to had expired"));
+        } finally {
+            tearDownIdp(systemProperties);
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_expiredSessionIsNotReportedAsABlockedCookie() throws Exception {
+        // The realistic "walked away at the IdP" case arrives exactly like this, because the
+        // container reaps the session (30 minutes by default) long before saml.request.id.ttl
+        // (3600 seconds) can prune an ID, so the AuthnRequest IDs go with it and the branch that
+        // counts pruned IDs is never reached. Reported as the SameSite case it sends an operator
+        // whose cookie settings are already right off to change them.
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+            request.setMethod("POST");
+            request.setParameter("SAMLResponse", "PHNhbWxwOlJlc3BvbnNlIC8+");
+            request.addCookie(new Cookie("jsessionid", "AB1C2D3E4F5061728394A5B6C7D8E9F0"));
+            // the cookie demonstrably arrived; there is simply no session behind it any more
+            assertNotNull(request.getRequestedSessionId());
+            assertNull(request.getSession(false));
+
+            // still refused: bouncing back to an IdP that is already authenticated would only
+            // post the same unmatched assertion straight back
+            assertNull(authenticator.getLoginCredential());
+            assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+            final String warning = appender.warnings().get(0);
+            assertTrue(warning, warning.contains("session it belongs to had expired"));
+            assertFalse(warning, warning.contains("tomcat.sameSiteCookies"));
+            // raising the TTL cannot extend a session that is already the shorter of the two
+            assertTrue(warning, warning.contains("raising that value does not help"));
+        } finally {
+            tearDownIdp(systemProperties);
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_prunedRequestIdsStillNameTheTtl() throws Exception {
+        // The third case: the session is alive and its cookie is valid, and only the IDs it held
+        // ran out of time. That one really is about saml.request.id.ttl, so the session-expiry
+        // wording must not take it over.
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = getMockRequest();
+            request.addCookie(new Cookie("jsessionid", "AB1C2D3E4F5061728394A5B6C7D8E9F0"));
+            authenticator.getLoginCredential();
+            final String requestId = pendingRequestIds(request.getSession(false)).iterator().next();
+            assertTrue(request.isRequestedSessionIdValid());
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                clock.addAndGet(3601L * 1000L);
+                postSamlResponse(request, requestId);
+
+                assertNull(authenticator.getLoginCredential());
+                assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+                final String warning = appender.warnings().get(0);
+                assertTrue(warning, warning.contains("all 1 pending AuthnRequest ID(s) of the session had expired"));
+                assertFalse(warning, warning.contains("session it belongs to had expired"));
+                assertFalse(warning, warning.contains("tomcat.sameSiteCookies"));
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownIdp(systemProperties);
         }
     }
 


### PR DESCRIPTION
## The problem

An unmatched SAML response is reported by one of two warnings: the SameSite/cookie one, or
— since #3260 added it — the one that says the AuthnRequest IDs of a live session had passed
`saml.request.id.ttl`. Choosing between them turns on a counter that is only assigned inside
`if (session != null)`, so the second line needs a session that is **still alive** and whose
pending IDs this very request pruned.

**That combination essentially cannot occur under the shipped defaults, because the two
clocks are ordered the wrong way round:**

| clock | value | set where |
|---|---|---|
| AuthnRequest ID TTL | 3600 s (1 hour) | `DEFAULT_REQUEST_ID_TTL` |
| container session timeout | **30 minutes** | servlet container default — `WEB-INF/web.xml` sets no `session-timeout` and nothing calls `setMaxInactiveInterval` |

The session is discarded, IDs and all, some half an hour before any of those IDs can expire.
So the realistic case #3260 was written for — a user who walks away at the IdP and comes back
late — arrives with `getSession(false)` returning null, falls through to the `else` branch, and
is reported as a SameSite cookie problem. That is the exact misdiagnosis the split set out to
eliminate, in the one case that occurs in practice, and it sends an operator whose cookie
configuration is already correct off to change it.

The existing test could not catch this: `MockletHttpSession` never expires, so
`test_getLoginCredential_expiredRequestIdCannotBeAnswered` cannot observe the interaction.

## The change

The two are distinguishable, and `EntraIdAuthenticator` already does it: a browser that is not
sending the session cookie sends **no session id at all**, so a request that does carry one
demonstrably kept the cookie and lost only the session behind it.

Mirror that helper here under the same name and use it to pick a third message, which names the
container's session timeout rather than `saml.request.id.ttl` — raising the TTL cannot extend a
session that is already the shorter of the two — and says that starting the login again resolves
it.

```java
if (expiredCount > 0) {
    logUnmatchedSamlResponseAfterExpiry(expiredCount);
} else if (hasExpiredSession(request)) {
    logUnmatchedSamlResponseAfterSessionExpiry();
} else {
    logUnmatchedSamlResponse(0);
}
```

**Logging only.** All three paths still refuse the response and return `null`, because answering
an unmatched assertion with a fresh AuthnRequest would bounce off an IdP that is already
authenticated and come straight back. Neither existing message body is edited.

## Verification

- `SamlAuthenticatorTest` 40 -> 44, `org.codelibs.fess.sso.**` 252 -> 256, 0 failures
- `mvn -o clean javadoc:jar` passes
- All four new tests mutation-checked: deleting the new branch, and each of the two ways of
  weakening the predicate, turn at least one test red — two of them also redden pre-existing
  tests, so the existing branches stay pinned.

Documentation follows separately: `config/sso-saml.rst` currently says the TTL case logs "the
same warning", which is true today only because of the ordering above.
