### PR TITLE
fix(ldap): tell the user when the nested LDAP group walk fails (reland #3275)

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/FessSearchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/FessSearchAction.java
@@ -238,6 +238,11 @@ public abstract class FessSearchAction extends FessBaseAction {
      * @return The message key, or null when there is nothing to say.
      */
     protected String getPermissionStateMessageKey(final FessUser user) {
+        // "case null" as well as default: FessUser is Serializable and its implementations live in
+        // the session, so one that gains this field without changing serialVersionUID deserializes an
+        // older session with it null. A bare switch on a null selector throws, and this runs in
+        // hookBefore on every front page, so that would be a 500 on every request until the session
+        // is dropped.
         return switch (user.getPermissionState()) {
         case PENDING -> FessMessages.ERRORS_user_permissions_loading;
         case FAILED -> FessMessages.ERRORS_user_permissions_unavailable;

--- a/src/main/java/org/codelibs/fess/ldap/LdapManager.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapManager.java
@@ -22,6 +22,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -53,6 +54,7 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.timer.TimeoutManager;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.FessUser;
+import org.codelibs.fess.entity.FessUser.PermissionState;
 import org.codelibs.fess.exception.LdapConfigurationException;
 import org.codelibs.fess.exception.LdapOperationException;
 import org.codelibs.fess.helper.SystemHelper;
@@ -433,21 +435,93 @@ public class LdapManager {
         final String[] roles = roleSet.toArray(new String[roleSet.size()]);
 
         if (!subRoleSet.isEmpty()) {
-            TimeoutManager.getInstance().addTimeoutTarget(() -> {
-                sAMAccountGroupNameSet.stream().forEach(groupName -> {
-                    getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
-                        roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
-                    });
-                });
-                processSubRoles(ldapUser, bindDn, subRoleSet, groupFilter, roleSet);
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Roles (lazy loading): {}", roleSet);
-                }
-                lazyLoading.accept(roleSet.toArray(new String[roleSet.size()]));
-            }, 0, false);
+            // Set before scheduling, not inside the task: the task does not start until the timer
+            // notices it a second later, and the user is already being handed their direct groups
+            // right now. Only this branch schedules anything, so a deployment that leaves
+            // ldap.group.filter blank -- the shipped default -- never leaves RESOLVED.
+            ldapUser.setPermissionState(PermissionState.PENDING);
+            scheduleSubRoleUpdate(ldapUser, bindDn, subRoleSet, groupFilter, roleSet, sAMAccountGroupNameSet, lazyLoading);
         }
 
         return roles;
+    }
+
+    /**
+     * Schedules the nested-group resolution to run off the calling thread.
+     *
+     * <p>Split out from {@link #getRoles} so that the boundary is overridable: the body itself,
+     * {@link #updateSubRoles}, runs synchronously, so a test can drive the whole resolution
+     * without waiting on the shared timer.
+     *
+     * @param ldapUser the user whose groups are being resolved
+     * @param bindDn the bind DN for the search
+     * @param subRoleSet the group DNs to expand
+     * @param groupFilter the configured group filter
+     * @param roleSet the role set to add to
+     * @param sAMAccountGroupNameSet the group names still needing a sAMAccountName lookup
+     * @param lazyLoading the callback that publishes the resolved roles
+     */
+    protected void scheduleSubRoleUpdate(final LdapUser ldapUser, final String bindDn, final Set<String> subRoleSet,
+            final String groupFilter, final Set<String> roleSet, final Set<String> sAMAccountGroupNameSet,
+            final Consumer<String[]> lazyLoading) {
+        TimeoutManager.getInstance()
+                .addTimeoutTarget(
+                        () -> updateSubRoles(ldapUser, bindDn, subRoleSet, groupFilter, roleSet, sAMAccountGroupNameSet, lazyLoading), 0,
+                        false);
+    }
+
+    /**
+     * Resolves the nested groups and publishes the result.
+     *
+     * <p>Everything here can throw {@link LdapOperationException}. Without the catch below that
+     * throw escapes the {@code TimeoutManager} task, where the only handler is corelib's own
+     * "Failed to process a task." -- a message that names neither LDAP nor the user -- and
+     * {@code lazyLoading} is never called, so the user keeps their direct groups for the whole
+     * session with nothing connecting the two. The permissions already published by the
+     * synchronous pass are deliberately left in place; what changes is that the user is now told
+     * the rest is missing.
+     *
+     * @param ldapUser the user whose groups are being resolved
+     * @param bindDn the bind DN for the search
+     * @param subRoleSet the group DNs to expand
+     * @param groupFilter the configured group filter
+     * @param roleSet the role set to add to
+     * @param sAMAccountGroupNameSet the group names still needing a sAMAccountName lookup
+     * @param lazyLoading the callback that publishes the resolved roles
+     */
+    protected void updateSubRoles(final LdapUser ldapUser, final String bindDn, final Set<String> subRoleSet, final String groupFilter,
+            final Set<String> roleSet, final Set<String> sAMAccountGroupNameSet, final Consumer<String[]> lazyLoading) {
+        boolean resolved = false;
+        try {
+            // Inside the try, not above it: ComponentUtil.getComponent throws when the container is
+            // gone, and that throw on a TimeoutManager thread would leave the state PENDING forever
+            // -- the notice stuck on screen for the whole session, which is exactly what this method
+            // exists to avoid.
+            final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
+            sAMAccountGroupNameSet.stream().forEach(groupName -> {
+                getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
+                    roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
+                });
+            });
+            processSubRoles(ldapUser, bindDn, subRoleSet, groupFilter, roleSet);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Roles (lazy loading): {}", roleSet);
+            }
+            lazyLoading.accept(roleSet.toArray(new String[roleSet.size()]));
+            resolved = true;
+        } catch (final Exception e) {
+            logger.warn("Failed to resolve the nested LDAP groups of {}. Keeping the groups resolved so far.", ldapUser.getName(), e);
+        } finally {
+            if (resolved) {
+                ldapUser.setPermissionState(PermissionState.RESOLVED);
+            } else if (ldapUser.getPermissionState() == PermissionState.PENDING) {
+                // Only PENDING is downgraded, so a walk that failed cannot overwrite a RESOLVED a
+                // concurrent one already settled -- the user holds those groups either way, and
+                // claiming otherwise would show a failure notice over a complete permission set.
+                // The read-then-write is not atomic, but both writers are only reporting.
+                ldapUser.setPermissionState(PermissionState.FAILED);
+            }
+        }
     }
 
     /**
@@ -517,6 +591,7 @@ public class LdapManager {
             logger.debug("Group filter: {}", filter);
         }
         final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
+        final Set<String> sAMAccountGroupNameSet = new LinkedHashSet<>();
         search(bindDn, filter, null, () -> ldapUser.getEnvironment(), result -> {
             for (final SearchResult srcrslt : result) {
                 final String groupDn = srcrslt.getNameInNamespace();
@@ -526,12 +601,29 @@ public class LdapManager {
                 final String groupName = getSearchRoleName(groupDn);
                 final String roleType = updateSearchRoles(roleSet, groupDn, groupName);
                 if (fessConfig.getRoleSearchGroupPrefix().equals(roleType) && fessConfig.isLdapSamaccountnameGroup()) {
-                    getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
-                        roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
-                    });
+                    sAMAccountGroupNameSet.add(groupName);
                 }
             }
         });
+        // Collected above and looked up here, once the search has returned. getSAMAccountGroupName
+        // asks for the admin credentials, but getDirContext discards that request whenever a
+        // context is already open on this thread -- and inside the consumer above one is, the one
+        // search() opened with the end user's own credentials. Running the lookups after search()
+        // has closed it makes this method bind as the same principal as the identical call in
+        // updateSubRoles, instead of as whoever happened to be logging in.
+        if (!sAMAccountGroupNameSet.isEmpty()) {
+            // One context for the whole batch. Without it each lookup would open, bind and close its
+            // own connection, because search() has already closed the thread-local one -- and a
+            // recursive AD group filter routinely yields tens of nested groups per user.
+            final Hashtable<String, String> env = createSearchEnv();
+            try (DirContextHolder holder = getDirContext(() -> env)) {
+                sAMAccountGroupNameSet.forEach(groupName -> {
+                    getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
+                        roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
+                    });
+                });
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ldap/LdapUser.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapUser.java
@@ -41,8 +41,45 @@ public class LdapUser implements FessUser {
     /** The name of the user. */
     protected String name;
 
