### PR TITLE
fix(sso): stop an unparsable SAML response logging a stack trace

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -18,10 +18,13 @@ package org.codelibs.fess.sso.saml;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -45,6 +48,7 @@ import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.saml2.Auth;
 import org.codelibs.saml2.core.authn.AuthnRequestParams;
+import org.codelibs.saml2.core.exception.SAMLException;
 import org.codelibs.saml2.core.exception.ValidationException;
 import org.codelibs.saml2.core.logout.LogoutRequestParams;
 import org.codelibs.saml2.core.replay.InMemoryReplayCache;
@@ -474,6 +478,18 @@ public class SamlAuthenticator implements SsoAuthenticator {
                     if (!requestIdMap.isEmpty()) {
                         try {
                             return processSamlResponse(request, response, requestIdMap);
+                        } catch (final SAMLException e) {
+                            // The assertion consumer service is anonymous, and a SAMLResponse that
+                            // cannot be decoded or parsed is refused before the pending
+                            // AuthnRequest ID is consumed (see processSamlResponse), so the same
+                            // request can be repeated for the whole TTL. A stack trace per attempt
+                            // would let an unauthenticated client fill the log; SsoAction already
+                            // makes this split for SsoStateException.
+                            logger.warn("Authentication failed: {}", describeSamlFailure(e));
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Authentication failed.", e);
+                            }
+                            return null;
                         } catch (final Exception e) {
                             logger.warn("Authentication failed.", e);
                             return null;
@@ -510,6 +526,38 @@ public class SamlAuthenticator implements SsoAuthenticator {
             }
 
         }).orElse(null);
