### PR TITLE
fix(ldap): bound the LDAP connect, read and search waits

### DIFF
--- a/src/main/java/org/codelibs/fess/ldap/LdapManager.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapManager.java
@@ -32,9 +32,11 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.naming.CommunicationException;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
+import javax.naming.TimeLimitExceededException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.BasicAttribute;
@@ -70,6 +72,19 @@ import jakarta.annotation.PostConstruct;
  */
 public class LdapManager {
     private static final Logger logger = LogManager.getLogger(LdapManager.class);
+
+    /**
+     * The JNDI environment property bounding the connection setup. The JDK LDAP provider applies it to the TCP
+     * connect, to the TLS handshake and to the response of the initial bind, so an unset value leaves a bind
+     * against an unresponsive directory waiting forever.
+     */
+    protected static final String JNDI_CONNECT_TIMEOUT = "com.sun.jndi.ldap.connect.timeout";
+
+    /**
+     * The JNDI environment property bounding how long a bound connection waits for a response. It does not apply
+     * to the initial bind, which is bounded by {@link #JNDI_CONNECT_TIMEOUT}.
+     */
+    protected static final String JNDI_READ_TIMEOUT = "com.sun.jndi.ldap.read.timeout";
 
     /** A thread-local variable to hold the directory context. */
     protected ThreadLocal<DirContextHolder> contextLocal = new ThreadLocal<>();
@@ -119,6 +134,8 @@ public class LdapManager {
         if (providerUrl != null && providerUrl.startsWith("ldaps://")) {
             putEnv(env, Context.SECURITY_PROTOCOL, "ssl");
         }
+        putTimeoutEnv(env, JNDI_CONNECT_TIMEOUT, getConnectTimeout());
+        putTimeoutEnv(env, JNDI_READ_TIMEOUT, getReadTimeout());
         return env;
     }
 
@@ -134,6 +151,47 @@ public class LdapManager {
             throw new LdapConfigurationException(key + " is null.");
         }
         env.put(key, value);
+    }
+
+    /**
+     * Puts a timeout property to the environment. A value of 0 or less leaves the property unset, which restores
+     * the JNDI default of waiting for the JDK/OS default (the connect timeout) or forever (the read timeout).
+     *
+     * @param env The environment.
+     * @param key The JNDI property name.
+     * @param timeout The timeout in milliseconds.
+     */
+    protected void putTimeoutEnv(final Hashtable<String, String> env, final String key, final int timeout) {
+        if (timeout > 0) {
+            env.put(key, Integer.toString(timeout));
+        }
+    }
+
+    /**
+     * Returns the configured connection timeout in milliseconds.
+     *
+     * @return The connection timeout, or 0 or less to leave it unbounded.
+     */
+    protected int getConnectTimeout() {
+        return fessConfig.getLdapConnectTimeoutAsInteger().intValue();
+    }
+
+    /**
+     * Returns the configured read timeout in milliseconds.
+     *
+     * @return The read timeout, or 0 or less to leave it unbounded.
+     */
+    protected int getReadTimeout() {
+        return fessConfig.getLdapReadTimeoutAsInteger().intValue();
+    }
+
+    /**
+     * Returns the configured search time limit in milliseconds.
+     *
+     * @return The search time limit, or 0 or less for no limit.
+     */
+    protected int getSearchTimeLimit() {
+        return fessConfig.getLdapSearchTimeLimitAsInteger().intValue();
     }
 
     /**
@@ -411,8 +469,7 @@ public class LdapManager {
         final Hashtable<String, String> env = createSearchEnv();
         try (DirContextHolder holder = getDirContext(() -> env)) {
             final DirContext context = holder.get();
-            final SearchControls searchControls = new SearchControls();
-            searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+            final SearchControls searchControls = createSearchControls(null);
             if (logger.isDebugEnabled()) {
                 logger.debug("Searching for sAMAccountName of group: {} on {}", groupName, bindDn);
             }
@@ -1568,11 +1625,7 @@ public class LdapManager {
     protected void search(final String baseDn, final String filter, final String[] returningAttrs,
             final Supplier<Hashtable<String, String>> envSupplier, final SearchConsumer consumer) {
         try (DirContextHolder holder = getDirContext(envSupplier)) {
-            final SearchControls controls = new SearchControls();
-            controls.setSearchScope(SearchControls.SUBTREE_SCOPE);
-            if (returningAttrs != null) {
-                controls.setReturningAttributes(returningAttrs);
-            }
+            final SearchControls controls = createSearchControls(returningAttrs);
 
             final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
             final long startTime = systemHelper.getCurrentTimeAsLong();
@@ -1583,8 +1636,48 @@ public class LdapManager {
             }
             consumer.accept(list);
         } catch (final NamingException e) {
+            if (isDirectoryUnavailable(e)) {
+                // The caller may run on a request thread and only report this at debug level, so surface the
+                // timeout here where the operation and the bounds that produced it are still known.
+                logger.warn("LDAP directory did not answer the search: baseDn={}, filter={}, readTimeout={}ms, timeLimit={}ms", baseDn,
+                        filter, getReadTimeout(), getSearchTimeLimit(), e);
+            }
             throw new LdapOperationException("Failed to search " + baseDn + " with " + filter, e);
         }
+    }
+
+    /**
+     * Creates the search controls used by every LDAP search, applying the configured search time limit.
+     *
+     * @param returningAttrs The attributes to return from the search, or null for all attributes.
+     * @return The search controls.
+     */
+    protected SearchControls createSearchControls(final String[] returningAttrs) {
+        final SearchControls controls = new SearchControls();
+        controls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        if (returningAttrs != null) {
+            controls.setReturningAttributes(returningAttrs);
+        }
+        final int timeLimit = getSearchTimeLimit();
+        if (timeLimit > 0) {
+            // SearchControls already defaults to 0, which is its own contract for "no limit".
+            controls.setTimeLimit(timeLimit);
+        }
+        return controls;
+    }
+
+    /**
+     * Determines whether the given exception means the directory did not answer. The JDK LDAP provider
+     * reports both a connect timeout and a read timeout as a {@link CommunicationException} (the read timeout
+     * carries a "LDAP response read timed out" cause), and the server side time limit as a
+     * {@link TimeLimitExceededException}. A {@link CommunicationException} also covers a connection that failed
+     * outright, which is equally worth reporting to an operator.
+     *
+     * @param e The naming exception.
+     * @return True if the directory did not answer.
+     */
+    protected boolean isDirectoryUnavailable(final NamingException e) {
+        return e instanceof CommunicationException || e instanceof TimeLimitExceededException;
     }
 
     /**
@@ -1675,7 +1768,10 @@ public class LdapManager {
             contextLocal.set(holder);
             return holder;
         } catch (final NamingException e) {
-            throw new LdapOperationException("Failed to create DirContext.", e);
+            // The provider URL is the only part of env that is safe to report; the rest holds credentials.
+            throw new LdapOperationException(
+                    "Failed to create DirContext: url=" + env.get(Context.PROVIDER_URL) + ", connectTimeout=" + getConnectTimeout() + "ms",
+                    e);
         }
     }
 

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -1855,6 +1855,15 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. true */
     String LDAP_AUTH_VALIDATION = "ldap.auth.validation";
 
