### PR TITLE
refactor(sso): remove duplication across the SSO authenticators

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/SsoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/SsoAuthenticator.java
@@ -28,6 +28,15 @@ import org.lastaflute.web.response.ActionResponse;
  * OAuth, SPNEGO, or other authentication mechanisms. Each authenticator is responsible
  * for obtaining login credentials, resolving user information, and managing SSO
  * lifecycle operations like logout and metadata exchange.
+ *
+ * An implementation has to satisfy two separate conventions to be reachable:
+ * <ul>
+ * <li>It must be registered in DI under the name {@code <sso.type> + "Authenticator"}, because
+ * {@link SsoManager#getAuthenticator()} resolves the active provider by that name.</li>
+ * <li>It must call {@link SsoManager#register(SsoAuthenticator)} from its initialization method, or
+ * {@code FessLoginAssist} will never invoke its {@link #resolveCredential(LoginCredentialResolver)}
+ * and a logged-in user will not be resolved.</li>
+ * </ul>
  */
 public interface SsoAuthenticator {
 
@@ -45,16 +54,29 @@ public interface SsoAuthenticator {
 
     /**
      * Gets the action response for the specified SSO response type.
+     *
+     * Only a protocol with its own metadata or single-logout endpoint implements this; the default
+     * reports that this provider does not participate in the operation, which {@code SsoAction}
+     * answers with a 400.
+     *
      * @param responseType The type of SSO response required.
-     * @return The action response.
+     * @return The action response, or null if this provider has no response for the type.
      */
-    ActionResponse getResponse(SsoResponseType responseType);
+    default ActionResponse getResponse(final SsoResponseType responseType) {
+        return null;
+    }
 
     /**
      * Performs logout for the specified user.
+     *
+     * The default reports that this provider has no single-logout endpoint, leaving the caller to
+     * end the local session only.
+     *
      * @param user The user to logout.
-     * @return The logout URL or null if not applicable.
+     * @return The logout URL, or null if not applicable.
      */
-    String logout(FessUserBean user);
+    default String logout(final FessUserBean user) {
+        return null;
+    }
 
 }

--- a/src/main/java/org/codelibs/fess/sso/SsoManager.java
+++ b/src/main/java/org/codelibs/fess/sso/SsoManager.java
@@ -17,6 +17,7 @@ package org.codelibs.fess.sso;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,13 +69,7 @@ public class SsoManager {
      *         or no credential could be obtained
      */
     public LoginCredential getLoginCredential() {
-        if (available()) {
-            final SsoAuthenticator authenticator = getAuthenticator();
-            if (authenticator != null) {
-                return authenticator.getLoginCredential();
-            }
-        }
-        return null;
+        return withAuthenticator(SsoAuthenticator::getLoginCredential);
     }
 
     /**
@@ -84,13 +79,7 @@ public class SsoManager {
      * @return The action response from the SSO authenticator, or null if SSO is not available
      */
     public ActionResponse getResponse(final SsoResponseType responseType) {
-        if (available()) {
-            final SsoAuthenticator authenticator = getAuthenticator();
-            if (authenticator != null) {
-                return authenticator.getResponse(responseType);
-            }
-        }
-        return null;
+        return withAuthenticator(authenticator -> authenticator.getResponse(responseType));
     }
 
     /**
@@ -100,13 +89,23 @@ public class SsoManager {
      * @return The logout URL from the SSO authenticator, or null if SSO is not available
      */
     public String logout(final FessUserBean user) {
-        if (available()) {
-            final SsoAuthenticator authenticator = getAuthenticator();
-            if (authenticator != null) {
-                return authenticator.logout(user);
-            }
+        return withAuthenticator(authenticator -> authenticator.logout(user));
+    }
+
+    /**
+     * Applies the given operation to the configured SSO authenticator.
+     *
+     * @param <T> The result type of the operation.
+     * @param operation The operation to apply.
+     * @return The result of the operation, or null if SSO is unavailable or no authenticator is
+     *         registered for the configured type.
+     */
+    protected <T> T withAuthenticator(final Function<SsoAuthenticator, T> operation) {
+        if (!available()) {
+            return null;
         }
-        return null;
+        final SsoAuthenticator authenticator = getAuthenticator();
+        return authenticator != null ? operation.apply(authenticator) : null;
     }
 
     /**
@@ -142,7 +141,7 @@ public class SsoManager {
      * @return Array of all registered SSO authenticators
      */
     public SsoAuthenticator[] getAuthenticators() {
-        return authenticatorList.toArray(new SsoAuthenticator[authenticatorList.size()]);
+        return authenticatorList.toArray(new SsoAuthenticator[0]);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -37,12 +37,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.Pair;
-import org.codelibs.core.stream.StreamUtil;
 import org.codelibs.core.timer.TimeoutManager;
 import org.codelibs.curl.Curl;
 import org.codelibs.curl.CurlException;
@@ -59,14 +57,12 @@ import org.codelibs.fess.exception.SsoStateException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.sso.SsoAuthenticator;
-import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.util.DocumentUtil;
 import org.codelibs.opensearch.runner.net.OpenSearchCurl;
 import org.dbflute.optional.OptionalEntity;
 import org.dbflute.optional.OptionalThing;
 import org.lastaflute.web.login.credential.LoginCredential;
-import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.response.HtmlResponse;
 import org.lastaflute.web.util.LaRequestUtil;
 
@@ -217,6 +213,12 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      */
     protected static final long MAX_GRAPH_THROTTLE_SECONDS = 60L * 60L;
 
+    /** The Microsoft Graph scope that asks for the permissions granted to the app registration. */
+    protected static final String GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.com/.default";
+
+    /** Base URL of the Microsoft Graph v1.0 endpoint. */
+    protected static final String GRAPH_V1_URL = "https://graph.microsoft.com/v1.0";
+
     /**
      * Scopes requested at the v2.0 authorization endpoint. msal4j already prepends
      * {@code openid profile offline_access} to the token request (its
@@ -224,7 +226,10 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * asked for the same set the token exchange goes on to request, rather than relying on the
      * app registration's static permissions happening to include them.
      */
-    protected static final String V2_SCOPES = "openid profile offline_access https://graph.microsoft.com/.default";
+    protected static final String V2_SCOPES = "openid profile offline_access " + GRAPH_DEFAULT_SCOPE;
+
+    /** {@link #V2_SCOPES} percent-encoded once, since it never varies. */
+    protected static final String V2_SCOPES_ENCODED = URLEncoder.encode(V2_SCOPES, Constants.UTF_8_CHARSET);
 
     /**
      * Response parameters whose values are credentials. Their values are truncated before being
@@ -463,10 +468,9 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         storeStateInSession(request.getSession(), state, nonce);
 
         final String responseMode = getResponseMode();
-        final String authUrl = getAuthority() + getTenant() + "/oauth2/v2.0/authorize?response_type=code&scope="
-                + URLEncoder.encode(V2_SCOPES, Constants.UTF_8_CHARSET) + "&response_mode=" + responseMode + "&redirect_uri="
-                + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id=" + getClientId() + "&state=" + state
-                + "&nonce=" + nonce;
+        final String authUrl = getAuthorityUrl() + "oauth2/v2.0/authorize?response_type=code&scope=" + V2_SCOPES_ENCODED + "&response_mode="
+                + responseMode + "&redirect_uri=" + URLEncoder.encode(getReplyUrl(request), Constants.UTF_8_CHARSET) + "&client_id="
+                + getClientId() + "&state=" + state + "&nonce=" + nonce;
         if (logger.isDebugEnabled()) {
             logger.debug("redirect to: {}", authUrl);
         }
@@ -650,7 +654,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             if (logger.isDebugEnabled()) {
                 logger.debug("nonce={}", nonce);
             }
-            if (StringUtils.isEmpty(nonce) || !nonce.equals(stateData.getNonce())) {
+            if (StringUtil.isEmpty(nonce) || !nonce.equals(stateData.getNonce())) {
                 throw new SsoStateException("could not validate nonce");
             }
         } catch (final SsoLoginException e) {
@@ -695,7 +699,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             }
             final String clientId = getClientId();
             final String clientSecret = getClientSecret();
-            final String authority = getAuthority() + getTenant() + "/";
+            final String authority = getAuthorityUrl();
             if (logger.isDebugEnabled()) {
                 logger.debug("Building a client application for authority={}", authority);
             }
@@ -719,7 +723,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The key.
      */
     protected String buildClientApplicationKey() {
-        return buildClientApplicationKey(getClientId(), getClientSecret(), getAuthority() + getTenant() + "/");
+        return buildClientApplicationKey(getClientId(), getClientSecret(), getAuthorityUrl());
     }
 
     /**
@@ -780,7 +784,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The authentication result containing the access token.
      */
     public IAuthenticationResult getAccessToken(final String refreshToken) {
-        final String authority = getAuthority() + getTenant() + "/";
+        final String authority = getAuthorityUrl();
         if (logger.isDebugEnabled()) {
             logger.debug("refreshToken={}, authority={}", maskSecret(refreshToken), authority);
         }
@@ -788,7 +792,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             final ConfidentialClientApplication app = getClientApplication();
 
             final RefreshTokenParameters parameters =
-                    RefreshTokenParameters.builder(Collections.singleton("https://graph.microsoft.com/.default"), refreshToken).build();
+                    RefreshTokenParameters.builder(Collections.singleton(GRAPH_DEFAULT_SCOPE), refreshToken).build();
 
             final IAuthenticationResult result = app.acquireToken(parameters).get(acquisitionTimeout, TimeUnit.MILLISECONDS);
             if (result == null) {
@@ -807,7 +811,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The authentication result containing the access token.
      */
     protected IAuthenticationResult getAccessToken(final AuthorizationCode authorizationCode, final String currentUri) {
-        final String authority = getAuthority() + getTenant() + "/";
+        final String authority = getAuthorityUrl();
         final String authCode = authorizationCode.getValue();
         if (logger.isDebugEnabled()) {
             logger.debug("authCode={}, authority={}, uri={}", maskSecret(authCode), authority, currentUri);
@@ -816,7 +820,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             final ConfidentialClientApplication app = getClientApplication();
 
             final AuthorizationCodeParameters parameters = AuthorizationCodeParameters.builder(authCode, new URI(currentUri))
-                    .scopes(Collections.singleton("https://graph.microsoft.com/.default"))
+                    .scopes(Collections.singleton(GRAPH_DEFAULT_SCOPE))
                     .build();
 
             final IAuthenticationResult result = app.acquireToken(parameters).get(acquisitionTimeout, TimeUnit.MILLISECONDS);
@@ -838,9 +842,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         try {
             final ConfidentialClientApplication app = getClientApplication();
 
-            final SilentParameters parameters = SilentParameters
-                    .builder(Collections.singleton("https://graph.microsoft.com/.default"), user.getAuthenticationResult().account())
-                    .build();
+            final SilentParameters parameters =
+                    SilentParameters.builder(Collections.singleton(GRAPH_DEFAULT_SCOPE), user.getAuthenticationResult().account()).build();
 
             final IAuthenticationResult result = app.acquireTokenSilently(parameters).get(acquisitionTimeout, TimeUnit.MILLISECONDS);
             if (logger.isDebugEnabled()) {
@@ -872,7 +875,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The validated state data.
      */
     protected StateData validateState(final HttpSession session, final String state) {
-        if (StringUtils.isNotEmpty(state)) {
+        if (StringUtil.isNotEmpty(state)) {
             final StateData stateDataInSession = removeStateFromSession(session, state);
             if (stateDataInSession != null) {
                 return stateDataInSession;
@@ -989,8 +992,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         }
 
         // Retrieve direct group/role memberships; group IDs are collected for the parent walk below.
-        final boolean resolved =
-                processDirectMemberOf(user, groupList, roleList, groupIdsForParentLookup, "https://graph.microsoft.com/v1.0/me/memberOf");
+        final boolean resolved = processDirectMemberOf(user, groupList, roleList, groupIdsForParentLookup, GRAPH_V1_URL + "/me/memberOf");
 
         if (logger.isDebugEnabled()) {
             logger.debug("[updateMemberOf] Direct groups retrieved. Total groups: {}, Total roles: {}, Group IDs for parent lookup: {}",
@@ -1025,8 +1027,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             }
         }
 
-        user.setGroups(groupList.stream().distinct().toArray(n -> new String[n]));
-        user.setRoles(roleList.stream().distinct().toArray(n -> new String[n]));
+        user.setGroups(groupList.stream().distinct().toArray(String[]::new));
+        user.setRoles(roleList.stream().distinct().toArray(String[]::new));
         user.resetPermissions();
 
         // No firstResolution guard: the only case that must not touch the state -- a re-resolution
@@ -1070,8 +1072,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @param user The Entra ID user to seed.
      */
     public void applyDefaultMemberships(final EntraIdUser user) {
-        user.setGroups(getDefaultGroupList().stream().distinct().toArray(n -> new String[n]));
-        user.setRoles(getDefaultRoleList().stream().distinct().toArray(n -> new String[n]));
+        user.setGroups(getDefaultGroupList().stream().distinct().toArray(String[]::new));
+        user.setRoles(getDefaultRoleList().stream().distinct().toArray(String[]::new));
     }
 
     /**
@@ -1126,6 +1128,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 @SuppressWarnings("unchecked")
                 final List<Map<String, Object>> memberOfList = (List<Map<String, Object>>) contentMap.get("value");
                 final FessConfig fessConfig = ComponentUtil.getFessConfig();
+                final String[] names = fessConfig.getEntraIdPermissionFields();
+                final boolean useDomainServices = fessConfig.isEntraIdUseDomainServices();
                 for (final Map<String, Object> memberOf : memberOfList) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("member={}", memberOf);
@@ -1160,21 +1164,13 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                     } else {
                         logger.warn("id is empty: {}", memberOf);
                     }
-                    final String[] names = fessConfig.getEntraIdPermissionFields();
-                    final boolean useDomainServices = fessConfig.isEntraIdUseDomainServices();
                     for (final String name : names) {
                         final String value = (String) memberOf.get(name);
                         if (StringUtil.isNotBlank(value)) {
                             if (logger.isDebugEnabled()) {
                                 logger.debug("{} is a member of {}", name, value);
                             }
-                            if (memberType.contains("group")) {
-                                addGroupOrRoleName(groupList, value, useDomainServices);
-                            } else if (memberType.contains("role")) {
-                                addGroupOrRoleName(roleList, value, useDomainServices);
-                            } else {
-                                addGroupOrRoleName(groupList, value, useDomainServices);
-                            }
+                            addGroupOrRoleName(memberType.contains("role") ? roleList : groupList, value, useDomainServices);
                         } else if (logger.isDebugEnabled()) {
                             logger.debug("{} is empty: {}", name, memberOf);
                         }
@@ -1277,8 +1273,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
         }
         final AtomicBoolean failed = new AtomicBoolean();
         final Pair<String[], String[]> groupsAndRoles = getParentGroup(user, id, depth, failed);
-        StreamUtil.stream(groupsAndRoles.getFirst()).of(stream -> stream.forEach(groupList::add));
-        StreamUtil.stream(groupsAndRoles.getSecond()).of(stream -> stream.forEach(roleList::add));
+        Collections.addAll(groupList, groupsAndRoles.getFirst());
+        Collections.addAll(roleList, groupsAndRoles.getSecond());
         if (logger.isDebugEnabled()) {
             logger.debug("[processParentGroup] Completed for id: {}, depth: {}, added groups: {}, added roles: {}, failed: {}", id, depth,
                     groupsAndRoles.getFirst().length, groupsAndRoles.getSecond().length, failed.get());
@@ -1472,12 +1468,12 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                     logger.debug("[getParentGroup] Recursively getting parent groups for: {}", value);
                 }
                 final Pair<String[], String[]> groupsAndRoles = getParentGroup(user, value, depth + 1, failed);
-                StreamUtil.stream(groupsAndRoles.getFirst()).of(stream1 -> stream1.forEach(groupList::add));
-                StreamUtil.stream(groupsAndRoles.getSecond()).of(stream2 -> stream2.forEach(roleList::add));
+                Collections.addAll(groupList, groupsAndRoles.getFirst());
+                Collections.addAll(roleList, groupsAndRoles.getSecond());
             }
         }
-        final Pair<String[], String[]> result = new Pair<>(groupList.stream().distinct().toArray(n1 -> new String[n1]),
-                roleList.stream().distinct().toArray(n2 -> new String[n2]));
+        final Pair<String[], String[]> result =
+                new Pair<>(groupList.stream().distinct().toArray(String[]::new), roleList.stream().distinct().toArray(String[]::new));
         if (logger.isDebugEnabled()) {
             logger.debug("[getParentGroup] Result for id {}: {} groups, {} roles", id, result.getFirst().length, result.getSecond().length);
         }
@@ -1503,7 +1499,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @throws IOException If Microsoft Graph could not be reached or returned an error.
      */
     protected String[] getMemberGroupIds(final EntraIdUser user, final String id) throws IOException {
-        return getMemberGroupIds(user, id, "https://graph.microsoft.com/v1.0/groups/" + id + "/getMemberGroups");
+        return getMemberGroupIds(user, id, GRAPH_V1_URL + "/groups/" + id + "/getMemberGroups");
     }
 
     /**
@@ -1580,7 +1576,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      *         {@link #processGroup(EntraIdUser, List, List, String, String)}.
      */
     protected boolean processGroup(final EntraIdUser user, final List<String> groupList, final List<String> roleList, final String id) {
-        return processGroup(user, groupList, roleList, id, "https://graph.microsoft.com/v1.0/groups/" + id);
+        return processGroup(user, groupList, roleList, id, GRAPH_V1_URL + "/groups/" + id);
     }
 
     /**
@@ -1648,19 +1644,51 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Reads an Entra ID setting, preferring the {@code entraid.*} key and falling back to the
+     * legacy {@code aad.*} key.
+     *
+     * <p>{@code getSystemProperty} only substitutes the default when a key is absent, so a key that
+     * is present but empty would otherwise arrive at the caller as {@code ""}. Both keys are
+     * therefore tested with {@link StringUtil#isBlank(String)} and the default is returned when
+     * neither holds a value.
+     *
+     * @param key The {@code entraid.*} configuration key.
+     * @param legacyKey The legacy {@code aad.*} configuration key.
+     * @param defaultValue The value to use when neither key holds a value.
+     * @return The configured value, or defaultValue.
+     */
+    protected String getEntraIdProperty(final String key, final String legacyKey, final String defaultValue) {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        final String value = fessConfig.getSystemProperty(key);
+        if (StringUtil.isNotBlank(value)) {
+            return value;
+        }
+        final String legacyValue = fessConfig.getSystemProperty(legacyKey);
+        return StringUtil.isBlank(legacyValue) ? defaultValue : legacyValue;
+    }
+
+    /**
+     * Reads a comma-separated Entra ID setting as a list of trimmed, non-blank values.
+     *
+     * @param key The {@code entraid.*} configuration key.
+     * @param legacyKey The legacy {@code aad.*} configuration key.
+     * @return The configured values, or an empty list when neither key holds a value.
+     */
+    protected List<String> getDefaultList(final String key, final String legacyKey) {
+        final String value = getEntraIdProperty(key, legacyKey, StringUtil.EMPTY);
+        if (StringUtil.isBlank(value)) {
+            return Collections.emptyList();
+        }
+        return split(value, ",").get(stream -> stream.filter(StringUtil::isNotBlank).map(String::trim).collect(Collectors.toList()));
+    }
+
+    /**
      * Gets the default group list for users.
      * Uses new entraid.default.groups key with fallback to legacy aad.default.groups.
      * @return The default group list.
      */
     protected List<String> getDefaultGroupList() {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_DEFAULT_GROUPS);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_DEFAULT_GROUPS);
-        }
-        if (StringUtil.isBlank(value)) {
-            return Collections.emptyList();
-        }
-        return split(value, ",").get(stream -> stream.filter(StringUtil::isNotBlank).map(String::trim).collect(Collectors.toList()));
+        return getDefaultList(ENTRAID_DEFAULT_GROUPS, AAD_DEFAULT_GROUPS);
     }
 
     /**
@@ -1669,14 +1697,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The default role list.
      */
     protected List<String> getDefaultRoleList() {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_DEFAULT_ROLES);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_DEFAULT_ROLES);
-        }
-        if (StringUtil.isBlank(value)) {
-            return Collections.emptyList();
-        }
-        return split(value, ",").get(stream -> stream.filter(StringUtil::isNotBlank).map(String::trim).collect(Collectors.toList()));
+        return getDefaultList(ENTRAID_DEFAULT_ROLES, AAD_DEFAULT_ROLES);
     }
 
     /**
@@ -1724,11 +1745,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The client ID.
      */
     protected String getClientId() {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_CLIENT_ID);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_CLIENT_ID, StringUtil.EMPTY);
-        }
-        return value;
+        return getEntraIdProperty(ENTRAID_CLIENT_ID, AAD_CLIENT_ID, StringUtil.EMPTY);
     }
 
     /**
@@ -1737,11 +1754,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The client secret.
      */
     protected String getClientSecret() {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_CLIENT_SECRET);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_CLIENT_SECRET, StringUtil.EMPTY);
-        }
-        return value;
+        return getEntraIdProperty(ENTRAID_CLIENT_SECRET, AAD_CLIENT_SECRET, StringUtil.EMPTY);
     }
 
     /**
@@ -1750,11 +1763,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The tenant ID.
      */
     protected String getTenant() {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_TENANT);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_TENANT, StringUtil.EMPTY);
-        }
-        return value;
+        return getEntraIdProperty(ENTRAID_TENANT, AAD_TENANT, StringUtil.EMPTY);
     }
 
     /**
@@ -1763,17 +1772,16 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The authority URL.
      */
     protected String getAuthority() {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_AUTHORITY);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_AUTHORITY, DEFAULT_AUTHORITY);
