### PR TITLE
fix(sso): keep an externally authenticated admin signed in

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/login/FessLoginAssist.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/FessLoginAssist.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.app.web.base.login;
 
 import java.lang.reflect.Method;
+import java.time.LocalDateTime;
 import java.util.function.Function;
 
 import org.apache.logging.log4j.LogManager;
@@ -181,6 +182,47 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
      */
     protected void insertLogin(final Object member) {
         // nothing
+    }
+
+    // -----------------------------------------------------
+    //                                LoginSession SyncCheck
+    //                                ----------------------
+    /**
+     * Determines whether the login session of the given user bean should be sync-checked.
+     *
+     * <p>The sync check asks "can this user still log in?" and answers it with
+     * {@link #doFindLoginUser(String)}, i.e. a lookup of {@link FessUserBean#getUserId()} in the
+     * {@code .fess_user} index. That is the right question for a user who lives in that index, but
+     * it is not answerable there for a user authenticated by an external identity provider: LDAP,
+     * SAML, OpenID Connect, Entra ID and SPNEGO logins never write a user document, so the lookup
+     * finds nothing and the check can only ever fail. The failure branch of
+     * {@code syncCheckLoginSessionIfNeeds} logs the user out and invalidates the session, so an
+     * externally authenticated administrator was signed out of the admin console after the check
+     * interval (300 seconds) and sent to the local password form, which offers no way back to the
+     * identity provider.</p>
+     *
+     * <p>Restricting the check to a {@link User} entity, the only type that {@code .fess_user} can
+     * answer for, therefore removes a guaranteed-failing lookup rather than weakening a check. For
+     * an external user, the identity provider owns the account lifecycle and the session lifetime;
+     * Fess has no local record whose absence could mean anything.</p>
+     *
+     * <p>Local-user semantics are unchanged: deleting a user in the admin UI still ends that
+     * user's session within the check interval. The only behaviour given up is the incidental
+     * ability to end an externally authenticated user's session by creating and then deleting a
+     * local user document that happens to share the external user's name.</p>
+     *
+     * @param userBean the logged-in user bean to be checked (NotNull)
+     * @param checkDt the date-time of the latest sync check, empty if not checked yet (NotNull)
+     * @param currentDt the current date-time (NotNull)
+     * @return true if the sync check should be performed
+     */
+    @Override
+    protected boolean needsLoginSessionSyncCheck(final FessUserBean userBean, final OptionalThing<LocalDateTime> checkDt,
+            final LocalDateTime currentDt) {
+        if (!(userBean.getFessUser() instanceof User)) {
+            return false;
+        }
+        return super.needsLoginSessionSyncCheck(userBean, checkDt, currentDt);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/base/login/FessLoginAssist.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/FessLoginAssist.java
@@ -184,6 +184,9 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
         // nothing
     }
 
+    // ===================================================================================
+    //                                                                         Login Check
+    //                                                                         ===========
     // -----------------------------------------------------
     //                                LoginSession SyncCheck
     //                                ----------------------