+    }
+
+    /**
+     * Renders a SAML failure as the single line that stands in for its stack trace at WARN.
+     *
+     * <p>The cause chain is rendered, not just {@code getMessage()}, because the exception a
+     * malformed response produces is often the one that says the least: java-saml wraps a parse
+     * failure as {@code XMLParsingException("Failed to load XML data.", cause)}, whose own
+     * message names neither what failed nor where. Everything actionable lives further down the
+     * chain, so dropping it would trade a noisy log for a useless one.</p>
+     *
+     * <p>Split out as its own method so that an extension can reshape or shorten this line
+     * without having to re-implement the WARN/DEBUG split around it. The full stack trace stays
+     * available at DEBUG either way.</p>
+     *
+     * @param throwable The failure to describe.
+     * @return The chain rendered as {@code Type: message} entries joined by {@code " <- "},
+     *         stopping at the first cause already seen so that a cyclic chain terminates.
+     */
+    protected String describeSamlFailure(final Throwable throwable) {
+        final Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        final StringBuilder buf = new StringBuilder();
+        for (Throwable current = throwable; current != null && seen.add(current); current = current.getCause()) {
+            if (buf.length() > 0) {
+                buf.append(" <- ");
+            }
+            buf.append(current.getClass().getSimpleName());
+            if (StringUtil.isNotBlank(current.getMessage())) {
+                buf.append(": ").append(current.getMessage());
+            }
+        }
+        return buf.toString();
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.sso.saml;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -27,6 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
@@ -37,6 +40,9 @@ import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.saml2.core.exception.SAMLException;
+import org.codelibs.saml2.core.exception.ValidationException;
+import org.codelibs.saml2.core.exception.XMLParsingException;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
 import org.junit.jupiter.api.Assertions;
@@ -46,6 +52,8 @@ import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.response.StreamResponse;
 
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 public class SamlAuthenticatorTest extends UnitFessTestCase {
@@ -664,6 +672,224 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             systemProperties.remove("saml.security.want_xml_validation");
             tearDownIdp(systemProperties);
         }
+    }
+
+    /**
+     * Wraps an authenticator whose response processing always fails with {@code failure}, so that
+     * a test can choose the exception {@code getLoginCredential} has to classify. The instance is
+     * deliberately left without {@code defaultSettings}: the SAMLResponse branch reaches the
+     * override before anything asks for settings, so a test that needed them would be testing a
+     * different path than the one it names.
+     */
+    private SamlAuthenticator failingAuthenticator(final RuntimeException failure) {
+        return new SamlAuthenticator() {
+            @Override
+            protected LoginCredential processSamlResponse(final HttpServletRequest request, final HttpServletResponse response,
+                    final Map<String, Long> requestIdMap) {
+                throw failure;
+            }
+        };
+    }
+
+    /**
+     * Seeds a session with one pending AuthnRequest ID and puts {@code samlResponse} on the
+     * request, which is the state a malformed callback arrives in.
+     *
+     * @param authenticator The authenticator that sends the AuthnRequest.
+     * @param samlResponse The raw value of the SAMLResponse parameter.
+     * @return The request, now carrying both the session and the response.
+     */
+    private MockletHttpServletRequest postRawSamlResponse(final SamlAuthenticator authenticator, final String samlResponse) {
+        final MockletHttpServletRequest request = getMockRequest();
+        authenticator.getLoginCredential();
+        request.setMethod("POST");
+        request.setParameter("SAMLResponse", samlResponse);
+        return request;
+    }
+
+    /** A SAMLResponse that is not base64 at all, the cheapest payload an anonymous client can send. */
+    private static final String NOT_BASE64 = "!!! not base64 at all !!!";
+
+    /** A SAMLResponse that decodes cleanly and is then not parsable as XML. */
+    private static final String BROKEN_XML = Base64.getEncoder().encodeToString("<samlp:Response".getBytes(StandardCharsets.UTF_8));
+
+    @Test
+    public void test_getLoginCredential_unparsableResponseIsWarnedWithoutAStackTrace() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = postRawSamlResponse(authenticator, NOT_BASE64);
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                assertNull(authenticator.getLoginCredential());
+
+                // /sso/ is anonymous, so this is a rejected request rather than a fault of this
+                // server: one line, and no stack trace an unauthenticated client can repeat.
+                final List<LogEvent> warnEvents = appender.eventsAt(Level.WARN);
+                assertEquals(1, warnEvents.size(), String.valueOf(appender.warnings()));
+                assertEquals("Authentication failed: ValidationException: SAML Response could not be processed",
+                        appender.warnings().get(0));
+                assertNull(warnEvents.get(0).getThrown(), String.valueOf(warnEvents.get(0).getThrown()));
+                // the pending ID is not consumed by the failure, which is what makes the same
+                // request repeatable for the whole TTL and therefore worth not tracing
+                assertEquals(1, pendingRequestIds(request.getSession(false)).size());
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_brokenXmlResponseIsWarnedWithoutAStackTrace() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            // base64 that decodes fine and is then not XML reaches the same throw by a different
+            // route, so neither a stricter decoder nor a stricter parser alone closes this
+            postRawSamlResponse(authenticator, BROKEN_XML);
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                assertNull(authenticator.getLoginCredential());
+
+                final List<LogEvent> warnEvents = appender.eventsAt(Level.WARN);
+                assertEquals(1, warnEvents.size(), String.valueOf(appender.warnings()));
+                assertEquals("Authentication failed: ValidationException: SAML Response could not be processed",
+                        appender.warnings().get(0));
+                assertNull(warnEvents.get(0).getThrown(), String.valueOf(warnEvents.get(0).getThrown()));
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_unparsableResponseKeepsTheStackTraceAtDebug() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            postRawSamlResponse(authenticator, NOT_BASE64);
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                assertNull(authenticator.getLoginCredential());
+
+                // dropping the trace from the WARN must not drop it from the build: an operator
+                // chasing a real IdP problem raises the level and gets everything back
+                final List<LogEvent> traced = appender.eventsAt(Level.DEBUG)
+                        .stream()
+                        .filter(e -> "Authentication failed.".equals(e.getMessage().getFormattedMessage()))
+                        .toList();
+                assertEquals(1, traced.size(), String.valueOf(appender.messagesAt(Level.DEBUG)));
+                assertTrue(String.valueOf(traced.get(0).getThrown()), traced.get(0).getThrown() instanceof ValidationException);
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_unparsableResponseCanBeRepeatedWithThePendingRequestId() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = postRawSamlResponse(authenticator, NOT_BASE64);
+            final Set<String> pending = pendingRequestIds(request.getSession(false));
+            assertEquals(1, pending.size(), String.valueOf(pending));
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                assertNull(authenticator.getLoginCredential());
+                assertNull(authenticator.getLoginCredential());
+                assertNull(authenticator.getLoginCredential());
+
+                // this is the whole reason the trace has to go: the failure leaves the pending ID
+                // in place, so the very same anonymous request answers again and again
+                assertEquals(3, appender.warnings().size(), String.valueOf(appender.warnings()));
+                Assertions.assertEquals(pending, pendingRequestIds(request.getSession(false)));
+                appender.eventsAt(Level.WARN).forEach(e -> assertNull(e.getThrown(), e.getMessage().getFormattedMessage()));
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_unparsableResponseWarningNamesTheNestedCause() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = postRawSamlResponse(authenticator, BROKEN_XML);
+            // java-saml's own wrapper for a parse failure, whose message names neither what
+            // failed nor where: dropping the cause chain here would leave the WARN useless
+            final RuntimeException failure = new XMLParsingException("Failed to load XML data.",
+                    new IOException("Stream closed", new IllegalStateException("underlying detail")));
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                assertNull(failingAuthenticator(failure).getLoginCredential());
+
+                assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+                assertEquals("Authentication failed: XMLParsingException: Failed to load XML data."
+                        + " <- IOException: Stream closed <- IllegalStateException: underlying detail", appender.warnings().get(0));
+            } finally {
+                appender.detach();
+            }
+            assertEquals(1, pendingRequestIds(request.getSession(false)).size());
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_getLoginCredential_nonSamlFailureKeepsItsStackTrace() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            postRawSamlResponse(authenticator, BROKEN_XML);
+            // anything that is not a SAML failure is a bug in this server rather than a payload an
+            // anonymous client chose, so it keeps the trace it always had
+            final RuntimeException failure = new IllegalStateException("something this server got wrong");
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                assertNull(failingAuthenticator(failure).getLoginCredential());
+
+                final List<LogEvent> warnEvents = appender.eventsAt(Level.WARN);
+                assertEquals(1, warnEvents.size(), String.valueOf(appender.warnings()));
+                assertEquals("Authentication failed.", appender.warnings().get(0));
+                assertSame(failure, warnEvents.get(0).getThrown());
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_describeSamlFailure_stopsOnACyclicCauseChain() throws Exception {
+        final SAMLException first = new SAMLException("first");
+        final SAMLException second = new SAMLException("second", first);
+        first.initCause(second);
+
+        // a chain that points back at itself must end the rendering, not the request
+        assertEquals("SAMLException: first <- SAMLException: second", new SamlAuthenticator().describeSamlFailure(first));
     }
 
     @Test