-        }
-        if (StringUtil.isBlank(value)) {
-            // getSystemProperty only falls back to the default when the key is absent, so a legacy
-            // aad.authority that is present but empty arrives here as "". Left alone, getAuthUrl
-            // would build a scheme-less URL and redirect the browser back inside Fess.
-            return DEFAULT_AUTHORITY;
-        }
-        return value;
+        return getEntraIdProperty(ENTRAID_AUTHORITY, AAD_AUTHORITY, DEFAULT_AUTHORITY);
+    }
+
+    /**
+     * Builds the tenant's authority URL, the prefix every Entra ID endpoint is hung off.
+     *
+     * @return The authority URL, with a trailing slash.
+     */
+    protected String getAuthorityUrl() {
+        return getAuthority() + getTenant() + "/";
     }
 
     /**
@@ -1783,10 +1791,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      *         that has already been divided by 1000.
      */
     protected long getStateTtl() {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_STATE_TTL);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_STATE_TTL, DEFAULT_STATE_TTL);
-        }
+        final String value = getEntraIdProperty(ENTRAID_STATE_TTL, AAD_STATE_TTL, DEFAULT_STATE_TTL);
         try {
             return Long.parseLong(value.trim());
         } catch (final NumberFormatException e) {
@@ -1802,14 +1807,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return The reply URL.
      */
     protected String getReplyUrl(final HttpServletRequest request) {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_REPLY_URL);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_REPLY_URL, StringUtil.EMPTY);
