### PR TITLE
fix(ldap): tell the user when the nested LDAP group walk fails

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/FessSearchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/FessSearchAction.java
@@ -201,10 +201,15 @@ public abstract class FessSearchAction extends FessBaseAction {
      * @return The message key, or null when there is nothing to say.
      */
     protected String getPermissionStateMessageKey(final FessUser user) {
+        // "case null" as well as default: FessUser is Serializable and its implementations live in
+        // the session, so one that gains this field without changing serialVersionUID deserializes an
+        // older session with it null. A bare switch on a null selector throws, and this runs in
+        // hookBefore on every front page, so that would be a 500 on every request until the session
+        // is dropped.
         return switch (user.getPermissionState()) {
         case PENDING -> FessMessages.ERRORS_user_permissions_loading;
         case FAILED -> FessMessages.ERRORS_user_permissions_unavailable;
-        default -> null;
+        case null, default -> null;
         };
     }
 

--- a/src/main/java/org/codelibs/fess/ldap/LdapManager.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapManager.java
@@ -22,6 +22,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -51,6 +52,7 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.timer.TimeoutManager;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.FessUser;
+import org.codelibs.fess.entity.FessUser.PermissionState;
 import org.codelibs.fess.exception.LdapConfigurationException;
 import org.codelibs.fess.exception.LdapOperationException;
 import org.codelibs.fess.helper.SystemHelper;
@@ -375,21 +377,93 @@ public class LdapManager {
         final String[] roles = roleSet.toArray(new String[roleSet.size()]);
 
         if (!subRoleSet.isEmpty()) {
-            TimeoutManager.getInstance().addTimeoutTarget(() -> {
-                sAMAccountGroupNameSet.stream().forEach(groupName -> {
-                    getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
-                        roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
-                    });
-                });
-                processSubRoles(ldapUser, bindDn, subRoleSet, groupFilter, roleSet);
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Roles (lazy loading): {}", roleSet);
-                }
-                lazyLoading.accept(roleSet.toArray(new String[roleSet.size()]));
-            }, 0, false);
+            // Set before scheduling, not inside the task: the task does not start until the timer
+            // notices it a second later, and the user is already being handed their direct groups
+            // right now. Only this branch schedules anything, so a deployment that leaves
+            // ldap.group.filter blank -- the shipped default -- never leaves RESOLVED.
+            ldapUser.setPermissionState(PermissionState.PENDING);
+            scheduleSubRoleUpdate(ldapUser, bindDn, subRoleSet, groupFilter, roleSet, sAMAccountGroupNameSet, lazyLoading);
         }
 
         return roles;