### PR DESCRIPTION
## The problem

`/sso/` is anonymous, answers GET as well as POST (`containsSamlResponse` reads a request
parameter), and Fess ships `rate.limit.enabled=false`. A request carrying a malformed
`SAMLResponse` makes Fess log a **full stack trace at WARN**:

- `Auth.processResponse` constructs the `SamlResponse` *before* validating it, and the
  constructor's `loadXmlFromBase64` throws `ValidationException`
- `ValidationException extends SAMLException extends RuntimeException` — unchecked
- nothing in `processSamlResponse`'s loop catches it, so it lands in
  `catch (final Exception e) { logger.warn("Authentication failed.", e); }`

The pending AuthnRequest ID is **not** consumed by the failure (deliberately — see
`processSamlResponse`), so one prior `GET /sso/` lets the same request be repeated for the
whole TTL. Across the 40 pre-existing tests this catch had no coverage at all.

This is **log hygiene and consistency, not an emergency.** Measured against 15.7, which
auto-rearmed `SAML_STATE` on the following request, the delta is exactly 2x — 5 traces per 10
identical requests then, 1 per request now. (15.8 is in fact *better* on session pressure:
`getSession(false)` no longer mints a session per cookie-less request.)

The real justification is that `SsoAction` already makes this exact split for
`SsoStateException`, with the comment *"A stack trace per attempt would let an
unauthenticated client fill the log"*, and #3263 did the same for SPNEGO. The SAML assertion
consumer service was the last SSO path still violating that policy.

## The change

A `catch (final SAMLException e)` branch before the existing one: message-only at WARN, full
stack trace at DEBUG, still `return null`. **No behavioural change** — both branches already
returned null.

`getMessage()` alone is not enough, because java-saml wraps a parse failure as
`XMLParsingException("Failed to load XML data.", cause)`, whose own message names neither what
failed nor where. `describeSamlFailure` renders the cause chain as `Type: message` joined by
`" <- "`, stopping at the first already-seen throwable so a cyclic chain terminates:

```
Authentication failed: ValidationException: SAML Response could not be processed
Authentication failed: XMLParsingException: Failed to load XML data. <- IOException: Stream closed
```

The catch is deliberately **not** widened beyond `SAMLException`; anything else keeps its trace.

## Honest scope

java-saml's own `org.codelibs.saml2.core.util.Util` logs a second trace for the same request
(`Load XML error: Cannot parse a document.`, WARN with the throwable attached; that logger is
`level="info"` with additivity, so it reaches `fess.log`). **This change roughly halves the
volume rather than eliminating it** — the remainder needs a java-saml change, which is not
worth a dependency bump for 15.8.

Diagnostics are not lost: everything reaching this catch is either self-describing
(`No private key available for decrypt, check settings`) or already traced by that `Util` line.

## Verification

- `SamlAuthenticatorTest` 40 -> 47, `org.codelibs.fess.sso.**` 252 -> 259, 0 failures
- `mvn -o clean javadoc:jar` passes
- 5 mutations, all killed: restoring the old WARN (4 red), deleting the DEBUG line, not
  following `getCause()`, widening the catch to `RuntimeException`, and removing the cycle
  guard — the last one OOMs the fork, which is how we know the guard is load-bearing.