-        }
-        if (StringUtil.isNotBlank(value)) {
-            return value;
-        }
-        return request.getRequestURL().toString();
+        final String value = getEntraIdProperty(ENTRAID_REPLY_URL, AAD_REPLY_URL, StringUtil.EMPTY);
+        return StringUtil.isNotBlank(value) ? value : request.getRequestURL().toString();
     }
 
     /**
@@ -1825,14 +1824,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      * @return Either {@code query} or {@code form_post}.
      */
     protected String getResponseMode() {
-        String value = ComponentUtil.getFessConfig().getSystemProperty(ENTRAID_RESPONSE_MODE);
-        if (StringUtil.isBlank(value)) {
-            value = ComponentUtil.getFessConfig().getSystemProperty(AAD_RESPONSE_MODE, RESPONSE_MODE_QUERY);
-        }
-        if (StringUtil.isBlank(value)) {
-            return RESPONSE_MODE_QUERY;
-        }
-        value = value.trim();
+        final String value = getEntraIdProperty(ENTRAID_RESPONSE_MODE, AAD_RESPONSE_MODE, RESPONSE_MODE_QUERY).trim();
         if (RESPONSE_MODE_QUERY.equals(value) || RESPONSE_MODE_FORM_POST.equals(value)) {
             return value;
         }
@@ -1875,11 +1867,6 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      */
     public void setMaxGroupDepth(final int maxGroupDepth) {
         this.maxGroupDepth = maxGroupDepth;
-    }
-
-    @Override
-    public ActionResponse getResponse(final SsoResponseType responseType) {
-        return null;
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
@@ -31,13 +31,10 @@ import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist.LoginCredentialResolver;
 import org.codelibs.fess.app.web.base.login.OpenIdConnectCredential;
 import org.codelibs.fess.crawler.Constants;
-import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.sso.SsoAuthenticator;
-import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalEntity;
 import org.lastaflute.web.login.credential.LoginCredential;
-import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.response.HtmlResponse;
 import org.lastaflute.web.util.LaRequestUtil;
 
@@ -246,23 +243,7 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
      */
     protected void parseJwtClaim(final String jwtClaim, final Map<String, Object> attributes) throws IOException {
         try (final JsonParser jsonParser = jsonFactory.createJsonParser(jwtClaim)) {
-            while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
-                final String name = jsonParser.getCurrentName();
-                if (name != null) {
-                    jsonParser.nextToken();
-
-                    if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
-                        // Handle array type
-                        attributes.put(name, parseArray(jsonParser));
-                    } else if (jsonParser.getCurrentToken() == JsonToken.START_OBJECT) {
-                        // Handle nested object type
-                        attributes.put(name, parseObject(jsonParser));
-                    } else {
-                        // Handle primitive types (string, number, boolean, etc.)
-                        attributes.put(name, parsePrimitive(jsonParser));
-                    }
-                }
-            }
+            attributes.putAll(parseObject(jsonParser));
         }
     }
 