+    }
+
+    /**
+     * Schedules the nested-group resolution to run off the calling thread.
+     *
+     * <p>Split out from {@link #getRoles} so that the boundary is overridable: the body itself,
+     * {@link #updateSubRoles}, runs synchronously, so a test can drive the whole resolution
+     * without waiting on the shared timer.
+     *
+     * @param ldapUser the user whose groups are being resolved
+     * @param bindDn the bind DN for the search
+     * @param subRoleSet the group DNs to expand
+     * @param groupFilter the configured group filter
+     * @param roleSet the role set to add to
+     * @param sAMAccountGroupNameSet the group names still needing a sAMAccountName lookup
+     * @param lazyLoading the callback that publishes the resolved roles
+     */
+    protected void scheduleSubRoleUpdate(final LdapUser ldapUser, final String bindDn, final Set<String> subRoleSet,
+            final String groupFilter, final Set<String> roleSet, final Set<String> sAMAccountGroupNameSet,
+            final Consumer<String[]> lazyLoading) {
+        TimeoutManager.getInstance()
+                .addTimeoutTarget(
+                        () -> updateSubRoles(ldapUser, bindDn, subRoleSet, groupFilter, roleSet, sAMAccountGroupNameSet, lazyLoading), 0,
+                        false);
+    }
+
+    /**
+     * Resolves the nested groups and publishes the result.
+     *
+     * <p>Everything here can throw {@link LdapOperationException}. Without the catch below that
+     * throw escapes the {@code TimeoutManager} task, where the only handler is corelib's own
+     * "Failed to process a task." -- a message that names neither LDAP nor the user -- and
+     * {@code lazyLoading} is never called, so the user keeps their direct groups for the whole
+     * session with nothing connecting the two. The permissions already published by the
+     * synchronous pass are deliberately left in place; what changes is that the user is now told
+     * the rest is missing.
+     *
+     * @param ldapUser the user whose groups are being resolved
+     * @param bindDn the bind DN for the search
+     * @param subRoleSet the group DNs to expand
+     * @param groupFilter the configured group filter
+     * @param roleSet the role set to add to
+     * @param sAMAccountGroupNameSet the group names still needing a sAMAccountName lookup
+     * @param lazyLoading the callback that publishes the resolved roles
+     */
+    protected void updateSubRoles(final LdapUser ldapUser, final String bindDn, final Set<String> subRoleSet, final String groupFilter,
+            final Set<String> roleSet, final Set<String> sAMAccountGroupNameSet, final Consumer<String[]> lazyLoading) {
+        boolean resolved = false;
+        try {
+            // Inside the try, not above it: ComponentUtil.getComponent throws when the container is
+            // gone, and that throw on a TimeoutManager thread would leave the state PENDING forever
+            // -- the notice stuck on screen for the whole session, which is exactly what this method
+            // exists to avoid.
+            final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
+            sAMAccountGroupNameSet.stream().forEach(groupName -> {
+                getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
+                    roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
+                });
+            });
+            processSubRoles(ldapUser, bindDn, subRoleSet, groupFilter, roleSet);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Roles (lazy loading): {}", roleSet);
+            }
+            lazyLoading.accept(roleSet.toArray(new String[roleSet.size()]));
+            resolved = true;
+        } catch (final Exception e) {
+            logger.warn("Failed to resolve the nested LDAP groups of {}. Keeping the groups resolved so far.", ldapUser.getName(), e);
+        } finally {
+            if (resolved) {
+                ldapUser.setPermissionState(PermissionState.RESOLVED);
+            } else if (ldapUser.getPermissionState() == PermissionState.PENDING) {
+                // Only PENDING is downgraded, so a walk that failed cannot overwrite a RESOLVED a
+                // concurrent one already settled -- the user holds those groups either way, and
+                // claiming otherwise would show a failure notice over a complete permission set.
+                // The read-then-write is not atomic, but both writers are only reporting.
+                ldapUser.setPermissionState(PermissionState.FAILED);
+            }
+        }
     }
 
     /**
@@ -460,6 +534,7 @@ public class LdapManager {
             logger.debug("Group filter: {}", filter);
         }
         final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
+        final Set<String> sAMAccountGroupNameSet = new LinkedHashSet<>();
         search(bindDn, filter, null, () -> ldapUser.getEnvironment(), result -> {
             for (final SearchResult srcrslt : result) {
                 final String groupDn = srcrslt.getNameInNamespace();
@@ -469,12 +544,29 @@ public class LdapManager {
                 final String groupName = getSearchRoleName(groupDn);
                 final String roleType = updateSearchRoles(roleSet, groupDn, groupName);
                 if (fessConfig.getRoleSearchGroupPrefix().equals(roleType) && fessConfig.isLdapSamaccountnameGroup()) {
-                    getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
-                        roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
-                    });
+                    sAMAccountGroupNameSet.add(groupName);
                 }
             }
         });
+        // Collected above and looked up here, once the search has returned. getSAMAccountGroupName
+        // asks for the admin credentials, but getDirContext discards that request whenever a
+        // context is already open on this thread -- and inside the consumer above one is, the one
+        // search() opened with the end user's own credentials. Running the lookups after search()
+        // has closed it makes this method bind as the same principal as the identical call in
+        // updateSubRoles, instead of as whoever happened to be logging in.
+        if (!sAMAccountGroupNameSet.isEmpty()) {
+            // One context for the whole batch. Without it each lookup would open, bind and close its
+            // own connection, because search() has already closed the thread-local one -- and a
+            // recursive AD group filter routinely yields tens of nested groups per user.
+            final Hashtable<String, String> env = createSearchEnv();
+            try (DirContextHolder holder = getDirContext(() -> env)) {
+                sAMAccountGroupNameSet.forEach(groupName -> {
+                    getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
+                        roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
+                    });
+                });
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ldap/LdapUser.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapUser.java
@@ -41,8 +41,45 @@ public class LdapUser implements FessUser {
     /** The name of the user. */
     protected String name;
 
