### PR TITLE
fix(theme/bootstrap): restore code content literally and escape text sharing a block with a fence

### DIFF
--- a/src/main/webapp/themes/bootstrap/assets/markdown.js
+++ b/src/main/webapp/themes/bootstrap/assets/markdown.js
@@ -1,11 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // Minimal in-repo Markdown renderer for the Fess static theme SPA.
-// Produces HTML from a safe subset of Markdown. All input is HTML-escaped
-// before pattern substitution — no raw user strings appear in output.
+// Produces HTML from a safe subset of Markdown. Every user-derived string is
+// HTML-escaped — inline text by inlineMarkdown() before pattern substitution,
+// fenced-code content at extraction time — so only renderer-generated markup
+// reaches the output unescaped.
 // The caller MUST pass the return value through sanitizeHtml() before
 // appending to the live DOM (defense-in-depth).
 
 import { escapeHtml, isSafeHref } from "./format.js";
+
+// Extracted fenced code blocks are parked under a NUL-delimited placeholder
+// (see steps 2/5). Placeholders are the only strings that bypass escaping, so
+// they must be unforgeable: parseMarkdown strips NUL from the input, and these
+// patterns match a whole placeholder rather than a prefix.
+const CODEBLOCK_SPLIT_RE = /(\x00CODEBLOCK\d+\x00)/;
+const CODEBLOCK_ONLY_RE = /^\x00CODEBLOCK\d+\x00$/;
 
 /**
  * Parse a limited subset of Markdown to HTML.
@@ -27,8 +36,9 @@ import { escapeHtml, isSafeHref } from "./format.js";
 export function parseMarkdown(text) {
   if (!text || typeof text !== "string") return "";
 
-  // Step 1: Normalise line endings.
-  const normalised = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  // Step 1: Normalise line endings, and drop NUL so input cannot forge one of
+  // the NUL-delimited placeholders used here and by inlineMarkdown().
+  const normalised = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\x00/g, "");
 
   // Step 2: Extract fenced code blocks so their contents are not processed by
   // inline rules.  Replace each block with a unique placeholder token.
@@ -61,7 +71,11 @@ export function parseMarkdown(text) {
 // ---------------------------------------------------------------------------
 
 /**
- * Split text into block-level units by one or more blank lines.
+ * Split text into block-level units by one or more blank lines, then split each
+ * of those at code-block placeholder boundaries so a placeholder always stands
+ * alone as its own block.  A fence that is not followed by a blank line would
+ * otherwise share a block with the text after it, and processBlock() cannot
+ * both pass a placeholder through and escape its neighbours.
  * Preserves non-empty blocks only.
  *
  * @param {string} text
@@ -70,6 +84,7 @@ export function parseMarkdown(text) {
 function splitBlocks(text) {
   return text
     .split(/\n{2,}/)
+    .flatMap(b => b.split(CODEBLOCK_SPLIT_RE))
     .map(b => b.trim())
     .filter(b => b.length > 0);
 }
@@ -241,8 +256,9 @@ function renderBlockquote(lines) {
  * @returns {string} HTML string.
  */
 function processBlock(block) {
-  // Code block placeholder — pass through.
-  if (block.startsWith("\x00CODEBLOCK")) return block;
+  // Code block placeholder — pass through.  Tested against the whole block: a
+  // prefix test would also return anything sharing the block with it unescaped.
+  if (CODEBLOCK_ONLY_RE.test(block)) return block;
 
   const lines = block.split("\n");
 

--- a/src/main/webapp/themes/bootstrap/assets/markdown.js
+++ b/src/main/webapp/themes/bootstrap/assets/markdown.js
@@ -57,10 +57,12 @@ export function parseMarkdown(text) {
   // Step 4: Process each block.
   const parts = blocks.map(block => processBlock(block));
 
-  // Step 5: Restore code blocks.
+  // Step 5: Restore code blocks. The replacement is a function so that `$&`,
+  // "$`", `$'` and `$1` in the code content are inserted literally instead of
+  // being read as substitution patterns.
   let html = parts.join("\n");
   codeBlocks.forEach((cb, idx) => {
-    html = html.replace("\x00CODEBLOCK" + idx + "\x00", cb);
+    html = html.replace("\x00CODEBLOCK" + idx + "\x00", () => cb);
   });
 
   return html;
@@ -401,9 +403,10 @@ function inlineMarkdown(text) {
     return '<a href="' + url + '" target="_blank" rel="nofollow noopener noreferrer">' + url + "</a>";
   });
 
-  // Restore inline code placeholders.
+  // Restore inline code placeholders. As in step 5 of parseMarkdown, the
+  // replacement is a function so `$&` and friends in the code are literal.
   inlineCodes.forEach((ic, idx) => {
-    s = s.replace("\x00IC" + idx + "\x00", ic);
+    s = s.replace("\x00IC" + idx + "\x00", () => ic);
   });
 
   return s;

--- a/src/test/js/themes/bootstrap/markdown.test.js
+++ b/src/test/js/themes/bootstrap/markdown.test.js
@@ -132,3 +132,62 @@ describe("parseMarkdown: inline constructs", () => {
     expect(parseMarkdown(undefined)).toBe("");
   });
 });