@@ -374,7 +355,8 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
      * @return the redirect URL
      */
     protected String getOicRedirectUrl() {
-        return ComponentUtil.getSystemProperties().getProperty(OIC_REDIRECT_URL, buildDefaultRedirectUrl());
+        final String redirectUrl = ComponentUtil.getSystemProperties().getProperty(OIC_REDIRECT_URL);
+        return redirectUrl != null ? redirectUrl : buildDefaultRedirectUrl();
     }
 
     /**
@@ -428,13 +410,4 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
         resolver.resolve(OpenIdConnectCredential.class, credential -> OptionalEntity.of(credential.getUser()));
     }
 
-    @Override
-    public ActionResponse getResponse(final SsoResponseType responseType) {
-        return null;
-    }
-
-    @Override
-    public String logout(final FessUserBean user) {
-        return null;
-    }
 }

--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -453,7 +453,7 @@ public class SamlAuthenticator implements SsoAuthenticator {
         }
         if (!warnings.equals(loggedSecurityWarnings.getAndSet(warnings)) && !warnings.isEmpty()) {
             logger.warn("Insecure SAML settings: {}. See the SAML SSO documentation for the recommended values.",
-                    warnings.stream().collect(Collectors.joining(", ")));
+                    String.join(", ", warnings));
         }
     }
 
@@ -616,7 +616,7 @@ public class SamlAuthenticator implements SsoAuthenticator {
             logUnmatchedSamlResponse(requestIdMap.size());
             return null;
         }
-        final String errors = lastAuth.getErrors().stream().collect(Collectors.joining(", "));
+        final String errors = String.join(", ", lastAuth.getErrors());
         if (lastAuth.isDebugActive() && StringUtil.isNotBlank(lastAuth.getLastErrorReason())) {
             logger.warn("Authentication Failure: {} - Reason: {}", errors, lastAuth.getLastErrorReason());
         } else {
@@ -936,21 +936,22 @@ public class SamlAuthenticator implements SsoAuthenticator {
      *         against an elapsed time that has already been divided by 1000.
      */
     protected long getRequestIdTtl() {
+        final long defaultTtl = Long.parseLong(DEFAULT_REQUEST_ID_TTL);
         final String value = ComponentUtil.getFessConfig().getSystemProperty(SAML_REQUEST_ID_TTL);
         if (StringUtil.isBlank(value)) {
-            return Long.parseLong(DEFAULT_REQUEST_ID_TTL);
+            return defaultTtl;
         }
         final long requestIdTtl;
         try {
             requestIdTtl = Long.parseLong(value.trim());
         } catch (final NumberFormatException e) {
             logger.warn("Invalid {}: {}. Using {} seconds.", SAML_REQUEST_ID_TTL, value, DEFAULT_REQUEST_ID_TTL);
-            return Long.parseLong(DEFAULT_REQUEST_ID_TTL);
+            return defaultTtl;
         }
         if (requestIdTtl <= 0) {
             logger.warn("{} must be a positive number of seconds: {}. Using {} seconds.", SAML_REQUEST_ID_TTL, value,
                     DEFAULT_REQUEST_ID_TTL);
-            return Long.parseLong(DEFAULT_REQUEST_ID_TTL);
+            return defaultTtl;
         }
         return requestIdTtl;
     }