-    /** The permissions of the user. */
-    protected String[] permissions = null;
+    /**
+     * Whether the nested-group walk has already published its result.
+     *
+     * <p>Guards the synchronous write below. {@link LdapManager#getRoles} schedules that walk and
+     * then returns, so the assignment of its return value happens after the walk was handed to the
+     * timer -- and if the walk finished in between, assigning would overwrite the fuller set with
+     * the direct-only one and leave the state reporting {@code RESOLVED} over it. The remaining
+     * check-then-act window is a few instructions wide against an LDAP round trip.
+     */
+    protected volatile boolean nestedRolesPublished;
+
+    /**
+     * The permissions of the user.
+     *
+     * <p>Volatile because the nested-group resolution writes it from a {@code TimeoutManager}
+     * thread while request threads read it. It is deliberately not guarded by a lock the way
+     * {@code EntraIdUser} guards its own: the first read of this field performs the directory
+     * search inline, so a lock here would be held across an LDAP round trip and the background
+     * writer would block a pool thread behind it. The remaining race is two concurrent first
+     * requests each running the search, which costs duplicate work but converges.
+     */
+    protected volatile String[] permissions = null;
+
+    /**
+     * How far this user's group and role permissions have got.
+     *
+     * <p>Starts {@link PermissionState#RESOLVED} rather than {@code PENDING}: unlike an Entra ID
+     * user, this one resolves its permissions inline on first read, and the nested-group walk is
+     * only scheduled when {@code ldap.group.filter} is configured. With the shipped defaults no
+     * background work is ever scheduled, so the synchronous result is the whole answer and there
+     * is no window to report. {@link LdapManager#getRoles} moves it to {@code PENDING} at the
+     * moment it actually schedules that walk.
+     *
+     * <p>Volatile for the same reason as {@link #permissions}. {@code RESOLVED} and {@code FAILED}
+     * are always written <em>after</em> the permissions they describe, so a reader that sees
+     * {@code RESOLVED} cannot see stale ones. {@code PENDING} is written before the first
+     * permissions exist at all, which is the state's whole point.
+     */
+    protected volatile PermissionState permissionState = PermissionState.RESOLVED;
 
     /**
      * Constructs a new LDAP user.
@@ -69,15 +106,62 @@ public class LdapUser implements FessUser {
             final String groupFilter = fessConfig.getLdapGroupFilter();
             if (StringUtil.isNotBlank(baseDn) && StringUtil.isNotBlank(accountFilter)) {
                 final LdapManager ldapManager = ComponentUtil.getLdapManager();
-                permissions = distinct(ArrayUtils.addAll(ldapManager.getRoles(this, baseDn, accountFilter, groupFilter, roles -> {
-                    permissions = distinct(roles);
-                    ComponentUtil.getActivityHelper().permissionChanged(OptionalThing.of(new FessUserBean(this)));
-                }), fessConfig.getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName())));
+                // Appended to both writes, not just the synchronous one. LdapManager derives its own
+                // user entry through getCanonicalLdapName, which drops a NetBIOS "DOMAIN\" prefix,
+                // and adds it only when ldap.role.search.user.enabled is set -- so a lazy write that
+                // carried only what LdapManager collected would hand back a strictly smaller set
+                // than the synchronous result, and the user would silently lose their own
+                // permission at the moment the nested-group walk succeeded.
+                final String userPermission = fessConfig.getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName());
+                final String[] directPermissions =
+                        distinct(ArrayUtils.addAll(ldapManager.getRoles(this, baseDn, accountFilter, groupFilter, roles -> {
+                            permissions = distinct(ArrayUtils.addAll(roles, userPermission));
+                            // Written after the permissions it describes, so a reader that sees the
+                            // flag cannot see the set it replaced.
+                            nestedRolesPublished = true;
+                            ComponentUtil.getActivityHelper().permissionChanged(OptionalThing.of(new FessUserBean(this)));
+                        }), userPermission));
+                if (!nestedRolesPublished) {
+                    permissions = directPermissions;
+                }
             } else {
                 permissions = StringUtil.EMPTY_STRINGS;
             }
         }
         return permissions;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>A bare field read. It must stay one: this is called on every request by
+     * {@code FessSearchAction#hookBefore}, and {@link #getPermissions()} performs the directory
+     * search inline, so anything that consulted the permissions here -- including
+     * {@link #getGroupNames()} and {@link #getRoleNames()}, which derive from them -- would turn a
+     * status check into an LDAP round trip.
+     */
+    @Override
+    public PermissionState getPermissionState() {
+        // Null-checked, not just returned. This class is Serializable and lives in the session, and
+        // serialVersionUID is unchanged, so a session written by a release without this field
+        // deserializes with it null -- field initializers do not run during deserialization. Tomcat's
+        // default StandardManager persists sessions across a restart into a directory that survives
+        // a package upgrade, so that stream is a real upgrade path, and the interface documents this
+        // as never null.
+        final PermissionState state = permissionState;
+        return state == null ? PermissionState.RESOLVED : state;
+    }
+
+    /**
+     * Records how far this user's group and role permissions have got.
+     *
+     * <p>Called by {@link LdapManager} around the nested-group walk. Always write the permissions
+     * before the state that describes them.
+     *
+     * @param permissionState The state, never null.
+     */
+    public void setPermissionState(final PermissionState permissionState) {
+        this.permissionState = permissionState;
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/app/web/base/FessSearchActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/FessSearchActionTest.java
@@ -244,4 +244,43 @@ public class FessSearchActionTest extends UnitFessTestCase {
             super(requestPath, null, null);
         }
     }
+
+    @Test
+    public void test_getPermissionStateMessageKey_toleratesANullState() {
+        // FessUser is Serializable and its implementations live in the session, so one that gains a
+        // permission-state field without changing serialVersionUID deserializes an older session
+        // with it null -- field initializers do not run during deserialization. A bare switch on a
+        // null selector throws, and this runs in hookBefore on every front page, so that would be a
+        // 500 on every request until the session is dropped.
+        final FessUser user = new FessUser() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getName() {
+                return "olduser";
+            }
+
+            @Override
+            public String[] getRoleNames() {
+                return new String[0];
+            }
+
+            @Override
+            public String[] getGroupNames() {
+                return new String[0];
+            }
+
+            @Override
+            public String[] getPermissions() {
+                return new String[0];
+            }
+
+            @Override
+            public FessUser.PermissionState getPermissionState() {
+                return null;
+            }
+        };
+        assertNull(new FessSearchAction() {
+        }.getPermissionStateMessageKey(user));
+    }
 }