+
+describe("parseMarkdown: code content is restored literally", () => {
+  // String.prototype.replace() reads $&, $`, $' and $n in a *string* replacement
+  // as substitution patterns. escapeHtml() rewrites ' to &#39;, so an apostrophe
+  // after a '$' reaches the restore step as "$&#39;", where $& expands to the
+  // matched text -- the internal placeholder itself. Passing a replacer function
+  // instead is what keeps these verbatim, so each case below is a live check of
+  // that, not of the escaping.
+  it.each([
+    ["a$&b", "a$&amp;b"],
+    ["a$'b", "a$&#39;b"],
+    ["a$`b", "a$`b"],
+    ["a$1b", "a$1b"],
+  ])("keeps %s verbatim inside a fenced block", (code, expected) => {
+    expect(parseMarkdown("```\n" + code + "\n```")).toBe("<pre><code>" + expected + "</code></pre>");
+  });
+
+  // No backtick row here: a single-backtick span closes at the first inner
+  // backtick, so "$`" is not expressible inline.
+  it.each([
+    ["a$&b", "a$&amp;b"],
+    ["a$'b", "a$&#39;b"],
+    ["a$1b", "a$1b"],
+  ])("keeps %s verbatim inside an inline code span", (code, expected) => {
+    expect(parseMarkdown("x `" + code + "` y")).toBe("<p>x <code>" + expected + "</code> y</p>");
+  });
+});
+
+describe("parseMarkdown: a fence never carries its neighbours out unescaped", () => {
+  // splitBlocks() splits on blank lines, so without the placeholder-boundary
+  // split a fence not followed by a blank line shares a block with the text
+  // after it, and processBlock() returned that whole block early -- reaching the
+  // output without ever passing through escapeHtml().
+  it("escapes text following a fence with no blank line between them", () => {
+    expect(parseMarkdown("```\nc\n```\n<script>alert(1)</script>")).toBe(
+      "<pre><code>c</code></pre>\n<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>"
+    );
+  });
+
+  it("escapes text preceding a fence with no blank line between them", () => {
+    expect(parseMarkdown("<b>lead</b>\n```\nc\n```")).toBe(
+      "<p>&lt;b&gt;lead&lt;/b&gt;</p>\n<pre><code>c</code></pre>"
+    );
+  });
+
+  it("renders two fences with no blank line between them as sibling blocks", () => {
+    expect(parseMarkdown("```\na\n```\n```\nb\n```")).toBe(
+      "<pre><code>a</code></pre>\n<pre><code>b</code></pre>"
+    );
+  });
+
+  it("strips NUL so input cannot forge a code-block placeholder", () => {
+    // Placeholders are the only strings that bypass escaping; a forged one used
+    // to reproduce the raw passthrough with no fence present at all.
+    expect(parseMarkdown("\u0000CODEBLOCK0\u0000<script>alert(1)</script>")).toBe(
+      "<p>CODEBLOCK0&lt;script&gt;alert(1)&lt;/script&gt;</p>"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two defects in the static theme's Markdown renderer (`themes/bootstrap/assets/markdown.js`), plus regression tests that fail without the fixes.

`chat.js` calls `parseMarkdown()` on every RAG stream chunk, so this is the module's highest-traffic path and its input is LLM-derived.

## 1. Code content was not restored literally

Both placeholder-restore sites passed the replacement to `String.prototype.replace()` as a **string**, so `$&`, `` $` ``, `$'` and `$1` in code content were read as substitution patterns instead of being inserted literally. `escapeHtml()` rewrites `'` to `&#39;`, so an apostrophe after a `$` reaches this point as `"$&#39;"` — and `$&` expands to the matched text, which is the internal placeholder:

A fenced block whose body is `x$'y` and one whose body is ``x$`y``:

| body | before | after |
|---|---|---|
| `x$'y` | `<pre><code>x␀CODEBLOCK0␀#39;y</code></pre>` | `<pre><code>x$&#39;y</code></pre>` |
| ``x$`y`` | `<pre><code>xy</code></pre>` | ``<pre><code>x$`y</code></pre>`` |

The first leaks the internal sentinel into visible output; the second silently eats the surrounding content. Inline `` `code` `` spans had the same defect via their own placeholder.

Fixed by passing a replacer **function**: a function's return value is never scanned for `$` patterns. Same bug class as the `Matcher.quoteReplacement()` fix in c5fb358.

## 2. Text sharing a block with a fence bypassed escaping

`processBlock()` detected the fenced-code placeholder with `startsWith()`, a prefix test. `splitBlocks()` splits on blank lines, so a fence *not* followed by a blank line left the placeholder and the text after it in a single block — and that whole block was returned early, reaching the output without ever passing through `escapeHtml()`:

````
in : ```\nc\n```\n<script>alert(1)</script>
out: <pre><code>c</code></pre>\n<script>alert(1)</script>
````

Adding a blank line after the fence escaped the same input correctly.

**This was not exploitable**: the downstream `sanitizeHtml()` tag/attribute allowlist drops the markup that lands in the output. But it made the sanitizer the *only* defense rather than the second layer the module header describes, so the header comment was false as written and is corrected here.

`splitBlocks()` now splits at placeholder boundaries as well, so a placeholder always stands alone in its own block, and `processBlock()` matches the whole block instead of a prefix. Splitting — rather than only tightening the test — keeps adjacent fences with no blank line between them rendering as sibling `<pre>` elements; text around a fence is now escaped and inline-processed like any other paragraph, and a fence followed by a blank line is unaffected.

Step 1 also strips NUL from the input. Placeholders are the only strings that bypass escaping, so input must not be able to forge one: a hand-written NUL-delimited `CODEBLOCK0` placeholder followed by markup, with no fence present at all, reproduced the same raw passthrough on its own.

## Tests

`src/test/js/themes/bootstrap/markdown.test.js` gains 12 cases. 8 of them fail against the pre-fix renderer:

```
Tests  8 failed | 30 passed (38)
```

and the full suite passes with the fixes:

```
Test Files  17 passed (17)
     Tests  448 passed (448)
```

Assertions are on the full output string rather than substring containment, so a partial restore cannot pass. The remaining 4 cases guard behaviour the fix must not regress (`$1` with no capture group; adjacent fences still rendering as siblings).

## Notes

- The two fix commits predate #3194/#3195 and were rebased onto current master; the only conflict was the module header comment, resolved to keep master's "static theme SPA" wording with the corrected accuracy claim.
- The same two defects exist in the 10 derived copies of `markdown.js` in `codelibs/fess-themes`; a companion PR covers those.