@@ -192,24 +195,25 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
      *
      * <p>The sync check asks "can this user still log in?" and answers it with
      * {@link #doFindLoginUser(String)}, i.e. a lookup of {@link FessUserBean#getUserId()} in the
-     * {@code .fess_user} index. That is the right question for a user who lives in that index, but
-     * it is not answerable there for a user authenticated by an external identity provider: LDAP,
-     * SAML, OpenID Connect, Entra ID and SPNEGO logins never write a user document, so the lookup
-     * finds nothing and the check can only ever fail. The failure branch of
-     * {@code syncCheckLoginSessionIfNeeds} logs the user out and invalidates the session, so an
-     * externally authenticated administrator was signed out of the admin console after the check
-     * interval (300 seconds) and sent to the local password form, which offers no way back to the
-     * identity provider.</p>
+     * {@code fess_user.user} index; when that lookup finds nothing,
+     * {@code syncCheckLoginSessionIfNeeds} logs the user out and invalidates the session. Only a
+     * {@link User} entity lives in that index, so only for a {@link User} is the question
+     * answerable, and the check is restricted to one here.</p>
      *
-     * <p>Restricting the check to a {@link User} entity, the only type that {@code .fess_user} can
-     * answer for, therefore removes a guaranteed-failing lookup rather than weakening a check. For
-     * an external user, the identity provider owns the account lifecycle and the session lifetime;
-     * Fess has no local record whose absence could mean anything.</p>
+     * <p>A user authenticated by an external identity provider (LDAP, SAML, OpenID Connect, Entra
+     * ID or SPNEGO) is built from the provider's response, and no login path writes a user
+     * document for one. Without this restriction such a user is logged out at the first check
+     * interval and sent to the local password form, which offers no way back to the identity
+     * provider. For them the identity provider, not Fess, owns the account lifecycle.</p>
      *
-     * <p>Local-user semantics are unchanged: deleting a user in the admin UI still ends that
-     * user's session within the check interval. The only behaviour given up is the incidental
-     * ability to end an externally authenticated user's session by creating and then deleting a
-     * local user document that happens to share the external user's name.</p>
+     * <p>Local users are unaffected: deleting one in the admin UI still ends that user's admin
+     * session within the check interval. What is given up is that same revocation for an
+     * externally authenticated user who <em>does</em> have a local document, which is not merely
+     * hypothetical - {@link #resolveCredential(CredentialResolver)} prefers LDAP over the local
+     * index, so with LDAP configured a user present in both logs in as an
+     * {@link org.codelibs.fess.ldap.LdapUser}, and with {@code ldap.admin.enabled} the admin UI
+     * creates and deletes the LDAP entry and the user document together. Deleting such a user
+     * still blocks further logins, but no longer ends an admin session that is already open.</p>
      *
      * @param userBean the logged-in user bean to be checked (NotNull)
      * @param checkDt the date-time of the latest sync check, empty if not checked yet (NotNull)
@@ -225,6 +229,9 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
         return super.needsLoginSessionSyncCheck(userBean, checkDt, currentDt);
     }
 
+    // -----------------------------------------------------
+    //                                            Permission
+    //                                            ----------
     /**
      * Checks if the current user has permission to access the given resource.
      * For admin actions, verifies that the user has appropriate admin roles or

--- a/src/test/java/org/codelibs/fess/app/web/base/login/FessLoginAssistTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/FessLoginAssistTest.java
@@ -395,14 +395,14 @@ public class FessLoginAssistTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_needsSyncCheck_emptyUserBean_doesNotThrow() {
+    public void test_needsSyncCheck_emptyUserBean_skipsCheck() {
         final FessUserBean bean = FessUserBean.empty(); // wraps a null FessUser
         assertNull(bean.getFessUser());
         assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.of(STALE_CHECK_DT), NOW));
     }
 
     @Test
-    public void test_needsSyncCheck_nullBackedUserBean_doesNotThrow() {
+    public void test_needsSyncCheck_nullBackedUserBean_skipsCheck() {
         final FessUserBean bean = new FessUserBean(null);
         assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.empty(), NOW));
     }
@@ -444,6 +444,35 @@ public class FessLoginAssistTest extends UnitFessTestCase {
 
         assertTrue(assist.callSyncCheckLoginSession(bean));
         assertEquals(1, bhv.selectCalls.get());
+        assertEquals(0, assist.logoutCalls.get());
+    }
+
+    @Test
+    public void test_syncCheckLoginSession_localUserWithinInterval_keepsSessionWithoutQuery() {
+        // pins that the fixed clock is honoured: with the real clock, FRESH_CHECK_DT would be
+        // stale and the check would issue a query.
+        final ExposedLoginAssist assist = newExposedAssist();
+        final CountingUserBhv bhv = installCountingUserBhv(assist, newLocalUser("alice"));
+        final FessUserBean bean = new FessUserBean(newLocalUser("alice"));
+        bean.manageLastestSyncCheckTime(FRESH_CHECK_DT);
+
+        assertTrue(assist.callSyncCheckLoginSession(bean));
+        assertEquals(0, bhv.selectCalls.get());
+        assertEquals(0, assist.logoutCalls.get());
+    }
+
+    @Test
+    public void test_syncCheckLoginSession_ldapUserWithLocalDocument_keepsSessionWithoutQuery() {
+        // the behaviour the javadoc says is given up: resolveCredential prefers LDAP, so a user
+        // present in both LDAP and the user index logs in as an LdapUser. Deleting that user in
+        // the admin UI no longer ends the session, because the check is skipped, not answered.
+        final ExposedLoginAssist assist = newExposedAssist();
+        final CountingUserBhv bhv = installCountingUserBhv(assist, newLocalUser("bob")); // document exists
+        final FessUserBean bean = new FessUserBean(new LdapUser(new Hashtable<>(), "bob"));
+        bean.manageLastestSyncCheckTime(STALE_CHECK_DT);
+
+        assertTrue(assist.callSyncCheckLoginSession(bean));
+        assertEquals(0, bhv.selectCalls.get());
         assertEquals(0, assist.logoutCalls.get());
     }
 

--- a/src/test/java/org/codelibs/fess/app/web/base/login/FessLoginAssistTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/FessLoginAssistTest.java
@@ -15,14 +15,19 @@
  */
 package org.codelibs.fess.app.web.base.login;
 
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.Hashtable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.fess.app.service.UserService;
 import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.helper.PasswordHashHelper;
+import org.codelibs.fess.ldap.LdapUser;
+import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.user.cbean.UserCB;
 import org.codelibs.fess.opensearch.user.exbhv.UserBhv;
@@ -31,8 +36,11 @@ import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.bhv.readable.CBCall;
 import org.dbflute.optional.OptionalEntity;
+import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.lastaflute.core.time.TimeManager;
+import org.lastaflute.web.login.TypicalLoginAssist;
 
 /**
  * Unit tests for {@link FessLoginAssist}, focusing on the BCrypt-aware local
@@ -340,20 +348,173 @@ public class FessLoginAssistTest extends UnitFessTestCase {
     }
 
     // ---------------------------------------------------------------------
+    // needsLoginSessionSyncCheck
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void test_needsSyncCheck_samlUser_staleCheckTime_skipsCheck() {
+        final FessUserBean bean = new FessUserBean(newSamlUser("saml-admin"));
+        assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.of(STALE_CHECK_DT), NOW));
+    }
+
+    @Test
+    public void test_needsSyncCheck_ldapUser_staleCheckTime_skipsCheck() {
+        final FessUserBean bean = new FessUserBean(new LdapUser(new Hashtable<>(), "ldap-admin"));
+        assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.of(STALE_CHECK_DT), NOW));
+    }
+
+    @Test
+    public void test_needsSyncCheck_openIdUser_staleCheckTime_skipsCheck() {
+        final FessUserBean bean = new FessUserBean(newOpenIdUser("oidc-admin"));
+        assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.of(STALE_CHECK_DT), NOW));
+    }
+
+    @Test
+    public void test_needsSyncCheck_externalUser_neverCheckedYet_skipsCheck() {
+        // super returns true for "no check yet"; the external-user guard must run first.
+        final FessUserBean bean = new FessUserBean(newSamlUser("saml-admin"));
+        assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.empty(), NOW));
+    }
+
+    @Test
+    public void test_needsSyncCheck_localUser_staleCheckTime_performsCheck() {
+        final FessUserBean bean = new FessUserBean(newLocalUser("alice"));
+        assertTrue(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.of(STALE_CHECK_DT), NOW));
+    }
+
+    @Test
+    public void test_needsSyncCheck_localUser_withinInterval_skipsCheck() {
+        final FessUserBean bean = new FessUserBean(newLocalUser("alice"));
+        assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.of(FRESH_CHECK_DT), NOW));
+    }
+
+    @Test
+    public void test_needsSyncCheck_localUser_neverCheckedYet_performsCheck() {
+        final FessUserBean bean = new FessUserBean(newLocalUser("alice"));
+        assertTrue(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.empty(), NOW));
+    }
+
+    @Test
+    public void test_needsSyncCheck_emptyUserBean_doesNotThrow() {
+        final FessUserBean bean = FessUserBean.empty(); // wraps a null FessUser
+        assertNull(bean.getFessUser());
+        assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.of(STALE_CHECK_DT), NOW));
+    }
+
+    @Test
+    public void test_needsSyncCheck_nullBackedUserBean_doesNotThrow() {
+        final FessUserBean bean = new FessUserBean(null);
+        assertFalse(loginAssist.needsLoginSessionSyncCheck(bean, OptionalThing.empty(), NOW));
+    }
+
+    // ---------------------------------------------------------------------
+    // syncCheckLoginSessionIfNeeds (end-to-end through TypicalLoginAssist)
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void test_syncCheckLoginSession_externalUser_keepsSessionWithoutQuery() {
+        final ExposedLoginAssist assist = newExposedAssist();
+        final CountingUserBhv bhv = installCountingUserBhv(assist, null);
+        final FessUserBean bean = new FessUserBean(newSamlUser("saml-admin"));
+        bean.manageLastestSyncCheckTime(STALE_CHECK_DT);
+
+        assertTrue(assist.callSyncCheckLoginSession(bean));
+        assertEquals(0, bhv.selectCalls.get());
+        assertEquals(0, assist.logoutCalls.get());
+    }
+
+    @Test
+    public void test_syncCheckLoginSession_localUserDeleted_logsOut() {
+        final ExposedLoginAssist assist = newExposedAssist();
+        final CountingUserBhv bhv = installCountingUserBhv(assist, null); // the document is gone
+        final FessUserBean bean = new FessUserBean(newLocalUser("alice"));
+        bean.manageLastestSyncCheckTime(STALE_CHECK_DT);
+
+        assertFalse(assist.callSyncCheckLoginSession(bean));
+        assertEquals(1, bhv.selectCalls.get());
+        assertEquals(1, assist.logoutCalls.get());
+    }
+
+    @Test
+    public void test_syncCheckLoginSession_localUserStillPresent_keepsSession() {
+        final ExposedLoginAssist assist = newExposedAssist();
+        final CountingUserBhv bhv = installCountingUserBhv(assist, newLocalUser("alice"));
+        final FessUserBean bean = new FessUserBean(newLocalUser("alice"));
+        bean.manageLastestSyncCheckTime(STALE_CHECK_DT);
+
+        assertTrue(assist.callSyncCheckLoginSession(bean));
+        assertEquals(1, bhv.selectCalls.get());
+        assertEquals(0, assist.logoutCalls.get());
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 
+    /** Fixed "now" used by the sync-check tests. */
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 1, 2, 3, 4, 5);
+
+    /** Older than the 300-second default sync-check interval. */
+    private static final LocalDateTime STALE_CHECK_DT = NOW.minusSeconds(310);
+
+    /** Well within the 300-second default sync-check interval. */
+    private static final LocalDateTime FRESH_CHECK_DT = NOW.minusSeconds(10);
+
+    private static SamlCredential.SamlUser newSamlUser(final String nameId) {
+        return new SamlCredential.SamlUser(nameId, "session-index", null, null, null, new String[0], new String[] { "admin" });
+    }
+
+    private static OpenIdConnectCredential.OpenIdUser newOpenIdUser(final String name) {
+        return new OpenIdConnectCredential.OpenIdUser(name, new String[0], new String[] { "admin" });
+    }
+
+    private static User newLocalUser(final String name) {
+        final User user = new User();
+        user.setName(name);
+        return user;
+    }
+
+    private ExposedLoginAssist newExposedAssist() {
+        final ExposedLoginAssist assist = new ExposedLoginAssist();
+        setField(TypicalLoginAssist.class, assist, "timeManager", newFixedTimeManager(NOW));
+        return assist;
+    }
+
+    private static TimeManager newFixedTimeManager(final LocalDateTime fixed) {
+        return (TimeManager) Proxy.newProxyInstance(TimeManager.class.getClassLoader(), new Class<?>[] { TimeManager.class },
+                (proxy, method, args) -> {
+                    final String name = method.getName();
+                    if ("currentDateTime".equals(name)) {
+                        return fixed;
+                    }
+                    if ("toString".equals(name)) {
+                        return "fixedTimeManager:" + fixed;
+                    }
+                    if ("hashCode".equals(name)) {
+                        return Integer.valueOf(System.identityHashCode(proxy));
+                    }
+                    if ("equals".equals(name)) {
+                        return Boolean.valueOf(proxy == args[0]);
+                    }
+                    throw new UnsupportedOperationException(name);
+                });
+    }
+
     private void installUserBhv(final User stored) {
-        final UserBhv bhv = new UserBhv() {
-            @Override
-            public OptionalEntity<User> selectEntity(final CBCall<UserCB> cbLambda) {
-                return stored == null ? OptionalEntity.empty() : OptionalEntity.of(stored);
-            }
-        };
+        installCountingUserBhv(loginAssist, stored);
+    }
+
+    private CountingUserBhv installCountingUserBhv(final FessLoginAssist target, final User stored) {
+        final CountingUserBhv bhv = new CountingUserBhv(stored);
+        setField(FessLoginAssist.class, target, "userBhv", bhv);
+        return bhv;
+    }
+
+    private static void setField(final Class<?> declaringType, final Object target, final String name, final Object value) {
         try {
-            final java.lang.reflect.Field f = FessLoginAssist.class.getDeclaredField("userBhv");
+            final java.lang.reflect.Field f = declaringType.getDeclaredField(name);
             f.setAccessible(true);
-            f.set(loginAssist, bhv);
+            f.set(target, value);
         } catch (final Exception e) {
             throw new IllegalStateException(e);
         }
@@ -378,6 +539,39 @@ public class FessLoginAssistTest extends UnitFessTestCase {
     // ---------------------------------------------------------------------
     // Fakes
     // ---------------------------------------------------------------------
+
+    /** Counts the {@code .fess_user} lookups issued by the login-session sync check. */
+    private static class CountingUserBhv extends UserBhv {
+        final AtomicInteger selectCalls = new AtomicInteger(0);
+        private final User stored;
+
+        CountingUserBhv(final User stored) {
+            this.stored = stored;
+        }
+
+        @Override
+        public OptionalEntity<User> selectEntity(final CBCall<UserCB> cbLambda) {
+            selectCalls.incrementAndGet();
+            return stored == null ? OptionalEntity.empty() : OptionalEntity.of(stored);
+        }
+    }
+
+    /**
+     * Exposes the protected sync-check entry point of {@code TypicalLoginAssist} and replaces
+     * {@code logout()} with a counter, so the whole flow can run without a servlet session.
+     */
+    private static class ExposedLoginAssist extends FessLoginAssist {
+        final AtomicInteger logoutCalls = new AtomicInteger(0);
+
+        @Override
+        public void logout() {
+            logoutCalls.incrementAndGet();
+        }
+
+        boolean callSyncCheckLoginSession(final FessUserBean userBean) {
+            return syncCheckLoginSessionIfNeeds(userBean);
+        }
+    }
 
     private static class RecordingUserService extends UserService {
         final AtomicInteger updateCalls = new AtomicInteger(0);


### PR DESCRIPTION
## The problem

`FessUserBean` is a `TypicalUserBean`, so LastaFlute sync-checks the login session every 300
seconds and answers "can this user still log in?" with a lookup of the user name in the
`fess_user.user` index. When the lookup finds nothing, the session is invalidated and the request
is redirected to the login page.

**No login path writes a user document for an externally authenticated user.** LDAP, SAML,
OpenID Connect, Entra ID and SPNEGO logins all build their user object from the identity
provider's response; the only `userBhv` writes are admin user CRUD, role/group cascades and
password change. So unless an administrator also created a local user document of the same name,
the lookup can only fail.

So an externally authenticated administrator can use the HTML admin console for at most 300
seconds before being dropped onto the local password form — which offers **no way back to the
identity provider**. An admin POST in flight at that moment is silently discarded. Recovery
requires manually visiting `/sso/` or the search root.

**Only `FessAdminAction` is affected**, because it is the only base action supplying a live
LoginManager (`FessAdminAction:221-223`). `FessSearchAction` and `FessApiAction:80-82` pass
`OptionalThing.empty()`, so the search UI and `/api/admin/*` never run the check. `/api/v1/*` and
`/api/v2/*` are served by `WebApiManager` filters rather than actions — v1 by the
`fess-webapp-v1-api` plugin — so they never reach it either.

**This is not a regression.** The sync check has behaved this way for as long as `FessUserBean`
has implemented `SyncCheckable`. It has gone unnoticed because the admin console is normally
driven by the local `admin` account, which does have a user document, and because
`lastestSyncCheckTime` is stamped at login — so the first admin request always passes and the
trap only springs five minutes in.

### Reproduced end to end

Against a real Fess + OpenSearch stack, with a local admin session:

```
admin/dashboard                            -> 200
+310s, user doc PRESENT                    -> 200   (control: the check ran and passed)
delete the admin doc from fess_user
doc gone, <300s since last check           -> 200   (proves the interval is the trigger)
+310s, doc gone                            -> 302 Location: /login/
search / with the same cookie              -> 200   (search is unaffected)
```

## The change

Restrict the check to a `User` entity, the only type `fess_user.user` can answer for.

This is **semantically correct rather than a workaround**: for an external user the identity
provider owns the account lifecycle, and the local index is not where that account lives. It also
saves an OpenSearch query every five minutes per external admin session.

Overriding `needsLoginSessionSyncCheck` rather than `findLoginSessionSyncCheckUser` is what skips
the query rather than merely ignoring its result.

`FessUserBean.empty()` wraps `null`, and `null instanceof User` is false, so that path is safe.

### The trade-off, stated precisely

Local users are unaffected: deleting one in the admin UI still ends that user's admin session
within the check interval.

What is given up is that same revocation for an externally authenticated user who **does** have a
local user document. That is not merely hypothetical: `resolveCredential` prefers LDAP over the
local index, so with LDAP configured a user present in both logs in as an `LdapUser`, and with
`ldap.admin.enabled` the admin UI creates and deletes the LDAP entry and the user document
together. Deleting such a user still blocks further logins, but no longer ends an admin session
that is already open. Worth a release note.

Two adjacent gaps are out of scope here and deserve their own issues: the login page has no route
back to the identity provider, and Fess sets no `session-timeout` at all (`web.xml` leaves the
container default, an idle timeout), so nothing bounds an external session's lifetime.

## Verification

- `FessLoginAssistTest` 16 -> 30 tests (surefire confirms `Tests run: 30`, so all 14 new methods
  execute); `web.base.**` + `sso.**` + `ldap.**` 372/0/0
- `mvn -o formatter:validate license:check` clean; `mvn -o clean javadoc:jar` passes with no new
  warning
- Five of the new tests go through LastaFlute's real `syncCheckLoginSessionIfNeeds` with a fixed
  clock and a counting behaviour, asserting query and logout counts:
  external+stale -> `true`, **0 queries**, 0 logouts; local deleted+stale -> `false`, 1 query,
  1 logout; local present+stale -> `true`, 1 query, 0 logouts; local present+fresh -> `true`,
  **0 queries**; LDAP user with a local document present+stale -> `true`, **0 queries**
- Mutations, all killed. Four worth noting: issuing the lookup before the short-circuit reddens
  the `0 queries` assertion (so that assertion is load-bearing, not just the return value);
  rewriting `instanceof` as `getClass() != User.class` NPEs on the null-backed beans — which is
  why `instanceof` is the right test; disabling the guard is caught by the LDAP-with-document
  test on `selectCalls` alone, since the stored document keeps the return value `true`; and
  replacing the fixed clock with the real one reddens the within-interval test alone