-    /** The permissions of the user. */
-    protected String[] permissions = null;
+    /**
+     * Whether the nested-group walk has already published its result.
+     *
+     * <p>Guards the synchronous write below. {@link LdapManager#getRoles} schedules that walk and
+     * then returns, so the assignment of its return value happens after the walk was handed to the
+     * timer -- and if the walk finished in between, assigning would overwrite the fuller set with
+     * the direct-only one and leave the state reporting {@code RESOLVED} over it. The remaining
+     * check-then-act window is a few instructions wide against an LDAP round trip.
+     */
+    protected volatile boolean nestedRolesPublished;
+
+    /**
+     * The permissions of the user.
+     *
+     * <p>Volatile because the nested-group resolution writes it from a {@code TimeoutManager}
+     * thread while request threads read it. It is deliberately not guarded by a lock the way
+     * {@code EntraIdUser} guards its own: the first read of this field performs the directory
+     * search inline, so a lock here would be held across an LDAP round trip and the background
+     * writer would block a pool thread behind it. The remaining race is two concurrent first
+     * requests each running the search, which costs duplicate work but converges.
+     */
+    protected volatile String[] permissions = null;
+
+    /**
+     * How far this user's group and role permissions have got.
+     *
+     * <p>Starts {@link PermissionState#RESOLVED} rather than {@code PENDING}: unlike an Entra ID
+     * user, this one resolves its permissions inline on first read, and the nested-group walk is
+     * only scheduled when {@code ldap.group.filter} is configured. With the shipped defaults no
+     * background work is ever scheduled, so the synchronous result is the whole answer and there
+     * is no window to report. {@link LdapManager#getRoles} moves it to {@code PENDING} at the
+     * moment it actually schedules that walk.
+     *
+     * <p>Volatile for the same reason as {@link #permissions}. {@code RESOLVED} and {@code FAILED}
+     * are always written <em>after</em> the permissions they describe, so a reader that sees
+     * {@code RESOLVED} cannot see stale ones. {@code PENDING} is written before the first
+     * permissions exist at all, which is the state's whole point.
+     */
+    protected volatile PermissionState permissionState = PermissionState.RESOLVED;
 
     /**
      * Constructs a new LDAP user.
@@ -69,15 +106,62 @@ public class LdapUser implements FessUser {
             final String groupFilter = fessConfig.getLdapGroupFilter();
             if (StringUtil.isNotBlank(baseDn) && StringUtil.isNotBlank(accountFilter)) {
                 final LdapManager ldapManager = ComponentUtil.getLdapManager();
-                permissions = distinct(ArrayUtils.addAll(ldapManager.getRoles(this, baseDn, accountFilter, groupFilter, roles -> {
-                    permissions = distinct(roles);
-                    ComponentUtil.getActivityHelper().permissionChanged(OptionalThing.of(new FessUserBean(this)));
-                }), fessConfig.getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName())));
+                // Appended to both writes, not just the synchronous one. LdapManager derives its own
+                // user entry through getCanonicalLdapName, which drops a NetBIOS "DOMAIN\" prefix,
+                // and adds it only when ldap.role.search.user.enabled is set -- so a lazy write that
+                // carried only what LdapManager collected would hand back a strictly smaller set
+                // than the synchronous result, and the user would silently lose their own
+                // permission at the moment the nested-group walk succeeded.
+                final String userPermission = fessConfig.getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName());
+                final String[] directPermissions =
+                        distinct(ArrayUtils.addAll(ldapManager.getRoles(this, baseDn, accountFilter, groupFilter, roles -> {
+                            permissions = distinct(ArrayUtils.addAll(roles, userPermission));
+                            // Written after the permissions it describes, so a reader that sees the
+                            // flag cannot see the set it replaced.
+                            nestedRolesPublished = true;
+                            ComponentUtil.getActivityHelper().permissionChanged(OptionalThing.of(new FessUserBean(this)));
+                        }), userPermission));
+                if (!nestedRolesPublished) {
+                    permissions = directPermissions;
+                }
             } else {
                 permissions = StringUtil.EMPTY_STRINGS;
             }
         }
         return permissions;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>A bare field read. It must stay one: this is called on every request by
+     * {@code FessSearchAction#hookBefore}, and {@link #getPermissions()} performs the directory
+     * search inline, so anything that consulted the permissions here -- including
+     * {@link #getGroupNames()} and {@link #getRoleNames()}, which derive from them -- would turn a
+     * status check into an LDAP round trip.
+     */
+    @Override
+    public PermissionState getPermissionState() {
+        // Null-checked, not just returned. This class is Serializable and lives in the session, and
+        // serialVersionUID is unchanged, so a session written by a release without this field
+        // deserializes with it null -- field initializers do not run during deserialization. Tomcat's
+        // default StandardManager persists sessions across a restart into a directory that survives
+        // a package upgrade, so that stream is a real upgrade path, and the interface documents this
+        // as never null.
+        final PermissionState state = permissionState;
+        return state == null ? PermissionState.RESOLVED : state;
+    }
+
+    /**
+     * Records how far this user's group and role permissions have got.
+     *
+     * <p>Called by {@link LdapManager} around the nested-group walk. Always write the permissions
+     * before the state that describes them.
+     *
+     * @param permissionState The state, never null.
+     */
+    public void setPermissionState(final PermissionState permissionState) {
+        this.permissionState = permissionState;
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/app/web/base/FessSearchActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/FessSearchActionTest.java
@@ -298,4 +298,43 @@ public class FessSearchActionTest extends UnitFessTestCase {
             super(requestPath, null, null);
         }
     }