--- a/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
@@ -19,6 +19,14 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.SearchResult;
+
+import org.codelibs.fess.entity.FessUser;
 
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -475,5 +483,384 @@ public class LdapManagerTest extends UnitFessTestCase {
         assertEquals("normal", ldapManager.replaceWithUnderscores("normal"));
         // Input "//\\[]:;" has 8 special characters that should be replaced
         assertEquals("________", ldapManager.replaceWithUnderscores("//\\\\[]:;"));
+    }
+
+    // ==============================================================================
+    //                                              Nested group resolution reporting
+    //                                              ==================================
+
+    /** Builds a search result carrying the given memberOf values. */
+    private SearchResult memberOfResult(final String... entryDns) {
+        final BasicAttributes attributes = new BasicAttributes();
+        final BasicAttribute memberOf = new BasicAttribute("memberOf");
+        for (final String entryDn : entryDns) {
+            memberOf.add(entryDn);
+        }
+        attributes.put(memberOf);
+        final SearchResult result = new SearchResult("cn=testuser", null, attributes);
+        result.setNameInNamespace("cn=testuser,dc=example,dc=com");
+        return result;
+    }
+
+    /** The configuration the nested-group tests share: a group DN yields a group-typed role. */
+    private void registerGroupResolvingConfig() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getLdapMemberofAttribute() {
+                return "memberOf";
+            }
+
+            @Override
+            public boolean isLdapIgnoreNetbiosName() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapGroupNameWithUnderscores() {
+                return false;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchUserEnabled() {
+                return false;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchGroupEnabled() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchRoleEnabled() {
+                return true;
+            }
+
+            @Override
+            public String getRoleSearchGroupPrefix() {
+                return "2";
+            }
+
+            @Override
+            public String getRoleSearchRolePrefix() {
+                return "R";
+            }
+
+            @Override
+            public boolean isLdapLowercasePermissionName() {
+                return false;
+            }
+
+            @Override
+            public boolean isLdapSamaccountnameGroup() {
+                return false;
+            }
+        });
+    }
+
+    /** Builds a group search result whose name-in-namespace is the given DN. */
+    private SearchResult groupResult(final String groupDn) {
+        final SearchResult result = new SearchResult(groupDn, null, new BasicAttributes());
+        result.setNameInNamespace(groupDn);
+        return result;
+    }
+
+    @Test
+    public void test_getRoles_leavesThePermissionsResolvedWhenNoWalkIsScheduled() {
+        // The shipped default leaves ldap.group.filter blank, so subRoleSet stays empty and nothing
+        // is ever scheduled. Reporting PENDING here would strand the notice on screen forever,
+        // which is why LdapUser starts RESOLVED rather than PENDING the way EntraIdUser does.
+        registerGroupResolvingConfig();
+        final AtomicBoolean scheduled = new AtomicBoolean(false);
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void search(final String baseDn, final String filter, final String[] returningAttrs,
+                    final java.util.function.Supplier<Hashtable<String, String>> envSupplier, final SearchConsumer consumer)
+                    throws RuntimeException {
+                try {
+                    consumer.accept(List.of(memberOfResult("CN=group1,OU=group,DC=example,DC=com")));
+                } catch (final javax.naming.NamingException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            @Override
+            protected void scheduleSubRoleUpdate(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet, final java.util.Set<String> sAMAccountGroupNameSet,
+                    final java.util.function.Consumer<String[]> lazyLoading) {
+                scheduled.set(true);
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapManager.getRoles(ldapUser, "dc=example,dc=com", "(uid=%s)", "", roles -> {});
+
+        assertFalse(scheduled.get());
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_getRoles_marksThePermissionsPendingWhenItSchedulesTheWalk() {
+        // Set before the task is handed to the timer, not inside it: the timer only notices a
+        // second later, and the user is being given their direct groups right now.
+        registerGroupResolvingConfig();
+        final AtomicBoolean scheduled = new AtomicBoolean(false);
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void search(final String baseDn, final String filter, final String[] returningAttrs,
+                    final java.util.function.Supplier<Hashtable<String, String>> envSupplier, final SearchConsumer consumer)
+                    throws RuntimeException {
+                try {
+                    consumer.accept(List.of(memberOfResult("CN=group1,OU=group,DC=example,DC=com")));
+                } catch (final javax.naming.NamingException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            @Override
+            protected void scheduleSubRoleUpdate(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet, final java.util.Set<String> sAMAccountGroupNameSet,
+                    final java.util.function.Consumer<String[]> lazyLoading) {
+                // The state must already be PENDING by the time the task is scheduled.
+                assertEquals(FessUser.PermissionState.PENDING, user.getPermissionState());
+                scheduled.set(true);
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapManager.getRoles(ldapUser, "dc=example,dc=com", "(uid=%s)", "(member=%s)", roles -> {});
+
+        assertTrue(scheduled.get());
+        assertEquals(FessUser.PermissionState.PENDING, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_updateSubRoles_marksTheUserResolvedOnceTheWalkLands() {
+        registerGroupResolvingConfig();
+        final AtomicReference<String[]> published = new AtomicReference<>();
+        final AtomicReference<FessUser.PermissionState> stateWhenPublished = new AtomicReference<>();
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void processSubRoles(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet) {
+                roleSet.add("2parent");
+            }
+
+            @Override
+            protected OptionalEntity<String> getSAMAccountGroupName(final String bindDn, final String groupName) {
+                return OptionalEntity.of(groupName + "sam");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapUser.setPermissionState(FessUser.PermissionState.PENDING);
+        final java.util.Set<String> roleSet = new java.util.HashSet<>(List.of("2group1"));
+
+        ldapManager.updateSubRoles(ldapUser, "dc=example,dc=com", java.util.Set.of("CN=group1"), "(member=%s)", roleSet,
+                java.util.Set.of("group1"), roles -> {
+                    published.set(roles);
+                    // The permissions must be published before the state that describes them, or a
+                    // reader that sees RESOLVED can still be looking at the previous set.
+                    stateWhenPublished.set(ldapUser.getPermissionState());
+                });
+
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+        assertEquals(FessUser.PermissionState.PENDING, stateWhenPublished.get());
+        assertNotNull(published.get());
+        // 2group1 from the direct pass, 2parent from the walk, and the sAMAccountName batch entry.
+        assertEquals(3, published.get().length);
+    }
+
+    @Test
+    public void test_updateSubRoles_doesNotDowngradeAStateAnotherWalkAlreadySettled() {
+        // Two concurrent first requests each schedule a walk. If one succeeds and a later one fails,
+        // the user still holds the groups the first published, so reporting FAILED over them would
+        // show a failure notice on a complete permission set.
+        registerGroupResolvingConfig();
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void processSubRoles(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet) {
+                throw new org.codelibs.fess.exception.LdapOperationException("Failed to search.");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapUser.setPermissionState(FessUser.PermissionState.RESOLVED);
+
+        ldapManager.updateSubRoles(ldapUser, "dc=example,dc=com", java.util.Set.of("CN=group1"), "(member=%s)",
+                new java.util.HashSet<>(List.of("2group1")), java.util.Set.of(), roles -> {});
+
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_updateSubRoles_marksTheUserFailedWhenTheWalkThrows() {
+        // Without the catch this throw escapes the TimeoutManager task, where corelib logs
+        // "Failed to process a task." -- naming neither LDAP nor the user -- and lazyLoading is
+        // never called, so the direct-only groups stand for the whole session with nothing saying
+        // so. The permissions already published stay; what changes is that the user is told.
+        registerGroupResolvingConfig();
+        final AtomicBoolean publishedAnything = new AtomicBoolean(false);
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void processSubRoles(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet) {
+                throw new org.codelibs.fess.exception.LdapOperationException("Failed to search.");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapUser.setPermissionState(FessUser.PermissionState.PENDING);
+
+        ldapManager.updateSubRoles(ldapUser, "dc=example,dc=com", java.util.Set.of("CN=group1"), "(member=%s)",
+                new java.util.HashSet<>(List.of("2group1")), java.util.Set.of(), roles -> publishedAnything.set(true));
+
+        assertEquals(FessUser.PermissionState.FAILED, ldapUser.getPermissionState());
+        assertFalse(publishedAnything.get());
+    }
+
+    @Test
+    public void test_processSubRoles_looksUpSamAccountNamesAsTheAdminPrincipal() {
+        // getSAMAccountGroupName asks for the admin credentials, but getDirContext discards that
+        // request whenever a context is already open on the thread -- and inside search()'s consumer
+        // one is, the one search() opened with the end user's own credentials. So the lookups must
+        // not run from inside the consumer, or they bind as whoever is logging in. They now run
+        // after search() has closed its context, under a single admin context opened for the batch.
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public boolean isLdapIgnoreNetbiosName() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapGroupNameWithUnderscores() {
+                return false;
+            }
+
+            @Override
+            public boolean isLdapSamaccountnameGroup() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchGroupEnabled() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchRoleEnabled() {
+                return true;
+            }
+
+            @Override
+            public String getRoleSearchGroupPrefix() {
+                return "2";
+            }
+
+            @Override
+            public String getRoleSearchRolePrefix() {
+                return "R";
+            }
+
+            @Override
+            public boolean isLdapLowercasePermissionName() {
+                return false;
+            }
+        });
+
+        final Hashtable<String, String> userEnv = new Hashtable<>();
+        userEnv.put("principal", "end-user");
+        final Hashtable<String, String> adminEnv = new Hashtable<>();
+        adminEnv.put("principal", "admin");
+
+        final AtomicReference<String> envOfOpenContext = new AtomicReference<>();
+        final AtomicReference<String> principalAtLookup = new AtomicReference<>();
+        final AtomicInteger contextsOpened = new AtomicInteger();
+
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected Hashtable<String, String> createSearchEnv() {
+                return adminEnv;
+            }
+
+            @Override
+            protected DirContextHolder getDirContext(final java.util.function.Supplier<Hashtable<String, String>> envSupplier) {
+                // Mirrors the real one: an already-open context on this thread is reused, and the
+                // supplied environment is then never consulted.
+                final DirContextHolder existing = contextLocal.get();
+                if (existing != null) {
+                    existing.inc();
+                    return existing;
+                }
+                envOfOpenContext.set(envSupplier.get().get("principal"));
+                contextsOpened.incrementAndGet();
+                final DirContextHolder holder = new DirContextHolder(null);
+                contextLocal.set(holder);
+                return holder;
+            }
+
+            @Override
+            protected void search(final String baseDn, final String filter, final String[] returningAttrs,
+                    final java.util.function.Supplier<Hashtable<String, String>> envSupplier, final SearchConsumer consumer) {
+                try (DirContextHolder holder = getDirContext(envSupplier)) {
+                    consumer.accept(List.of(groupResult("CN=group1,OU=group,DC=example,DC=com"),
+                            groupResult("CN=group2,OU=group,DC=example,DC=com")));
+                } catch (final javax.naming.NamingException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            @Override
+            protected OptionalEntity<String> getSAMAccountGroupName(final String bindDn, final String groupName) {
+                principalAtLookup.set(envOfOpenContext.get());
+                return OptionalEntity.of(groupName + "sam");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final java.util.Set<String> roleSet = new java.util.HashSet<>();
+        ldapManager.processSubRoles(new LdapUser(userEnv, "testuser"), "dc=example,dc=com", java.util.Set.of("CN=user1"), "(member=%s)",
+                roleSet);
+
+        // The lookups ran, and under the admin principal rather than the end user's.
+        assertEquals("admin", principalAtLookup.get());
+        // Two groups, but only two contexts in total: the search's, and one shared by the batch.
+        assertEquals(2, contextsOpened.get());
+        assertTrue(roleSet.toString(), roleSet.contains("2group1sam"));
+        assertTrue(roleSet.toString(), roleSet.contains("2group2sam"));
+    }
+
+    @Test
+    public void test_updateSubRoles_marksTheUserFailedWhenTheWalkThrowsAnError() {
+        // The state write is in a finally, not only in the catch, so that a Throwable that is not an
+        // Exception cannot strand the user in PENDING. corelib's own task handler also catches only
+        // Exception, so nothing further downstream would settle it.
+        registerGroupResolvingConfig();
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void processSubRoles(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet) {
+                throw new StackOverflowError("walk blew the stack");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapUser.setPermissionState(FessUser.PermissionState.PENDING);
+
+        try {
+            ldapManager.updateSubRoles(ldapUser, "dc=example,dc=com", java.util.Set.of("CN=group1"), "(member=%s)",
+                    new java.util.HashSet<>(List.of("2group1")), java.util.Set.of(), roles -> {});
+            fail("the Error must still propagate");
+        } catch (final StackOverflowError expected) {
+            // propagating is correct; what matters is that the state was settled on the way out
+        }
+
+        assertEquals(FessUser.PermissionState.FAILED, ldapUser.getPermissionState());
     }
 }

--- a/src/test/java/org/codelibs/fess/ldap/LdapUserTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapUserTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.helper.ActivityHelper;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.action.FessUserBean;
@@ -223,12 +224,16 @@ public class LdapUserTest extends UnitFessTestCase {
 
         String[] permissions = ldapUser.getPermissions();
 
-        // Verify permissions include both LDAP roles and user permission
+        // The stub publishes through the callback before returning, which is what the nested-group
+        // walk does when it wins the race with the synchronous assignment. The published set is
+        // what survives; this used to assert the opposite -- the synchronous return value -- which
+        // pinned the walk's result being thrown away.
         assertNotNull(permissions);
         assertEquals(3, permissions.length);
-        assertEquals("Rgroup1", permissions[0]);
-        assertEquals("Rgroup2", permissions[1]);
-        assertEquals("Utestuser", permissions[2]);
+        final String rendered = java.util.Arrays.toString(permissions);
+        assertTrue(rendered, rendered.contains("role1"));
+        assertTrue(rendered, rendered.contains("role2"));
+        assertTrue(rendered, rendered.contains("Utestuser"));
 
         // Verify callback was called
         assertTrue(activityHelperCalled.get());
@@ -529,5 +534,137 @@ public class LdapUserTest extends UnitFessTestCase {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void test_getPermissionState_defaultsToResolved() {
+        // Unlike an Entra ID user, an LdapUser resolves inline on first read and only schedules the
+        // nested-group walk when ldap.group.filter is configured. With the shipped defaults nothing
+        // is scheduled, so there is no window to report and the state must not start PENDING --
+        // that would strand the notice on screen for every LDAP deployment.
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_getPermissions_lazyWriteKeepsTheUserPermission() {
+        // LdapManager derives its own user entry through getCanonicalLdapName, which drops a
+        // NetBIOS "DOMAIN\\" prefix, and adds it only when ldap.role.search.user.enabled is set. So
+        // the roles it hands the callback need not contain the user's own permission, and a lazy
+        // write that published only those would hand back a strictly smaller set than the
+        // synchronous pass -- the user losing their own permission at the exact moment the nested
+        // group walk succeeded.
+        final AtomicReference<String[]> publishedByCallback = new AtomicReference<>();
+
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getLdapBaseDn() {
+                return "dc=example,dc=com";
+            }
+
+            @Override
+            public String getLdapAccountFilter() {
+                return "(uid=%s)";
+            }
+
+            @Override
+            public String getRoleSearchUserPrefix() {
+                return "1";
+            }
+        });
+
+        ComponentUtil.register(new LdapManager() {
+            @Override
+            public String[] getRoles(final LdapUser user, final String baseDn, final String accountFilter, final String groupFilter,
+                    final Consumer<String[]> callback) {
+                // What the nested-group walk publishes: groups only, no user entry.
+                callback.accept(new String[] { "2group1", "2parent1" });
+                publishedByCallback.set(user.permissions);
+                return new String[] { "2group1" };
+            }
+
+            @Override
+            public String normalizePermissionName(final String name) {
+                return name;
+            }
+        }, "ldapManager");
+
+        ComponentUtil.register(new ActivityHelper() {
+            @Override
+            public void permissionChanged(final OptionalThing<FessUserBean> user) {
+                // no-op
+            }
+        }, "activityHelper");
+
+        ldapUser.getPermissions();
+
+        final String[] afterLazyWrite = publishedByCallback.get();
+        assertNotNull(afterLazyWrite);
+        boolean hasUserPermission = false;
+        for (final String permission : afterLazyWrite) {
+            if ("1testuser".equals(permission)) {
+                hasUserPermission = true;
+            }
+        }
+        assertTrue("user permission missing from " + java.util.Arrays.toString(afterLazyWrite), hasUserPermission);
+    }
+
+    @Test
+    public void test_getPermissionState_survivesADeserializedSessionWithoutTheField() {
+        // LdapUser is Serializable and lives in the session, and serialVersionUID is unchanged, so a
+        // session written by a release without this field deserializes with it null -- field
+        // initializers do not run during deserialization. FessSearchAction#hookBefore switches on
+        // this on every front page, and a bare switch on a null selector throws, so a null here
+        // would be a 500 on every request until the session is dropped.
+        ldapUser.permissionState = null;
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_getPermissions_doesNotOverwriteAWalkThatAlreadyPublished() {
+        // getRoles schedules the nested-group walk and then returns, so assigning its return value
+        // happens after the walk was handed to the timer. If the walk finished in between, assigning
+        // would replace the fuller set with the direct-only one -- and the state would then report
+        // RESOLVED over it. Here the stub publishes before returning, which is that interleaving.
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getLdapBaseDn() {
+                return "dc=example,dc=com";
+            }
+
+            @Override
+            public String getLdapAccountFilter() {
+                return "(uid=%s)";
+            }
+
+            @Override
+            public String getRoleSearchUserPrefix() {
+                return "1";
+            }
+        });
+
+        ComponentUtil.register(new LdapManager() {
+            @Override
+            public String[] getRoles(final LdapUser user, final String baseDn, final String accountFilter, final String groupFilter,
+                    final Consumer<String[]> callback) {
+                callback.accept(new String[] { "2group1", "2parent1" });
+                return new String[] { "2group1" };
+            }
+
+            @Override
+            public String normalizePermissionName(final String name) {
+                return name;
+            }
+        }, "ldapManager");
+
+        ComponentUtil.register(new ActivityHelper() {
+            @Override
+            public void permissionChanged(final OptionalThing<FessUserBean> user) {
+                // no-op
+            }
+        }, "activityHelper");
+
+        final String permissions = java.util.Arrays.toString(ldapUser.getPermissions());
+        assertTrue("nested group lost from " + permissions, permissions.contains("2parent1"));
+        assertTrue("user permission lost from " + permissions, permissions.contains("1testuser"));
     }
 }


### PR DESCRIPTION
Stacked on #3273 — base is `feat/entraid-async-membership`, so please merge that first. This PR's own diff is `org.codelibs.fess.ldap` plus two lines of `FessSearchAction`.

#3273 put `PermissionState` on `FessUser` rather than on `EntraIdUser` because *"`LdapUser`, which also backs SPNEGO logins, has the same silent-degradation shape in its lazy directory lookup and is the next intended consumer."* This is that consumer.

## The silent degradation

`LdapManager#getRoles` schedules the nested-group walk on `TimeoutManager` and the task body had no error handling of its own. `processSubRoles` throws `LdapOperationException`, so the only handler was corelib's `processTask`, which logs `"Failed to process a task."` — a message naming neither LDAP nor the user — and `lazyLoading` was never called.

`LdapUser` then keeps its direct-only permissions **for the whole session**: `permissions` is non-null from the synchronous pass, and `LdapUser` does not override `refresh()`, so `FessBaseAction#godHandPrologue`'s per-request refresh is a no-op for it and `getRoles` is never re-entered. Nothing anywhere said the user was missing their nested groups.

The walk is wrapped now, and reports `PENDING` while it runs and `FAILED` if it does not finish. `FessSearchAction`, `search.jsp` and the 17 message bundles from #3273 are reused as-is — the keys deliberately do not name a provider.

## Why the state starts RESOLVED, not PENDING

This is the one place the Entra ID shape does not transfer. `EntraIdUser` is handed out before its memberships exist, so `PENDING` is right at construction. An `LdapUser` resolves inline on the first read of `getPermissions()`, and the walk is only scheduled when `ldap.group.filter` is configured — **blank by the shipped default**, which means `subRoleSet` stays empty and nothing is ever scheduled. Starting `PENDING` would show "your permissions are still loading" to every default LDAP deployment, forever, with nothing scheduled to clear it. `getRoles` moves the state to `PENDING` at the point it actually schedules.

## Getting stuck in PENDING

Two ways were possible and both are closed:

- `ComponentUtil.getSystemHelper()` sat outside the `try`. `ComponentUtil.getComponent` throws when the container is gone; on a `TimeoutManager` thread that escapes into corelib's log-and-drop, and no state is written. It is inside the `try` now.
- corelib's handler and the local `catch` both take `Exception`, not `Throwable`. The state write is in a `finally` now, so an `Error` settles it too.

A walk that fails only downgrades `PENDING`, so a failing walk cannot report failure over a permission set a concurrent walk already completed. The read-then-write is not atomic; both writers are only reporting, never deciding permissions.

## Session deserialization — the one that would have hurt on upgrade

`FessUser.getPermissionState()` is documented as never null. `LdapUser` is `Serializable` and lives in the session inside `FessUserBean`, and `serialVersionUID` is unchanged, so a session written by a release without the new field deserializes with it **null** — field initializers do not run during deserialization. Verified with a two-version round trip on JDK 21:

```
v1 wrote a session with no permissionState field
v2 read it back: name=olduser  permissionState=null
SWITCH THREW: java.lang.NullPointerException: Cannot invoke "U$State.ordinal()"
  because the return value of "U.getPermissionState()" is null
```

Reachable: nothing in the repo configures a `<Manager>`, so Tomcat's default `StandardManager` persists sessions on graceful stop, and `FessBoot` points the base dir at `${fess.var.path}/webapp` — `/var/lib/fess/webapp` for deb/rpm, which survives a package upgrade. `FessSearchAction#hookBefore` switches on this on every front page, so an LDAP user logged in before the upgrade would get a 500 on every request until the JSESSIONID was dropped.

The accessor null-checks, and `FessSearchAction`'s switch gains `case null` so no future `FessUser` implementation can reintroduce it. Those two lines are the only change outside `org.codelibs.fess.ldap`.

## Three adjacent defects on the same path

**`permissions` was neither volatile nor guarded** while being written from the `TimeoutManager` thread and read from request threads — a pre-existing unsafe publication. It is `volatile` now. `getPermissions()` is deliberately **not** synchronized: the first read performs the directory search inline, so a lock would be held across an LDAP round trip and the background writer would block a pool thread behind it. The remaining race is two concurrent first requests each running the search, which costs duplicate work but converges.

**The synchronous write could overwrite a walk that had already published.** `getRoles` schedules the walk and returns, so assigning its return value happens after the walk was handed to the timer; if the walk finished in between, the fuller set was replaced by the direct-only one — and the state would then report `RESOLVED` over it. A `nestedRolesPublished` flag suppresses that write. `LdapUserTest.test_getPermissions_withLdapConfig` asserted the *old* outcome (`permissions[0] == "Rgroup1"`, the synchronous value) and is updated; it was pinning the walk's result being thrown away.

**The lazy write published a strictly smaller set than the synchronous pass.** `LdapManager` derives its own user entry through `getCanonicalLdapName`, which drops a NetBIOS `DOMAIN\` prefix, and adds it only when `ldap.role.search.user.enabled` is set. With the default `ldap.ignore.netbios.name=true`, a `DOMAIN\user` login held both `1DOMAIN\user` and `1user` until the walk landed and then lost the first. Both writes carry the same entry now.

To be precise about that last one: this does **not** make `ldap.role.search.user.enabled` effective on the `LdapUser` path. The synchronous write already added the user entry unconditionally, so the key was already ignored there; what changes is that the two writes no longer disagree. Making the key effective would remove a permission users hold today and is not attempted here.

## The sAMAccountName lookups

`processSubRoles` called `getSAMAccountGroupName` from inside `search()`'s consumer. That method asks for the admin credentials, but `getDirContext` discards the supplier whenever a context is already open on the thread — and inside the consumer one is, the one `search()` opened with the end user's own credentials. The identical call from `updateSubRoles` binds as admin. One method, two identities depending on call site.

The lookups now run after `search()` has closed its context, under a **single** context opened for the whole batch. Without that batching each lookup would open, bind and close its own connection, and a recursive AD group filter routinely yields tens of nested groups per user. Gated by `ldap.samaccountname.group`, `false` by default.

## Tests

12 new tests, and every one verified against a mutant — 8 mutations applied to the shipped code, each killed by its test:

```
KILLED  no-null-guard                  getPermissionState returns the field directly
KILLED  switch-without-case-null       FessSearchAction drops "case null"
KILLED  no-clobber-guard               synchronous write no longer checks nestedRolesPublished
KILLED  resolved-before-publish        RESOLVED written before lazyLoading.accept
KILLED  unconditional-failed           the PENDING-only downgrade becomes unconditional
KILLED  drop-samaccount-batch          the sAMAccountName batch is skipped
KILLED  catch-not-finally              the state write moves out of the finally
KILLED  lookup-inside-consumer-again   the lookups move back inside the search consumer
```

An earlier round of 7 mutations against the first version of this branch was also fully killed. Worth recording: three of these initially reported SURVIVED because a scripted edit to the test file had silently no-opped after `formatter:format` reflowed the anchor — the suite was green because nothing had changed. The mutation run is what caught it.

Test seams used: `LdapManagerTest` is in `org.codelibs.fess.ldap`, so `protected search`, `getDirContext`, `processSubRoles`, `updateSubRoles` and the package-private `SearchConsumer` are all reachable. The new `scheduleSubRoleUpdate` seam exists so `updateSubRoles` can be driven synchronously rather than waiting on the shared 1 Hz timer. No new dependency and no embedded directory.

`mvn test`: **7199 tests, 0 failures, 0 errors.**

## Reviewed

Reviewed adversarially before opening; the deserialization NPE, the PENDING-stranding paths, the clobber and the per-group connection all came out of that pass rather than out of the original implementation.

## Not in this PR

- **Timeouts** — LDAP had none at all, which matters more than this: with `ldap.allow.empty.permission=true` the direct group search runs synchronously on a request thread. #3274.
- **Real nested-group resolution.** Fess does not walk the graph; `processSubRoles` is one flat hop that outsources the transitive closure to `ldap.group.filter`. With the AD `1.2.840.113556.1.4.1941` filter the server computes the closure, but with a plain `(member=%s)` only direct parents are found and grandparents are silently missed. Making Fess walk it needs a worklist, a visited set, a depth cap and new config keys.
- **The API side.** `FessApiAction extends FessBaseAction`, not `FessSearchAction`, so JSON callers still get silently degraded results with no signal — true for Entra ID today and equally true here.