@@ -996,13 +997,12 @@ public class SamlAuthenticator implements SsoAuthenticator {
 
     @Override
     public String logout(final FessUserBean user) {
-        if (user.getFessUser() instanceof SamlUser) {
+        if (user.getFessUser() instanceof final SamlUser samlUser) {
             return LaRequestUtil.getOptionalRequest().map(request -> {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Logging out with SAML Authenticator");
                 }
                 final HttpServletResponse response = LaResponseUtil.getResponse();
-                final SamlUser samlUser = (SamlUser) user.getFessUser();
                 try {
                     final Saml2Settings settings = getSettings();
                     if (settings.getIdpSingleLogoutServiceUrl() == null) {
@@ -1034,6 +1034,31 @@ public class SamlAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Builds the exception used to report a failed SSO request to the user.
+     *
+     * @param action The action being performed, used as the log message.
+     * @param msg The reason, shown to the user.
+     * @param cause The underlying cause. An {@code SsoStateException} marks the failure as caused
+     *        by the client, which {@code SsoAction} logs without a stack trace.
+     * @return The exception to throw.
+     */
+    protected SsoMessageException processFailure(final String action, final String msg, final Exception cause) {
+        return new SsoMessageException(messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
+                action, cause);
+    }
+
+    /**
+     * Builds the exception used to report a failed SSO request that has no underlying exception.
+     *
+     * @param action The action being performed, used as the log message.
+     * @param msg The reason, shown to the user.
+     * @return The exception to throw.
+     */
+    protected SsoMessageException processFailure(final String action, final String msg) {
+        return processFailure(action, msg, new SsoProcessException(msg));
+    }
+
+    /**
      * Gets the metadata response.
      *
      * <p>The SP metadata is what the IdP is registered from, so it has to be obtainable before
@@ -1055,18 +1080,14 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 // caller
                 final List<String> settingsErrors = settings.checkSPSettings();
                 if (!settingsErrors.isEmpty()) {
-                    final String msg = settingsErrors.stream().collect(Collectors.joining(", "));
-                    throw new SsoMessageException(
-                            messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
-                            "Failed to process metadata.", new SsoProcessException(msg));
+                    final String msg = String.join(", ", settingsErrors);
+                    throw processFailure("Failed to process metadata.", msg);
                 }
                 final String metadata = settings.getSPMetadata();
                 final List<String> errors = Saml2Settings.validateMetadata(metadata);
                 if (!errors.isEmpty()) {
-                    final String msg = errors.stream().collect(Collectors.joining(", "));
-                    throw new SsoMessageException(
-                            messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
-                            "Failed to process metadata.", new SsoProcessException(msg));
+                    final String msg = String.join(", ", errors);
+                    throw processFailure("Failed to process metadata.", msg);
                 }
                 return new StreamResponse("metadata.xml").contentType("application/samlmetadata+xml").stream(out -> {
                     try (final Writer writer = new OutputStreamWriter(out.stream(), Constants.UTF_8_CHARSET)) {
@@ -1076,14 +1097,9 @@ public class SamlAuthenticator implements SsoAuthenticator {
             } catch (final SsoMessageException e) {
                 throw e;
             } catch (final Exception e) {
-                throw new SsoMessageException(
-                        messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, e.getMessage()),
-                        "Failed to process metadata.", e);
+                throw processFailure("Failed to process metadata.", e.getMessage(), e);
             }
-        })
-                .orElseThrow(() -> new SsoMessageException(
-                        messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, "Invalid state."),
-                        "Failed to process metadata.", new SsoProcessException("Invalid state.")));
+        }).orElseThrow(() -> processFailure("Failed to process metadata.", "Invalid state."));
     }
 
     /**
@@ -1120,26 +1136,20 @@ public class SamlAuthenticator implements SsoAuthenticator {
                     // deployment that leaves single logout unconfigured would answer the very
                     // same anonymous visit with a stack trace per request.
                     final String msg = "This endpoint expects a SAML logout message from the IdP.";
-                    throw new SsoMessageException(
-                            messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
-                            "Failed to log out.", new SsoStateException(msg));
+                    throw processFailure("Failed to log out.", msg, new SsoStateException(msg));
                 }
                 final Saml2Settings settings = getSettings();
                 if (settings.getIdpSingleLogoutServiceResponseUrl() == null) {
                     final String msg = "IdP single logout service URL is not configured.";
-                    throw new SsoMessageException(
-                            messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
-                            "Failed to log out.", new SsoProcessException(msg));
+                    throw processFailure("Failed to log out.", msg);
                 }
                 final Auth auth = new Auth(settings, request, response);
                 // stay=true keeps java-saml from committing the servlet response itself
                 final String redirectUrl = auth.processSLO(false, null, true);
                 final List<String> errors = auth.getErrors();
                 if (!errors.isEmpty()) {
-                    final String msg = errors.stream().collect(Collectors.joining(", "));
-                    throw new SsoMessageException(
-                            messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, msg),
-                            "Failed to log out.", new SsoProcessException(msg));
+                    final String msg = String.join(", ", errors);
+                    throw processFailure("Failed to log out.", msg);
                 }
                 if (StringUtil.isNotBlank(redirectUrl)) {
                     // an IdP-initiated LogoutRequest: send our LogoutResponse back to the IdP
@@ -1149,13 +1159,8 @@ public class SamlAuthenticator implements SsoAuthenticator {
             } catch (final SsoMessageException e) {
                 throw e;
             } catch (final Exception e) {
-                throw new SsoMessageException(
-                        messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, e.getMessage()),
-                        "Failed to log out.", e);
+                throw processFailure("Failed to log out.", e.getMessage(), e);
             }
-        })
-                .orElseThrow(() -> new SsoMessageException(
-                        messages -> messages.addErrorsFailedToProcessSsoRequest(UserMessages.GLOBAL_PROPERTY_KEY, "Invalid state."),
-                        "Failed to log out.", new SsoProcessException("Invalid state.")));
+        }).orElseThrow(() -> processFailure("Failed to log out.", "Invalid state."));
     }
 }

--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -33,18 +33,14 @@ import org.codelibs.fess.app.web.base.login.FessLoginAssist.LoginCredentialResol
 import org.codelibs.fess.app.web.base.login.SpnegoCredential;
 import org.codelibs.fess.exception.SsoLoginException;
 import org.codelibs.fess.exception.SsoStateException;
-import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.sso.SsoAuthenticator;
-import org.codelibs.fess.sso.SsoResponseType;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.spnego.SpnegoFilterConfig;
-import org.codelibs.spnego.SpnegoHttpFilter;
 import org.codelibs.spnego.SpnegoHttpFilter.Constants;
 import org.codelibs.spnego.SpnegoHttpServletResponse;
 import org.codelibs.spnego.SpnegoPrincipal;
 import org.dbflute.optional.OptionalEntity;
 import org.lastaflute.web.login.credential.LoginCredential;
-import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.servlet.filter.RequestLoggingFilter;
 import org.lastaflute.web.util.LaRequestUtil;
 import org.lastaflute.web.util.LaResponseUtil;
@@ -513,7 +509,7 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
          */
         @Override
         public String getInitParameter(final String name) {
-            if (SpnegoHttpFilter.Constants.LOGGER_LEVEL.equals(name)) {
+            if (Constants.LOGGER_LEVEL.equals(name)) {
                 final String logLevel = getProperty(SPNEGO_LOGGER_LEVEL, StringUtil.EMPTY);
                 if (StringUtil.isNotBlank(logLevel)) {
                     if (isSupportedLoggerLevel(logLevel)) {
@@ -534,48 +530,48 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 // the quietest setting it actually understands.
                 return "7";
             }
-            if (SpnegoHttpFilter.Constants.LOGIN_CONF.equals(name)) {
+            if (Constants.LOGIN_CONF.equals(name)) {
                 return getResourcePath(getProperty(SPNEGO_LOGIN_CONF, "auth_login.conf"));
             }
-            if (SpnegoHttpFilter.Constants.KRB5_CONF.equals(name)) {
+            if (Constants.KRB5_CONF.equals(name)) {
                 return getResourcePath(getProperty(SPNEGO_KRB5_CONF, "krb5.conf"));
             }
-            if (SpnegoHttpFilter.Constants.CLIENT_MODULE.equals(name)) {
+            if (Constants.CLIENT_MODULE.equals(name)) {
                 return getProperty(SPNEGO_LOGIN_CLIENT_MODULE, "spnego-client");
             }
-            if (SpnegoHttpFilter.Constants.SERVER_MODULE.equals(name)) {
+            if (Constants.SERVER_MODULE.equals(name)) {
                 return getProperty(SPNEGO_LOGIN_SERVER_MODULE, "spnego-server");
             }
-            if (SpnegoHttpFilter.Constants.PREAUTH_USERNAME.equals(name)) {
+            if (Constants.PREAUTH_USERNAME.equals(name)) {
                 // Empty by default so that keytab-based server login is used when the server login
                 // module is configured for it (the library only uses a keytab when both preauth
                 // username and password are empty).
                 return getProperty(SPNEGO_PREAUTH_USERNAME, StringUtil.EMPTY);
             }
-            if (SpnegoHttpFilter.Constants.PREAUTH_PASSWORD.equals(name)) {
+            if (Constants.PREAUTH_PASSWORD.equals(name)) {
                 return getProperty(SPNEGO_PREAUTH_PASSWORD, StringUtil.EMPTY);
             }
-            if (SpnegoHttpFilter.Constants.ALLOW_BASIC.equals(name)) {
+            if (Constants.ALLOW_BASIC.equals(name)) {
                 // SECURITY NOTE: Basic authentication is enabled by default for compatibility.
                 // For production, consider setting spnego.allow.basic to false.
                 return getProperty(SPNEGO_ALLOW_BASIC, "true");
             }
-            if (SpnegoHttpFilter.Constants.ALLOW_UNSEC_BASIC.equals(name)) {
+            if (Constants.ALLOW_UNSEC_BASIC.equals(name)) {
                 // SECURITY: unsecure basic authentication is disabled by default so that basic
                 // credentials are never offered over plain HTTP. When false, basic auth is only
                 // offered over HTTPS. Enable only if you fully understand the risk.
                 return getProperty(SPNEGO_ALLOW_UNSECURE_BASIC, "false");
             }
-            if (SpnegoHttpFilter.Constants.PROMPT_NTLM.equals(name)) {
+            if (Constants.PROMPT_NTLM.equals(name)) {
                 return getProperty(SPNEGO_PROMPT_NTLM, "true");
             }
-            if (SpnegoHttpFilter.Constants.ALLOW_LOCALHOST.equals(name)) {
+            if (Constants.ALLOW_LOCALHOST.equals(name)) {
                 // SECURITY: localhost bypass is disabled by default. When enabled, the spnego library
                 // authenticates same-host requests as the server OS user without Kerberos verification,
                 // which is unsafe behind a same-host reverse proxy. Opt in explicitly if required.
                 return getProperty(SPNEGO_ALLOW_LOCALHOST, "false");
             }
-            if (SpnegoHttpFilter.Constants.ALLOW_DELEGATION.equals(name)) {
+            if (Constants.ALLOW_DELEGATION.equals(name)) {
                 return getProperty(SPNEGO_ALLOW_DELEGATION, "false");
             }
             // NOTE: spnego.exclude.dirs is deliberately not mapped. Only SpnegoHttpFilter consumes it,
@@ -709,34 +705,6 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
             }
             return OptionalEntity.empty();
         });
-    }
-
-    /**
-     * Gets the action response for the specified SSO response type.
-     *
-     * SPNEGO authentication typically doesn't require special response handling
-     * for metadata or logout operations, so this method returns null.
-     *
-     * @param responseType The type of SSO response requested
-     * @return Always returns null for SPNEGO authentication
-     */
-    @Override
-    public ActionResponse getResponse(final SsoResponseType responseType) {
-        return null;
-    }
-
-    /**
-     * Performs logout for the specified user.
-     *
-     * SPNEGO authentication relies on the underlying Kerberos infrastructure
-     * for session management, so no specific logout URL is provided.
-     *
-     * @param user The user to logout
-     * @return Always returns null as SPNEGO doesn't provide a logout URL
-     */
-    @Override
-    public String logout(final FessUserBean user) {
-        return null;
     }
 
 }


### PR DESCRIPTION
## Summary

Quality-only cleanup of `org.codelibs.fess.sso`. No behavior change is intended — this removes duplication, drops boilerplate, and moves two concepts to the right layer. Net **-46 lines** (202 insertions, 248 deletions) across 6 files.

## Reuse and simplification

- **`EntraIdAuthenticator`** — nine getters each hand-wrote the same "read the `entraid.*` key, else the legacy `aad.*` key, else the default" sequence, and two of them bolted on an extra blank guard because `getSystemProperty` only substitutes a default for an *absent* key. All nine now go through one `getEntraIdProperty()` helper that answers the blank case once. `getDefaultGroupList()` and `getDefaultRoleList()` were byte-identical apart from two constants and now share `getDefaultList()`.
- **`SamlAuthenticator`** — the same three-line `SsoMessageException` assembly appeared nine times, differing only in the message, the action label and the cause type. Added `processFailure()` (two overloads) and delegated.
- **`SsoManager`** — the `available()` → `getAuthenticator()` → null-check preamble was copied into all three delegating methods. Added `withAuthenticator()`; the three public signatures are unchanged.
- **`OpenIdConnectAuthenticator`** — `parseJwtClaim()` re-implemented `parseObject()` statement for statement. It now delegates.

## Altitude

- `getResponse()` and `logout()` are protocol-specific concepts that only `SamlAuthenticator` actually implements; the other three carried `return null;` stubs. Both interface methods now have a `default` returning null, and the five stub overrides are gone. Adding a `default` body is **source- and binary-compatible** for out-of-tree authenticators, which simply keep overriding.
- Documented on `SsoAuthenticator` the two separate conventions an implementation must satisfy to be reachable: the DI component name (`<sso.type> + "Authenticator"`) that `SsoManager` resolves the active provider by, and the `register()` call that `FessLoginAssist` depends on in order to resolve a logged-in user. Getting either wrong fails silently in a different way, and neither was written down.

## Efficiency

- `processDirectMemberOf()` re-read `getEntraIdPermissionFields()` and `isEntraIdUseDomainServices()` once **per member** (and per `@odata.nextLink` page), although `fessConfig` was already hoisted one line above the loop. Both are now read once per page. A user in 200 groups paid that 200 times.
- `V2_SCOPES` is percent-encoded once as a constant instead of on every authorization redirect.
- `getOicRedirectUrl()` evaluated `buildDefaultRedirectUrl()` as an argument even when `oic.redirect.url` is configured and the result is discarded.

## Also

- Extracted the repeated Microsoft Graph scope (4 occurrences) and v1.0 endpoint prefix (3 occurrences) into constants, so a sovereign-cloud deployment no longer has to edit unrelated lines.
- `getAuthority() + getTenant() + "/"` was assembled at five call sites; it is now `getAuthorityUrl()`. No normalization was added, so the produced URL is unchanged.
- Replaced commons-lang3 `StringUtils` (2 sites) with the codelibs `StringUtil` used 34 times elsewhere in the same file — no file under `org.codelibs.fess.sso` depends on commons-lang3 now.
- Dropped the redundant `SpnegoHttpFilter.` qualifier at 12 sites where `Constants` is already imported directly and used unqualified elsewhere in the file.
- `String.join` instead of `stream().collect(joining())` (5 sites), `String[]::new` instead of `n -> new String[n]` (6 sites), `Collections.addAll` instead of a stream-to-`forEach` array append (4 sites), an `instanceof` pattern variable, and a three-way `if/else` whose first and last branches were identical.

## Verification

- `mvn compile` — success
- `mvn javadoc:javadoc` — success (the one remaining warning is pre-existing and in an unrelated file)
- `mvn formatter:format` + `mvn license:format` — applied
- **313 unit tests pass**: the six SSO test classes plus the caller-side `FessLoginAssistTest`, `SsoActionTest` and `LogoutHandlerTest`

## Deliberately not done

Three findings were left for maintainer triage rather than applied here:

- **The per-session pending-callback machinery is duplicated between SAML and Entra ID** (~64 lines: the expiry prune, the surplus prune, and a byte-identical `hasExpiredSession`). A shared helper would have to be a **new public class**, because the two authenticators live in sibling subpackages — that is public API surface, so it seemed better raised than decided here.
- **Two config channels.** Eight sites in the OIDC and SPNEGO authenticators read through `ComponentUtil.getSystemProperties().getProperty(...)` while the rest of the package uses `getFessConfig().getSystemProperty(...)`. Unifying them would make `-Dfess.system.<key>` start working for those keys — an improvement, but an observable behavior change that should ship deliberately.
- **`public IAuthenticationResult getAccessToken(String refreshToken)` has no caller** anywhere in the repository, but it is public API on a public class, so removing or deprecating it is a maintainer call.