+
+    @Test
+    public void test_getPermissionStateMessageKey_toleratesANullState() {
+        // FessUser is Serializable and its implementations live in the session, so one that gains a
+        // permission-state field without changing serialVersionUID deserializes an older session
+        // with it null -- field initializers do not run during deserialization. A bare switch on a
+        // null selector throws, and this runs in hookBefore on every front page, so that would be a
+        // 500 on every request until the session is dropped.
+        final FessUser user = new FessUser() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getName() {
+                return "olduser";
+            }
+
+            @Override
+            public String[] getRoleNames() {
+                return new String[0];
+            }
+
+            @Override
+            public String[] getGroupNames() {
+                return new String[0];
+            }
+
+            @Override
+            public String[] getPermissions() {
+                return new String[0];
+            }
+
+            @Override
+            public FessUser.PermissionState getPermissionState() {
+                return null;
+            }
+        };
+        assertNull(new FessSearchAction() {
+        }.getPermissionStateMessageKey(user));
+    }
 }

--- a/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
@@ -20,6 +20,8 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import javax.naming.CommunicationException;
@@ -27,11 +29,14 @@ import javax.naming.Context;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
 import org.apache.logging.log4j.Level;
+import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.exception.LdapOperationException;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -489,6 +494,385 @@ public class LdapManagerTest extends UnitFessTestCase {
         assertEquals("normal", ldapManager.replaceWithUnderscores("normal"));
         // Input "//\\[]:;" has 8 special characters that should be replaced
         assertEquals("________", ldapManager.replaceWithUnderscores("//\\\\[]:;"));
+    }
+
+    // ==============================================================================
+    //                                              Nested group resolution reporting
+    //                                              ==================================
+
+    /** Builds a search result carrying the given memberOf values. */
+    private SearchResult memberOfResult(final String... entryDns) {
+        final BasicAttributes attributes = new BasicAttributes();
+        final BasicAttribute memberOf = new BasicAttribute("memberOf");
+        for (final String entryDn : entryDns) {
+            memberOf.add(entryDn);
+        }
+        attributes.put(memberOf);
+        final SearchResult result = new SearchResult("cn=testuser", null, attributes);
+        result.setNameInNamespace("cn=testuser,dc=example,dc=com");
+        return result;
+    }
+
+    /** The configuration the nested-group tests share: a group DN yields a group-typed role. */
+    private void registerGroupResolvingConfig() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getLdapMemberofAttribute() {
+                return "memberOf";
+            }
+
+            @Override
+            public boolean isLdapIgnoreNetbiosName() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapGroupNameWithUnderscores() {
+                return false;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchUserEnabled() {
+                return false;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchGroupEnabled() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchRoleEnabled() {
+                return true;
+            }
+
+            @Override
+            public String getRoleSearchGroupPrefix() {
+                return "2";
+            }
+
+            @Override
+            public String getRoleSearchRolePrefix() {
+                return "R";
+            }
+
+            @Override
+            public boolean isLdapLowercasePermissionName() {
+                return false;
+            }
+
+            @Override
+            public boolean isLdapSamaccountnameGroup() {
+                return false;
+            }
+        });
+    }
+
+    /** Builds a group search result whose name-in-namespace is the given DN. */
+    private SearchResult groupResult(final String groupDn) {
+        final SearchResult result = new SearchResult(groupDn, null, new BasicAttributes());
+        result.setNameInNamespace(groupDn);
+        return result;
+    }
+
+    @Test
+    public void test_getRoles_leavesThePermissionsResolvedWhenNoWalkIsScheduled() {
+        // The shipped default leaves ldap.group.filter blank, so subRoleSet stays empty and nothing
+        // is ever scheduled. Reporting PENDING here would strand the notice on screen forever,
+        // which is why LdapUser starts RESOLVED rather than PENDING the way EntraIdUser does.
+        registerGroupResolvingConfig();
+        final AtomicBoolean scheduled = new AtomicBoolean(false);
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void search(final String baseDn, final String filter, final String[] returningAttrs,
+                    final java.util.function.Supplier<Hashtable<String, String>> envSupplier, final SearchConsumer consumer)
+                    throws RuntimeException {
+                try {
+                    consumer.accept(List.of(memberOfResult("CN=group1,OU=group,DC=example,DC=com")));
+                } catch (final javax.naming.NamingException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            @Override
+            protected void scheduleSubRoleUpdate(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet, final java.util.Set<String> sAMAccountGroupNameSet,
+                    final java.util.function.Consumer<String[]> lazyLoading) {
+                scheduled.set(true);
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapManager.getRoles(ldapUser, "dc=example,dc=com", "(uid=%s)", "", roles -> {});
+
+        assertFalse(scheduled.get());
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_getRoles_marksThePermissionsPendingWhenItSchedulesTheWalk() {
+        // Set before the task is handed to the timer, not inside it: the timer only notices a
+        // second later, and the user is being given their direct groups right now.
+        registerGroupResolvingConfig();
+        final AtomicBoolean scheduled = new AtomicBoolean(false);
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void search(final String baseDn, final String filter, final String[] returningAttrs,
+                    final java.util.function.Supplier<Hashtable<String, String>> envSupplier, final SearchConsumer consumer)
+                    throws RuntimeException {
+                try {
+                    consumer.accept(List.of(memberOfResult("CN=group1,OU=group,DC=example,DC=com")));
+                } catch (final javax.naming.NamingException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            @Override
+            protected void scheduleSubRoleUpdate(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet, final java.util.Set<String> sAMAccountGroupNameSet,
+                    final java.util.function.Consumer<String[]> lazyLoading) {
+                // The state must already be PENDING by the time the task is scheduled.
+                assertEquals(FessUser.PermissionState.PENDING, user.getPermissionState());
+                scheduled.set(true);
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapManager.getRoles(ldapUser, "dc=example,dc=com", "(uid=%s)", "(member=%s)", roles -> {});
+
+        assertTrue(scheduled.get());
+        assertEquals(FessUser.PermissionState.PENDING, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_updateSubRoles_marksTheUserResolvedOnceTheWalkLands() {
+        registerGroupResolvingConfig();
+        final AtomicReference<String[]> published = new AtomicReference<>();
+        final AtomicReference<FessUser.PermissionState> stateWhenPublished = new AtomicReference<>();
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void processSubRoles(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet) {
+                roleSet.add("2parent");
+            }
+
+            @Override
+            protected OptionalEntity<String> getSAMAccountGroupName(final String bindDn, final String groupName) {
+                return OptionalEntity.of(groupName + "sam");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapUser.setPermissionState(FessUser.PermissionState.PENDING);
+        final java.util.Set<String> roleSet = new java.util.HashSet<>(List.of("2group1"));
+
+        ldapManager.updateSubRoles(ldapUser, "dc=example,dc=com", java.util.Set.of("CN=group1"), "(member=%s)", roleSet,
+                java.util.Set.of("group1"), roles -> {
+                    published.set(roles);
+                    // The permissions must be published before the state that describes them, or a
+                    // reader that sees RESOLVED can still be looking at the previous set.
+                    stateWhenPublished.set(ldapUser.getPermissionState());
+                });
+
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+        assertEquals(FessUser.PermissionState.PENDING, stateWhenPublished.get());
+        assertNotNull(published.get());
+        // 2group1 from the direct pass, 2parent from the walk, and the sAMAccountName batch entry.
+        assertEquals(3, published.get().length);
+    }
+
+    @Test
+    public void test_updateSubRoles_doesNotDowngradeAStateAnotherWalkAlreadySettled() {
+        // Two concurrent first requests each schedule a walk. If one succeeds and a later one fails,
+        // the user still holds the groups the first published, so reporting FAILED over them would
+        // show a failure notice on a complete permission set.
+        registerGroupResolvingConfig();
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void processSubRoles(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet) {
+                throw new org.codelibs.fess.exception.LdapOperationException("Failed to search.");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapUser.setPermissionState(FessUser.PermissionState.RESOLVED);
+
+        ldapManager.updateSubRoles(ldapUser, "dc=example,dc=com", java.util.Set.of("CN=group1"), "(member=%s)",
+                new java.util.HashSet<>(List.of("2group1")), java.util.Set.of(), roles -> {});
+
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_updateSubRoles_marksTheUserFailedWhenTheWalkThrows() {
+        // Without the catch this throw escapes the TimeoutManager task, where corelib logs
+        // "Failed to process a task." -- naming neither LDAP nor the user -- and lazyLoading is
+        // never called, so the direct-only groups stand for the whole session with nothing saying
+        // so. The permissions already published stay; what changes is that the user is told.
+        registerGroupResolvingConfig();
+        final AtomicBoolean publishedAnything = new AtomicBoolean(false);
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void processSubRoles(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet) {
+                throw new org.codelibs.fess.exception.LdapOperationException("Failed to search.");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapUser.setPermissionState(FessUser.PermissionState.PENDING);
+
+        ldapManager.updateSubRoles(ldapUser, "dc=example,dc=com", java.util.Set.of("CN=group1"), "(member=%s)",
+                new java.util.HashSet<>(List.of("2group1")), java.util.Set.of(), roles -> publishedAnything.set(true));
+
+        assertEquals(FessUser.PermissionState.FAILED, ldapUser.getPermissionState());
+        assertFalse(publishedAnything.get());
+    }
+
+    @Test
+    public void test_processSubRoles_looksUpSamAccountNamesAsTheAdminPrincipal() {
+        // getSAMAccountGroupName asks for the admin credentials, but getDirContext discards that
+        // request whenever a context is already open on the thread -- and inside search()'s consumer
+        // one is, the one search() opened with the end user's own credentials. So the lookups must
+        // not run from inside the consumer, or they bind as whoever is logging in. They now run
+        // after search() has closed its context, under a single admin context opened for the batch.
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public boolean isLdapIgnoreNetbiosName() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapGroupNameWithUnderscores() {
+                return false;
+            }
+
+            @Override
+            public boolean isLdapSamaccountnameGroup() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchGroupEnabled() {
+                return true;
+            }
+
+            @Override
+            public boolean isLdapRoleSearchRoleEnabled() {
+                return true;
+            }
+
+            @Override
+            public String getRoleSearchGroupPrefix() {
+                return "2";
+            }
+
+            @Override
+            public String getRoleSearchRolePrefix() {
+                return "R";
+            }
+
+            @Override
+            public boolean isLdapLowercasePermissionName() {
+                return false;
+            }
+        });
+
+        final Hashtable<String, String> userEnv = new Hashtable<>();
+        userEnv.put("principal", "end-user");
+        final Hashtable<String, String> adminEnv = new Hashtable<>();
+        adminEnv.put("principal", "admin");
+
+        final AtomicReference<String> envOfOpenContext = new AtomicReference<>();
+        final AtomicReference<String> principalAtLookup = new AtomicReference<>();
+        final AtomicInteger contextsOpened = new AtomicInteger();
+
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected Hashtable<String, String> createSearchEnv() {
+                return adminEnv;
+            }
+
+            @Override
+            protected DirContextHolder getDirContext(final java.util.function.Supplier<Hashtable<String, String>> envSupplier) {
+                // Mirrors the real one: an already-open context on this thread is reused, and the
+                // supplied environment is then never consulted.
+                final DirContextHolder existing = contextLocal.get();
+                if (existing != null) {
+                    existing.inc();
+                    return existing;
+                }
+                envOfOpenContext.set(envSupplier.get().get("principal"));
+                contextsOpened.incrementAndGet();
+                final DirContextHolder holder = new DirContextHolder(null);
+                contextLocal.set(holder);
+                return holder;
+            }
+
+            @Override
+            protected void search(final String baseDn, final String filter, final String[] returningAttrs,
+                    final java.util.function.Supplier<Hashtable<String, String>> envSupplier, final SearchConsumer consumer) {
+                try (DirContextHolder holder = getDirContext(envSupplier)) {
+                    consumer.accept(List.of(groupResult("CN=group1,OU=group,DC=example,DC=com"),
+                            groupResult("CN=group2,OU=group,DC=example,DC=com")));
+                } catch (final javax.naming.NamingException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            @Override
+            protected OptionalEntity<String> getSAMAccountGroupName(final String bindDn, final String groupName) {
+                principalAtLookup.set(envOfOpenContext.get());
+                return OptionalEntity.of(groupName + "sam");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final java.util.Set<String> roleSet = new java.util.HashSet<>();
+        ldapManager.processSubRoles(new LdapUser(userEnv, "testuser"), "dc=example,dc=com", java.util.Set.of("CN=user1"), "(member=%s)",
+                roleSet);
+
+        // The lookups ran, and under the admin principal rather than the end user's.
+        assertEquals("admin", principalAtLookup.get());
+        // Two groups, but only two contexts in total: the search's, and one shared by the batch.
+        assertEquals(2, contextsOpened.get());
+        assertTrue(roleSet.toString(), roleSet.contains("2group1sam"));
+        assertTrue(roleSet.toString(), roleSet.contains("2group2sam"));
+    }
+
+    @Test
+    public void test_updateSubRoles_marksTheUserFailedWhenTheWalkThrowsAnError() {
+        // The state write is in a finally, not only in the catch, so that a Throwable that is not an
+        // Exception cannot strand the user in PENDING. corelib's own task handler also catches only
+        // Exception, so nothing further downstream would settle it.
+        registerGroupResolvingConfig();
+        final LdapManager ldapManager = new LdapManager() {
+            @Override
+            protected void processSubRoles(final LdapUser user, final String bindDn, final java.util.Set<String> subRoleSet,
+                    final String groupFilter, final java.util.Set<String> roleSet) {
+                throw new StackOverflowError("walk blew the stack");
+            }
+        };
+        ldapManager.fessConfig = ComponentUtil.getFessConfig();
+
+        final LdapUser ldapUser = new LdapUser(new Hashtable<>(), "testuser");
+        ldapUser.setPermissionState(FessUser.PermissionState.PENDING);
+
+        try {
+            ldapManager.updateSubRoles(ldapUser, "dc=example,dc=com", java.util.Set.of("CN=group1"), "(member=%s)",
+                    new java.util.HashSet<>(List.of("2group1")), java.util.Set.of(), roles -> {});
+            fail("the Error must still propagate");
+        } catch (final StackOverflowError expected) {
+            // propagating is correct; what matters is that the state was settled on the way out
+        }
+
+        assertEquals(FessUser.PermissionState.FAILED, ldapUser.getPermissionState());
     }
 
     // ========================================================================

--- a/src/test/java/org/codelibs/fess/ldap/LdapUserTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapUserTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.helper.ActivityHelper;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.action.FessUserBean;
@@ -223,12 +224,16 @@ public class LdapUserTest extends UnitFessTestCase {
 
         String[] permissions = ldapUser.getPermissions();
 
-        // Verify permissions include both LDAP roles and user permission
+        // The stub publishes through the callback before returning, which is what the nested-group
+        // walk does when it wins the race with the synchronous assignment. The published set is
+        // what survives; this used to assert the opposite -- the synchronous return value -- which
+        // pinned the walk's result being thrown away.
         assertNotNull(permissions);
         assertEquals(3, permissions.length);
-        assertEquals("Rgroup1", permissions[0]);
-        assertEquals("Rgroup2", permissions[1]);
-        assertEquals("Utestuser", permissions[2]);
+        final String rendered = java.util.Arrays.toString(permissions);
+        assertTrue(rendered, rendered.contains("role1"));
+        assertTrue(rendered, rendered.contains("role2"));
+        assertTrue(rendered, rendered.contains("Utestuser"));
 
         // Verify callback was called
         assertTrue(activityHelperCalled.get());
@@ -529,5 +534,137 @@ public class LdapUserTest extends UnitFessTestCase {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void test_getPermissionState_defaultsToResolved() {
+        // Unlike an Entra ID user, an LdapUser resolves inline on first read and only schedules the
+        // nested-group walk when ldap.group.filter is configured. With the shipped defaults nothing
+        // is scheduled, so there is no window to report and the state must not start PENDING --
+        // that would strand the notice on screen for every LDAP deployment.
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_getPermissions_lazyWriteKeepsTheUserPermission() {
+        // LdapManager derives its own user entry through getCanonicalLdapName, which drops a
+        // NetBIOS "DOMAIN\\" prefix, and adds it only when ldap.role.search.user.enabled is set. So
+        // the roles it hands the callback need not contain the user's own permission, and a lazy
+        // write that published only those would hand back a strictly smaller set than the
+        // synchronous pass -- the user losing their own permission at the exact moment the nested
+        // group walk succeeded.
+        final AtomicReference<String[]> publishedByCallback = new AtomicReference<>();
+
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getLdapBaseDn() {
+                return "dc=example,dc=com";
+            }
+
+            @Override
+            public String getLdapAccountFilter() {
+                return "(uid=%s)";
+            }
+
+            @Override
+            public String getRoleSearchUserPrefix() {
+                return "1";
+            }
+        });
+
+        ComponentUtil.register(new LdapManager() {
+            @Override
+            public String[] getRoles(final LdapUser user, final String baseDn, final String accountFilter, final String groupFilter,
+                    final Consumer<String[]> callback) {
+                // What the nested-group walk publishes: groups only, no user entry.
+                callback.accept(new String[] { "2group1", "2parent1" });
+                publishedByCallback.set(user.permissions);
+                return new String[] { "2group1" };
+            }
+
+            @Override
+            public String normalizePermissionName(final String name) {
+                return name;
+            }
+        }, "ldapManager");
+
+        ComponentUtil.register(new ActivityHelper() {
+            @Override
+            public void permissionChanged(final OptionalThing<FessUserBean> user) {
+                // no-op
+            }
+        }, "activityHelper");
+
+        ldapUser.getPermissions();
+
+        final String[] afterLazyWrite = publishedByCallback.get();
+        assertNotNull(afterLazyWrite);
+        boolean hasUserPermission = false;
+        for (final String permission : afterLazyWrite) {
+            if ("1testuser".equals(permission)) {
+                hasUserPermission = true;
+            }
+        }
+        assertTrue("user permission missing from " + java.util.Arrays.toString(afterLazyWrite), hasUserPermission);
+    }
+
+    @Test
+    public void test_getPermissionState_survivesADeserializedSessionWithoutTheField() {
+        // LdapUser is Serializable and lives in the session, and serialVersionUID is unchanged, so a
+        // session written by a release without this field deserializes with it null -- field
+        // initializers do not run during deserialization. FessSearchAction#hookBefore switches on
+        // this on every front page, and a bare switch on a null selector throws, so a null here
+        // would be a 500 on every request until the session is dropped.
+        ldapUser.permissionState = null;
+        assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
+    }
+
+    @Test
+    public void test_getPermissions_doesNotOverwriteAWalkThatAlreadyPublished() {
+        // getRoles schedules the nested-group walk and then returns, so assigning its return value
+        // happens after the walk was handed to the timer. If the walk finished in between, assigning
+        // would replace the fuller set with the direct-only one -- and the state would then report
+        // RESOLVED over it. Here the stub publishes before returning, which is that interleaving.
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getLdapBaseDn() {
+                return "dc=example,dc=com";
+            }
+
+            @Override
+            public String getLdapAccountFilter() {
+                return "(uid=%s)";
+            }
+
+            @Override
+            public String getRoleSearchUserPrefix() {
+                return "1";
+            }
+        });
+
+        ComponentUtil.register(new LdapManager() {
+            @Override
+            public String[] getRoles(final LdapUser user, final String baseDn, final String accountFilter, final String groupFilter,
+                    final Consumer<String[]> callback) {
+                callback.accept(new String[] { "2group1", "2parent1" });
+                return new String[] { "2group1" };
+            }
+
+            @Override
+            public String normalizePermissionName(final String name) {
+                return name;
+            }
+        }, "ldapManager");
+
+        ComponentUtil.register(new ActivityHelper() {
+            @Override
+            public void permissionChanged(final OptionalThing<FessUserBean> user) {
+                // no-op
+            }
+        }, "activityHelper");
+
+        final String permissions = java.util.Arrays.toString(ldapUser.getPermissions());
+        assertTrue("nested group lost from " + permissions, permissions.contains("2parent1"));
+        assertTrue("user permission lost from " + permissions, permissions.contains("1testuser"));
     }
 }


### PR DESCRIPTION
Relands #3275, which never reached `master`.

## What happened

- #3273 (`feat/entraid-async-membership` -> `master`) was squash-merged at 2026-08-12 23:08 UTC.
- #3275 (`fix/ldap-nested-group-permission-state` -> `feat/entraid-async-membership`) was merged at 2026-08-13 00:47 UTC, i.e. **after** its base branch had already been merged into `master`.

So #3275's commit landed on `feat/entraid-async-membership` only. `master` has none of it: `LdapUser` still has no `permissionState`, `permissions` is still non-volatile, and `LdapManager#updateSubRoles` still has no error handling around the nested-group walk.

#3275 itself cannot be reopened -- GitHub does not allow reopening a merged PR -- and a PR from `feat/entraid-async-membership` to `master` is not usable either: that branch is 9 commits behind and merging it would revert #3274, #3276 and the rest. So this branch is `master` plus a cherry-pick of the missing commit.

## The change

Identical to #3275; see that PR for the reasoning. In short: `LdapUser` becomes the second consumer of `FessUser.PermissionState`, the background nested-group walk reports PENDING while it runs and FAILED if it does not finish, and three adjacent defects on the same path are fixed (non-volatile `permissions`, the synchronous write overwriting a completed walk, and the lazy write publishing a smaller permission set than the synchronous one).

## Conflict resolution

The cherry-pick conflicted in one file, `LdapManagerTest.java`, because #3274's timeout tests and #3275's tests were both appended at the end of the class. Both sets are kept; the imports are the union. No production file conflicted.

## Verification

`mvn clean test` over the LDAP, search-action, message and Entra ID SSO test classes touched by this change: 280 tests, 0 failures, 0 errors.

`mvn formatter:format license:format` produces no changes.