+    /** The key of the configuration. e.g. 10000 */
+    String LDAP_CONNECT_TIMEOUT = "ldap.connect.timeout";
+
+    /** The key of the configuration. e.g. 30000 */
+    String LDAP_READ_TIMEOUT = "ldap.read.timeout";
+
+    /** The key of the configuration. e.g. 60000 */
+    String LDAP_SEARCH_TIME_LIMIT = "ldap.search.time.limit";
+
     /** The key of the configuration. e.g. -1 */
     String LDAP_MAX_USERNAME_LENGTH = "ldap.max.username.length";
 
@@ -9016,6 +9025,57 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     boolean isLdapAuthValidation();
 
     /**
+     * Get the value for the key 'ldap.connect.timeout'. <br>
+     * The value is, e.g. 10000 <br>
+     * comment: Timeout (milliseconds) to establish an LDAP connection. This also bounds the TLS handshake and the initial bind response. 0 or less leaves it to the JDK/OS default.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getLdapConnectTimeout();
+
+    /**
+     * Get the value for the key 'ldap.connect.timeout' as {@link Integer}. <br>
+     * The value is, e.g. 10000 <br>
+     * comment: Timeout (milliseconds) to establish an LDAP connection. This also bounds the TLS handshake and the initial bind response. 0 or less leaves it to the JDK/OS default.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getLdapConnectTimeoutAsInteger();
+
+    /**
+     * Get the value for the key 'ldap.read.timeout'. <br>
+     * The value is, e.g. 30000 <br>
+     * comment: Timeout (milliseconds) to wait for an LDAP response after the connection is bound. 0 or less waits indefinitely.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getLdapReadTimeout();
+
+    /**
+     * Get the value for the key 'ldap.read.timeout' as {@link Integer}. <br>
+     * The value is, e.g. 30000 <br>
+     * comment: Timeout (milliseconds) to wait for an LDAP response after the connection is bound. 0 or less waits indefinitely.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getLdapReadTimeoutAsInteger();
+
+    /**
+     * Get the value for the key 'ldap.search.time.limit'. <br>
+     * The value is, e.g. 60000 <br>
+     * comment: Server side time limit (milliseconds) for an LDAP search. 0 or less means no limit.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getLdapSearchTimeLimit();
+
+    /**
+     * Get the value for the key 'ldap.search.time.limit' as {@link Integer}. <br>
+     * The value is, e.g. 60000 <br>
+     * comment: Server side time limit (milliseconds) for an LDAP search. 0 or less means no limit.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getLdapSearchTimeLimitAsInteger();
+
+    /**
      * Get the value for the key 'ldap.max.username.length'. <br>
      * The value is, e.g. -1 <br>
      * comment: Maximum username length for LDAP.
@@ -13407,6 +13467,30 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return is(FessConfig.LDAP_AUTH_VALIDATION);
         }
 
+        public String getLdapConnectTimeout() {
+            return get(FessConfig.LDAP_CONNECT_TIMEOUT);
+        }
+
+        public Integer getLdapConnectTimeoutAsInteger() {
+            return getAsInteger(FessConfig.LDAP_CONNECT_TIMEOUT);
+        }
+
+        public String getLdapReadTimeout() {
+            return get(FessConfig.LDAP_READ_TIMEOUT);
+        }
+
+        public Integer getLdapReadTimeoutAsInteger() {
+            return getAsInteger(FessConfig.LDAP_READ_TIMEOUT);
+        }
+
+        public String getLdapSearchTimeLimit() {
+            return get(FessConfig.LDAP_SEARCH_TIME_LIMIT);
+        }
+
+        public Integer getLdapSearchTimeLimitAsInteger() {
+            return getAsInteger(FessConfig.LDAP_SEARCH_TIME_LIMIT);
+        }
+
         public String getLdapMaxUsernameLength() {
             return get(FessConfig.LDAP_MAX_USERNAME_LENGTH);
         }
@@ -14540,6 +14624,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.LDAP_ADMIN_GROUP_OBJECT_CLASSES, "groupOfNames");
             defaultMap.put(FessConfig.LDAP_ADMIN_SYNC_PASSWORD, "true");
             defaultMap.put(FessConfig.LDAP_AUTH_VALIDATION, "true");
+            defaultMap.put(FessConfig.LDAP_CONNECT_TIMEOUT, "10000");
+            defaultMap.put(FessConfig.LDAP_READ_TIMEOUT, "30000");
+            defaultMap.put(FessConfig.LDAP_SEARCH_TIME_LIMIT, "60000");
             defaultMap.put(FessConfig.LDAP_MAX_USERNAME_LENGTH, "-1");
             defaultMap.put(FessConfig.LDAP_IGNORE_NETBIOS_NAME, "true");
             defaultMap.put(FessConfig.LDAP_GROUP_NAME_WITH_UNDERSCORES, "false");

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1535,6 +1535,12 @@ ldap.admin.sync.password=true
 
 # Whether to validate LDAP authentication.
 ldap.auth.validation=true
+# Timeout (milliseconds) to establish an LDAP connection. This also bounds the TLS handshake and the initial bind response. 0 or less leaves it to the JDK/OS default.
+ldap.connect.timeout=10000
+# Timeout (milliseconds) to wait for an LDAP response after the connection is bound. 0 or less waits indefinitely.
+ldap.read.timeout=30000
+# Server side time limit (milliseconds) for an LDAP search. 0 or less means no limit.
+ldap.search.time.limit=60000
 # Maximum username length for LDAP.
 ldap.max.username.length=-1
 # Whether to ignore NetBIOS name in LDAP.

--- a/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
@@ -18,10 +18,24 @@ package org.codelibs.fess.ldap;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
+import javax.naming.CommunicationException;
+import javax.naming.Context;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+
+import org.apache.logging.log4j.Level;
+import org.codelibs.fess.exception.LdapOperationException;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalEntity;
@@ -475,5 +489,274 @@ public class LdapManagerTest extends UnitFessTestCase {
         assertEquals("normal", ldapManager.replaceWithUnderscores("normal"));
         // Input "//\\[]:;" has 8 special characters that should be replaced
         assertEquals("________", ldapManager.replaceWithUnderscores("//\\\\[]:;"));
+    }
+
+    // ========================================================================
+    // Tests for Directory Timeouts
+    // ========================================================================
+
+    /**
+     * Pins the shipped defaults. They are read with the raw keys rather than the generated accessors so this
+     * assertion is about what {@code fess_config.properties} actually ships, not about the accessor wiring.
+     */
+    @Test
+    public void test_ldapTimeoutDefaults() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+
+        assertEquals("10000", fessConfig.get("ldap.connect.timeout"));
+        assertEquals("30000", fessConfig.get("ldap.read.timeout"));
+        assertEquals("60000", fessConfig.get("ldap.search.time.limit"));
+    }
+
+    @Test
+    public void test_createEnvironment_appliesTimeouts() {
+        ComponentUtil.setFessConfig(timeoutConfig(10000, 30000, 60000));
+        final LdapManager ldapManager = new LdapManager();
+        ldapManager.init();
+
+        final Hashtable<String, String> env =
+                ldapManager.createEnvironment("com.sun.jndi.ldap.LdapCtxFactory", "simple", "ldap://localhost:389", "cn=admin", "secret");
+
+        assertEquals("10000", env.get("com.sun.jndi.ldap.connect.timeout"));
+        assertEquals("30000", env.get("com.sun.jndi.ldap.read.timeout"));
+        // The pre-existing entries must survive.
+        assertEquals("ldap://localhost:389", env.get(Context.PROVIDER_URL));
+        assertEquals("cn=admin", env.get(Context.SECURITY_PRINCIPAL));
+        assertEquals("secret", env.get(Context.SECURITY_CREDENTIALS));
+    }
+
+    @Test
+    public void test_createEnvironment_omitsNonPositiveTimeouts() {
+        ComponentUtil.setFessConfig(timeoutConfig(0, 1500, 60000));
+        final LdapManager ldapManager = new LdapManager();
+        ldapManager.init();
+
+        Hashtable<String, String> env =
+                ldapManager.createEnvironment("com.sun.jndi.ldap.LdapCtxFactory", "simple", "ldap://localhost:389", "cn=admin", "secret");
+
+        // 0 means "leave it to the JDK/OS default", so the property must not be present at all.
+        assertNull(env.get("com.sun.jndi.ldap.connect.timeout"));
+        assertEquals("1500", env.get("com.sun.jndi.ldap.read.timeout"));
+
+        ComponentUtil.setFessConfig(timeoutConfig(1500, -1, 60000));
+        ldapManager.init();
+        env = ldapManager.createEnvironment("com.sun.jndi.ldap.LdapCtxFactory", "simple", "ldap://localhost:389", "cn=admin", "secret");
+
+        assertEquals("1500", env.get("com.sun.jndi.ldap.connect.timeout"));
+        assertNull(env.get("com.sun.jndi.ldap.read.timeout"));
+    }
+
+    @Test
+    public void test_search_appliesSearchTimeLimit() throws Exception {
+        ComponentUtil.setFessConfig(timeoutConfig(10000, 30000, 45000));
+        final CapturingDirContext context = new CapturingDirContext();
+        final CapturingLdapManager ldapManager = new CapturingLdapManager(context);
+        ldapManager.init();
+
+        final String[] returningAttrs = { "memberOf" };
+        ldapManager.search("dc=example,dc=com", "(cn=test)", returningAttrs, Hashtable::new, result -> {});
+
+        assertEquals("dc=example,dc=com", context.capturedName);
+        assertEquals("(cn=test)", context.capturedFilter);
+        assertEquals(45000, context.capturedControls.getTimeLimit());
+        assertEquals(SearchControls.SUBTREE_SCOPE, context.capturedControls.getSearchScope());
+        assertEquals(1, context.capturedControls.getReturningAttributes().length);
+        assertEquals("memberOf", context.capturedControls.getReturningAttributes()[0]);
+    }
+
+    @Test
+    public void test_search_nonPositiveTimeLimitMeansNoLimit() throws Exception {
+        final CapturingDirContext context = new CapturingDirContext();
+        final CapturingLdapManager ldapManager = new CapturingLdapManager(context);
+
+        // 0 is SearchControls' own contract for "wait indefinitely", and a negative value must not be
+        // forwarded to SearchControls either.
+        for (final int timeLimit : new int[] { 0, -1 }) {
+            ComponentUtil.setFessConfig(timeoutConfig(10000, 30000, timeLimit));
+            ldapManager.init();
+            ldapManager.search("dc=example,dc=com", "(cn=test)", null, Hashtable::new, result -> {});
+            assertEquals(0, context.capturedControls.getTimeLimit());
+        }
+
+        ComponentUtil.setFessConfig(timeoutConfig(10000, 30000, 5000));
+        ldapManager.init();
+        ldapManager.search("dc=example,dc=com", "(cn=test)", null, Hashtable::new, result -> {});
+        assertEquals(5000, context.capturedControls.getTimeLimit());
+    }
+
+    @Test
+    public void test_getSAMAccountGroupName_appliesSearchTimeLimit() throws Exception {
+        ComponentUtil.setFessConfig(timeoutConfig(10000, 30000, 45000));
+        final CapturingDirContext context = new CapturingDirContext();
+        // getSAMAccountGroupName runs context.search directly instead of going through search().
+        final CapturingLdapManager ldapManager = new CapturingLdapManager(context) {
+            @Override
+            protected Hashtable<String, String> createSearchEnv() {
+                return new Hashtable<>();
+            }
+        };
+        ldapManager.init();
+
+        ldapManager.getSAMAccountGroupName("dc=example,dc=com", "testGroup");
+
+        assertEquals("dc=example,dc=com", context.capturedName);
+        assertEquals("(name=testGroup)", context.capturedFilter);
+        assertEquals(45000, context.capturedControls.getTimeLimit());
+        assertEquals(SearchControls.SUBTREE_SCOPE, context.capturedControls.getSearchScope());
+    }
+
+    @Test
+    public void test_search_warnsOnlyWhenTheDirectoryDoesNotAnswer() throws Exception {
+        ComponentUtil.setFessConfig(timeoutConfig(10000, 30000, 45000));
+        final CapturingDirContext context = new CapturingDirContext();
+        final CapturingLdapManager ldapManager = new CapturingLdapManager(context);
+        ldapManager.init();
+
+        final LogCapturingAppender appender = LogCapturingAppender.attach(LdapManager.class);
+        try {
+            // A read timeout reaches JNDI callers as a CommunicationException.
+            context.searchException = new CommunicationException("LDAP response read timed out, timeout used: 30000 ms.");
+            try {
+                ldapManager.search("dc=example,dc=com", "(cn=test)", null, Hashtable::new, result -> {});
+                fail("LdapOperationException should be thrown.");
+            } catch (final LdapOperationException e) {
+                assertTrue(e.getMessage().contains("dc=example,dc=com"));
+            }
+
+            final List<String> warnings = appender.warnings();
+            assertEquals(1, warnings.size());
+            assertTrue(warnings.get(0).contains("dc=example,dc=com"));
+            assertTrue(warnings.get(0).contains("(cn=test)"));
+            assertTrue(warnings.get(0).contains("30000"));
+            assertTrue(warnings.get(0).contains("45000"));
+
+            // An ordinary directory error is not a timeout and must not be promoted to WARN.
+            context.searchException = new NameNotFoundException("dc=example,dc=com");
+            try {
+                ldapManager.search("dc=example,dc=com", "(cn=test)", null, Hashtable::new, result -> {});
+                fail("LdapOperationException should be thrown.");
+            } catch (final LdapOperationException e) {
+                // expected
+            }
+            assertEquals(1, appender.warnings().size());
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_getDirContext_failureNamesTheTarget() {
+        ComponentUtil.setFessConfig(timeoutConfig(10000, 30000, 45000));
+        final LdapManager ldapManager = new LdapManager();
+        ldapManager.init();
+
+        final Hashtable<String, String> env = new Hashtable<>();
+        // An unresolvable factory fails inside InitialDirContext without touching the network.
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "org.codelibs.fess.ldap.NoSuchLdapCtxFactory");
+        env.put(Context.PROVIDER_URL, "ldap://ldap.example.com:389");
+
+        try {
+            ldapManager.getDirContext(() -> env);
+            fail("LdapOperationException should be thrown.");
+        } catch (final LdapOperationException e) {
+            // validate() reports this message at WARN, so it has to say which directory and which bound.
+            assertTrue(e.getMessage().contains("ldap://ldap.example.com:389"), e.getMessage());
+            assertTrue(e.getMessage().contains("connectTimeout=10000ms"), e.getMessage());
+        }
+    }
+
+    private static FessConfig timeoutConfig(final int connectTimeout, final int readTimeout, final int searchTimeLimit) {
+        return new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Integer getLdapConnectTimeoutAsInteger() {
+                return Integer.valueOf(connectTimeout);
+            }
+
+            @Override
+            public Integer getLdapReadTimeoutAsInteger() {
+                return Integer.valueOf(readTimeout);
+            }
+
+            @Override
+            public Integer getLdapSearchTimeLimitAsInteger() {
+                return Integer.valueOf(searchTimeLimit);
+            }
+        };
+    }
+
+    /** An {@link LdapManager} whose directory context is a {@link CapturingDirContext}. */
+    private static class CapturingLdapManager extends LdapManager {
+        private final CapturingDirContext context;
+
+        CapturingLdapManager(final CapturingDirContext context) {
+            this.context = context;
+        }
+
+        @Override
+        protected DirContextHolder getDirContext(final Supplier<Hashtable<String, String>> envSupplier) {
+            return new DirContextHolder(context);
+        }
+    }
+
+    /** A directory context that records the {@link SearchControls} it is handed. */
+    private static class CapturingDirContext extends InitialDirContext {
+        String capturedName;
+
+        String capturedFilter;
+
+        SearchControls capturedControls;
+
+        NamingException searchException;
+
+        CapturingDirContext() throws NamingException {
+            super(true); // lazy: do not resolve an initial context
+        }
+
+        @Override
+        public NamingEnumeration<SearchResult> search(final String name, final String filter, final SearchControls cons)
+                throws NamingException {
+            capturedName = name;
+            capturedFilter = filter;
+            capturedControls = cons;
+            if (searchException != null) {
+                throw searchException;
+            }
+            return new EmptySearchResults();
+        }
+
+        @Override
+        public void close() {
+            // nothing to release
+        }
+    }
+
+    /** An empty result enumeration, enough for {@link java.util.Collections#list}. */
+    private static class EmptySearchResults implements NamingEnumeration<SearchResult> {
+        @Override
+        public boolean hasMoreElements() {
+            return false;
+        }
+
+        @Override
+        public SearchResult nextElement() {
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public boolean hasMore() {
+            return false;
+        }
+
+        @Override
+        public SearchResult next() {
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void close() {
+            // nothing to release
+        }
     }
 }


### PR DESCRIPTION
## Problem

`LdapManager` sets no timeouts of any kind. `createEnvironment` never sets `com.sun.jndi.ldap.connect.timeout` or `com.sun.jndi.ldap.read.timeout`, and `search` builds its `SearchControls` with only a scope and returning attributes. There is no `ldap.*` timeout key anywhere — not in `fess_config.properties`, not in `FessProp`, not in `Constants`.

This matters most under the shipped default `ldap.allow.empty.permission=true`, where `login()` never calls `getPermissions()` and so **no group search happens on the login thread at all**. The first group search then runs **on a request thread**, opening a fresh `InitialDirContext` (the login thread's `contextLocal` holder is long gone). With no read timeout, a directory that stops answering blocks that request thread indefinitely.

## Configuration

Three new keys on the `fess_config.properties` channel — operational tuning rather than per-deployment directory topology, so deliberately not on the Admin General screen alongside `ldap.base.dn` and friends.

| Key | Default | Bounds |
|---|---|---|
| `ldap.connect.timeout` | `10000` | `com.sun.jndi.ldap.connect.timeout` |
| `ldap.read.timeout` | `30000` | `com.sun.jndi.ldap.read.timeout` |
| `ldap.search.time.limit` | `60000` | `SearchControls.setTimeLimit` |

All milliseconds. **0 or less disables that bound**: the JNDI properties are then not set at all, and `setTimeLimit` is not called, leaving `SearchControls`' own `0 = no limit` default.

### Why these defaults

Measured on JDK 21.0.6 against a socket that accepts and never answers.

- **`ldap.connect.timeout=10000`.** This property does not only bound the TCP connect. The JDK LDAP provider also applies it to the TLS handshake **and to the response of the initial bind** — `com.sun.jndi.ldap.read.timeout` does *not* apply to the bind. With only the read timeout set, a bind against an unresponsive directory waited the full 20 s of the test until the server closed the socket. So the value has to leave room for server-side password verification, not just a handshake. 10 s is 3-5x a bad-case bind over a WAN with TLS, and replaces an OS default of roughly 130 s on Linux.
- **`ldap.read.timeout=30000`.** Bounds the wait for *each* response on a bound connection, so it is per-message rather than per-search: a search streaming many entries resets it on every entry. 30 s per message is far beyond any legitimate directory.
- **`ldap.search.time.limit=60000`.** The only bound measured across a whole search, and therefore the only one that could truncate a legitimately slow large AD group enumeration. Deliberately the loosest of the three; a login already taking a minute is broken for an interactive request path.

None of the three can break a directory that answers today; each bounds one that has stopped.

## Changes

- `createEnvironment` sets both JNDI properties. Both `createAdminEnv()` and `createSearchEnv()` funnel through it, and so does the per-user env, which matters because `LdapUser.getEnvironment()` is what the lazy request-thread group search reuses.
- New `createSearchControls(String[])` applies the time limit and is used by **both** search sites: `search(...)` and the direct `context.search(...)` in `getSAMAccountGroupName`, which bypassed `search()`. Those are the only two places in `src/main/java` that build an LDAP `SearchControls`.
- `search(...)` logs a WARN naming the baseDn, filter and configured bounds when the directory does not answer, then rethrows unchanged. Its caller (`getRoles` → `LdapUser.getPermissions()`) runs on a request thread and does not log the failure, so without this the hang that this PR bounds would still be invisible. JNDI reports connect and read timeouts as `CommunicationException` and the server-side limit as `TimeLimitExceededException`; both are matched, ordinary directory errors such as `NameNotFoundException` are not. The predicate is named `isDirectoryUnavailable` and the message says the directory "did not answer" rather than that it timed out, because `CommunicationException` also covers a connection that failed outright.
- `getDirContext`'s exception message now carries the provider URL and connect timeout. It previously read only `Failed to create DirContext.`, which is what `validate()` prints at WARN — naming neither the directory nor the bound. Credentials are excluded.

No existing log level is changed. `login()` still reports `LdapOperationException` at DEBUG, because that same catch also handles ordinary bad-credential failures (`AuthenticationException` is wrapped into it) and raising it would log a WARN for every wrong password.

## Tests

8 new tests in `LdapManagerTest`, each verified to fail before the change:

```
test_createEnvironment_appliesTimeouts:520            expected: <10000> but was: <null>
test_createEnvironment_omitsNonPositiveTimeouts:539   expected: <1500> but was: <null>
test_getDirContext_failureNamesTheTarget:663          Failed to create DirContext. ==> expected: <true> but was: <false>
test_getSAMAccountGroupName_appliesSearchTimeLimit:604 expected: <45000> but was: <0>
test_search_appliesSearchTimeLimit:561                expected: <45000> but was: <0>
test_search_nonPositiveTimeLimitMeansNoLimit:584      expected: <5000> but was: <0>
test_search_warnsOnlyWhenTheDirectoryDoesNotAnswer:627 expected: <1> but was: <0>
test_ldapTimeoutDefaults:506                          ConfigPropertyNotFound
```

They use the existing same-package seams (`protected getDirContext`, `protected search`, package-private `SearchConsumer`) plus an `InitialDirContext` subclass that records the `SearchControls` it is handed. No new dependency and no embedded directory — this project has neither.

One trap worth recording for future config work: `FessConfigImpl extends FessConfig.SimpleImpl`, so the `defaultMap` in `FessConfig.java` is a **live runtime fallback**, not a test-only stub. Reverting `fess_config.properties` alone left `test_ldapTimeoutDefaults` green; the red-before-green run needed both that file and the three `defaultMap` lines reverted. Adding a key to only one of the two is silently survivable.

`mvn test`: 7176 tests, 0 failures, 0 errors.

## Not in this PR

- **No `setCountLimit`.** Silently truncating a user's group list changes their permissions — a correctness change, not a timeout bound.
- **`getSAMAccountGroupName`'s catch is unchanged.** Already WARN and already names the operation, and it runs on a background task rather than the request thread.
- **Documentation.** The three keys need a `fess-docs` entry; that is a separate repo and a separate PR.
