### PR TITLE
refactor: modernize control flow, regenerate FessConfig, rename api.v2.* keys

### DIFF
--- a/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
@@ -78,7 +78,6 @@ public class SearchEngineApiManager extends BaseApiManager {
      * Initializes the API manager with the admin server path prefix.
      */
     public SearchEngineApiManager() {
-        super();
         setPathPrefix(ADMIN_SERVER);
     }
 

--- a/src/main/java/org/codelibs/fess/api/v2/SessionCsrfTokenManager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SessionCsrfTokenManager.java
@@ -57,7 +57,7 @@ public class SessionCsrfTokenManager {
      */
     public String issue(final HttpSession session) {
         final Object existing = session.getAttribute(SESSION_ATTR);
-        if (existing instanceof String s && !s.isEmpty()) {
+        if (existing instanceof final String s && !s.isEmpty()) {
             if (logger.isDebugEnabled()) {
                 // m-9: log token length only — NEVER log the token value itself.
                 // m-19: log a truncated SHA-256 of the session id instead of the raw id
@@ -92,7 +92,7 @@ public class SessionCsrfTokenManager {
             return false;
         }
         final Object stored = session.getAttribute(SESSION_ATTR);
-        if (!(stored instanceof String s) || s.isEmpty()) {
+        if (!(stored instanceof final String s) || s.isEmpty()) {
             if (logger.isDebugEnabled()) {
                 logger.debug("[csrf.verify] rejected: no stored token in session; sessionIdHash={}", redactSessionId(session));
             }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/CacheHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/CacheHandler.java
@@ -97,8 +97,8 @@ public class CacheHandler {
         // the login-required check below) — in production FessConfig is always present.
         try {
             final org.codelibs.fess.mylasta.direction.FessConfig cfg = ComponentUtil.getFessConfig();
-            V2ParamValidator.checkArray(req.getParameterValues("hq"), cfg.getApiV2ParamMaxArraySizeAsInteger(),
-                    cfg.getApiV2ParamMaxLengthAsInteger(), "hq");
+            V2ParamValidator.checkArray(req.getParameterValues("hq"), cfg.getApiParamMaxArraySizeOrDefault(),
+                    cfg.getApiParamMaxLengthOrDefault(), "hq");
         } catch (final InvalidRequestParameterException e) {
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, e.getMessage());
             return;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
@@ -377,7 +377,7 @@ public class ChatStreamHandler {
      */
     protected long resolveKeepaliveIntervalMs(final FessConfig fessConfig) {
         try {
-            final Integer v = fessConfig.getApiV2ChatStreamKeepaliveIntervalMsAsInteger();
+            final Integer v = fessConfig.getApiChatStreamKeepaliveIntervalMsAsInteger();
             if (v == null) {
                 return 15000L;
             }
@@ -417,10 +417,9 @@ public class ChatStreamHandler {
             logger.debug("ChatStreamHandler: keepalive pool unavailable; pinger disabled for this request");
             return null;
         }
-        // Use fixed-delay (not fixed-rate) scheduling: a heartbeat needs no catch-up
-        // semantics, and fixed-rate would queue burst pings if a write is delayed by
-        // writeLock contention during a long chunk flush.
-        final ScheduledFuture<?> future = pool.scheduleWithFixedDelay(() -> {
+
+        // scheduleWithFixedDelay never returns null, so no null-check/assert is needed here.
+        return pool.scheduleWithFixedDelay(() -> {
             try {
                 synchronized (writeLock) {
                     writer.write(": keepalive\n\n");
@@ -432,8 +431,6 @@ public class ChatStreamHandler {
                 logger.debug("SSE keep-alive write failed", e);
             }
         }, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
-        // scheduleWithFixedDelay never returns null, so no null-check/assert is needed here.
-        return future;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ClickHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ClickHandler.java
@@ -119,10 +119,7 @@ public class ClickHandler {
 
     private String stringOrNull(final Map<String, Object> body, final String key) {
         final Object v = body.get(key);
-        if (v == null) {
-            return null;
-        }
-        if (!(v instanceof String)) {
+        if ((v == null) || !(v instanceof String)) {
             return null;
         }
         return (String) v;
@@ -204,7 +201,7 @@ public class ClickHandler {
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "rt must not be negative");
             return;
         }
-        if (rt instanceof Number && ((Number) rt).longValue() > cfg.getApiV2ClickMaxRtAsLong()) {
+        if (rt instanceof Number && ((Number) rt).longValue() > cfg.getApiClickMaxTimestampOrDefault()) {
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INVALID_REQUEST, "rt exceeds the maximum");
             return;
         }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/CsrfRequirement.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/CsrfRequirement.java
@@ -70,23 +70,21 @@ public class CsrfRequirement {
             return false;
         }
         final String m = method.toUpperCase(Locale.ROOT);
-        if ("GET".equals(m) || "HEAD".equals(m) || "OPTIONS".equals(m)) {
+        if ("GET".equals(m) || "HEAD".equals(m) || "OPTIONS".equals(m) || (subPath == null)) {
             return false;
         }
-        if (subPath == null) {
+        switch (subPath) {
+        case "/auth/login":
             return false;
-        }
-        if ("/auth/login".equals(subPath)) {
-            return false;
-        }
-        if ("/auth/logout".equals(subPath)) {
+        case "/auth/logout":
             return true;
-        }
-        if ("/auth/password".equals(subPath)) {
+        case "/auth/password":
             return true;
-        }
-        if ("/click".equals(subPath)) {
+        case "/click":
             return true;
+        case null:
+        default:
+            break;
         }
         if (subPath.startsWith("/documents/") && subPath.endsWith("/favorite")) {
             return true;

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoriteGetHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoriteGetHandler.java
@@ -118,7 +118,7 @@ public class FavoriteGetHandler {
             final Map<String, Object> doc = docOpt.get();
             final String url = DocumentUtil.getValue(doc, fessConfig.getIndexFieldUrl(), String.class);
             final Long countValue = DocumentUtil.getValue(doc, fessConfig.getIndexFieldFavoriteCount(), Long.class);
-            final long count = countValue == null ? 0L : countValue.longValue();
+            final long count = countValue == null ? 0L : countValue;
 
             boolean favorite = false;
             final UserInfoHelper userInfoHelper = ComponentUtil.getUserInfoHelper();

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
@@ -262,7 +262,7 @@ public class FavoritePostHandler {
                             throw new FavoriteAddFailedException("URL is null");
                         }
                         final Long existingCount = DocumentUtil.getValue(doc, cfg.getIndexFieldFavoriteCount(), Long.class);
-                        favoriteCountHolder[0] = existingCount == null ? 0L : existingCount.longValue();
+                        favoriteCountHolder[0] = existingCount == null ? 0L : existingCount;
 
                         // M-9: addUrl returns false when the (user, url) pair already exists
                         // (or the user info cannot be resolved). Treat the duplicate case as

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritesListHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritesListHandler.java
@@ -189,7 +189,7 @@ public class FavoritesListHandler {
     private void writeEmpty(final HttpServletResponse res) throws IOException {
         final Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("record_count", 0);
-        payload.put("data", new ArrayList<Map<String, Object>>());
+        payload.put("data", new ArrayList<>());
         ComponentUtil.getV2EnvelopeWriter().writeSuccess(res, payload);
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
@@ -179,7 +179,7 @@ public class LoginHandler {
             if (username.length() > 100) {
                 throw new InvalidRequestParameterException("username exceeds the maximum length of 100");
             }
-            if (password.length() > fessConfig.getPasswordMaxLengthAsInteger()) {
+            if (password.length() > fessConfig.getPasswordMaxLengthOrDefault()) {
                 throw new InvalidRequestParameterException("password exceeds the maximum length");
             }
         } catch (final InvalidRequestParameterException e) {
@@ -391,11 +391,8 @@ public class LoginHandler {
      * paths below the app root are always safe.
      */
     private void addReturnTo(final Map<String, Object> payload, final String returnTo) {
-        if (returnTo == null) {
-            return;
-        }
         // Silent-drop oversized return_to values before any further validation.
-        if (returnTo.length() > 10000) {
+        if ((returnTo == null) || (returnTo.length() > 10000)) {
             return;
         }
         // Reject if it contains any ASCII control character (includes \r, \n, \t, NUL).
@@ -421,7 +418,7 @@ public class LoginHandler {
      * is not what the wire contract intends.
      */
     private String stringOrNull(final Object v) {
-        return v instanceof String s ? s : null;
+        return v instanceof final String s ? s : null;
     }
 
     /** Separator for USER-scope composite keys. NUL cannot appear in a resolved IP. */

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRateLimiter.java
@@ -166,7 +166,7 @@ public class LoginRateLimiter {
             // Conservative idle threshold: any hit older than the sweep interval is stale.
             // (The handler's sliding windows are bounded by 60s; we use 5min as a defensive
             // upper bound so this remains safe even if future callers raise window sizes.)
-            final long idleWindowMs = (long) SWEEP_INTERVAL_SECONDS * 1_000L;
+            final long idleWindowMs = SWEEP_INTERVAL_SECONDS * 1_000L;
             String victim = null;
             for (final Map.Entry<String, Entry> en : entries.entrySet()) {
                 final Entry candidate = en.getValue();
@@ -192,18 +192,15 @@ public class LoginRateLimiter {
                 if (capWarnLogged && entries.size() < effectiveCap / 2) {
                     capWarnLogged = false;
                 }
-            } else {
-                // All entries are either locked-out or have a recent hit. Best-effort policy:
-                // allow the map to grow by one rather than evicting a locked entry, and log
-                // WARN so operators see the cap-pressure signal.
-                if (!capWarnLogged) {
-                    logger.warn(
-                            "LoginRateLimiter entries map at cap={} but no idle entry to evict "
-                                    + "(all locked or active); growing temporarily. "
-                                    + "Consider increasing theme.api.login.rate.limit.max.entries or investigating traffic anomaly.",
-                            effectiveCap);
-                    capWarnLogged = true;
-                }
+            } else // All entries are either locked-out or have a recent hit. Best-effort policy:
+            // allow the map to grow by one rather than evicting a locked entry, and log
+            // WARN so operators see the cap-pressure signal.
+            if (!capWarnLogged) {
+                logger.warn("""
+                        LoginRateLimiter entries map at cap={} but no idle entry to evict \
+                        (all locked or active); growing temporarily. \
+                        Consider increasing theme.api.login.rate.limit.max.entries or investigating traffic anomaly.""", effectiveCap);
+                capWarnLogged = true;
             }
         }
         final Entry e = new Entry();
@@ -279,7 +276,7 @@ public class LoginRateLimiter {
         }
         final String mapKey = scope.name() + ":" + key;
         final long now = clock.getAsLong();
-        final long windowMs = (long) windowSeconds * 1_000L;
+        final long windowMs = windowSeconds * 1_000L;
         final Entry e;
         synchronized (entries) {
             Entry existing = entries.get(mapKey);
@@ -330,7 +327,7 @@ public class LoginRateLimiter {
         }
         final String mapKey = scope.name() + ":" + key;
         final long now = clock.getAsLong();
-        final long windowMs = (long) windowSeconds * 1_000L;
+        final long windowMs = windowSeconds * 1_000L;
         final Entry e;
         synchronized (entries) {
             e = entries.get(mapKey);
@@ -428,7 +425,7 @@ public class LoginRateLimiter {
                 // Retry-After stays truthful instead of self-extending on every retry.
                 return false;
             }
-            e.lockUntilEpochMs = now + (long) lockoutSeconds * 1_000L;
+            e.lockUntilEpochMs = now + lockoutSeconds * 1_000L;
             return true;
         }
     }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
@@ -196,7 +196,7 @@ public class PasswordChangeHandler {
             return;
         }
         try {
-            final int maxPwLen = ComponentUtil.getFessConfig().getPasswordMaxLengthAsInteger();
+            final int maxPwLen = ComponentUtil.getFessConfig().getPasswordMaxLengthOrDefault();
             if (currentPw.length() > maxPwLen) {
                 throw new InvalidRequestParameterException("current_password exceeds the maximum length of " + maxPwLen);
             }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/TargetOriginResolver.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/TargetOriginResolver.java
@@ -116,14 +116,14 @@ public class TargetOriginResolver {
         // X-Forwarded-Host may already include a port (host:port); if a separate
         // X-Forwarded-Port is supplied and the host lacks one, append it.
         final String trimmedHost = host.trim();
-        String origin = proto.trim() + "://" + trimmedHost;
+        final StringBuilder origin = new StringBuilder().append(proto.trim()).append("://").append(trimmedHost);
         if (!hasPort(trimmedHost)) {
             final String port = firstValue(request.getHeader("X-Forwarded-Port"));
             if (StringUtil.isNotBlank(port)) {
-                origin = origin + ":" + port.trim();
+                origin.append(":").append(port.trim());
             }
         }
-        return OriginUtil.canonicalize(origin);
+        return OriginUtil.canonicalize(origin.toString());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/V2JsonRequestParams.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/V2JsonRequestParams.java
@@ -78,20 +78,20 @@ public class V2JsonRequestParams extends SearchRequestParams {
 
     @Override
     public String getQuery() {
-        return V2ParamValidator.checkMaxLength(request.getParameter("q"), fessConfig.getApiV2ParamMaxLengthAsInteger(), "q");
+        return V2ParamValidator.checkMaxLength(request.getParameter("q"), fessConfig.getApiParamMaxLengthOrDefault(), "q");
     }
 
     @Override
     public String[] getExtraQueries() {
-        V2ParamValidator.checkArray(request.getParameterValues("ex_q"), fessConfig.getApiV2ParamMaxArraySizeAsInteger(),
-                fessConfig.getApiV2ParamMaxLengthAsInteger(), "ex_q");
+        V2ParamValidator.checkArray(request.getParameterValues("ex_q"), fessConfig.getApiParamMaxArraySizeOrDefault(),
+                fessConfig.getApiParamMaxLengthOrDefault(), "ex_q");
         return getParamValueArray(request, "ex_q");
     }
 
     @Override
     public Map<String, String[]> getFields() {
-        final int maxItems = fessConfig.getApiV2ParamMaxArraySizeAsInteger();
-        final int maxLen = fessConfig.getApiV2ParamMaxLengthAsInteger();
+        final int maxItems = fessConfig.getApiParamMaxArraySizeOrDefault();
+        final int maxLen = fessConfig.getApiParamMaxLengthOrDefault();
         final Map<String, String[]> fields = new HashMap<>();
         for (final Map.Entry<String, String[]> entry : request.getParameterMap().entrySet()) {
             final String key = entry.getKey();
@@ -110,8 +110,8 @@ public class V2JsonRequestParams extends SearchRequestParams {
 
     @Override
     public Map<String, String[]> getConditions() {
-        final int maxItems = fessConfig.getApiV2ParamMaxArraySizeAsInteger();
-        final int maxLen = fessConfig.getApiV2ParamMaxLengthAsInteger();
+        final int maxItems = fessConfig.getApiParamMaxArraySizeOrDefault();
+        final int maxLen = fessConfig.getApiParamMaxLengthOrDefault();
         final Map<String, String[]> conditions = new HashMap<>();
         for (final Map.Entry<String, String[]> entry : request.getParameterMap().entrySet()) {
             final String key = entry.getKey();
@@ -130,8 +130,8 @@ public class V2JsonRequestParams extends SearchRequestParams {
 
     @Override
     public String[] getLanguages() {
-        V2ParamValidator.checkArray(request.getParameterValues("lang"), fessConfig.getApiV2ParamMaxArraySizeAsInteger(),
-                fessConfig.getApiV2ParamMaxLengthAsInteger(), "lang");
+        V2ParamValidator.checkArray(request.getParameterValues("lang"), fessConfig.getApiParamMaxArraySizeOrDefault(),
+                fessConfig.getApiParamMaxLengthOrDefault(), "lang");
         return getParamValueArray(request, "lang");
     }
 
@@ -142,8 +142,8 @@ public class V2JsonRequestParams extends SearchRequestParams {
 
     @Override
     public FacetInfo getFacetInfo() {
-        final int maxItems = fessConfig.getApiV2ParamMaxArraySizeAsInteger();
-        final int maxLen = fessConfig.getApiV2ParamMaxLengthAsInteger();
+        final int maxItems = fessConfig.getApiParamMaxArraySizeOrDefault();
+        final int maxLen = fessConfig.getApiParamMaxLengthOrDefault();
         V2ParamValidator.checkArray(request.getParameterValues("facet.field"), maxItems, maxLen, "facet.field");
         V2ParamValidator.checkArray(request.getParameterValues("facet.query"), maxItems, maxLen, "facet.query");
         return createFacetInfo(request);
@@ -151,7 +151,7 @@ public class V2JsonRequestParams extends SearchRequestParams {
 
     @Override
     public String getSort() {
-        return V2ParamValidator.checkMaxLength(request.getParameter("sort"), fessConfig.getApiV2ParamMaxLengthAsInteger(), "sort");
+        return V2ParamValidator.checkMaxLength(request.getParameter("sort"), fessConfig.getApiParamMaxLengthOrDefault(), "sort");
     }
 
     /**
@@ -267,7 +267,7 @@ public class V2JsonRequestParams extends SearchRequestParams {
                     // INVALID_REQUEST rather than silently serving the maximum page.
                     throw new InvalidPageSizeException("num must be positive, got: " + requested);
                 }
-                final int max = fessConfig.getPagingSearchPageMaxSizeAsInteger().intValue();
+                final int max = fessConfig.getPagingSearchPageMaxSizeAsInteger();
                 if (requested > max) {
                     pageSize = max;
                 } else {
@@ -342,7 +342,7 @@ public class V2JsonRequestParams extends SearchRequestParams {
 
     @Override
     public String getSimilarDocHash() {
-        return V2ParamValidator.checkMaxLength(request.getParameter("sdh"), fessConfig.getApiV2ParamMaxLengthAsInteger(), "sdh");
+        return V2ParamValidator.checkMaxLength(request.getParameter("sdh"), fessConfig.getApiParamMaxLengthOrDefault(), "sdh");
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/app/job/ScriptExecutorJob.java
+++ b/src/main/java/org/codelibs/fess/app/job/ScriptExecutorJob.java
@@ -39,7 +39,6 @@ public class ScriptExecutorJob implements LaJob {
      * Constructor.
      */
     public ScriptExecutorJob() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ScriptExecutorJob.class);

--- a/src/main/java/org/codelibs/fess/app/pager/RolePager.java
+++ b/src/main/java/org/codelibs/fess/app/pager/RolePager.java
@@ -30,7 +30,6 @@ public class RolePager implements Serializable {
      * Constructor.
      */
     public RolePager() {
-        super();
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/codelibs/fess/app/pager/RoleTypePager.java
+++ b/src/main/java/org/codelibs/fess/app/pager/RoleTypePager.java
@@ -29,7 +29,6 @@ public class RoleTypePager implements Serializable {
      * Constructor.
      */
     public RoleTypePager() {
-        super();
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/codelibs/fess/app/pager/SchedulerPager.java
+++ b/src/main/java/org/codelibs/fess/app/pager/SchedulerPager.java
@@ -29,7 +29,6 @@ public class SchedulerPager implements Serializable {
      * Constructor.
      */
     public SchedulerPager() {
-        super();
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/codelibs/fess/app/service/BoostDocumentRuleService.java
+++ b/src/main/java/org/codelibs/fess/app/service/BoostDocumentRuleService.java
@@ -39,7 +39,6 @@ public class BoostDocumentRuleService extends FessAppService {
      * Default constructor for BoostDocumentRuleService.
      */
     public BoostDocumentRuleService() {
-        super();
     }
 
     /** Database behavior for boost document rule operations. */

--- a/src/main/java/org/codelibs/fess/app/service/DataConfigService.java
+++ b/src/main/java/org/codelibs/fess/app/service/DataConfigService.java
@@ -62,7 +62,6 @@ public class DataConfigService extends FessAppService {
      * including CRUD operations and search functionality.
      */
     public DataConfigService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/service/DuplicateHostService.java
+++ b/src/main/java/org/codelibs/fess/app/service/DuplicateHostService.java
@@ -62,7 +62,6 @@ public class DuplicateHostService extends FessAppService {
      * including CRUD operations and search functionality.
      */
     public DuplicateHostService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/service/FileConfigService.java
+++ b/src/main/java/org/codelibs/fess/app/service/FileConfigService.java
@@ -46,7 +46,6 @@ public class FileConfigService extends FessAppService {
      * Creates a new instance with default values.
      */
     public FileConfigService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/service/KeyMatchService.java
+++ b/src/main/java/org/codelibs/fess/app/service/KeyMatchService.java
@@ -43,7 +43,6 @@ public class KeyMatchService extends FessAppService {
      * Default constructor.
      */
     public KeyMatchService() {
-        super();
     }
 
     /** The Fess config. */

--- a/src/main/java/org/codelibs/fess/app/service/LabelTypeService.java
+++ b/src/main/java/org/codelibs/fess/app/service/LabelTypeService.java
@@ -49,7 +49,6 @@ public class LabelTypeService extends FessAppService {
      * Default constructor.
      */
     public LabelTypeService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/service/PathMappingService.java
+++ b/src/main/java/org/codelibs/fess/app/service/PathMappingService.java
@@ -41,7 +41,6 @@ public class PathMappingService extends FessAppService {
      * Default constructor.
      */
     public PathMappingService() {
-        super();
     }
 
     /** Path mapping behavior. */

--- a/src/main/java/org/codelibs/fess/app/service/RelatedContentService.java
+++ b/src/main/java/org/codelibs/fess/app/service/RelatedContentService.java
@@ -43,7 +43,6 @@ public class RelatedContentService extends FessAppService {
      * Creates a new instance of RelatedContentService.
      */
     public RelatedContentService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/service/RelatedQueryService.java
+++ b/src/main/java/org/codelibs/fess/app/service/RelatedQueryService.java
@@ -43,7 +43,6 @@ public class RelatedQueryService extends FessAppService {
      * This constructor is used by the DI container to create an instance of the service.
      */
     public RelatedQueryService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/service/RoleService.java
+++ b/src/main/java/org/codelibs/fess/app/service/RoleService.java
@@ -60,7 +60,6 @@ public class RoleService {
      * Constructor.
      */
     public RoleService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/service/RoleTypeService.java
+++ b/src/main/java/org/codelibs/fess/app/service/RoleTypeService.java
@@ -38,7 +38,6 @@ public class RoleTypeService {
      * Constructor.
      */
     public RoleTypeService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/service/ScheduledJobService.java
+++ b/src/main/java/org/codelibs/fess/app/service/ScheduledJobService.java
@@ -42,7 +42,6 @@ public class ScheduledJobService {
      * Constructor.
      */
     public ScheduledJobService() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ScheduledJobService.class);

--- a/src/main/java/org/codelibs/fess/app/service/SearchLogService.java
+++ b/src/main/java/org/codelibs/fess/app/service/SearchLogService.java
@@ -683,16 +683,12 @@ public class SearchLogService {
      * @throws FessSystemException if the entity type is not recognized
      */
     public void deleteSearchLog(final Object e) {
-        if (e instanceof final ClickLog clickLog) {
-            clickLogBhv.delete(clickLog);
-        } else if (e instanceof final FavoriteLog favoriteLog) {
-            favoriteLogBhv.delete(favoriteLog);
-        } else if (e instanceof final UserInfo userInfo) {
-            userInfoBhv.delete(userInfo);
-        } else if (e instanceof final SearchLog searchLog) {
-            searchLogBhv.delete(searchLog);
-        } else {
-            throw new FessSystemException("Unknown log entity: " + e);
+        switch (e) {
+        case final ClickLog clickLog -> clickLogBhv.delete(clickLog);
+        case final FavoriteLog favoriteLog -> favoriteLogBhv.delete(favoriteLog);
+        case final UserInfo userInfo -> userInfoBhv.delete(userInfo);
+        case final SearchLog searchLog -> searchLogBhv.delete(searchLog);
+        case null, default -> throw new FessSystemException("Unknown log entity: " + e);
         }
     }
 }

--- a/src/main/java/org/codelibs/fess/app/service/UserService.java
+++ b/src/main/java/org/codelibs/fess/app/service/UserService.java
@@ -255,10 +255,10 @@ public class UserService {
             userBhv.update(entity, op -> {
                 op.setRefreshPolicy(Constants.TRUE);
                 if (seqNo != null && seqNo.longValue() >= 0L) {
-                    op.setIfSeqNo(seqNo.longValue());
+                    op.setIfSeqNo(seqNo);
                 }
                 if (primaryTerm != null && primaryTerm.longValue() >= 0L) {
-                    op.setIfPrimaryTerm(primaryTerm.longValue());
+                    op.setIfPrimaryTerm(primaryTerm);
                 }
             });
             if (logger.isDebugEnabled()) {

--- a/src/main/java/org/codelibs/fess/app/service/WebConfigService.java
+++ b/src/main/java/org/codelibs/fess/app/service/WebConfigService.java
@@ -45,7 +45,6 @@ public class WebConfigService extends FessAppService {
      * Default constructor.
      */
     public WebConfigService() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/RootAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/RootAction.java
@@ -30,7 +30,6 @@ public class RootAction extends FessSearchAction {
      * Constructor.
      */
     public RootAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/admin/AdminAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/AdminAction.java
@@ -67,7 +67,6 @@ public class AdminAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminAction() {
-        super();
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/app/web/admin/accesstoken/AdminAccesstokenAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/accesstoken/AdminAccesstokenAction.java
@@ -54,7 +54,6 @@ public class AdminAccesstokenAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminAccesstokenAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(AdminAccesstokenAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/admin/accesstoken/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/accesstoken/EditForm.java
@@ -32,7 +32,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/backup/AdminBackupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/backup/AdminBackupAction.java
@@ -96,7 +96,6 @@ public class AdminBackupAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminBackupAction() {
-        super();
     }
 
     /**
@@ -413,17 +412,18 @@ public class AdminBackupAction extends FessAdminAction {
             }
             if (id.endsWith(NDJSON_EXTENTION)) {
                 final String name = id.substring(0, id.length() - NDJSON_EXTENTION.length());
-                if ("search_log".equals(name)) {
+                switch (name) {
+                case "search_log":
                     return writeNdjsonResponse(id, getSearchLogNdjsonWriteCall());
-                }
-                if ("user_info".equals(name)) {
+                case "user_info":
                     return writeNdjsonResponse(id, getUserInfoNdjsonWriteCall());
-                }
-                if ("click_log".equals(name)) {
+                case "click_log":
                     return writeNdjsonResponse(id, getClickLogNdjsonWriteCall());
-                }
-                if ("favorite_log".equals(name)) {
+                case "favorite_log":
                     return writeNdjsonResponse(id, getFavoriteLogNdjsonWriteCall());
+                case null:
+                default:
+                    break;
                 }
             } else if ("fess.json".equals(id)) {
                 return asStream(id).contentTypeOctetStream().stream(out -> {

--- a/src/main/java/org/codelibs/fess/app/web/admin/badword/AdminBadwordAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/badword/AdminBadwordAction.java
@@ -61,7 +61,6 @@ public class AdminBadwordAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminBadwordAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/badword/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/badword/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/AdminBoostdocAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/AdminBoostdocAction.java
@@ -47,7 +47,6 @@ public class AdminBoostdocAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminBoostdocAction() {
-        super();
     }
 
     /** The role for this action. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/crawlinginfo/AdminCrawlinginfoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/crawlinginfo/AdminCrawlinginfoAction.java
@@ -42,7 +42,6 @@ public class AdminCrawlinginfoAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminCrawlinginfoAction() {
-        super();
     }
 
     /** The role for this action. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/dashboard/AdminDashboardAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dashboard/AdminDashboardAction.java
@@ -35,7 +35,6 @@ public class AdminDashboardAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDashboardAction() {
-        super();
     }
 
     /** The role for this action. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/dataconfig/AdminDataconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dataconfig/AdminDataconfigAction.java
@@ -61,7 +61,6 @@ public class AdminDataconfigAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDataconfigAction() {
-        super();
     }
 
     /** The role for this action. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/dataconfig/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dataconfig/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/design/AdminDesignAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/design/AdminDesignAction.java
@@ -52,7 +52,6 @@ public class AdminDesignAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDesignAction() {
-        super();
     }
 
     private static final String CACHE_AND_SESSION_INVALIDATE_STATEMENT = "<!--CACHE_AND_SESSION_INVALIDATE-->";

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/AdminDictAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/AdminDictAction.java
@@ -37,7 +37,6 @@ public class AdminDictAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDictAction() {
-        super();
     }
 
     /** The role for this action. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/kuromoji/AdminDictKuromojiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/kuromoji/AdminDictKuromojiAction.java
@@ -56,7 +56,6 @@ public class AdminDictKuromojiAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDictKuromojiAction() {
-        super();
     }
 
     /** The role for this action. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/kuromoji/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/kuromoji/EditForm.java
@@ -29,7 +29,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/mapping/AdminDictMappingAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/mapping/AdminDictMappingAction.java
@@ -58,7 +58,6 @@ public class AdminDictMappingAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDictMappingAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/mapping/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/mapping/EditForm.java
@@ -30,7 +30,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/protwords/AdminDictProtwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/protwords/AdminDictProtwordsAction.java
@@ -56,7 +56,6 @@ public class AdminDictProtwordsAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDictProtwordsAction() {
-        super();
     }
 
     /** The role for this action. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/protwords/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/protwords/EditForm.java
@@ -30,7 +30,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/stemmeroverride/AdminDictStemmeroverrideAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/stemmeroverride/AdminDictStemmeroverrideAction.java
@@ -56,7 +56,6 @@ public class AdminDictStemmeroverrideAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDictStemmeroverrideAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/stemmeroverride/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/stemmeroverride/EditForm.java
@@ -30,7 +30,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/stopwords/AdminDictStopwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/stopwords/AdminDictStopwordsAction.java
@@ -54,7 +54,6 @@ public class AdminDictStopwordsAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDictStopwordsAction() {
-        super();
     }
 
     /** The role for this action. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/stopwords/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/stopwords/EditForm.java
@@ -30,7 +30,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/synonym/AdminDictSynonymAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/synonym/AdminDictSynonymAction.java
@@ -73,7 +73,6 @@ public class AdminDictSynonymAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDictSynonymAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/synonym/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/synonym/EditForm.java
@@ -30,7 +30,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/duplicatehost/AdminDuplicatehostAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/duplicatehost/AdminDuplicatehostAction.java
@@ -45,7 +45,6 @@ public class AdminDuplicatehostAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminDuplicatehostAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/duplicatehost/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/duplicatehost/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/elevateword/AdminElevatewordAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/elevateword/AdminElevatewordAction.java
@@ -69,7 +69,6 @@ public class AdminElevatewordAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminElevatewordAction() {
-        super();
     }
 
     /** Role constant for admin elevate word management access control. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/elevateword/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/elevateword/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/failureurl/AdminFailureurlAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/failureurl/AdminFailureurlAction.java
@@ -39,7 +39,6 @@ public class AdminFailureurlAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminFailureurlAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/failureurl/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/failureurl/EditForm.java
@@ -31,7 +31,6 @@ public class EditForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/fileauth/AdminFileauthAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/fileauth/AdminFileauthAction.java
@@ -54,7 +54,6 @@ public class AdminFileauthAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminFileauthAction() {
-        super();
     }
 
     /** The role name for file authentication administration. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/fileauth/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/fileauth/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/fileconfig/AdminFileconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/fileconfig/AdminFileconfigAction.java
@@ -57,7 +57,6 @@ public class AdminFileconfigAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminFileconfigAction() {
-        super();
     }
 
     /** The role name for file configuration administration. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/fileconfig/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/fileconfig/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/general/AdminGeneralAction.java
@@ -53,7 +53,6 @@ public class AdminGeneralAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminGeneralAction() {
-        super();
     }
 
     /** The role name for general settings administration. */
@@ -537,10 +536,7 @@ public class AdminGeneralAction extends FessAdminAction {
     }
 
     private boolean isRagSectionVisible() {
-        if (!fessConfig.isRagChatEnabled()) {
-            return false;
-        }
-        if (!ComponentUtil.hasComponent("llmClientManager")) {
+        if (!fessConfig.isRagChatEnabled() || !ComponentUtil.hasComponent("llmClientManager")) {
             return false;
         }
         final LlmClientManager llmClientManager = ComponentUtil.getComponent("llmClientManager");
@@ -560,10 +556,7 @@ public class AdminGeneralAction extends FessAdminAction {
     }
 
     private static boolean isValidRagLlmName(final String name) {
-        if (!ComponentUtil.getFessConfig().isRagChatEnabled()) {
-            return false;
-        }
-        if (!ComponentUtil.hasComponent("llmClientManager")) {
+        if (!ComponentUtil.getFessConfig().isRagChatEnabled() || !ComponentUtil.hasComponent("llmClientManager")) {
             return false;
         }
         final LlmClientManager llmClientManager = ComponentUtil.getComponent("llmClientManager");

--- a/src/main/java/org/codelibs/fess/app/web/admin/group/AdminGroupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/group/AdminGroupAction.java
@@ -51,7 +51,6 @@ public class AdminGroupAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminGroupAction() {
-        super();
     }
 
     /** The role name for group administration. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/group/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/group/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/joblog/AdminJoblogAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/joblog/AdminJoblogAction.java
@@ -42,7 +42,6 @@ public class AdminJoblogAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminJoblogAction() {
-        super();
     }
 
     /** The role name for job log administration. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/keymatch/AdminKeymatchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/keymatch/AdminKeymatchAction.java
@@ -51,7 +51,6 @@ public class AdminKeymatchAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminKeymatchAction() {
-        super();
     }
 
     /** The role name for key match administration. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/keymatch/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/keymatch/EditForm.java
@@ -32,7 +32,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/labeltype/AdminLabeltypeAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/labeltype/AdminLabeltypeAction.java
@@ -54,7 +54,6 @@ public class AdminLabeltypeAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminLabeltypeAction() {
-        super();
     }
 
     /** The role name for label type administration. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/labeltype/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/labeltype/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/log/AdminLogAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/log/AdminLogAction.java
@@ -51,7 +51,6 @@ public class AdminLogAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminLogAction() {
-        super();
     }
 
     /** The role name for log administration. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/maintenance/AdminMaintenanceAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/maintenance/AdminMaintenanceAction.java
@@ -63,7 +63,6 @@ public class AdminMaintenanceAction extends FessAdminAction {
      * Default constructor for AdminMaintenanceAction.
      */
     public AdminMaintenanceAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/pathmap/AdminPathmapAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/pathmap/AdminPathmapAction.java
@@ -53,7 +53,6 @@ public class AdminPathmapAction extends FessAdminAction {
      * Default constructor for AdminPathmapAction.
      */
     public AdminPathmapAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/admin/pathmap/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/pathmap/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/plugin/AdminPluginAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/plugin/AdminPluginAction.java
@@ -52,7 +52,6 @@ public class AdminPluginAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminPluginAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/relatedcontent/AdminRelatedcontentAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/relatedcontent/AdminRelatedcontentAction.java
@@ -47,7 +47,6 @@ public class AdminRelatedcontentAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminRelatedcontentAction() {
-        super();
     }
 
     /** Role name for admin related content operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/relatedcontent/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/relatedcontent/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/relatedquery/AdminRelatedqueryAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/relatedquery/AdminRelatedqueryAction.java
@@ -54,7 +54,6 @@ public class AdminRelatedqueryAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminRelatedqueryAction() {
-        super();
     }
 
     /** Role name for admin related query operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/relatedquery/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/relatedquery/EditForm.java
@@ -48,7 +48,6 @@ public class EditForm extends CreateForm {
      * Default constructor for EditForm.
      */
     public EditForm() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/reqheader/AdminReqheaderAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/reqheader/AdminReqheaderAction.java
@@ -53,7 +53,6 @@ public class AdminReqheaderAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminReqheaderAction() {
-        super();
     }
 
     /** Role name for admin request header operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/reqheader/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/reqheader/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/role/AdminRoleAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/role/AdminRoleAction.java
@@ -47,7 +47,6 @@ public class AdminRoleAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminRoleAction() {
-        super();
     }
 
     /** Role name for admin role operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/role/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/role/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/scheduler/AdminSchedulerAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/scheduler/AdminSchedulerAction.java
@@ -51,7 +51,6 @@ public class AdminSchedulerAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminSchedulerAction() {
-        super();
     }
 
     /** Role name for admin scheduler operations */
@@ -194,12 +193,19 @@ public class AdminSchedulerAction extends FessAdminAction {
                 final String decodedName = new String(Base64.getUrlDecoder().decode(name), Constants.CHARSET_UTF_8);
                 scheduledJobForm.name = MessageFormat.format(fessConfig.getJobTemplateTitle(type), decodedName);
                 final String[] ids = { "", "", "" };
-                if (Constants.WEB_CRAWLER_TYPE.equals(type)) {
+                switch (type) {
+                case Constants.WEB_CRAWLER_TYPE:
                     ids[0] = "\"" + id + "\"";
-                } else if (Constants.FILE_CRAWLER_TYPE.equals(type)) {
+                    break;
+                case Constants.FILE_CRAWLER_TYPE:
                     ids[1] = "\"" + id + "\"";
-                } else if (Constants.DATA_CRAWLER_TYPE.equals(type)) {
+                    break;
+                case Constants.DATA_CRAWLER_TYPE:
                     ids[2] = "\"" + id + "\"";
+                    break;
+                case null:
+                default:
+                    break;
                 }
                 scheduledJobForm.scriptData =
                         MessageFormat.format(fessConfig.getJobTemplateScript(), ids[0], ids[1], ids[2], id.replace('-', '_'));

--- a/src/main/java/org/codelibs/fess/app/web/admin/scheduler/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/scheduler/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/searchlist/AdminSearchlistAction.java
@@ -64,7 +64,6 @@ public class AdminSearchlistAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminSearchlistAction() {
-        super();
     }
 
     /** Role name for admin search list operations */
@@ -604,8 +603,7 @@ public class AdminSearchlistAction extends FessAdminAction {
                 fessConfig.getIndexFieldSeqNo(), fessConfig.getIndexFieldPrimaryTerm());
 
         // Collect candidate fields from config definitions and document keys
-        final Set<String> candidateFields = new java.util.TreeSet<>();
-        candidateFields.addAll(arrayFieldSet);
+        final Set<String> candidateFields = new java.util.TreeSet<>(arrayFieldSet);
         candidateFields.addAll(dateFieldSet);
         candidateFields.addAll(integerFieldSet);
         candidateFields.addAll(longFieldSet);
@@ -702,7 +700,6 @@ public class AdminSearchlistAction extends FessAdminAction {
          * Default constructor.
          */
         protected WebRenderData() {
-            super();
         }
 
         /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/searchlist/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/searchlist/EditForm.java
@@ -38,6 +38,5 @@ public class EditForm extends CreateForm {
      * Default constructor for EditForm.
      */
     public EditForm() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/admin/searchlist/ListForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/searchlist/ListForm.java
@@ -42,7 +42,6 @@ public class ListForm extends SearchRequestParams {
      * Default constructor.
      */
     public ListForm() {
-        super();
     }
 
     /** The search query string. */

--- a/src/main/java/org/codelibs/fess/app/web/admin/searchlog/AdminSearchlogAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/searchlog/AdminSearchlogAction.java
@@ -39,7 +39,6 @@ public class AdminSearchlogAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminSearchlogAction() {
-        super();
     }
 
     /** Role name for admin search log operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/sereq/AdminSereqAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/sereq/AdminSereqAction.java
@@ -49,7 +49,6 @@ public class AdminSereqAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminSereqAction() {
-        super();
     }
 
     /** Role name for admin search request operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/storage/AdminStorageAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/storage/AdminStorageAction.java
@@ -57,7 +57,6 @@ public class AdminStorageAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminStorageAction() {
-        super();
     }
 
     /** Role name for admin storage operations */
@@ -363,20 +362,6 @@ public class AdminStorageAction extends FessAdminAction {
 
         list.addAll(fileList);
         return list;
-    }
-
-    /**
-     * Extracts the file name from a full object path.
-     *
-     * @param objectName the full object path
-     * @return the file name portion of the path
-     */
-    private static String getName(final String objectName) {
-        final String[] values = objectName.split("/");
-        if (values.length == 0) {
-            return StringUtil.EMPTY;
-        }
-        return values[values.length - 1];
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/suggest/AdminSuggestAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/suggest/AdminSuggestAction.java
@@ -34,7 +34,6 @@ public class AdminSuggestAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminSuggestAction() {
-        super();
     }
 
     /** Role name for admin suggest operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoAction.java
@@ -46,7 +46,6 @@ public class AdminSysteminfoAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminSysteminfoAction() {
-        super();
     }
 
     /** Role name for admin system info operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/theme/AdminThemeAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/theme/AdminThemeAction.java
@@ -68,7 +68,6 @@ public class AdminThemeAction extends FessAdminAction {
 
     /** Default constructor. */
     public AdminThemeAction() {
-        super();
     }
 
     @Resource
@@ -229,65 +228,33 @@ public class AdminThemeAction extends FessAdminAction {
      * @param ex the install exception raised by the installer
      */
     static void mapInstallExceptionToMessage(final FessMessages messages, final StaticThemeInstaller.InstallException ex) {
-        if (ex.getCause() instanceof ThemeManifestException tme) {
+        if (ex.getCause() instanceof final ThemeManifestException tme) {
             addErrorForManifestCode(messages, tme.code());
             return;
         }
         switch (ex.code()) {
-        case SIZE_LIMIT:
-            messages.addErrorsThemeInstallSizeLimit(GLOBAL);
-            break;
-        case ENTRY_LIMIT:
-            messages.addErrorsThemeInstallEntryLimit(GLOBAL);
-            break;
-        case RATIO_LIMIT:
-            messages.addErrorsThemeInstallRatioLimit(GLOBAL);
-            break;
-        case ZIP_BOMB_RATIO:
-            messages.addErrorsThemeInstallZipBombRatio(GLOBAL);
-            break;
-        default:
-            messages.addErrorsFailedToUploadTheme(GLOBAL, String.valueOf(ex.getMessage()));
-            break;
+        case SIZE_LIMIT -> messages.addErrorsThemeInstallSizeLimit(GLOBAL);
+        case ENTRY_LIMIT -> messages.addErrorsThemeInstallEntryLimit(GLOBAL);
+        case RATIO_LIMIT -> messages.addErrorsThemeInstallRatioLimit(GLOBAL);
+        case ZIP_BOMB_RATIO -> messages.addErrorsThemeInstallZipBombRatio(GLOBAL);
+        default -> messages.addErrorsFailedToUploadTheme(GLOBAL, String.valueOf(ex.getMessage()));
         }
     }
 
     private static void addErrorForManifestCode(final FessMessages messages, final ThemeManifestException.Code code) {
         switch (code) {
-        case PARSE_FAILED:
-            messages.addErrorsThemeManifestParseFailed(GLOBAL);
-            break;
-        case EMPTY:
-            messages.addErrorsThemeManifestEmpty(GLOBAL);
-            break;
-        case NOT_MAPPING:
-            messages.addErrorsThemeManifestNotMapping(GLOBAL);
-            break;
-        case FIELD_TOO_LONG:
-            messages.addErrorsThemeManifestFieldTooLong(GLOBAL);
-            break;
-        case UNSUPPORTED_API_VERSION:
-            messages.addErrorsThemeManifestUnsupportedApiVersion(GLOBAL);
-            break;
-        case UNSUPPORTED_KIND:
-            messages.addErrorsThemeManifestUnsupportedKind(GLOBAL);
-            break;
-        case INVALID_NAME:
-            messages.addErrorsThemeManifestInvalidName(GLOBAL);
-            break;
-        case DISPLAY_NAME_REQUIRED:
-            messages.addErrorsThemeManifestDisplayNameRequired(GLOBAL);
-            break;
-        case INVALID_VERSION:
-            messages.addErrorsThemeManifestInvalidVersion(GLOBAL);
-            break;
-        case UNSAFE_ENTRY:
-            messages.addErrorsThemeManifestUnsafeEntry(GLOBAL);
-            break;
-        case OTHER:
-        default:
-            messages.addErrorsFailedToUploadTheme(GLOBAL, "");
-            break;
+        case PARSE_FAILED -> messages.addErrorsThemeManifestParseFailed(GLOBAL);
+        case EMPTY -> messages.addErrorsThemeManifestEmpty(GLOBAL);
+        case NOT_MAPPING -> messages.addErrorsThemeManifestNotMapping(GLOBAL);
+        case FIELD_TOO_LONG -> messages.addErrorsThemeManifestFieldTooLong(GLOBAL);
+        case UNSUPPORTED_API_VERSION -> messages.addErrorsThemeManifestUnsupportedApiVersion(GLOBAL);
+        case UNSUPPORTED_KIND -> messages.addErrorsThemeManifestUnsupportedKind(GLOBAL);
+        case INVALID_NAME -> messages.addErrorsThemeManifestInvalidName(GLOBAL);
+        case DISPLAY_NAME_REQUIRED -> messages.addErrorsThemeManifestDisplayNameRequired(GLOBAL);
+        case INVALID_VERSION -> messages.addErrorsThemeManifestInvalidVersion(GLOBAL);
+        case UNSAFE_ENTRY -> messages.addErrorsThemeManifestUnsafeEntry(GLOBAL);
+        case OTHER -> messages.addErrorsFailedToUploadTheme(GLOBAL, "");
+        default -> messages.addErrorsFailedToUploadTheme(GLOBAL, "");
         }
     }
 
@@ -326,18 +293,10 @@ public class AdminThemeAction extends FessAdminAction {
     static void mapDeleteExceptionToMessage(final FessMessages messages, final StaticThemeInstaller.InstallException ex,
             final String themeName) {
         switch (ex.code()) {
-        case ACTIVE_DEFAULT:
-            messages.addErrorsThemeIsActive(GLOBAL, themeName);
-            break;
-        case NOT_FOUND:
-            messages.addErrorsThemeNotFound(GLOBAL, themeName);
-            break;
-        case INVALID_NAME:
-            messages.addErrorsThemeNameInvalid(GLOBAL, themeName);
-            break;
-        default:
-            messages.addErrorsFailedToDeleteTheme(GLOBAL, themeName);
-            break;
+        case ACTIVE_DEFAULT -> messages.addErrorsThemeIsActive(GLOBAL, themeName);
+        case NOT_FOUND -> messages.addErrorsThemeNotFound(GLOBAL, themeName);
+        case INVALID_NAME -> messages.addErrorsThemeNameInvalid(GLOBAL, themeName);
+        default -> messages.addErrorsFailedToDeleteTheme(GLOBAL, themeName);
         }
     }
 
@@ -355,11 +314,9 @@ public class AdminThemeAction extends FessAdminAction {
         validate(form, messages -> {}, () -> asListHtml(form));
         verifyToken(() -> asListHtml(form));
         final String name = form.defaultTheme == null ? "" : form.defaultTheme.trim();
-        if (!name.isEmpty()) {
-            // existence check — refuse to point the default theme at a missing theme
-            if (themeRegistry.getTheme(name).isEmpty()) {
-                throwValidationError(m -> m.addErrorsThemeNotFound(GLOBAL, name), () -> asListHtml(form));
-            }
+        // existence check — refuse to point the default theme at a missing theme
+        if (!name.isEmpty() && themeRegistry.getTheme(name).isEmpty()) {
+            throwValidationError(m -> m.addErrorsThemeNotFound(GLOBAL, name), () -> asListHtml(form));
         }
         try {
             final FessConfig fessConfig = ComponentUtil.getFessConfig();

--- a/src/main/java/org/codelibs/fess/app/web/admin/user/AdminUserAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/user/AdminUserAction.java
@@ -57,7 +57,6 @@ public class AdminUserAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminUserAction() {
-        super();
     }
 
     /** Role name for admin user operations */
@@ -450,27 +449,14 @@ public class AdminUserAction extends FessAdminAction {
      */
     protected void addPasswordValidationError(final FessMessages messages, final String errorKey) {
         switch (errorKey) {
-        case "errors.password_length":
-            messages.addErrorsPasswordLength("password", String.valueOf(ComponentUtil.getFessConfig().getPasswordMinLengthAsInteger()));
-            break;
-        case "errors.password_no_uppercase":
-            messages.addErrorsPasswordNoUppercase("password");
-            break;
-        case "errors.password_no_lowercase":
-            messages.addErrorsPasswordNoLowercase("password");
-            break;
-        case "errors.password_no_digit":
-            messages.addErrorsPasswordNoDigit("password");
-            break;
-        case "errors.password_no_special_char":
-            messages.addErrorsPasswordNoSpecialChar("password");
-            break;
-        case "errors.password_is_blacklisted":
-            messages.addErrorsPasswordIsBlacklisted("password");
-            break;
-        default:
-            messages.addErrorsBlankPassword("password");
-            break;
+        case "errors.password_length" -> messages.addErrorsPasswordLength("password",
+                String.valueOf(ComponentUtil.getFessConfig().getPasswordMinLengthAsInteger()));
+        case "errors.password_no_uppercase" -> messages.addErrorsPasswordNoUppercase("password");
+        case "errors.password_no_lowercase" -> messages.addErrorsPasswordNoLowercase("password");
+        case "errors.password_no_digit" -> messages.addErrorsPasswordNoDigit("password");
+        case "errors.password_no_special_char" -> messages.addErrorsPasswordNoSpecialChar("password");
+        case "errors.password_is_blacklisted" -> messages.addErrorsPasswordIsBlacklisted("password");
+        default -> messages.addErrorsBlankPassword("password");
         }
     }
 

--- a/src/main/java/org/codelibs/fess/app/web/admin/user/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/user/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/webauth/AdminWebauthAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/webauth/AdminWebauthAction.java
@@ -54,7 +54,6 @@ public class AdminWebauthAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminWebauthAction() {
-        super();
     }
 
     /** Role name for admin web auth operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/webauth/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/webauth/EditForm.java
@@ -32,7 +32,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/webconfig/AdminWebconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/webconfig/AdminWebconfigAction.java
@@ -58,7 +58,6 @@ public class AdminWebconfigAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminWebconfigAction() {
-        super();
     }
 
     /** Role name for admin web config operations */

--- a/src/main/java/org/codelibs/fess/app/web/admin/webconfig/EditForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/webconfig/EditForm.java
@@ -33,7 +33,6 @@ public class EditForm extends CreateForm {
      * Creates a new EditForm instance.
      */
     public EditForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/wizard/AdminWizardAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/wizard/AdminWizardAction.java
@@ -54,7 +54,6 @@ public class AdminWizardAction extends FessAdminAction {
      * Default constructor.
      */
     public AdminWizardAction() {
-        super();
     }
 
     /** Role name for admin wizard operations */

--- a/src/main/java/org/codelibs/fess/app/web/api/ApiResult.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/ApiResult.java
@@ -127,7 +127,6 @@ public class ApiResult {
          * Default constructor for ApiUpdateResponse.
          */
         public ApiUpdateResponse() {
-            super();
         }
 
         /**
@@ -167,7 +166,6 @@ public class ApiResult {
          * Default constructor for ApiStartJobResponse.
          */
         public ApiStartJobResponse() {
-            super();
         }
 
         /**
@@ -343,7 +341,6 @@ public class ApiResult {
          * Default constructor for ApiDocsResponse.
          */
         public ApiDocsResponse() {
-            super();
         }
 
         /**
@@ -494,7 +491,6 @@ public class ApiResult {
          * Default constructor for ApiLogResponse.
          */
         public ApiLogResponse() {
-            super();
         }
 
         /**
@@ -525,7 +521,6 @@ public class ApiResult {
          * Default constructor for ApiLogsResponse.
          */
         public ApiLogsResponse() {
-            super();
         }
 
         /**
@@ -570,7 +565,6 @@ public class ApiResult {
          * Default constructor for ApiLogFilesResponse.
          */
         public ApiLogFilesResponse() {
-            super();
         }
 
         /**
@@ -661,7 +655,6 @@ public class ApiResult {
          * Default constructor for ApiSystemInfoResponse.
          */
         public ApiSystemInfoResponse() {
-            super();
         }
 
         /** System properties. */
@@ -728,7 +721,6 @@ public class ApiResult {
          * Default constructor for ApiErrorResponse.
          */
         public ApiErrorResponse() {
-            super();
         }
 
         /**
@@ -768,7 +760,6 @@ public class ApiResult {
          * Default constructor for ApiPluginResponse.
          */
         public ApiPluginResponse() {
-            super();
         }
 
         /**
@@ -798,7 +789,6 @@ public class ApiResult {
          * Default constructor for ApiStorageResponse.
          */
         public ApiStorageResponse() {
-            super();
         }
 
         /**
@@ -828,7 +818,6 @@ public class ApiResult {
          * Default constructor for ApiStatsResponse.
          */
         public ApiStatsResponse() {
-            super();
         }
 
         /**

--- a/src/main/java/org/codelibs/fess/app/web/api/FessApiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/FessApiAction.java
@@ -46,7 +46,6 @@ public abstract class FessApiAction extends FessBaseAction {
      * Default constructor.
      */
     public FessApiAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/FessApiAdminAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/FessApiAdminAction.java
@@ -37,7 +37,6 @@ public abstract class FessApiAdminAction extends FessApiAction {
      * Default constructor.
      */
     public FessApiAdminAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/accesstoken/ApiAdminAccesstokenAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/accesstoken/ApiAdminAccesstokenAction.java
@@ -51,7 +51,6 @@ public class ApiAdminAccesstokenAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminAccesstokenAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminAccesstokenAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/accesstoken/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/accesstoken/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/accesstoken/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/accesstoken/SearchBody.java
@@ -30,6 +30,5 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupAction.java
@@ -57,7 +57,6 @@ public class ApiAdminBackupAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminBackupAction() {
-        super();
     }
 
     /**
@@ -122,17 +121,18 @@ public class ApiAdminBackupAction extends FessApiAdminAction {
                 });
             }
             final String name = id.substring(0, id.length() - NDJSON_EXTENTION.length());
-            if ("search_log".equals(name)) {
+            switch (name) {
+            case "search_log":
                 return writeNdjsonResponse(id, getSearchLogNdjsonWriteCall());
-            }
-            if ("user_info".equals(name)) {
+            case "user_info":
                 return writeNdjsonResponse(id, getUserInfoNdjsonWriteCall());
-            }
-            if ("click_log".equals(name)) {
+            case "click_log":
                 return writeNdjsonResponse(id, getClickLogNdjsonWriteCall());
-            }
-            if ("favorite_log".equals(name)) {
+            case "favorite_log":
                 return writeNdjsonResponse(id, getFavoriteLogNdjsonWriteCall());
+            case null:
+            default:
+                break;
             }
         }
 

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/badword/ApiAdminBadwordAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/badword/ApiAdminBadwordAction.java
@@ -60,7 +60,6 @@ public class ApiAdminBadwordAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminBadwordAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminBadwordAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/badword/DownloadBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/badword/DownloadBody.java
@@ -29,6 +29,5 @@ public class DownloadBody extends DownloadForm {
      * Default constructor.
      */
     public DownloadBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/badword/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/badword/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/badword/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/badword/SearchBody.java
@@ -30,6 +30,5 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/ApiAdminBoostdocAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/ApiAdminBoostdocAction.java
@@ -49,7 +49,6 @@ public class ApiAdminBoostdocAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminBoostdocAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminBoostdocAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/boostdoc/SearchBody.java
@@ -33,6 +33,5 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/crawlinginfo/ApiAdminCrawlinginfoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/crawlinginfo/ApiAdminCrawlinginfoAction.java
@@ -44,7 +44,6 @@ public class ApiAdminCrawlinginfoAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminCrawlinginfoAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminCrawlinginfoAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/crawlinginfo/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/crawlinginfo/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/crawlinginfo/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/crawlinginfo/SearchBody.java
@@ -30,6 +30,5 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/ApiAdminDataconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/ApiAdminDataconfigAction.java
@@ -52,7 +52,6 @@ public class ApiAdminDataconfigAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDataconfigAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminDataconfigAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dataconfig/SearchBody.java
@@ -36,6 +36,5 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/ApiAdminDictAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/ApiAdminDictAction.java
@@ -38,7 +38,6 @@ public class ApiAdminDictAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDictAction() {
-        super();
     }
 
     /** Dictionary manager for handling dictionary file operations */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/BaseSearchDictBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/BaseSearchDictBody.java
@@ -31,6 +31,5 @@ public class BaseSearchDictBody extends BaseSearchBody {
      * Default constructor for BaseSearchDictBody.
      */
     public BaseSearchDictBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/ListBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/ListBody.java
@@ -27,7 +27,6 @@ public class ListBody extends ListForm {
      * Default constructor.
      */
     public ListBody() {
-        super();
     }
 
     /** The ID of the dictionary. */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
@@ -48,7 +48,6 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDictKuromojiAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminDictKuromojiAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/DownloadBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/DownloadBody.java
@@ -29,6 +29,5 @@ public class DownloadBody extends DownloadForm {
      * Default constructor.
      */
     public DownloadBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/SearchBody.java
@@ -27,6 +27,5 @@ public class SearchBody extends BaseSearchDictBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/ApiAdminDictMappingAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/ApiAdminDictMappingAction.java
@@ -47,7 +47,6 @@ public class ApiAdminDictMappingAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDictMappingAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminDictMappingAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/DownloadBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/DownloadBody.java
@@ -29,6 +29,5 @@ public class DownloadBody extends DownloadForm {
      * Default constructor.
      */
     public DownloadBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/SearchBody.java
@@ -27,6 +27,5 @@ public class SearchBody extends BaseSearchDictBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/ApiAdminDictProtwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/ApiAdminDictProtwordsAction.java
@@ -47,7 +47,6 @@ public class ApiAdminDictProtwordsAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDictProtwordsAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminDictProtwordsAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/DownloadBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/DownloadBody.java
@@ -29,6 +29,5 @@ public class DownloadBody extends DownloadForm {
      * Default constructor.
      */
     public DownloadBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/SearchBody.java
@@ -27,6 +27,5 @@ public class SearchBody extends BaseSearchDictBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/ApiAdminDictStemmeroverrideAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/ApiAdminDictStemmeroverrideAction.java
@@ -48,7 +48,6 @@ public class ApiAdminDictStemmeroverrideAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDictStemmeroverrideAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminDictStemmeroverrideAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/DownloadBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/DownloadBody.java
@@ -29,6 +29,5 @@ public class DownloadBody extends DownloadForm {
      * Default constructor.
      */
     public DownloadBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/SearchBody.java
@@ -27,6 +27,5 @@ public class SearchBody extends BaseSearchDictBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/ApiAdminDictStopwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/ApiAdminDictStopwordsAction.java
@@ -48,7 +48,6 @@ public class ApiAdminDictStopwordsAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDictStopwordsAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminDictStopwordsAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/DownloadBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/DownloadBody.java
@@ -29,6 +29,5 @@ public class DownloadBody extends DownloadForm {
      * Default constructor.
      */
     public DownloadBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/SearchBody.java
@@ -27,6 +27,5 @@ public class SearchBody extends BaseSearchDictBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/ApiAdminDictSynonymAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/ApiAdminDictSynonymAction.java
@@ -48,7 +48,6 @@ public class ApiAdminDictSynonymAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDictSynonymAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ApiAdminDictSynonymAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/DownloadBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/DownloadBody.java
@@ -29,6 +29,5 @@ public class DownloadBody extends DownloadForm {
      * Default constructor.
      */
     public DownloadBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/SearchBody.java
@@ -27,6 +27,5 @@ public class SearchBody extends BaseSearchDictBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/documents/ApiAdminDocumentsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/documents/ApiAdminDocumentsAction.java
@@ -61,7 +61,6 @@ public class ApiAdminDocumentsAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDocumentsAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/ApiAdminDuplicatehostAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/ApiAdminDuplicatehostAction.java
@@ -55,7 +55,6 @@ public class ApiAdminDuplicatehostAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminDuplicatehostAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/duplicatehost/SearchBody.java
@@ -33,6 +33,5 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/ApiAdminElevatewordAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/ApiAdminElevatewordAction.java
@@ -71,7 +71,6 @@ public class ApiAdminElevatewordAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminElevatewordAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/DownloadBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/DownloadBody.java
@@ -29,6 +29,5 @@ public class DownloadBody extends DownloadForm {
      * Default constructor.
      */
     public DownloadBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/elevateword/SearchBody.java
@@ -30,6 +30,5 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor for SearchBody.
      */
     public SearchBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/failureurl/ApiAdminFailureurlAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/failureurl/ApiAdminFailureurlAction.java
@@ -49,7 +49,6 @@ public class ApiAdminFailureurlAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminFailureurlAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/failureurl/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/failureurl/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/failureurl/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/failureurl/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** The URL that failed during crawling */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileauth/ApiAdminFileauthAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileauth/ApiAdminFileauthAction.java
@@ -56,7 +56,6 @@ public class ApiAdminFileauthAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminFileauthAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileauth/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileauth/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileauth/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileauth/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** File authentication configuration ID */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/ApiAdminFileconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/ApiAdminFileconfigAction.java
@@ -59,7 +59,6 @@ public class ApiAdminFileconfigAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminFileconfigAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/fileconfig/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Name of the file crawling configuration */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/general/ApiAdminGeneralAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/general/ApiAdminGeneralAction.java
@@ -44,7 +44,6 @@ public class ApiAdminGeneralAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminGeneralAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/general/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/general/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/group/ApiAdminGroupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/group/ApiAdminGroupAction.java
@@ -51,7 +51,6 @@ public class ApiAdminGroupAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminGroupAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/group/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/group/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/group/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/group/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Group ID */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/joblog/ApiAdminJoblogAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/joblog/ApiAdminJoblogAction.java
@@ -50,7 +50,6 @@ public class ApiAdminJoblogAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminJoblogAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/joblog/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/joblog/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/joblog/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/joblog/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Job log ID */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/ApiAdminKeymatchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/ApiAdminKeymatchAction.java
@@ -53,7 +53,6 @@ public class ApiAdminKeymatchAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminKeymatchAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/keymatch/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Search term for key matching */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/ApiAdminLabeltypeAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/ApiAdminLabeltypeAction.java
@@ -58,7 +58,6 @@ public class ApiAdminLabeltypeAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminLabeltypeAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/labeltype/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Name of the label type */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/log/ApiAdminLogAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/log/ApiAdminLogAction.java
@@ -47,7 +47,6 @@ public class ApiAdminLogAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminLogAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/ApiAdminPathmapAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/ApiAdminPathmapAction.java
@@ -50,7 +50,6 @@ public class ApiAdminPathmapAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminPathmapAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/pathmap/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Regular expression pattern for path mapping */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/plugin/ApiAdminPluginAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/plugin/ApiAdminPluginAction.java
@@ -42,7 +42,6 @@ public class ApiAdminPluginAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminPluginAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/plugin/DeleteBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/plugin/DeleteBody.java
@@ -30,6 +30,5 @@ public class DeleteBody extends DeleteForm {
      * extending the standard plugin DeleteForm with JSON request body functionality.
      */
     public DeleteBody() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/ApiAdminRelatedcontentAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/ApiAdminRelatedcontentAction.java
@@ -53,7 +53,6 @@ public class ApiAdminRelatedcontentAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminRelatedcontentAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedcontent/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Search term for related content */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/ApiAdminRelatedqueryAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/ApiAdminRelatedqueryAction.java
@@ -56,7 +56,6 @@ public class ApiAdminRelatedqueryAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminRelatedqueryAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/relatedquery/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Search term for related queries */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/reqheader/ApiAdminReqheaderAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/reqheader/ApiAdminReqheaderAction.java
@@ -55,7 +55,6 @@ public class ApiAdminReqheaderAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminReqheaderAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/reqheader/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/reqheader/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/reqheader/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/reqheader/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Request header configuration ID */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/role/ApiAdminRoleAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/role/ApiAdminRoleAction.java
@@ -48,7 +48,6 @@ public class ApiAdminRoleAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminRoleAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/role/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/role/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/role/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/role/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Role ID */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/ApiAdminSchedulerAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/ApiAdminSchedulerAction.java
@@ -54,7 +54,6 @@ public class ApiAdminSchedulerAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminSchedulerAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/EditBody.java
@@ -33,7 +33,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/scheduler/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Scheduler ID */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/ApiAdminSearchlistAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/ApiAdminSearchlistAction.java
@@ -68,7 +68,6 @@ public class ApiAdminSearchlistAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminSearchlistAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/SearchBody.java
@@ -27,7 +27,6 @@ public class SearchBody extends ListForm {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     // `size` is an alias of `num`.

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/stats/ApiAdminStatsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/stats/ApiAdminStatsAction.java
@@ -53,7 +53,6 @@ public class ApiAdminStatsAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminStatsAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/storage/ApiAdminStorageAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/storage/ApiAdminStorageAction.java
@@ -54,7 +54,6 @@ public class ApiAdminStorageAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminStorageAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/suggest/ApiAdminSuggestAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/suggest/ApiAdminSuggestAction.java
@@ -35,7 +35,6 @@ public class ApiAdminSuggestAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminSuggestAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/systeminfo/ApiAdminSysteminfoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/systeminfo/ApiAdminSysteminfoAction.java
@@ -41,7 +41,6 @@ public class ApiAdminSysteminfoAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminSysteminfoAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/user/ApiAdminUserAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/user/ApiAdminUserAction.java
@@ -49,7 +49,6 @@ public class ApiAdminUserAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminUserAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/user/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/user/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/user/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/user/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** User ID */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/webauth/ApiAdminWebauthAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/webauth/ApiAdminWebauthAction.java
@@ -55,7 +55,6 @@ public class ApiAdminWebauthAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminWebauthAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/webauth/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/webauth/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/webauth/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/webauth/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Web authentication configuration ID */

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/webconfig/ApiAdminWebconfigAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/webconfig/ApiAdminWebconfigAction.java
@@ -58,7 +58,6 @@ public class ApiAdminWebconfigAction extends FessApiAdminAction {
      * Default constructor.
      */
     public ApiAdminWebconfigAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/webconfig/EditBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/webconfig/EditBody.java
@@ -28,7 +28,6 @@ public class EditBody extends EditForm {
      * Default constructor.
      */
     public EditBody() {
-        super();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/webconfig/SearchBody.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/webconfig/SearchBody.java
@@ -26,7 +26,6 @@ public class SearchBody extends BaseSearchBody {
      * Default constructor.
      */
     public SearchBody() {
-        super();
     }
 
     /** Name of the web crawling configuration */

--- a/src/main/java/org/codelibs/fess/app/web/base/FessAdminAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/FessAdminAction.java
@@ -57,7 +57,6 @@ public abstract class FessAdminAction extends FessBaseAction {
      * Default constructor.
      */
     public FessAdminAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/base/FessBaseAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/FessBaseAction.java
@@ -64,7 +64,6 @@ public abstract class FessBaseAction extends TypicalAction // has several interf
      * Default constructor.
      */
     public FessBaseAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/base/FessLoginAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/FessLoginAction.java
@@ -30,7 +30,6 @@ public abstract class FessLoginAction extends FessSearchAction {
      * Default constructor.
      */
     public FessLoginAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/base/FessSearchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/FessSearchAction.java
@@ -71,7 +71,6 @@ public abstract class FessSearchAction extends FessBaseAction {
      * Default constructor.
      */
     public FessSearchAction() {
-        super();
     }
 
     /** The field name used for label-based search filtering. */

--- a/src/main/java/org/codelibs/fess/app/web/base/SearchForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/SearchForm.java
@@ -112,7 +112,6 @@ public class SearchForm extends SearchRequestParams {
      * Default constructor for SearchForm.
      */
     public SearchForm() {
-        super();
     }
 
     // advance

--- a/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.entity.FessUser;
-import org.codelibs.fess.entity.FessUser.PermissionState;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.sso.entraid.EntraIdAuthenticator;
 import org.codelibs.fess.util.ComponentUtil;

--- a/src/main/java/org/codelibs/fess/app/web/base/login/FessLoginAssist.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/FessLoginAssist.java
@@ -65,7 +65,6 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
      * Default constructor.
      */
     public FessLoginAssist() {
-        super();
     }
 
     // ===================================================================================
@@ -378,7 +377,7 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
         final OptionalEntity<FessUser> userOpt = doFindLoginUser(username);
         if (userOpt.isPresent()) {
             final FessUser user = userOpt.get();
-            final String stored = (user instanceof User) ? ((User) user).getPassword() : null;
+            final String stored = (user instanceof final User u) ? u.getPassword() : null;
             if (stored != null && passwordHashHelper.matches(plainPassword, stored)) {
                 lazyUpgradePassword(username, plainPassword, stored, passwordHashHelper);
                 return userOpt;
@@ -474,7 +473,7 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
             return OptionalEntity.empty();
         }
         final FessUser user = userOpt.get();
-        final String stored = (user instanceof User) ? ((User) user).getPassword() : null;
+        final String stored = (user instanceof final User u) ? u.getPassword() : null;
         if (stored != null && stored.equals(cipheredPassword)) {
             return userOpt;
         }

--- a/src/main/java/org/codelibs/fess/app/web/cache/CacheAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/cache/CacheAction.java
@@ -37,7 +37,6 @@ public class CacheAction extends FessSearchAction {
      * Creates a new instance of CacheAction.
      */
     public CacheAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/cache/CacheForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/cache/CacheForm.java
@@ -55,6 +55,5 @@ public class CacheForm {
      * Default constructor for CacheForm.
      */
     public CacheForm() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/error/ErrorAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/error/ErrorAction.java
@@ -30,7 +30,6 @@ public class ErrorAction extends FessSearchAction {
      * Default constructor for ErrorAction.
      */
     public ErrorAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/error/ErrorBadrequestAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/error/ErrorBadrequestAction.java
@@ -30,7 +30,6 @@ public class ErrorBadrequestAction extends FessSearchAction {
      * Default constructor for ErrorBadrequestAction.
      */
     public ErrorBadrequestAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/error/ErrorBusyAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/error/ErrorBusyAction.java
@@ -29,7 +29,6 @@ public class ErrorBusyAction extends FessSearchAction {
      * Default constructor for ErrorBusyAction.
      */
     public ErrorBusyAction() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/error/ErrorForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/error/ErrorForm.java
@@ -47,6 +47,5 @@ public class ErrorForm {
      * Default constructor for ErrorForm.
      */
     public ErrorForm() {
-        super();
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/error/ErrorNotfoundAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/error/ErrorNotfoundAction.java
@@ -30,7 +30,6 @@ public class ErrorNotfoundAction extends FessSearchAction {
      * Default constructor for ErrorNotfoundAction.
      */
     public ErrorNotfoundAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/error/ErrorSystemerrorAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/error/ErrorSystemerrorAction.java
@@ -30,7 +30,6 @@ public class ErrorSystemerrorAction extends FessSearchAction {
      * Default constructor for ErrorSystemerrorAction.
      */
     public ErrorSystemerrorAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/go/GoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/go/GoAction.java
@@ -54,7 +54,6 @@ public class GoAction extends FessSearchAction {
      * Default constructor for GoAction.
      */
     public GoAction() {
-        super();
     }
 
     // ===================================================================================
@@ -157,11 +156,10 @@ public class GoAction extends FessSearchAction {
         if (!isFileSystemPath(targetUrl)) {
             if (isValidRedirectUrl(targetUrl)) {
                 return HtmlResponse.fromRedirectPathAsIs(DocumentUtil.encodeUrl(targetUrl + hash));
-            } else {
-                logger.warn("Invalid redirect URL detected: {}", targetUrl);
-                saveError(messages -> messages.addErrorsDocumentNotFound(GLOBAL, form.docId));
-                return redirect(ErrorAction.class);
             }
+            logger.warn("Invalid redirect URL detected: {}", targetUrl);
+            saveError(messages -> messages.addErrorsDocumentNotFound(GLOBAL, form.docId));
+            return redirect(ErrorAction.class);
         }
         if (!fessConfig.isSearchFileProxyEnabled()) {
             return HtmlResponse.fromRedirectPathAsIs(targetUrl + hash);

--- a/src/main/java/org/codelibs/fess/app/web/go/GoForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/go/GoForm.java
@@ -34,7 +34,6 @@ public class GoForm {
      * Default constructor for GoForm.
      */
     public GoForm() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/help/HelpAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/help/HelpAction.java
@@ -44,7 +44,6 @@ public class HelpAction extends FessSearchAction {
      * Default constructor for HelpAction.
      */
     public HelpAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/login/LoginAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/login/LoginAction.java
@@ -44,7 +44,6 @@ public class LoginAction extends FessLoginAction {
      * Default constructor.
      */
     public LoginAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(LoginAction.class);
@@ -187,27 +186,14 @@ public class LoginAction extends FessLoginAction {
      */
     protected void addPasswordValidationError(final FessMessages messages, final String errorKey) {
         switch (errorKey) {
-        case "errors.password_length":
-            messages.addErrorsPasswordLength(GLOBAL, String.valueOf(ComponentUtil.getFessConfig().getPasswordMinLengthAsInteger()));
-            break;
-        case "errors.password_no_uppercase":
-            messages.addErrorsPasswordNoUppercase(GLOBAL);
-            break;
-        case "errors.password_no_lowercase":
-            messages.addErrorsPasswordNoLowercase(GLOBAL);
-            break;
-        case "errors.password_no_digit":
-            messages.addErrorsPasswordNoDigit(GLOBAL);
-            break;
-        case "errors.password_no_special_char":
-            messages.addErrorsPasswordNoSpecialChar(GLOBAL);
-            break;
-        case "errors.password_is_blacklisted":
-            messages.addErrorsPasswordIsBlacklisted(GLOBAL);
-            break;
-        default:
-            messages.addErrorsBlankPassword(GLOBAL);
-            break;
+        case "errors.password_length" -> messages.addErrorsPasswordLength(GLOBAL,
+                String.valueOf(ComponentUtil.getFessConfig().getPasswordMinLengthAsInteger()));
+        case "errors.password_no_uppercase" -> messages.addErrorsPasswordNoUppercase(GLOBAL);
+        case "errors.password_no_lowercase" -> messages.addErrorsPasswordNoLowercase(GLOBAL);
+        case "errors.password_no_digit" -> messages.addErrorsPasswordNoDigit(GLOBAL);
+        case "errors.password_no_special_char" -> messages.addErrorsPasswordNoSpecialChar(GLOBAL);
+        case "errors.password_is_blacklisted" -> messages.addErrorsPasswordIsBlacklisted(GLOBAL);
+        default -> messages.addErrorsBlankPassword(GLOBAL);
         }
     }
 

--- a/src/main/java/org/codelibs/fess/app/web/logout/LogoutAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/logout/LogoutAction.java
@@ -33,7 +33,6 @@ public class LogoutAction extends FessSearchAction {
      * Default constructor.
      */
     public LogoutAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/osdd/OsddAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/osdd/OsddAction.java
@@ -28,7 +28,6 @@ public class OsddAction extends FessSearchAction {
      * Default constructor.
      */
     public OsddAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/app/web/profile/ProfileAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/profile/ProfileAction.java
@@ -41,7 +41,6 @@ public class ProfileAction extends FessSearchAction {
      * Default constructor.
      */
     public ProfileAction() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ProfileAction.class);
@@ -145,27 +144,14 @@ public class ProfileAction extends FessSearchAction {
      */
     protected void addPasswordValidationError(final FessMessages messages, final String errorKey) {
         switch (errorKey) {
-        case "errors.password_length":
-            messages.addErrorsPasswordLength(GLOBAL, String.valueOf(ComponentUtil.getFessConfig().getPasswordMinLengthAsInteger()));
-            break;
-        case "errors.password_no_uppercase":
-            messages.addErrorsPasswordNoUppercase(GLOBAL);
-            break;
-        case "errors.password_no_lowercase":
-            messages.addErrorsPasswordNoLowercase(GLOBAL);
-            break;
-        case "errors.password_no_digit":
-            messages.addErrorsPasswordNoDigit(GLOBAL);
-            break;
-        case "errors.password_no_special_char":
-            messages.addErrorsPasswordNoSpecialChar(GLOBAL);
-            break;
-        case "errors.password_is_blacklisted":
-            messages.addErrorsPasswordIsBlacklisted(GLOBAL);
-            break;
-        default:
-            messages.addErrorsBlankPassword(GLOBAL);
-            break;
+        case "errors.password_length" -> messages.addErrorsPasswordLength(GLOBAL,
+                String.valueOf(ComponentUtil.getFessConfig().getPasswordMinLengthAsInteger()));
+        case "errors.password_no_uppercase" -> messages.addErrorsPasswordNoUppercase(GLOBAL);
+        case "errors.password_no_lowercase" -> messages.addErrorsPasswordNoLowercase(GLOBAL);
+        case "errors.password_no_digit" -> messages.addErrorsPasswordNoDigit(GLOBAL);
+        case "errors.password_no_special_char" -> messages.addErrorsPasswordNoSpecialChar(GLOBAL);
+        case "errors.password_is_blacklisted" -> messages.addErrorsPasswordIsBlacklisted(GLOBAL);
+        default -> messages.addErrorsBlankPassword(GLOBAL);
         }
     }
 

--- a/src/main/java/org/codelibs/fess/app/web/search/SearchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/search/SearchAction.java
@@ -56,7 +56,6 @@ public class SearchAction extends FessSearchAction {
      * Default constructor.
      */
     public SearchAction() {
-        super();
     }
 
     // ===================================================================================
@@ -343,7 +342,6 @@ public class SearchAction extends FessSearchAction {
          * Default constructor.
          */
         public WebRenderData() {
-            super();
         }
 
         /**

--- a/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
@@ -241,14 +241,15 @@ public class SsoAction extends FessLoginAction {
                     logger.debug("Logout response.", e);
                 }
                 saveInfo(e.getMessageCode());
-            } else if (e.getCause() instanceof SsoStateException) {
-                // The endpoint is anonymous, so a request that is not a logout callback the IdP
-                // sent is a rejected request rather than a fault. A stack trace per attempt would
-                // let an unauthenticated client fill the log.
-                logger.warn("Failed to process SSO logout: {}", e.getCause().getMessage());
-                saveError(e.getMessageCode());
             } else {
-                logger.warn("Failed to log out.", e);
+                if (e.getCause() instanceof SsoStateException) {
+                    // The endpoint is anonymous, so a request that is not a logout callback the IdP
+                    // sent is a rejected request rather than a fault. A stack trace per attempt would
+                    // let an unauthenticated client fill the log.
+                    logger.warn("Failed to process SSO logout: {}", e.getCause().getMessage());
+                } else {
+                    logger.warn("Failed to log out.", e);
+                }
                 saveError(e.getMessageCode());
             }
             return redirect(LoginAction.class);

--- a/src/main/java/org/codelibs/fess/app/web/thumbnail/ThumbnailAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/thumbnail/ThumbnailAction.java
@@ -39,7 +39,6 @@ public class ThumbnailAction extends FessSearchAction {
      * Default constructor for ThumbnailAction.
      */
     public ThumbnailAction() {
-        super();
     }
 
     // ===================================================================================

--- a/src/main/java/org/codelibs/fess/chat/ChatClient.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatClient.java
@@ -329,11 +329,6 @@ public class ChatClient {
                     final LlmStreamCallback docNotFoundCallback =
                             new PhaseAwareStreamCallback(ChatPhaseCallback.PHASE_ANSWER, callback, rawDocNotFoundCallback);
                     llmClientManager.generateDocumentNotFoundResponse(userMessage, documentUrl, historyForAnswer, docNotFoundCallback);
-                    callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("[RAG] Phase {} completed. responseLength={}, phaseElapsedTime={}ms", ChatPhaseCallback.PHASE_ANSWER,
-                                fullResponse.length(), System.currentTimeMillis() - phaseStartTime);
-                    }
                 } else {
                     // Fetch full content and generate summary
                     phaseStartTime = System.currentTimeMillis();
@@ -361,11 +356,11 @@ public class ChatClient {
                     final LlmStreamCallback summaryCallback =
                             new PhaseAwareStreamCallback(ChatPhaseCallback.PHASE_ANSWER, callback, rawSummaryCallback);
                     llmClientManager.generateSummaryResponse(userMessage, fullDocs, historyForAnswer, summaryCallback);
-                    callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("[RAG] Phase {} completed. responseLength={}, phaseElapsedTime={}ms", ChatPhaseCallback.PHASE_ANSWER,
-                                fullResponse.length(), System.currentTimeMillis() - phaseStartTime);
-                    }
+                }
+                callback.onPhaseComplete(ChatPhaseCallback.PHASE_ANSWER);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("[RAG] Phase {} completed. responseLength={}, phaseElapsedTime={}ms", ChatPhaseCallback.PHASE_ANSWER,
+                            fullResponse.length(), System.currentTimeMillis() - phaseStartTime);
                 }
             } else {
                 // Phase 2: Search with query
@@ -373,7 +368,7 @@ public class ChatClient {
                 finalSearchQuery = query;
                 phaseStartTime = System.currentTimeMillis();
                 callback.onPhaseStart(ChatPhaseCallback.PHASE_SEARCH, "Searching documents...", query);
-                ChatSearchResult querySearchResult = searchWithQueryAndMetadata(query, safeFields, safeExtraQueries);
+                final ChatSearchResult querySearchResult = searchWithQueryAndMetadata(query, safeFields, safeExtraQueries);
                 List<Map<String, Object>> searchResults = querySearchResult.getDocuments();
                 searchQueryId = querySearchResult.getQueryId();
                 searchRequestedTime = querySearchResult.getRequestedTime();
@@ -536,8 +531,8 @@ public class ChatClient {
             final ChatMessage assistantMessage = ChatMessage.assistantMessage(fullResponse.toString());
             assistantMessage.setHtmlContent(htmlContent);
 
-            for (int i = 0; i < sources.size(); i++) {
-                populateUrlLink(sources.get(i));
+            for (final Map<String, Object> element : sources) {
+                populateUrlLink(element);
             }
             addSourcesToMessage(assistantMessage, sources, contextPath, searchQueryId, searchRequestedTime);
 
@@ -683,24 +678,17 @@ public class ChatClient {
      */
     protected String buildAssistantHistoryContent(final ChatMessage msg, final String mode, final int assistantMaxChars,
             final int summaryMaxChars) {
-        switch (mode) {
-        case "full":
-            return msg.getContent();
-        case "smart_summary":
-            // smart_summary is handled by extractHistoryForIntent / extractHistoryForAnswer;
-            // it must never reach this per-message renderer.
-            throw new IllegalStateException("smart_summary mode is not handled per-message");
-        case "source_titles":
-            return buildSourceTitlesContent(msg, summaryMaxChars);
-        case "source_titles_and_urls":
-            return buildSourceTitlesAndUrlsContent(msg);
-        case "truncated":
-            return buildTruncatedContent(msg, assistantMaxChars);
-        case "none":
-            return null;
-        default:
-            return msg.getContent();
-        }
+        return switch (mode) {
+        case "full" -> msg.getContent();
+        case "smart_summary" -> // smart_summary is handled by extractHistoryForIntent / extractHistoryForAnswer;
+                // it must never reach this per-message renderer.
+                throw new IllegalStateException("smart_summary mode is not handled per-message");
+        case "source_titles" -> buildSourceTitlesContent(msg, summaryMaxChars);
+        case "source_titles_and_urls" -> buildSourceTitlesAndUrlsContent(msg);
+        case "truncated" -> buildTruncatedContent(msg, assistantMaxChars);
+        case "none" -> null;
+        default -> msg.getContent();
+        };
     }
 
     /**
@@ -751,7 +739,8 @@ public class ChatClient {
             final String url = s.getUrl();
             if (title != null && !title.isEmpty() && url != null && !url.isEmpty()) {
                 return title + " (" + url + ")";
-            } else if (title != null && !title.isEmpty()) {
+            }
+            if (title != null && !title.isEmpty()) {
                 return title;
             } else if (url != null && !url.isEmpty()) {
                 return url;
@@ -780,17 +769,6 @@ public class ChatClient {
             return content;
         }
         return content.substring(0, maxChars) + "...";
-    }
-
-    /**
-     * Builds the source titles suffix string (e.g., "\n[Referenced documents: Title1, Title2]").
-     * Returns an empty string if no sources or titles are available.
-     *
-     * @param sources the source documents
-     * @return the source titles suffix, or empty string
-     */
-    private String buildSourceTitlesSuffix(final List<ChatSource> sources) {
-        return buildSourceTitlesSuffix(sources, Integer.MAX_VALUE);
     }
 
     private String buildSourceTitlesSuffix(final List<ChatSource> sources, final int maxSuffixLength) {
@@ -1143,7 +1121,7 @@ public class ChatClient {
             ComponentUtil.getSearchHelper().search(params, data, OptionalThing.empty());
 
             @SuppressWarnings("unchecked")
-            final List<Map<String, Object>> docs = (List<Map<String, Object>>) data.getDocumentItems();
+            final List<Map<String, Object>> docs = data.getDocumentItems();
             if (docs != null) {
                 return new ChatSearchResult(docs, data.getQueryId(), data.getRequestedTime());
             }
@@ -1201,7 +1179,7 @@ public class ChatClient {
             ComponentUtil.getSearchHelper().search(params, data, OptionalThing.empty());
 
             @SuppressWarnings("unchecked")
-            final List<Map<String, Object>> docs = (List<Map<String, Object>>) data.getDocumentItems();
+            final List<Map<String, Object>> docs = data.getDocumentItems();
             if (docs != null) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("[RAG] Document search completed. query={}, resultCount={}, elapsedTime={}ms", query, docs.size(),

--- a/src/main/java/org/codelibs/fess/chat/ChatSessionManager.java
+++ b/src/main/java/org/codelibs/fess/chat/ChatSessionManager.java
@@ -293,10 +293,8 @@ public class ChatSessionManager {
             }
         }
 
-        if (removed > 0) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Removed expired chat sessions. removedCount={}, remainingCount={}", removed, sessionCache.size());
-            }
+        if ((removed > 0) && logger.isDebugEnabled()) {
+            logger.debug("Removed expired chat sessions. removedCount={}, remainingCount={}", removed, sessionCache.size());
         }
     }
 

--- a/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
+++ b/src/main/java/org/codelibs/fess/chat/DefaultChatContentFetcher.java
@@ -18,11 +18,13 @@ package org.codelibs.fess.chat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -259,7 +261,7 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
             final Map<String, Object> doc = e.getValue();
             final Object snippet = doc.get(highlightField);
             return isChunkedStatus(doc) && doc.get("content") instanceof List<?> && !hasUsableChunkVectors(doc)
-                    && !(snippet instanceof String && StringUtil.isNotBlank((String) snippet))
+                    && (!(snippet instanceof String) || !StringUtil.isNotBlank((String) snippet))
                     && !alreadyHighlightedIds.contains(e.getKey());
         }).map(Map.Entry::getKey).collect(Collectors.toList());
         if (targetIds.isEmpty()) {
@@ -375,10 +377,9 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
      */
     protected String selectBySemanticSimilarity(final List<String> chunks, final Map<String, Object> doc, final float[] queryVector) {
         final Object vectorFieldValue = doc.get(Constants.CONTENT_CHUNK_VECTOR_FIELD);
-        if (!(vectorFieldValue instanceof List<?>)) {
+        if (!(vectorFieldValue instanceof final List<?> vectorEntries)) {
             return null;
         }
-        final List<?> vectorEntries = (List<?>) vectorFieldValue;
         final int n = Math.min(chunks.size(), vectorEntries.size());
         final List<Map.Entry<Integer, Double>> scored = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
@@ -390,7 +391,7 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
         if (scored.isEmpty()) {
             return null;
         }
-        scored.sort((a, b) -> Double.compare(b.getValue(), a.getValue()));
+        scored.sort(Comparator.comparing(Entry<Integer, Double>::getValue).reversed());
         final int topK = Math.max(1, getChatTopK());
         final Set<Integer> selectedIndexes =
                 scored.stream().limit(topK).map(Map.Entry::getKey).collect(Collectors.toCollection(TreeSet::new));
@@ -432,8 +433,7 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
         if (value instanceof float[]) {
             return (float[]) value;
         }
-        if (value instanceof List<?>) {
-            final List<?> list = (List<?>) value;
+        if (value instanceof final List<?> list) {
             final float[] result = new float[list.size()];
             for (int i = 0; i < list.size(); i++) {
                 final Object element = list.get(i);
@@ -627,10 +627,7 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
      * @return {@link Strategy#HIGHLIGHT} for large documents, otherwise {@link Strategy#FULL}
      */
     protected Strategy decideStrategy(final String docId, final Long contentLength, final ChatContentRequest request) {
-        if (StringUtil.isBlank(request.getQuery())) {
-            return Strategy.FULL; // no query to highlight with
-        }
-        if (contentLength == null) {
+        if (StringUtil.isBlank(request.getQuery()) || (contentLength == null)) {
             return Strategy.FULL; // unknown size (e.g. summary path) -> full, no regression
         }
         return contentLength.longValue() > getFulltextThreshold() ? Strategy.HIGHLIGHT : Strategy.FULL;
@@ -706,9 +703,7 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
         if (value instanceof String && StringUtil.isNotBlank((String) value)) {
             try {
                 return Long.valueOf((String) value);
-            } catch (final NumberFormatException e) {
-                return null;
-            }
+            } catch (final NumberFormatException e) {}
         }
         return null;
     }
@@ -786,7 +781,7 @@ public class DefaultChatContentFetcher implements ChatContentFetcher {
             ComponentUtil.getSearchHelper().search(params, data, OptionalThing.empty());
 
             @SuppressWarnings("unchecked")
-            final List<Map<String, Object>> docs = (List<Map<String, Object>>) data.getDocumentItems();
+            final List<Map<String, Object>> docs = data.getDocumentItems();
             if (docs == null) {
                 return Collections.emptyList();
             }

--- a/src/main/java/org/codelibs/fess/chunk/ChunkBoundaryFinder.java
+++ b/src/main/java/org/codelibs/fess/chunk/ChunkBoundaryFinder.java
@@ -502,23 +502,19 @@ public class ChunkBoundaryFinder {
      * @return true if the code point is a breakable space
      */
     protected boolean isBreakableSpace(final int cp) {
-        if (cp == ' ') {
-            // By far the most common code point in extracted text: check it before anything else.
+        if ((cp == ' ') || Character.isWhitespace(cp)) {
             return true;
         }
-        if (Character.isWhitespace(cp)) {
-            return true;
-        }
-        switch (cp) {
+        return switch (cp) {
         case 0x0085: // NEXT LINE (NEL) -- Character.isWhitespace() rejects it
         case 0x00A0: // NO-BREAK SPACE
         case 0x2007: // FIGURE SPACE
         case 0x202F: // NARROW NO-BREAK SPACE
         case 0x200B: // ZERO WIDTH SPACE
-            return true;
+            yield true;
         default:
-            return false;
-        }
+            yield false;
+        };
     }
 
     /**
@@ -538,7 +534,7 @@ public class ChunkBoundaryFinder {
      * @return true if the code point is a sentence terminator
      */
     protected boolean isSentenceTerminator(final int cp) {
-        switch (cp) {
+        return switch (cp) {
         case '.':
         case '!':
         case '?':
@@ -572,10 +568,10 @@ public class ChunkBoundaryFinder {
         case 0x10FB: // ჻ Georgian paragraph separator
         case 0x0E5B: // ๛ Thai khomut (end of a passage)
         case 0x2E3C: // stenographic full stop
-            return true;
+            yield true;
         default:
-            return false;
-        }
+            yield false;
+        };
     }
 
     /**
@@ -585,7 +581,7 @@ public class ChunkBoundaryFinder {
      * @return true if the code point is a clause separator
      */
     protected boolean isClauseSeparator(final int cp) {
-        switch (cp) {
+        return switch (cp) {
         case ',':
         case ';':
         case ':':
@@ -613,10 +609,10 @@ public class ChunkBoundaryFinder {
         case 0x17D6: // ៖ Khmer camnuc pii kuuh
         case 0x0F0B: // ་ Tibetan tsheg -- the intersyllabic separator Tibetan uses for a space
         case 0x0E5A: // ๚ Thai angkhankhu
-            return true;
+            yield true;
         default:
-            return false;
-        }
+            yield false;
+        };
     }
 
     /**
@@ -652,7 +648,7 @@ public class ChunkBoundaryFinder {
      * @return true if a following digit disqualifies this code point as a boundary
      */
     protected boolean isPunctuationRequiringNonDigit(final int cp) {
-        switch (cp) {
+        return switch (cp) {
         case '-':
         case 0x2010: // ‐
         case 0xFF0E: // ．
@@ -660,10 +656,10 @@ public class ChunkBoundaryFinder {
         case 0xFF1A: // ：
         case 0x301C: // 〜
         case 0xFF5E: // ～
-            return true;
+            yield true;
         default:
-            return false;
-        }
+            yield false;
+        };
     }
 
     /**
@@ -673,7 +669,7 @@ public class ChunkBoundaryFinder {
      * @return true if the code point is a closing mark
      */
     protected boolean isClosingBracket(final int cp) {
-        switch (cp) {
+        return switch (cp) {
         case ')':
         case ']':
         case '}':
@@ -691,10 +687,10 @@ public class ChunkBoundaryFinder {
         case 0x3009: // 〉
         case 0x2019: // ’
         case 0x201D: // ”
-            return true;
+            yield true;
         default:
-            return false;
-        }
+            yield false;
+        };
     }
 
     /**
@@ -704,7 +700,7 @@ public class ChunkBoundaryFinder {
      * @return true if the code point is an opening mark
      */
     protected boolean isOpeningBracket(final int cp) {
-        switch (cp) {
+        return switch (cp) {
         case '(':
         case '[':
         case '{':
@@ -720,10 +716,10 @@ public class ChunkBoundaryFinder {
         case 0x3008: // 〈
         case 0x2018: // ‘
         case 0x201C: // “
-            return true;
+            yield true;
         default:
-            return false;
-        }
+            yield false;
+        };
     }
 
     /**
@@ -814,11 +810,7 @@ public class ChunkBoundaryFinder {
         if (cp >= 0xFE00 && cp <= 0xFE0F || cp >= 0xE0100 && cp <= 0xE01EF) {
             return true;
         }
-        if (cp >= 0x1F3FB && cp <= 0x1F3FF) {
-            // Emoji modifiers (skin tone): general category Sk, so getType() misses them.
-            return true;
-        }
-        if (cp >= 0xE0020 && cp <= 0xE007F) {
+        if ((cp >= 0x1F3FB && cp <= 0x1F3FF) || (cp >= 0xE0020 && cp <= 0xE007F)) {
             // Tag characters: the payload of an emoji tag sequence such as the Scotland flag.
             return true;
         }
@@ -845,23 +837,6 @@ public class ChunkBoundaryFinder {
     }
 
     /**
-     * Returns true if the code point, when it appears immediately before a candidate boundary,
-     * joins that boundary's code point into the same grapheme cluster -- so a boundary must not
-     * be placed right after it either.
-     *
-     * <p>This is the backward-looking counterpart of {@link #isClusterContinuation}, which asks
-     * the same question about the code point <em>at</em> the candidate boundary. It carries the
-     * cases where the <em>preceding</em> code point is an ordinary spacing letter that
-     * nonetheless owns the one after it -- the Khmer coeng and the Thai/Lao pre-base vowels. {@link
-     * #adjustToClusterStart} tests both directions, so both must be overridable for a subclass
-     * that redefines cluster joining to take full effect: overriding only
-     * {@link #isClusterContinuation} would leave this direction on the built-in zero-width-joiner
-     * rule.</p>
-     *
-     * @param cp the code point immediately before the candidate boundary
-     * @return true if a boundary must not be placed right after this code point
-     */
-    /**
      * Returns true if the code point exists specifically to forbid a break on both of its sides.
      *
      * <p>{@code U+2060} WORD JOINER and {@code U+FEFF} ZWNBSP are defined as no-break glue, and
@@ -879,15 +854,25 @@ public class ChunkBoundaryFinder {
         return cp == 0x2060 || cp == 0xFEFF || cp == 0x200C;
     }
 
+    /**
+     * Returns true if the code point, when it appears immediately before a candidate boundary,
+     * joins that boundary's code point into the same grapheme cluster -- so a boundary must not
+     * be placed right after it either.
+     *
+     * <p>This is the backward-looking counterpart of {@link #isClusterContinuation}, which asks
+     * the same question about the code point <em>at</em> the candidate boundary. It carries the
+     * cases where the <em>preceding</em> code point is an ordinary spacing letter that
+     * nonetheless owns the one after it -- the Khmer coeng and the Thai/Lao pre-base vowels. {@link
+     * #adjustToClusterStart} tests both directions, so both must be overridable for a subclass
+     * that redefines cluster joining to take full effect: overriding only
+     * {@link #isClusterContinuation} would leave this direction on the built-in zero-width-joiner
+     * rule.</p>
+     *
+     * @param cp the code point immediately before the candidate boundary
+     * @return true if a boundary must not be placed right after this code point
+     */
     protected boolean isClusterJoiner(final int cp) {
-        if (cp == ZWJ) {
-            return true;
-        }
-        if (cp == '\r') {
-            // UAX #29 GB3: CR and LF are one cluster, so a boundary may not fall between them.
-            return true;
-        }
-        if (isNoBreakGlue(cp)) {
+        if ((cp == ZWJ) || (cp == '\r') || isNoBreakGlue(cp)) {
             return true;
         }
         if (cp >= 0x2066 && cp <= 0x2068 || cp >= 0x202A && cp <= 0x202B || cp >= 0x202D && cp <= 0x202E) {

--- a/src/main/java/org/codelibs/fess/chunk/LengthChunker.java
+++ b/src/main/java/org/codelibs/fess/chunk/LengthChunker.java
@@ -198,12 +198,11 @@ public class LengthChunker implements Chunker {
                     windowSize(chunkSize, normalizeBoundaryPercent(getLookbackPercent(), MAX_LOOKBACK_PERCENT, LOOKBACK_PERCENT_PROPERTY));
             final int lookahead = windowSize(chunkSize,
                     normalizeBoundaryPercent(getLookaheadPercent(), MAX_LOOKAHEAD_PERCENT, LOOKAHEAD_PERCENT_PROPERTY));
-            logger.info(
-                    "[Chunk] Boundary-aware splitting is enabled: {}={} is a target, not a ceiling. "
-                            + "Chunks range from {} to {} characters (lookback={}, lookahead={}); "
-                            + "expect more chunks per document than a fixed-length split, which counts against {}.",
-                    CHUNK_SIZE_PROPERTY, chunkSize, chunkSize - lookback,
-                    chunkSize + Math.max(lookahead, 2 * ChunkBoundaryFinder.MAX_CLUSTER_ADJUST), lookback, lookahead,
+            logger.info("""
+                    [Chunk] Boundary-aware splitting is enabled: {}={} is a target, not a ceiling. \
+                    Chunks range from {} to {} characters (lookback={}, lookahead={}); \
+                    expect more chunks per document than a fixed-length split, which counts against {}.""", CHUNK_SIZE_PROPERTY, chunkSize,
+                    chunkSize - lookback, chunkSize + Math.max(lookahead, 2 * ChunkBoundaryFinder.MAX_CLUSTER_ADJUST), lookback, lookahead,
                     "content_chunker.max_chunks_per_document");
         } catch (final Exception e) {
             // Diagnostics only; never let a config-read failure break component registration.
@@ -311,12 +310,7 @@ public class LengthChunker implements Chunker {
                 end = start + Character.charCount(content.codePointAt(start));
             }
             chunks.add(content.substring(start, end));
-            if (chunks.size() >= limit) {
-                // Production bound: stop here instead of splitting the remainder only to have the
-                // caller discard it. See Chunker#split(String, int).
-                break;
-            }
-            if (end >= length) {
+            if ((chunks.size() >= limit) || (end >= length)) {
                 break;
             }
             int nextStart = end - overlap;

--- a/src/main/java/org/codelibs/fess/cors/DefaultCorsHandler.java
+++ b/src/main/java/org/codelibs/fess/cors/DefaultCorsHandler.java
@@ -40,7 +40,6 @@ public class DefaultCorsHandler extends CorsHandler {
      * standard CORS headers based on application configuration.
      */
     public DefaultCorsHandler() {
-        super();
     }
 
     /**
@@ -54,9 +53,10 @@ public class DefaultCorsHandler extends CorsHandler {
         final java.util.List<String> origins = fessConfig.getApiCorsAllowOriginList();
         origins.forEach(s -> factory.add(s, this));
         if (origins.contains(ALLOW_ORIGIN_ALL) && fessConfig.isApiCorsAllowCredentials()) {
-            logger.warn("Credentials are NOT sent for the '*' entry in api.cors.allow.origin (a literal '*' is returned). "
-                    + "Credentials are honored only for an exact match of an explicit Origin. "
-                    + "To allow credentialed cross-origin access, set explicit origins in api.cors.allow.origin.");
+            logger.warn("""
+                    Credentials are NOT sent for the '*' entry in api.cors.allow.origin (a literal '*' is returned). \
+                    Credentials are honored only for an exact match of an explicit Origin. \
+                    To allow credentialed cross-origin access, set explicit origins in api.cors.allow.origin.""");
         }
     }
 

--- a/src/main/java/org/codelibs/fess/crawler/FessCrawlerThread.java
+++ b/src/main/java/org/codelibs/fess/crawler/FessCrawlerThread.java
@@ -81,7 +81,6 @@ public class FessCrawlerThread extends CrawlerThread {
      * Default constructor.
      */
     public FessCrawlerThread() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(FessCrawlerThread.class);

--- a/src/main/java/org/codelibs/fess/crawler/interval/FessIntervalController.java
+++ b/src/main/java/org/codelibs/fess/crawler/interval/FessIntervalController.java
@@ -35,7 +35,6 @@ public class FessIntervalController extends DefaultIntervalController {
      * Default constructor.
      */
     public FessIntervalController() {
-        super();
     }
 
     /**
@@ -43,6 +42,7 @@ public class FessIntervalController extends DefaultIntervalController {
      *
      * @return the delay time in milliseconds after processing
      */
+    @Override
     public long getDelayMillisAfterProcessing() {
         return delayMillisAfterProcessing;
     }
@@ -52,6 +52,7 @@ public class FessIntervalController extends DefaultIntervalController {
      *
      * @param delayMillisAfterProcessing the delay time in milliseconds after processing
      */
+    @Override
     public void setDelayMillisAfterProcessing(final long delayMillisAfterProcessing) {
         this.delayMillisAfterProcessing = delayMillisAfterProcessing;
     }
@@ -61,6 +62,7 @@ public class FessIntervalController extends DefaultIntervalController {
      *
      * @return the delay time in milliseconds when no URLs are available
      */
+    @Override
     public long getDelayMillisAtNoUrlInQueue() {
         return delayMillisAtNoUrlInQueue;
     }
@@ -70,6 +72,7 @@ public class FessIntervalController extends DefaultIntervalController {
      *
      * @param delayMillisAtNoUrlInQueue the delay time in milliseconds when no URLs are available
      */
+    @Override
     public void setDelayMillisAtNoUrlInQueue(final long delayMillisAtNoUrlInQueue) {
         this.delayMillisAtNoUrlInQueue = delayMillisAtNoUrlInQueue;
     }
@@ -79,6 +82,7 @@ public class FessIntervalController extends DefaultIntervalController {
      *
      * @return the delay time in milliseconds before processing
      */
+    @Override
     public long getDelayMillisBeforeProcessing() {
         return delayMillisBeforeProcessing;
     }
@@ -88,6 +92,7 @@ public class FessIntervalController extends DefaultIntervalController {
      *
      * @param delayMillisBeforeProcessing the delay time in milliseconds before processing
      */
+    @Override
     public void setDelayMillisBeforeProcessing(final long delayMillisBeforeProcessing) {
         this.delayMillisBeforeProcessing = delayMillisBeforeProcessing;
     }
@@ -97,6 +102,7 @@ public class FessIntervalController extends DefaultIntervalController {
      *
      * @return the delay time in milliseconds for waiting for new URLs
      */
+    @Override
     public long getDelayMillisForWaitingNewUrl() {
         return delayMillisForWaitingNewUrl;
     }
@@ -106,6 +112,7 @@ public class FessIntervalController extends DefaultIntervalController {
      *
      * @param delayMillisForWaitingNewUrl the delay time in milliseconds for waiting for new URLs
      */
+    @Override
     public void setDelayMillisForWaitingNewUrl(final long delayMillisForWaitingNewUrl) {
         this.delayMillisForWaitingNewUrl = delayMillisForWaitingNewUrl;
     }

--- a/src/main/java/org/codelibs/fess/crawler/processor/FessResponseProcessor.java
+++ b/src/main/java/org/codelibs/fess/crawler/processor/FessResponseProcessor.java
@@ -41,7 +41,6 @@ public class FessResponseProcessor extends DefaultResponseProcessor {
      * Default constructor.
      */
     public FessResponseProcessor() {
-        super();
     }
 
     /** Logger instance for this class */

--- a/src/main/java/org/codelibs/fess/crawler/service/FessUrlQueueService.java
+++ b/src/main/java/org/codelibs/fess/crawler/service/FessUrlQueueService.java
@@ -76,7 +76,8 @@ public class FessUrlQueueService extends OpenSearchUrlQueueService {
                             new FunctionScoreQueryBuilder.FilterFunctionBuilder[] { new FunctionScoreQueryBuilder.FilterFunctionBuilder(
                                     new RandomScoreFunctionBuilder().seed(sessionId.hashCode())) }),
                     0, pollingFetchSize, SortBuilders.scoreSort().order(SortOrder.DESC));
-        } else if (!ORDER_SEQUENTIAL.equals(crawlOrder)) {
+        }
+        if (!ORDER_SEQUENTIAL.equals(crawlOrder)) {
             logger.warn("Invalid crawl order specified: {}. Falling back to sequential.", crawlOrder);
         }
         return super.fetchUrlQueueList(sessionId);

--- a/src/main/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformer.java
@@ -70,7 +70,6 @@ public abstract class AbstractFessFileTransformer extends AbstractTransformer im
      * Default constructor.
      */
     public AbstractFessFileTransformer() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(AbstractFessFileTransformer.class);

--- a/src/main/java/org/codelibs/fess/crawler/transformer/FessFileTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/FessFileTransformer.java
@@ -39,7 +39,6 @@ public class FessFileTransformer extends AbstractFessFileTransformer {
      * Default constructor.
      */
     public FessFileTransformer() {
-        super();
     }
 
     /** Logger instance for this class */

--- a/src/main/java/org/codelibs/fess/crawler/transformer/FessStandardTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/FessStandardTransformer.java
@@ -39,7 +39,6 @@ public class FessStandardTransformer extends AbstractFessFileTransformer {
      * Default constructor.
      */
     public FessStandardTransformer() {
-        super();
     }
 
     /** Logger instance for this class */

--- a/src/main/java/org/codelibs/fess/crawler/transformer/FessXpathTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/FessXpathTransformer.java
@@ -155,7 +155,6 @@ public class FessXpathTransformer extends XpathTransformer implements FessTransf
      * Default constructor.
      */
     public FessXpathTransformer() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/crawler/util/FessCrawlerConfig.java
+++ b/src/main/java/org/codelibs/fess/crawler/util/FessCrawlerConfig.java
@@ -28,7 +28,6 @@ public class FessCrawlerConfig extends OpenSearchCrawlerConfig {
      * Default constructor.
      */
     public FessCrawlerConfig() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/crypto/bcrypt/BCrypt.java
+++ b/src/main/java/org/codelibs/fess/crypto/bcrypt/BCrypt.java
@@ -216,7 +216,7 @@ public class BCrypt {
      */
     private static String encode_base64(final byte d[], final int len) throws IllegalArgumentException {
         int off = 0;
-        final StringBuffer rs = new StringBuffer();
+        final StringBuilder rs = new StringBuilder();
         int c1, c2;
 
         if (len <= 0 || len > d.length) {
@@ -224,7 +224,8 @@ public class BCrypt {
         }
 
         while (off < len) {
-            c1 = d[off++] & 0xff;
+            c1 = d[off] & 0xff;
+            off++;
             rs.append(base64_code[(c1 >> 2) & 0x3f]);
             c1 = (c1 & 0x03) << 4;
             if (off >= len) {
@@ -270,7 +271,7 @@ public class BCrypt {
      * @throws IllegalArgumentException if maxolen is invalid
      */
     private static byte[] decode_base64(final String s, final int maxolen) throws IllegalArgumentException {
-        final StringBuffer rs = new StringBuffer();
+        final StringBuilder rs = new StringBuilder();
         int off = 0;
         final int slen = s.length();
         int olen = 0;
@@ -282,7 +283,8 @@ public class BCrypt {
         }
 
         while (off < slen - 1 && olen < maxolen) {
-            c1 = char64(s.charAt(off++));
+            c1 = char64(s.charAt(off));
+            off++;
             c2 = char64(s.charAt(off++));
             if (c1 == -1 || c2 == -1) {
                 break;
@@ -336,7 +338,8 @@ public class BCrypt {
             n += S[0x100 | ((l >> 16) & 0xff)];
             n ^= S[0x200 | ((l >> 8) & 0xff)];
             n += S[0x300 | (l & 0xff)];
-            r ^= n ^ P[++i];
+            i++;
+            r ^= n ^ P[i];
 
             // Feistel substitution on right word
             n = S[(r >> 24) & 0xff];
@@ -479,7 +482,8 @@ public class BCrypt {
 
         ret = new byte[clen * 4];
         for (i = 0, j = 0; i < clen; i++) {
-            ret[j++] = (byte) ((cdata[i] >> 24) & 0xff);
+            ret[j] = (byte) ((cdata[i] >> 24) & 0xff);
+            j++;
             ret[j++] = (byte) ((cdata[i] >> 16) & 0xff);
             ret[j++] = (byte) ((cdata[i] >> 8) & 0xff);
             ret[j++] = (byte) (cdata[i] & 0xff);
@@ -500,7 +504,7 @@ public class BCrypt {
         byte passwordb[], saltb[], hashed[];
         char minor = (char) 0;
         int rounds, off = 0;
-        final StringBuffer rs = new StringBuffer();
+        final StringBuilder rs = new StringBuilder();
 
         if (salt.charAt(0) != '$' || salt.charAt(1) != '2') {
             throw new IllegalArgumentException("Invalid salt version");
@@ -560,7 +564,7 @@ public class BCrypt {
      * @return    an encoded salt value
      */
     public static String gensalt(final int log_rounds, final SecureRandom random) {
-        final StringBuffer rs = new StringBuffer();
+        final StringBuilder rs = new StringBuilder();
         final byte rnd[] = new byte[BCRYPT_SALT_LEN];
 
         random.nextBytes(rnd);

--- a/src/main/java/org/codelibs/fess/dict/DictionaryExpiredException.java
+++ b/src/main/java/org/codelibs/fess/dict/DictionaryExpiredException.java
@@ -31,7 +31,6 @@ public class DictionaryExpiredException extends RuntimeException {
      * has expired and is no longer valid for use.
      */
     public DictionaryExpiredException() {
-        super();
     }
 
     //    public DictionaryExpiredException() {

--- a/src/main/java/org/codelibs/fess/ds/callback/FileListIndexUpdateCallbackImpl.java
+++ b/src/main/java/org/codelibs/fess/ds/callback/FileListIndexUpdateCallbackImpl.java
@@ -294,13 +294,11 @@ public class FileListIndexUpdateCallbackImpl implements IndexUpdateCallback {
                     logger.debug("Using exclude pattern: {}", pattern);
                 }
             }
-            if (paramMap.get(URL_EXCLUDE_PATTERN) instanceof final Pattern pattern) {
-                if (pattern.matcher(url).matches()) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Skipping URL {} due to exclude pattern: {}", url, pattern);
-                    }
-                    return false;
+            if ((paramMap.get(URL_EXCLUDE_PATTERN) instanceof final Pattern pattern) && pattern.matcher(url).matches()) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Skipping URL {} due to exclude pattern: {}", url, pattern);
                 }
+                return false;
             }
         }
         return true;

--- a/src/main/java/org/codelibs/fess/embedding/AbstractEmbeddingClient.java
+++ b/src/main/java/org/codelibs/fess/embedding/AbstractEmbeddingClient.java
@@ -16,7 +16,6 @@
 package org.codelibs.fess.embedding;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;

--- a/src/main/java/org/codelibs/fess/embedding/EmbeddingClientManager.java
+++ b/src/main/java/org/codelibs/fess/embedding/EmbeddingClientManager.java
@@ -54,10 +54,7 @@ public class EmbeddingClientManager {
      */
     public boolean available() {
         final String embeddingType = getEmbeddingType();
-        if (Constants.NONE.equals(embeddingType)) {
-            return false;
-        }
-        if (!isContentChunkerEnabled()) {
+        if (Constants.NONE.equals(embeddingType) || !isContentChunkerEnabled()) {
             return false;
         }
         // resolveClient() (not getClient()) so a merely-unregistered client -- a legitimate
@@ -225,10 +222,7 @@ public class EmbeddingClientManager {
      */
     protected EmbeddingClient getAvailableClient() {
         final String embeddingType = getEmbeddingType();
-        if (Constants.NONE.equals(embeddingType)) {
-            throw new EmbeddingException("Embedding client is not available");
-        }
-        if (!isContentChunkerEnabled()) {
+        if (Constants.NONE.equals(embeddingType) || !isContentChunkerEnabled()) {
             throw new EmbeddingException("Embedding client is not available");
         }
         final EmbeddingClient client = getClient();

--- a/src/main/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClient.java
+++ b/src/main/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClient.java
@@ -25,9 +25,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -555,14 +555,14 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
             if (userInfoRejectionLogged.compareAndSet(false, true)) {
                 // Names the source and the remedy, never the value: the whole point is that the
                 // value holds a credential.
-                logger.error(
-                        "[Embedding:OPENSEARCH] {} embeds credentials in the URL (a 'user:password@' userinfo component). "
-                                + "The HTTP client rejects that form unconditionally (RFC 9110 4.2.4 forbids sending it), so it can "
-                                + "never work; reporting the provider as unavailable so no run is started against it. Remove the "
-                                + "userinfo part and configure {}.{} / {}.{} for the OpenSearch cluster itself, or "
-                                + "http.proxy.username / http.proxy.password when the endpoint sits behind an authenticating proxy. "
-                                + "The rejected value is not logged.",
-                        source, getConfigPrefix(), CONFIG_USERNAME, getConfigPrefix(), CONFIG_PASSWORD);
+                logger.error("""
+                        [Embedding:OPENSEARCH] {} embeds credentials in the URL (a 'user:password@' userinfo component). \
+                        The HTTP client rejects that form unconditionally (RFC 9110 4.2.4 forbids sending it), so it can \
+                        never work; reporting the provider as unavailable so no run is started against it. Remove the \
+                        userinfo part and configure {}.{} / {}.{} for the OpenSearch cluster itself, or \
+                        http.proxy.username / http.proxy.password when the endpoint sits behind an authenticating proxy. \
+                        The rejected value is not logged.""", source, getConfigPrefix(), CONFIG_USERNAME, getConfigPrefix(),
+                        CONFIG_PASSWORD);
             }
             return StringUtil.EMPTY;
         }

--- a/src/main/java/org/codelibs/fess/exception/ContainerNotAvailableException.java
+++ b/src/main/java/org/codelibs/fess/exception/ContainerNotAvailableException.java
@@ -24,7 +24,7 @@ public class ContainerNotAvailableException extends FessSystemException {
     private static final long serialVersionUID = 1L;
 
     /** The name of the component that is not available. */
-    private String componentName;
+    private final String componentName;
 
     /**
      * Constructor with component name.

--- a/src/main/java/org/codelibs/fess/filter/StaticThemeFilter.java
+++ b/src/main/java/org/codelibs/fess/filter/StaticThemeFilter.java
@@ -152,11 +152,10 @@ public class StaticThemeFilter implements Filter {
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
             throws IOException, ServletException {
         // Guard against non-HTTP invocations (e.g. cross-context dispatches in Tomcat).
-        if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+        if (!(request instanceof final HttpServletRequest req) || !(response instanceof HttpServletResponse)) {
             chain.doFilter(request, response);
             return;
         }
-        final HttpServletRequest req = (HttpServletRequest) request;
         final HttpServletResponse res = (HttpServletResponse) response;
 
         // Only intercept GET requests

--- a/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
@@ -29,8 +29,8 @@ import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.fess.api.v2.handlers.ChatRequestBody;
 import org.codelibs.fess.Constants;
+import org.codelibs.fess.api.v2.handlers.ChatRequestBody;
 import org.codelibs.fess.entity.ChatMessage.ChatSource;
 import org.codelibs.fess.entity.FacetQueryView;
 import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
@@ -89,7 +89,7 @@ public class ChatApiHelper {
         // Support nested fields object: {"fields": {"label": ... }}
         Object labelsRaw = null;
         final Object fieldsObj = raw.get("fields");
-        if (fieldsObj instanceof Map<?, ?> fieldsMap) {
+        if (fieldsObj instanceof final Map<?, ?> fieldsMap) {
             labelsRaw = fieldsMap.get("label");
         }
         // Fallback: legacy dotted-key "fields.label" (kept for backward compat during transition)
@@ -103,8 +103,8 @@ public class ChatApiHelper {
 
         final List<String> labelValues = toStringList(labelsRaw);
         final org.codelibs.fess.mylasta.direction.FessConfig cfg = ComponentUtil.getFessConfig();
-        final int maxArraySize = cfg.getApiV2ParamMaxArraySizeAsInteger();
-        final int maxElementLen = cfg.getApiV2ParamMaxLengthAsInteger();
+        final int maxArraySize = cfg.getApiParamMaxArraySizeOrDefault();
+        final int maxElementLen = cfg.getApiParamMaxLengthOrDefault();
         if (labelValues.size() > maxArraySize) {
             throw new ChatRequestBody.TooManyValuesException("fields.label exceeds the maximum number of values: " + maxArraySize);
         }
@@ -159,8 +159,8 @@ public class ChatApiHelper {
 
         final List<String> values = toStringList(exqRaw);
         final org.codelibs.fess.mylasta.direction.FessConfig cfg2 = ComponentUtil.getFessConfig();
-        final int maxArraySize2 = cfg2.getApiV2ParamMaxArraySizeAsInteger();
-        final int maxElementLen2 = cfg2.getApiV2ParamMaxLengthAsInteger();
+        final int maxArraySize2 = cfg2.getApiParamMaxArraySizeOrDefault();
+        final int maxElementLen2 = cfg2.getApiParamMaxLengthOrDefault();
         if (values.size() > maxArraySize2) {
             throw new ChatRequestBody.TooManyValuesException("extra_queries exceeds the maximum number of values: " + maxArraySize2);
         }
@@ -250,7 +250,7 @@ public class ChatApiHelper {
      */
     private List<String> toStringList(final Object raw) {
         final List<String> values = new ArrayList<>();
-        if (raw instanceof List<?> l) {
+        if (raw instanceof final List<?> l) {
             for (final Object o : l) {
                 if (o != null) {
                     values.add(o.toString());

--- a/src/main/java/org/codelibs/fess/helper/ChunkVectorHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ChunkVectorHelper.java
@@ -276,12 +276,12 @@ public class ChunkVectorHelper {
                 // is true but the model id was never set, so checkAvailabilityNow() can never
                 // succeed -- and the operator sees this same line on every scheduled run with no
                 // hint of what to change. Name both remediations.
-                logger.warn(
-                        "[ChunkVector] The embedding provider is not available; skipping chunk-vector processing to keep pending "
-                                + "documents pending. If this repeats on every run it is a misconfiguration rather than a transient "
-                                + "outage: set {} to a deployed model, or set {}={} to run chunk-only mode (content is chunked and "
-                                + "marked \"{}\" without vectors).",
-                        OPENSEARCH_MODEL_ID_PROPERTY, AbstractEmbeddingClient.EMBEDDING_NAME_PROPERTY, Constants.NONE, Constants.CHUNKED);
+                logger.warn("""
+                        [ChunkVector] The embedding provider is not available; skipping chunk-vector processing to keep pending \
+                        documents pending. If this repeats on every run it is a misconfiguration rather than a transient \
+                        outage: set {} to a deployed model, or set {}={} to run chunk-only mode (content is chunked and \
+                        marked "{}" without vectors).""", OPENSEARCH_MODEL_ID_PROPERTY, AbstractEmbeddingClient.EMBEDDING_NAME_PROPERTY,
+                        Constants.NONE, Constants.CHUNKED);
                 return "Embedding provider is not available. Skipped. If this repeats on every run, it is a misconfiguration rather "
                         + "than a transient outage: set " + OPENSEARCH_MODEL_ID_PROPERTY + " to a deployed model, or set "
                         + AbstractEmbeddingClient.EMBEDDING_NAME_PROPERTY + "=" + Constants.NONE + " to run chunk-only mode.";
@@ -826,10 +826,10 @@ public class ChunkVectorHelper {
             return true;
         }
         if (liveDimension.intValue() != configuredDimension) {
-            logger.error(
-                    "[ChunkVector] Embedding dimension mismatch: configured {}={} but the live {} mapping was created with "
-                            + "dimension={}. This looks like the embedding provider/model was switched without recreating the index. "
-                            + "Skipping this job run -- recreate the index (or restore the prior dimension) before re-running.",
+            logger.error("""
+                    [ChunkVector] Embedding dimension mismatch: configured {}={} but the live {} mapping was created with \
+                    dimension={}. This looks like the embedding provider/model was switched without recreating the index. \
+                    Skipping this job run -- recreate the index (or restore the prior dimension) before re-running.""",
                     AbstractEmbeddingClient.EMBEDDING_DIMENSION_PROPERTY, configuredDimension, Constants.CONTENT_CHUNK_VECTOR_FIELD,
                     liveDimension);
             return false;
@@ -889,10 +889,11 @@ public class ChunkVectorHelper {
             }
         }
         if (confirmedNotReady) {
-            logger.warn("[ChunkVector] The live index has no usable {} knn_vector mapping (the index was likely created while "
-                    + "embedding was disabled/chunk-only, or by a version without this feature). Writing vectors now would "
-                    + "dynamic-map them as a non-knn field, so this run is skipped. Recreate or reindex the index with "
-                    + "embedding enabled so the mapping is created, then re-run.", Constants.CONTENT_CHUNK_VECTOR_FIELD);
+            logger.warn("""
+                    [ChunkVector] The live index has no usable {} knn_vector mapping (the index was likely created while \
+                    embedding was disabled/chunk-only, or by a version without this feature). Writing vectors now would \
+                    dynamic-map them as a non-knn field, so this run is skipped. Recreate or reindex the index with \
+                    embedding enabled so the mapping is created, then re-run.""", Constants.CONTENT_CHUNK_VECTOR_FIELD);
             return false;
         }
         return true;
@@ -1368,10 +1369,9 @@ public class ChunkVectorHelper {
             return null;
         }
         final Object contentObj = doc.get(fessConfig.getIndexFieldContent());
-        if (!(contentObj instanceof List<?>) || ((List<?>) contentObj).isEmpty()) {
+        if (!(contentObj instanceof final List<?> contentList) || ((List<?>) contentObj).isEmpty()) {
             return null;
         }
-        final List<?> contentList = (List<?>) contentObj;
         final List<String> chunks = new ArrayList<>(contentList.size());
         for (final Object element : contentList) {
             chunks.add(String.valueOf(element));
@@ -1712,10 +1712,8 @@ public class ChunkVectorHelper {
         // Bounded walk: a malformed exception chain with a cycle longer than one frame must not
         // spin here.
         for (int depth = 0; cur != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++) {
-            if (cur.getClass().getName().endsWith("RetryableHttpException")) {
-                return true;
-            }
-            if (cur instanceof SocketException || cur instanceof InterruptedIOException || cur instanceof UnknownHostException) {
+            if (cur.getClass().getName().endsWith("RetryableHttpException") || cur instanceof SocketException
+                    || cur instanceof InterruptedIOException || cur instanceof UnknownHostException) {
                 return true;
             }
             final Throwable next = cur.getCause();

--- a/src/main/java/org/codelibs/fess/helper/CrawlerLogHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/CrawlerLogHelper.java
@@ -41,7 +41,6 @@ public class CrawlerLogHelper extends LogHelperImpl {
      * Creates a new instance of CrawlerLogHelper.
      */
     public CrawlerLogHelper() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(CrawlerLogHelper.class);

--- a/src/main/java/org/codelibs/fess/helper/CrawlerStatsHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/CrawlerStatsHelper.java
@@ -287,19 +287,13 @@ public class CrawlerStatsHelper {
      * @return the URL string or a default value if not extractable
      */
     protected String getUrl(final Object keyObj) {
-        if (keyObj instanceof final UrlQueue<?> urlQueue) {
-            return escapeValue(urlQueue.getUrl());
-        }
-        if (keyObj instanceof final StatsKeyObject statsKey) {
-            return escapeValue(statsKey.getUrl());
-        }
-        if (keyObj instanceof final String key) {
-            return escapeValue(key);
-        }
-        if (keyObj instanceof final Number key) {
-            return key.toString();
-        }
-        return "-";
+        return switch (keyObj) {
+        case final UrlQueue<?> urlQueue -> escapeValue(urlQueue.getUrl());
+        case final StatsKeyObject statsKey -> escapeValue(statsKey.getUrl());
+        case final String key -> escapeValue(key);
+        case final Number key -> key.toString();
+        case null, default -> "-";
+        };
     }
 
     /**
@@ -309,19 +303,13 @@ public class CrawlerStatsHelper {
      * @return Optional cache key string, empty if object type not supported
      */
     protected OptionalThing<String> getCacheKey(final Object keyObj) {
-        if (keyObj instanceof final UrlQueue<?> urlQueue) {
-            return OptionalThing.of(urlQueue.getId().toString());
-        }
-        if (keyObj instanceof final StatsKeyObject statsKey) {
-            return OptionalThing.of(statsKey.getId());
-        }
-        if (keyObj instanceof final String key) {
-            return OptionalThing.of(key);
-        }
-        if (keyObj instanceof final Number key) {
-            return OptionalThing.of(key.toString());
-        }
-        return OptionalThing.empty();
+        return switch (keyObj) {
+        case final UrlQueue<?> urlQueue -> OptionalThing.of(urlQueue.getId().toString());
+        case final StatsKeyObject statsKey -> OptionalThing.of(statsKey.getId());
+        case final String key -> OptionalThing.of(key);
+        case final Number key -> OptionalThing.of(key.toString());
+        case null, default -> OptionalThing.empty();
+        };
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/DocumentHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/DocumentHelper.java
@@ -300,20 +300,15 @@ public class DocumentHelper {
             final ResultData resultData = transformer.transform(responseData);
             final Object rawData = resultData.getRawData();
             if (rawData != null) {
-                @SuppressWarnings("unchecked")
-                final Map<String, Object> responseDataMap = (Map<String, Object>) rawData;
-                return responseDataMap;
-            } else {
-                final byte[] data = resultData.getData();
-                if (data != null) {
-                    try {
-                        final DataSerializer dataSerializer = ComponentUtil.getComponent("dataSerializer");
-                        @SuppressWarnings("unchecked")
-                        final Map<String, Object> responseDataMap = (Map<String, Object>) dataSerializer.fromBinaryToObject(data);
-                        return responseDataMap;
-                    } catch (final Exception e) {
-                        throw new CrawlerSystemException("Could not create an instance from bytes.", e);
-                    }
+                return (Map<String, Object>) rawData;
+            }
+            final byte[] data = resultData.getData();
+            if (data != null) {
+                try {
+                    final DataSerializer dataSerializer = ComponentUtil.getComponent("dataSerializer");
+                    return (Map<String, Object>) dataSerializer.fromBinaryToObject(data);
+                } catch (final Exception e) {
+                    throw new CrawlerSystemException("Could not create an instance from bytes.", e);
                 }
             }
             return null;

--- a/src/main/java/org/codelibs/fess/helper/KeyMatchHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/KeyMatchHelper.java
@@ -55,7 +55,6 @@ public class KeyMatchHelper extends AbstractConfigHelper {
      * Default constructor.
      */
     public KeyMatchHelper() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/LabelTypeHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/LabelTypeHelper.java
@@ -55,7 +55,6 @@ public class LabelTypeHelper extends AbstractConfigHelper {
      * Default constructor.
      */
     public LabelTypeHelper() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/LogNotificationHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/LogNotificationHelper.java
@@ -82,10 +82,8 @@ public class LogNotificationHelper {
             maxBufferSize = 1000;
         }
         queue.offer(event);
-        if (size.incrementAndGet() > maxBufferSize) {
-            if (queue.poll() != null) {
-                size.decrementAndGet();
-            }
+        if ((size.incrementAndGet() > maxBufferSize) && (queue.poll() != null)) {
+            size.decrementAndGet();
         }
     }
 

--- a/src/main/java/org/codelibs/fess/helper/PasswordHashHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PasswordHashHelper.java
@@ -192,7 +192,7 @@ public class PasswordHashHelper {
         if (cost == null) {
             return 10;
         }
-        final int c = cost.intValue();
+        final int c = cost;
         if (c < 4) {
             return 4;
         }
@@ -268,10 +268,7 @@ public class PasswordHashHelper {
      */
     public boolean upgradeEncoding(final String storedPassword) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        if (!fessConfig.isAppPasswordUpgradeEnabled()) {
-            return false;
-        }
-        if (storedPassword == null || storedPassword.isEmpty()) {
+        if (!fessConfig.isAppPasswordUpgradeEnabled() || storedPassword == null || storedPassword.isEmpty()) {
             return false;
         }
         final String idForEncode = resolveIdForEncode();
@@ -415,18 +412,12 @@ public class PasswordHashHelper {
      */
     protected String toJcaDigestName(final String algorithm) {
         final String lower = algorithm.toLowerCase(Locale.ROOT);
-        switch (lower) {
-        case "sha256":
-        case "sha-256":
-            return "SHA-256";
-        case "sha512":
-        case "sha-512":
-            return "SHA-512";
-        case "md5":
-            return "MD5";
-        default:
-            return null;
-        }
+        return switch (lower) {
+        case "sha256", "sha-256" -> "SHA-256";
+        case "sha512", "sha-512" -> "SHA-512";
+        case "md5" -> "MD5";
+        default -> null;
+        };
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/PathMappingHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PathMappingHelper.java
@@ -45,7 +45,6 @@ public class PathMappingHelper extends AbstractConfigHelper {
      * Default constructor.
      */
     public PathMappingHelper() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(PathMappingHelper.class);

--- a/src/main/java/org/codelibs/fess/helper/PluginHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PluginHelper.java
@@ -379,13 +379,11 @@ public class PluginHelper {
      */
     public void installArtifact(final Artifact artifact) {
         switch (artifact.getType()) {
-        case THEME:
+        case THEME -> {
             install(artifact);
             ComponentUtil.getThemeHelper().install(artifact);
-            break;
-        default:
-            install(artifact);
-            break;
+        }
+        default -> install(artifact);
         }
     }
 
@@ -450,13 +448,11 @@ public class PluginHelper {
         }
 
         switch (artifact.getType()) {
-        case THEME:
+        case THEME -> {
             ComponentUtil.getThemeHelper().uninstall(artifact);
             uninstall(fileName, jarPath);
-            break;
-        default:
-            uninstall(fileName, jarPath);
-            break;
+        }
+        default -> uninstall(fileName, jarPath);
         }
 
     }

--- a/src/main/java/org/codelibs/fess/helper/RelatedContentHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/RelatedContentHelper.java
@@ -55,7 +55,6 @@ public class RelatedContentHelper extends AbstractConfigHelper {
      * {@code @PostConstruct}.
      */
     public RelatedContentHelper() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(RelatedContentHelper.class);

--- a/src/main/java/org/codelibs/fess/helper/RelatedQueryHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/RelatedQueryHelper.java
@@ -51,7 +51,6 @@ public class RelatedQueryHelper extends AbstractConfigHelper {
      * Initializes the helper with an empty related query map.
      */
     public RelatedQueryHelper() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/RoleQueryHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/RoleQueryHelper.java
@@ -56,7 +56,6 @@ public class RoleQueryHelper {
      * Constructor.
      */
     public RoleQueryHelper() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(RoleQueryHelper.class);

--- a/src/main/java/org/codelibs/fess/helper/SambaHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SambaHelper.java
@@ -86,7 +86,6 @@ public class SambaHelper {
      * Constructor.
      */
     public SambaHelper() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/helper/SearchHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SearchHelper.java
@@ -113,7 +113,7 @@ public class SearchHelper {
     protected SearchRequestParamsRewriter[] searchRequestParamsRewriters = {};
 
     /** Jackson ObjectMapper for JSON serialization/deserialization. */
-    protected ObjectMapper mapper = new ObjectMapper();;
+    protected ObjectMapper mapper = new ObjectMapper();
 
     /**
      * Default constructor for creating a new SearchHelper instance.
@@ -668,14 +668,11 @@ public class SearchHelper {
                             final List<?> list = mapper.readValue(jsonBytes, List.class);
 
                             final List<RequestParameter> result = new ArrayList<>();
-                            for (Object item : list) {
-                                if (item instanceof List<?> pair) {
-                                    if (pair.size() == 2 && pair.get(0) instanceof String name
-                                            && pair.get(1) instanceof List<?> valueList) {
-                                        final String[] values =
-                                                valueList.stream().filter(v -> v instanceof String).toArray(n -> new String[n]);
-                                        result.add(new RequestParameter(name, values));
-                                    }
+                            for (final Object item : list) {
+                                if ((item instanceof final List<?> pair) && (pair.size() == 2 && pair.get(0) instanceof final String name
+                                        && pair.get(1) instanceof final List<?> valueList)) {
+                                    final String[] values = valueList.stream().filter(String.class::isInstance).toArray(n -> new String[n]);
+                                    result.add(new RequestParameter(name, values));
                                 }
                             }
                             LaResponseUtil.getOptionalResponse().ifPresent(res -> {

--- a/src/main/java/org/codelibs/fess/helper/SearchLogHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SearchLogHelper.java
@@ -278,7 +278,8 @@ public class SearchLogHelper {
     protected String determineAccessType(final Object accessType) {
         if (Constants.SEARCH_LOG_ACCESS_TYPE_JSON.equals(accessType)) {
             return Constants.SEARCH_LOG_ACCESS_TYPE_JSON;
-        } else if (Constants.SEARCH_LOG_ACCESS_TYPE_GSA.equals(accessType)) {
+        }
+        if (Constants.SEARCH_LOG_ACCESS_TYPE_GSA.equals(accessType)) {
             return Constants.SEARCH_LOG_ACCESS_TYPE_GSA;
         } else if (Constants.SEARCH_LOG_ACCESS_TYPE_OTHER.equals(accessType)) {
             return Constants.SEARCH_LOG_ACCESS_TYPE_OTHER;

--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -1216,12 +1216,12 @@ public class SystemHelper {
         }
 
         try {
-            final int maxLength = fessConfig.getPasswordMaxLengthAsInteger();
+            final int maxLength = fessConfig.getPasswordMaxLengthOrDefault();
             if (maxLength > 0 && password.length() > maxLength) {
                 return "errors.password_length";
             }
         } catch (final Exception e) {
-            // getPasswordMaxLengthAsInteger is unavailable in slim test harnesses — skip the check.
+            // getPasswordMaxLengthOrDefault is unavailable in slim test harnesses — skip the check.
         }
 
         if (fessConfig.isPasswordRequireUppercase() && !containsUppercase(password)) {

--- a/src/main/java/org/codelibs/fess/helper/UserInfoHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/UserInfoHelper.java
@@ -244,7 +244,7 @@ public class UserInfoHelper {
         }
 
         return LaRequestUtil.getOptionalRequest().map(req -> {
-            String forwardedProto = req.getHeader("X-Forwarded-Proto");
+            final String forwardedProto = req.getHeader("X-Forwarded-Proto");
             if ("https".equalsIgnoreCase(forwardedProto)) {
                 return true;
             }

--- a/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
+++ b/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
@@ -112,7 +112,6 @@ public class DocBoostMatcher {
                 return Float.parseFloat(value.toString());
             } catch (final NumberFormatException e) {
                 logger.warn("Failed to parse boost value: expression={}, value={}", boostExpression, value, e);
-                return 0.0f;
             }
         }
 

--- a/src/main/java/org/codelibs/fess/indexer/IndexUpdater.java
+++ b/src/main/java/org/codelibs/fess/indexer/IndexUpdater.java
@@ -150,7 +150,6 @@ public class IndexUpdater extends Thread {
      * Initializes a new instance with default settings.
      */
     public IndexUpdater() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/job/CrawlJob.java
+++ b/src/main/java/org/codelibs/fess/job/CrawlJob.java
@@ -110,7 +110,6 @@ public class CrawlJob extends ExecJob {
      * Initializes the job with default settings.
      */
     public CrawlJob() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/job/GenerateThumbnailJob.java
+++ b/src/main/java/org/codelibs/fess/job/GenerateThumbnailJob.java
@@ -59,7 +59,6 @@ public class GenerateThumbnailJob extends ExecJob {
      * Default constructor for the GenerateThumbnailJob.
      */
     public GenerateThumbnailJob() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/job/HtmlIndexExportFormatter.java
+++ b/src/main/java/org/codelibs/fess/job/HtmlIndexExportFormatter.java
@@ -56,10 +56,7 @@ public class HtmlIndexExportFormatter implements IndexExportFormatter {
 
         for (final Map.Entry<String, Object> entry : source.entrySet()) {
             final String field = entry.getKey();
-            if ("title".equals(field) || "content".equals(field) || "lang".equals(field)) {
-                continue;
-            }
-            if (excludeFields.contains(field)) {
+            if ("title".equals(field) || "content".equals(field) || "lang".equals(field) || excludeFields.contains(field)) {
                 continue;
             }
 

--- a/src/main/java/org/codelibs/fess/job/IndexExportJob.java
+++ b/src/main/java/org/codelibs/fess/job/IndexExportJob.java
@@ -94,14 +94,11 @@ public class IndexExportJob {
         if (format == null || format.trim().isEmpty()) {
             throw new IllegalArgumentException("Export format must not be null or empty");
         }
-        switch (format.trim().toLowerCase()) {
-        case "html":
-            return new HtmlIndexExportFormatter();
-        case "json":
-            return new JsonIndexExportFormatter();
-        default:
-            throw new IllegalArgumentException("Unsupported export format: " + format);
-        }
+        return switch (format.trim().toLowerCase()) {
+        case "html" -> new HtmlIndexExportFormatter();
+        case "json" -> new JsonIndexExportFormatter();
+        default -> throw new IllegalArgumentException("Unsupported export format: " + format);
+        };
     }
 
     /**
@@ -234,8 +231,8 @@ public class IndexExportJob {
 
             final String[] components = (host + "/" + path).split("/");
             final StringBuilder sanitized = new StringBuilder();
-            for (int i = 0; i < components.length; i++) {
-                String component = components[i].replaceAll("[<>:\"|?*\\\\]", "_");
+            for (final String component2 : components) {
+                String component = component2.replaceAll("[<>:\"|?*\\\\]", "_");
                 if (".".equals(component) || "..".equals(component)) {
                     continue;
                 }

--- a/src/main/java/org/codelibs/fess/job/JsonIndexExportFormatter.java
+++ b/src/main/java/org/codelibs/fess/job/JsonIndexExportFormatter.java
@@ -95,9 +95,7 @@ public class JsonIndexExportFormatter implements IndexExportFormatter {
                 appendJsonValue(json, entry.getValue());
             }
             json.append("}");
-        } else if (value instanceof Number) {
-            json.append(value);
-        } else if (value instanceof Boolean) {
+        } else if ((value instanceof Number) || (value instanceof Boolean)) {
             json.append(value);
         } else {
             json.append("\"").append(escapeJson(String.valueOf(value))).append("\"");

--- a/src/main/java/org/codelibs/fess/job/PythonJob.java
+++ b/src/main/java/org/codelibs/fess/job/PythonJob.java
@@ -55,7 +55,6 @@ public class PythonJob extends ExecJob {
      * Creates a new instance of the Python job with default settings.
      */
     public PythonJob() {
-        super();
     }
 
     /** The Python script filename to execute */

--- a/src/main/java/org/codelibs/fess/job/UpdateLabelJob.java
+++ b/src/main/java/org/codelibs/fess/job/UpdateLabelJob.java
@@ -48,7 +48,6 @@ public class UpdateLabelJob {
      * Default constructor for UpdateLabelJob.
      */
     public UpdateLabelJob() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/job/impl/ScriptExecutor.java
+++ b/src/main/java/org/codelibs/fess/job/impl/ScriptExecutor.java
@@ -30,7 +30,6 @@ public class ScriptExecutor extends JobExecutor {
      * Constructor.
      */
     public ScriptExecutor() {
-        super();
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/ldap/LdapManager.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapManager.java
@@ -175,7 +175,7 @@ public class LdapManager {
      * @return The connection timeout, or 0 or less to leave it unbounded.
      */
     protected int getConnectTimeout() {
-        return fessConfig.getLdapConnectTimeoutAsInteger().intValue();
+        return fessConfig.getLdapConnectTimeoutAsInteger();
     }
 
     /**
@@ -184,7 +184,7 @@ public class LdapManager {
      * @return The read timeout, or 0 or less to leave it unbounded.
      */
     protected int getReadTimeout() {
-        return fessConfig.getLdapReadTimeoutAsInteger().intValue();
+        return fessConfig.getLdapReadTimeoutAsInteger();
     }
 
     /**
@@ -193,7 +193,7 @@ public class LdapManager {
      * @return The search time limit, or 0 or less for no limit.
      */
     protected int getSearchTimeLimit() {
-        return fessConfig.getLdapSearchTimeLimitAsInteger().intValue();
+        return fessConfig.getLdapSearchTimeLimitAsInteger();
     }
 
     /**
@@ -555,7 +555,7 @@ public class LdapManager {
                 if (logger.isDebugEnabled()) {
                     logger.debug("sAMAccountName: {}", attribute);
                 }
-                if (attribute != null && attribute.get() instanceof String sAMAccountName) {
+                if (attribute != null && attribute.get() instanceof final String sAMAccountName) {
                     return OptionalEntity.of(sAMAccountName);
                 }
             }

--- a/src/main/java/org/codelibs/fess/ldap/LdapUtil.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapUtil.java
@@ -40,23 +40,12 @@ public final class LdapUtil {
         for (int i = 0; i < value.length(); i++) {
             final char c = value.charAt(i);
             switch (c) {
-            case '\\':
-                sb.append("\\5c");
-                break;
-            case '*':
-                sb.append("\\2a");
-                break;
-            case '(':
-                sb.append("\\28");
-                break;
-            case ')':
-                sb.append("\\29");
-                break;
-            case '\0':
-                sb.append("\\00");
-                break;
-            default:
-                sb.append(c);
+            case '\\' -> sb.append("\\5c");
+            case '*' -> sb.append("\\2a");
+            case '(' -> sb.append("\\28");
+            case ')' -> sb.append("\\29");
+            case '\0' -> sb.append("\\00");
+            default -> sb.append(c);
             }
         }
         return sb.toString();

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -961,12 +961,14 @@ public abstract class AbstractLlmClient implements LlmClient {
                 logger.debug("[RAG:EVAL] prompt={}", prompt);
             }
             final LlmChatRequest request = new LlmChatRequest();
-            request.addSystemMessage("You are a strict relevance evaluator. "
-                    + "Select ONLY documents that DIRECTLY address the user's specific question topic. "
-                    + "Do NOT select documents about different or merely related topics. "
-                    + "Do NOT select table-of-contents or index pages that lack substantive content. "
-                    + "Respond with JSON only. Do not include any text outside the JSON object.\n\n"
-                    + "Example output: {\"relevant_indexes\": [1, 3], \"has_relevant\": true}");
+            request.addSystemMessage("""
+                    You are a strict relevance evaluator. \
+                    Select ONLY documents that DIRECTLY address the user's specific question topic. \
+                    Do NOT select documents about different or merely related topics. \
+                    Do NOT select table-of-contents or index pages that lack substantive content. \
+                    Respond with JSON only. Do not include any text outside the JSON object.
+
+                    Example output: {"relevant_indexes": [1, 3], "has_relevant": true}""");
             request.addUserMessage(prompt);
             applyPromptTypeParams(request, "evaluation");
 
@@ -1305,12 +1307,11 @@ public abstract class AbstractLlmClient implements LlmClient {
 
         for (int i = history.size() - 1; i >= earliest; i--) {
             final int msgLen = history.get(i).getContent().length();
-            if (msgLen <= remaining) {
-                remaining -= msgLen;
-                startIndex = i;
-            } else {
+            if (msgLen > remaining) {
                 break;
             }
+            remaining -= msgLen;
+            startIndex = i;
         }
 
         for (int i = startIndex; i < history.size(); i++) {
@@ -1518,12 +1519,11 @@ public abstract class AbstractLlmClient implements LlmClient {
             for (int i = turn[0]; i < turn[1]; i++) {
                 turnLen += history.get(i).getContent().length();
             }
-            if (turnLen <= remaining) {
-                remaining -= turnLen;
-                firstIncludedTurn = t;
-            } else {
+            if (turnLen > remaining) {
                 break; // Stop at first non-fitting turn to maintain contiguous recency
             }
+            remaining -= turnLen;
+            firstIncludedTurn = t;
         }
 
         if (firstIncludedTurn < turns.size()) {
@@ -1586,16 +1586,16 @@ public abstract class AbstractLlmClient implements LlmClient {
             final String query = extractJsonString(response, "query");
             final String reasoning = extractJsonString(response, "reasoning");
 
-            if (intent == ChatIntent.SEARCH) {
-                return IntentDetectionResult.search(query, reasoning);
-            } else if (intent == ChatIntent.FAQ) {
-                return IntentDetectionResult.faq(query, reasoning);
-            } else if (intent == ChatIntent.SUMMARY) {
+            return switch (intent) {
+            case SEARCH -> IntentDetectionResult.search(query, reasoning);
+            case FAQ -> IntentDetectionResult.faq(query, reasoning);
+            case SUMMARY -> {
                 final String docUrl = extractJsonString(response, "url");
-                return IntentDetectionResult.summary(docUrl, reasoning);
-            } else {
-                return IntentDetectionResult.unclear(reasoning);
+                yield IntentDetectionResult.summary(docUrl, reasoning);
             }
+            case null -> IntentDetectionResult.unclear(reasoning);
+            default -> IntentDetectionResult.unclear(reasoning);
+            };
         } catch (final Exception e) {
             logger.warn("[RAG:INTENT] Failed to parse intent response, falling back to search. responseLength={}, responseHead={}",
                     response != null ? response.length() : 0, truncateForLog(response), e);
@@ -1809,20 +1809,21 @@ public abstract class AbstractLlmClient implements LlmClient {
      * @return the corresponding error code
      */
     protected String resolveErrorCode(final int statusCode) {
-        if (statusCode == 429) {
+        switch (statusCode) {
+        case 429:
             return LlmException.ERROR_RATE_LIMIT;
-        }
-        if (statusCode == 401 || statusCode == 403) {
+        case 401:
+        case 403:
             return LlmException.ERROR_AUTH;
-        }
-        if (statusCode == 404) {
+        case 404:
             return LlmException.ERROR_MODEL_NOT_FOUND;
-        }
-        if (statusCode == 408) {
+        case 408:
             return LlmException.ERROR_TIMEOUT;
-        }
-        if (statusCode == 502 || statusCode == 503) {
+        case 502:
+        case 503:
             return LlmException.ERROR_SERVICE_UNAVAILABLE;
+        default:
+            break;
         }
         return LlmException.ERROR_UNKNOWN;
     }

--- a/src/main/java/org/codelibs/fess/llm/LlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/LlmClient.java
@@ -79,7 +79,7 @@ public interface LlmClient {
      * @param history the conversation history for context
      * @return the detected intent with extracted keywords
      */
-    default IntentDetectionResult detectIntent(String userMessage, List<LlmMessage> history) {
+    default IntentDetectionResult detectIntent(final String userMessage, final List<LlmMessage> history) {
         return detectIntent(userMessage);
     }
 

--- a/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
+++ b/src/main/java/org/codelibs/fess/llm/LlmClientManager.java
@@ -221,10 +221,7 @@ public class LlmClientManager {
      */
     protected LlmClient getAvailableClient() {
         final String llmType = getLlmType();
-        if (Constants.NONE.equals(llmType)) {
-            throw new LlmException("LLM client is not available");
-        }
-        if (!isRagChatEnabled()) {
+        if (Constants.NONE.equals(llmType) || !isRagChatEnabled()) {
             throw new LlmException("LLM client is not available");
         }
         final LlmClient client = getClient();

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -1246,8 +1246,14 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. 100 */
     String QUERY_FACET_FIELDS_SIZE = "query.facet.fields.size";
 
+    /** The key of the configuration. e.g. 1000 */
+    String QUERY_FACET_FIELDS_SIZE_MAX = "query.facet.fields.size.max";
+
     /** The key of the configuration. e.g. 1 */
     String QUERY_FACET_FIELDS_min_doc_count = "query.facet.fields.min_doc_count";
+
+    /** The key of the configuration. e.g. 2147483647 */
+    String QUERY_FACET_FIELDS_min_doc_count_MAX = "query.facet.fields.min_doc_count.max";
 
     /** The key of the configuration. e.g. count.desc */
     String QUERY_FACET_FIELDS_SORT = "query.facet.fields.sort";
@@ -1506,6 +1512,15 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /** The key of the configuration. e.g. 100 */
     String PAGING_SEARCH_PAGE_MAX_SIZE = "paging.search.page.max.size";
+
+    /** The key of the configuration. e.g. 1000 */
+    String API_PARAM_MAX_LENGTH = "api.param.max.length";
+
+    /** The key of the configuration. e.g. 100 */
+    String API_PARAM_MAX_ARRAY_SIZE = "api.param.max.array.size";
+
+    /** The key of the configuration. e.g. 9999999999999 */
+    String API_CLICK_MAX_TIMESTAMP = "api.click.max.timestamp";
 
     /** The key of the configuration. e.g. -1 */
     String SEARCHLOG_AGG_SHARD_SIZE = "searchlog.agg.shard.size";
@@ -2014,6 +2029,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. 8 */
     String PASSWORD_MIN_LENGTH = "password.min.length";
 
+    /** The key of the configuration. e.g. 100 */
+    String PASSWORD_MAX_LENGTH = "password.max.length";
+
     /** The key of the configuration. e.g. false */
     String PASSWORD_REQUIRE_UPPERCASE = "password.require.uppercase";
 
@@ -2150,7 +2168,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     String THEME_API_LOGIN_RATE_LIMIT_MAX_ENTRIES = "theme.api.login.rate.limit.max.entries";
 
     /** The key of the configuration. e.g. 15000 */
-    String API_V2_CHAT_STREAM_KEEPALIVE_INTERVAL_MS = "api.v2.chat.stream.keepalive.interval.ms";
+    String API_CHAT_STREAM_KEEPALIVE_INTERVAL_MS = "api.chat.stream.keepalive.interval.ms";
 
     /**
      * Get the value of property as {@link String}.
@@ -2526,7 +2544,10 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * -Dlog4j2.formatMsgNoLookups=true<br>
      * -Dlog4j.skipJansi=true<br>
      *  <br>
-     * comment: JVM options for the chunk vector indexer process.
+     * comment: <br>
+     * With the shipped defaults the worst case is roughly 190-250 MB live (and ~235 MB of vectors alone<br>
+     * at dimension=1536), which does not fit a 256 MB heap with any GC headroom. Raise -Xmx further if<br>
+     * you raise bulk_size, max_chunks_per_document, concurrency, or the embedding dimension.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getJvmChunkOptions();
@@ -2935,7 +2956,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'api.json.response.headers'. <br>
      * The value is, e.g. Referrer-Policy:strict-origin-when-cross-origin <br>
-     * comment: Headers for API JSON response.
+     * comment: Headers for API JSON response. Access-Control-* and Timing-Allow-Origin are ignored here (CORS is controlled by api.cors.* / CorsFilter). Do not set Vary.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getApiJsonResponseHeaders();
@@ -2959,7 +2980,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'api.gsa.response.headers'. <br>
      * The value is, e.g. Referrer-Policy:strict-origin-when-cross-origin <br>
-     * comment: Headers for API GSA response.
+     * comment: Headers for API GSA response. Access-Control-* and Timing-Allow-Origin are ignored here (CORS is controlled by api.cors.* / CorsFilter). Do not set Vary.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getApiGsaResponseHeaders();
@@ -2983,7 +3004,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'api.dashboard.response.headers'. <br>
      * The value is, e.g. Referrer-Policy:strict-origin-when-cross-origin <br>
-     * comment: Headers for API dashboard response.
+     * comment: Headers for API dashboard response. Access-Control-* and Timing-Allow-Origin are ignored here (CORS is controlled by api.cors.* / CorsFilter). Do not set Vary.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getApiDashboardResponseHeaders();
@@ -2991,7 +3012,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'api.cors.allow.origin'. <br>
      * The value is, e.g. * <br>
-     * comment: Allowed origins for CORS.
+     * comment: Allowed origins for CORS. "*" returns a literal "*" (the request Origin is NOT reflected) and disables credentials. Set explicit origins (newline- or comma-separated) to allow credentialed cross-origin access.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getApiCorsAllowOrigin();
@@ -3032,7 +3053,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'api.cors.allow.credentials'. <br>
      * The value is, e.g. true <br>
-     * comment: Whether to allow credentials for CORS.
+     * comment: Whether to allow credentials for CORS. Honored only for an exact match of an explicit Origin; ignored when api.cors.allow.origin is "*".
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getApiCorsAllowCredentials();
@@ -3040,7 +3061,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Is the property for the key 'api.cors.allow.credentials' true? <br>
      * The value is, e.g. true <br>
-     * comment: Whether to allow credentials for CORS.
+     * comment: Whether to allow credentials for CORS. Honored only for an exact match of an explicit Origin; ignored when api.cors.allow.origin is "*".
      * @return The determination, true or false. (if not found, exception but basically no way)
      */
     boolean isApiCorsAllowCredentials();
@@ -4821,7 +4842,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * text/html=Content-Security-Policy: reflected-xss block<br>
      * text/html=X-Frame-Options: SAMEORIGIN<br>
      *  <br>
-     * comment: HTTP headers for the response.
+     * comment: HTTP headers for the response. Access-Control-* and Timing-Allow-Origin are ignored (CORS is controlled by api.cors.* / CorsFilter). Do not set Vary here.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getResponseHeaders();
@@ -5715,7 +5736,11 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'query.additional.api.response.fields'. <br>
      * The value is, e.g.  <br>
-     * comment: Additional API response fields for queries.
+     * comment: <br>
+     * Additional API response fields for queries.<br>
+     * This key only appends fields to the v2 API response allow-list (add-only).<br>
+     * Do not add ACL or internal fields (for example role, virtual_host); adding<br>
+     * them would expose access-control information in the search API response.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getQueryAdditionalApiResponseFields();
@@ -5723,7 +5748,11 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'query.additional.api.response.fields' as {@link Integer}. <br>
      * The value is, e.g.  <br>
-     * comment: Additional API response fields for queries.
+     * comment: <br>
+     * Additional API response fields for queries.<br>
+     * This key only appends fields to the v2 API response allow-list (add-only).<br>
+     * Do not add ACL or internal fields (for example role, virtual_host); adding<br>
+     * them would expose access-control information in the search API response.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      * @throws NumberFormatException When the property is not integer.
      */
@@ -6502,6 +6531,23 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     Integer getQueryFacetFieldsSizeAsInteger();
 
     /**
+     * Get the value for the key 'query.facet.fields.size.max'. <br>
+     * The value is, e.g. 1000 <br>
+     * comment: Upper clamp for facet.size (applied at the search chokepoint).
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getQueryFacetFieldsSizeMax();
+
+    /**
+     * Get the value for the key 'query.facet.fields.size.max' as {@link Integer}. <br>
+     * The value is, e.g. 1000 <br>
+     * comment: Upper clamp for facet.size (applied at the search chokepoint).
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getQueryFacetFieldsSizeMaxAsInteger();
+
+    /**
      * Get the value for the key 'query.facet.fields.min_doc_count'. <br>
      * The value is, e.g. 1 <br>
      * comment: Minimum document count for facet fields.
@@ -6517,6 +6563,23 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * @throws NumberFormatException When the property is not integer.
      */
     Integer getQueryFacetFieldsMinDocCountAsInteger();
+
+    /**
+     * Get the value for the key 'query.facet.fields.min_doc_count.max'. <br>
+     * The value is, e.g. 2147483647 <br>
+     * comment: Upper clamp for facet.minDocCount (applied at the search chokepoint).
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getQueryFacetFieldsMinDocCountMax();
+
+    /**
+     * Get the value for the key 'query.facet.fields.min_doc_count.max' as {@link Integer}. <br>
+     * The value is, e.g. 2147483647 <br>
+     * comment: Upper clamp for facet.minDocCount (applied at the search chokepoint).
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getQueryFacetFieldsMinDocCountMaxAsInteger();
 
     /**
      * Get the value for the key 'query.facet.fields.sort'. <br>
@@ -6893,7 +6956,12 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'role.search.guest.permissions'. <br>
      * The value is, e.g. {role}guest <br>
-     * comment: Guest permissions for search roles.
+     * comment: <br>
+     * Keep role.search.guest.permissions non-empty. It seeds the guest role that<br>
+     * keeps the anonymous search role set non-empty; if the resolved role set is<br>
+     * empty the role filter is skipped (fail-open), which can disable role-based<br>
+     * access control and expose documents to anonymous users.<br>
+     * Guest permissions for search roles.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getRoleSearchGuestPermissions();
@@ -6984,10 +7052,31 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'session.cookie.secure'. <br>
      * The value is, e.g.  <br>
-     * comment: Whether to add the Secure attribute to the session cookie (JSESSIONID) at startup.
+     * comment: <br>
+     * Whether to add the Secure attribute to the session cookie (JSESSIONID) at startup.<br>
+     * When blank (default), Tomcat's automatic behavior is used (Secure is added only for HTTPS requests).<br>
+     * Set to true for production HTTPS deployments, especially when TLS is terminated at a reverse proxy.<br>
+     * When true, the cookie is not sent over HTTP, so sessions will not be established for plain HTTP;<br>
+     * keep it blank for localhost development. The Secure attribute is also required when SameSite=none is used.<br>
+     * Changing this value requires a restart.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getSessionCookieSecure();
+
+    /**
+     * Get the value for the key 'session.cookie.secure' as {@link Integer}. <br>
+     * The value is, e.g.  <br>
+     * comment: <br>
+     * Whether to add the Secure attribute to the session cookie (JSESSIONID) at startup.<br>
+     * When blank (default), Tomcat's automatic behavior is used (Secure is added only for HTTPS requests).<br>
+     * Set to true for production HTTPS deployments, especially when TLS is terminated at a reverse proxy.<br>
+     * When true, the cookie is not sent over HTTP, so sessions will not be established for plain HTTP;<br>
+     * keep it blank for localhost development. The Secure attribute is also required when SameSite=none is used.<br>
+     * Changing this value requires a restart.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getSessionCookieSecureAsInteger();
 
     /**
      * Get the value for the key 'cookie.search.parameter.keys'. <br>
@@ -7739,6 +7828,57 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * @throws NumberFormatException When the property is not integer.
      */
     Integer getPagingSearchPageMaxSizeAsInteger();
+
+    /**
+     * Get the value for the key 'api.param.max.length'. <br>
+     * The value is, e.g. 1000 <br>
+     * comment: Maximum length of a v2 API string query parameter (q, sort, sdh). OWASP API4:2023.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getApiParamMaxLength();
+
+    /**
+     * Get the value for the key 'api.param.max.length' as {@link Integer}. <br>
+     * The value is, e.g. 1000 <br>
+     * comment: Maximum length of a v2 API string query parameter (q, sort, sdh). OWASP API4:2023.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getApiParamMaxLengthAsInteger();
+
+    /**
+     * Get the value for the key 'api.param.max.array.size'. <br>
+     * The value is, e.g. 100 <br>
+     * comment: Maximum number of values for a v2 API repeatable query parameter.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getApiParamMaxArraySize();
+
+    /**
+     * Get the value for the key 'api.param.max.array.size' as {@link Integer}. <br>
+     * The value is, e.g. 100 <br>
+     * comment: Maximum number of values for a v2 API repeatable query parameter.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getApiParamMaxArraySizeAsInteger();
+
+    /**
+     * Get the value for the key 'api.click.max.timestamp'. <br>
+     * The value is, e.g. 9999999999999 <br>
+     * comment: Maximum click-log timestamp (rt, epoch ms) accepted by the v2 click API. OWASP API4:2023.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getApiClickMaxTimestamp();
+
+    /**
+     * Get the value for the key 'api.click.max.timestamp' as {@link Long}. <br>
+     * The value is, e.g. 9999999999999 <br>
+     * comment: Maximum click-log timestamp (rt, epoch ms) accepted by the v2 click API. OWASP API4:2023.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not long.
+     */
+    Long getApiClickMaxTimestampAsLong();
 
     /**
      * Get the value for the key 'searchlog.agg.shard.size'. <br>
@@ -9576,6 +9716,23 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     Integer getPasswordMinLengthAsInteger();
 
     /**
+     * Get the value for the key 'password.max.length'. <br>
+     * The value is, e.g. 100 <br>
+     * comment: Maximum length of a password field.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getPasswordMaxLength();
+
+    /**
+     * Get the value for the key 'password.max.length' as {@link Integer}. <br>
+     * The value is, e.g. 100 <br>
+     * comment: Maximum length of a password field.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getPasswordMaxLengthAsInteger();
+
+    /**
      * Get the value for the key 'password.require.uppercase'. <br>
      * The value is, e.g. false <br>
      * comment: Require uppercase letters in password.
@@ -10175,9 +10332,29 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /**
      * Get the value for the key 'theme.api.csrf.server.origins'. <br>
      * The value is, e.g.  <br>
+     * comment: <br>
+     * Optional: canonical external origin(s) of this Fess instance (comma/newline separated),<br>
+     * e.g. https://fess.example.com. When set, these are treated as same-origin for the v2 CSRF<br>
+     * Origin check WITHOUT trusting forwarded headers. Recommended behind reverse proxies that are<br>
+     * not listed in rate.limit.trusted.proxies. When empty, the target origin is reconstructed from<br>
+     * trusted-proxy X-Forwarded-* headers, then from the servlet request.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getThemeApiCsrfServerOrigins();
+
+    /**
+     * Get the value for the key 'theme.api.csrf.server.origins' as {@link Integer}. <br>
+     * The value is, e.g.  <br>
+     * comment: <br>
+     * Optional: canonical external origin(s) of this Fess instance (comma/newline separated),<br>
+     * e.g. https://fess.example.com. When set, these are treated as same-origin for the v2 CSRF<br>
+     * Origin check WITHOUT trusting forwarded headers. Recommended behind reverse proxies that are<br>
+     * not listed in rate.limit.trusted.proxies. When empty, the target origin is reconstructed from<br>
+     * trusted-proxy X-Forwarded-* headers, then from the servlet request.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getThemeApiCsrfServerOriginsAsInteger();
 
     /**
      * Get the value for the key 'theme.api.login.rate.limit.per.ip.per.minute'. <br>
@@ -10240,7 +10417,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     Integer getThemeApiLoginRateLimitMaxEntriesAsInteger();
 
     /**
-     * Get the value for the key 'api.v2.chat.stream.keepalive.interval.ms'. <br>
+     * Get the value for the key 'api.chat.stream.keepalive.interval.ms'. <br>
      * The value is, e.g. 15000 <br>
      * comment: <br>
      * Interval between SSE keep-alive pings emitted by /api/v2/chat/stream. The<br>
@@ -10252,10 +10429,10 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * disable. Unit: milliseconds.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
-    String getApiV2ChatStreamKeepaliveIntervalMs();
+    String getApiChatStreamKeepaliveIntervalMs();
 
     /**
-     * Get the value for the key 'api.v2.chat.stream.keepalive.interval.ms' as {@link Integer}. <br>
+     * Get the value for the key 'api.chat.stream.keepalive.interval.ms' as {@link Integer}. <br>
      * The value is, e.g. 15000 <br>
      * comment: <br>
      * Interval between SSE keep-alive pings emitted by /api/v2/chat/stream. The<br>
@@ -10268,7 +10445,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      * @throws NumberFormatException When the property is not integer.
      */
-    Integer getApiV2ChatStreamKeepaliveIntervalMsAsInteger();
+    Integer getApiChatStreamKeepaliveIntervalMsAsInteger();
 
     /**
      * The simple implementation for configuration.
@@ -12251,12 +12428,28 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return getAsInteger(FessConfig.QUERY_FACET_FIELDS_SIZE);
         }
 
+        public String getQueryFacetFieldsSizeMax() {
+            return get(FessConfig.QUERY_FACET_FIELDS_SIZE_MAX);
+        }
+
+        public Integer getQueryFacetFieldsSizeMaxAsInteger() {
+            return getAsInteger(FessConfig.QUERY_FACET_FIELDS_SIZE_MAX);
+        }
+
         public String getQueryFacetFieldsMinDocCount() {
             return get(FessConfig.QUERY_FACET_FIELDS_min_doc_count);
         }
 
         public Integer getQueryFacetFieldsMinDocCountAsInteger() {
             return getAsInteger(FessConfig.QUERY_FACET_FIELDS_min_doc_count);
+        }
+
+        public String getQueryFacetFieldsMinDocCountMax() {
+            return get(FessConfig.QUERY_FACET_FIELDS_min_doc_count_MAX);
+        }
+
+        public Integer getQueryFacetFieldsMinDocCountMaxAsInteger() {
+            return getAsInteger(FessConfig.QUERY_FACET_FIELDS_min_doc_count_MAX);
         }
 
         public String getQueryFacetFieldsSort() {
@@ -12485,6 +12678,10 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
         public String getSessionCookieSecure() {
             return get(FessConfig.SESSION_COOKIE_SECURE);
+        }
+
+        public Integer getSessionCookieSecureAsInteger() {
+            return getAsInteger(FessConfig.SESSION_COOKIE_SECURE);
         }
 
         public String getCookieSearchParameterKeys() {
@@ -12841,6 +13038,30 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
         public Integer getPagingSearchPageMaxSizeAsInteger() {
             return getAsInteger(FessConfig.PAGING_SEARCH_PAGE_MAX_SIZE);
+        }
+
+        public String getApiParamMaxLength() {
+            return get(FessConfig.API_PARAM_MAX_LENGTH);
+        }
+
+        public Integer getApiParamMaxLengthAsInteger() {
+            return getAsInteger(FessConfig.API_PARAM_MAX_LENGTH);
+        }
+
+        public String getApiParamMaxArraySize() {
+            return get(FessConfig.API_PARAM_MAX_ARRAY_SIZE);
+        }
+
+        public Integer getApiParamMaxArraySizeAsInteger() {
+            return getAsInteger(FessConfig.API_PARAM_MAX_ARRAY_SIZE);
+        }
+
+        public String getApiClickMaxTimestamp() {
+            return get(FessConfig.API_CLICK_MAX_TIMESTAMP);
+        }
+
+        public Long getApiClickMaxTimestampAsLong() {
+            return getAsLong(FessConfig.API_CLICK_MAX_TIMESTAMP);
         }
 
         public String getSearchlogAggShardSize() {
@@ -13739,6 +13960,14 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return getAsInteger(FessConfig.PASSWORD_MIN_LENGTH);
         }
 
+        public String getPasswordMaxLength() {
+            return get(FessConfig.PASSWORD_MAX_LENGTH);
+        }
+
+        public Integer getPasswordMaxLengthAsInteger() {
+            return getAsInteger(FessConfig.PASSWORD_MAX_LENGTH);
+        }
+
         public String getPasswordRequireUppercase() {
             return get(FessConfig.PASSWORD_REQUIRE_UPPERCASE);
         }
@@ -14035,6 +14264,10 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return get(FessConfig.THEME_API_CSRF_SERVER_ORIGINS);
         }
 
+        public Integer getThemeApiCsrfServerOriginsAsInteger() {
+            return getAsInteger(FessConfig.THEME_API_CSRF_SERVER_ORIGINS);
+        }
+
         public String getThemeApiLoginRateLimitPerIpPerMinute() {
             return get(FessConfig.THEME_API_LOGIN_RATE_LIMIT_PER_IP_PER_MINUTE);
         }
@@ -14067,12 +14300,12 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return getAsInteger(FessConfig.THEME_API_LOGIN_RATE_LIMIT_MAX_ENTRIES);
         }
 
-        public String getApiV2ChatStreamKeepaliveIntervalMs() {
-            return get(FessConfig.API_V2_CHAT_STREAM_KEEPALIVE_INTERVAL_MS);
+        public String getApiChatStreamKeepaliveIntervalMs() {
+            return get(FessConfig.API_CHAT_STREAM_KEEPALIVE_INTERVAL_MS);
         }
 
-        public Integer getApiV2ChatStreamKeepaliveIntervalMsAsInteger() {
-            return getAsInteger(FessConfig.API_V2_CHAT_STREAM_KEEPALIVE_INTERVAL_MS);
+        public Integer getApiChatStreamKeepaliveIntervalMsAsInteger() {
+            return getAsInteger(FessConfig.API_CHAT_STREAM_KEEPALIVE_INTERVAL_MS);
         }
 
         @Override
@@ -14419,7 +14652,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.QUERY_FUZZY_TRANSPOSITIONS, "true");
             defaultMap.put(FessConfig.QUERY_FACET_FIELDS, "label");
             defaultMap.put(FessConfig.QUERY_FACET_FIELDS_SIZE, "100");
+            defaultMap.put(FessConfig.QUERY_FACET_FIELDS_SIZE_MAX, "1000");
             defaultMap.put(FessConfig.QUERY_FACET_FIELDS_min_doc_count, "1");
+            defaultMap.put(FessConfig.QUERY_FACET_FIELDS_min_doc_count_MAX, "2147483647");
             defaultMap.put(FessConfig.QUERY_FACET_FIELDS_SORT, "count.desc");
             defaultMap.put(FessConfig.QUERY_FACET_FIELDS_MISSING, "");
             defaultMap.put(FessConfig.QUERY_FACET_QUERIES,
@@ -14508,6 +14743,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.PAGING_SEARCH_PAGE_START, "0");
             defaultMap.put(FessConfig.PAGING_SEARCH_PAGE_SIZE, "10");
             defaultMap.put(FessConfig.PAGING_SEARCH_PAGE_MAX_SIZE, "100");
+            defaultMap.put(FessConfig.API_PARAM_MAX_LENGTH, "1000");
+            defaultMap.put(FessConfig.API_PARAM_MAX_ARRAY_SIZE, "100");
+            defaultMap.put(FessConfig.API_CLICK_MAX_TIMESTAMP, "9999999999999");
             defaultMap.put(FessConfig.SEARCHLOG_AGG_SHARD_SIZE, "-1");
             defaultMap.put(FessConfig.SEARCHLOG_REQUEST_HEADERS, "");
             defaultMap.put(FessConfig.SEARCHLOG_PROCESS_batch_size, "100");
@@ -14678,6 +14916,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.STORAGE_MAX_ITEMS_IN_PAGE, "1000");
             defaultMap.put(FessConfig.PASSWORD_INVALID_ADMIN_PASSWORDS, "admin");
             defaultMap.put(FessConfig.PASSWORD_MIN_LENGTH, "8");
+            defaultMap.put(FessConfig.PASSWORD_MAX_LENGTH, "100");
             defaultMap.put(FessConfig.PASSWORD_REQUIRE_UPPERCASE, "false");
             defaultMap.put(FessConfig.PASSWORD_REQUIRE_LOWERCASE, "false");
             defaultMap.put(FessConfig.PASSWORD_REQUIRE_DIGIT, "false");
@@ -14723,7 +14962,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.THEME_API_LOGIN_RATE_LIMIT_PER_USER_PER_MINUTE, "5");
             defaultMap.put(FessConfig.THEME_API_LOGIN_LOCKOUT_SECONDS, "900");
             defaultMap.put(FessConfig.THEME_API_LOGIN_RATE_LIMIT_MAX_ENTRIES, "100000");
-            defaultMap.put(FessConfig.API_V2_CHAT_STREAM_KEEPALIVE_INTERVAL_MS, "15000");
+            defaultMap.put(FessConfig.API_CHAT_STREAM_KEEPALIVE_INTERVAL_MS, "15000");
             defaultMap.put(FessConfig.lasta_di_SMART_DEPLOY_MODE, "warm");
             defaultMap.put(FessConfig.DEVELOPMENT_HERE, "true");
             defaultMap.put(FessConfig.ENVIRONMENT_TITLE, "Local Development");

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -1036,14 +1036,16 @@ public interface FessProp {
     String getJobTemplateTitleData();
 
     default String getJobTemplateTitle(final String type) {
-        if (Constants.WEB_CRAWLER_TYPE.equals(type)) {
+        switch (type) {
+        case Constants.WEB_CRAWLER_TYPE:
             return getJobTemplateTitleWeb();
-        }
-        if (Constants.FILE_CRAWLER_TYPE.equals(type)) {
+        case Constants.FILE_CRAWLER_TYPE:
             return getJobTemplateTitleFile();
-        }
-        if (Constants.DATA_CRAWLER_TYPE.equals(type)) {
+        case Constants.DATA_CRAWLER_TYPE:
             return getJobTemplateTitleData();
+        case null:
+        default:
+            break;
         }
         return "None";
     }
@@ -2459,7 +2461,7 @@ public interface FessProp {
     }
 
     /**
-     * Resolves {@code api.v2.chat.rate.limit.per.user.per.minute} from the system
+     * Resolves {@code api.chat.rate.limit.per.user.per.minute} from the system
      * properties, defaulting to {@code 30} on absence or parse failure. A return
      * value &le; 0 disables the chat rate limit entirely.
      *
@@ -2472,7 +2474,7 @@ public interface FessProp {
      */
     default int getChatRateLimitPerMinute() {
         try {
-            return Integer.parseInt(getSystemProperty("api.v2.chat.rate.limit.per.user.per.minute", "30"));
+            return Integer.parseInt(getSystemProperty("api.chat.rate.limit.per.user.per.minute", "30"));
         } catch (final NumberFormatException e) {
             return 30;
         }
@@ -2483,44 +2485,64 @@ public interface FessProp {
      * (e.g. {@code q}, {@code sort}, {@code sdh}). Enforced server-side per
      * OWASP API4:2023 guidance.
      *
+     * <p>Named {@code ...OrDefault} rather than {@code ...AsInteger}/{@code ...AsLong} on purpose: freegen
+     * emits those two suffixes for every key in {@code fess_config.properties}, and a generated declaration
+     * in {@link FessConfig} plus its {@code SimpleImpl} body would override this default and drop the
+     * fallback below.</p>
+     *
      * @return maximum character length; defaults to {@code 1000}
      */
-    default int getApiV2ParamMaxLengthAsInteger() {
-        final Integer value = getAsInteger("api.v2.param.max.length");
-        return value != null ? value.intValue() : 1000;
+    default int getApiParamMaxLengthOrDefault() {
+        final Integer value = getAsInteger("api.param.max.length");
+        return value != null ? value : 1000;
     }
 
     /**
      * Returns the maximum number of values allowed for a v2 API repeatable
      * query parameter (e.g. array-typed fields).
      *
+     * <p>Named {@code ...OrDefault} rather than {@code ...AsInteger}/{@code ...AsLong} on purpose: freegen
+     * emits those two suffixes for every key in {@code fess_config.properties}, and a generated declaration
+     * in {@link FessConfig} plus its {@code SimpleImpl} body would override this default and drop the
+     * fallback below.</p>
+     *
      * @return maximum item count; defaults to {@code 100}
      */
-    default int getApiV2ParamMaxArraySizeAsInteger() {
-        final Integer value = getAsInteger("api.v2.param.max.array.size");
-        return value != null ? value.intValue() : 100;
+    default int getApiParamMaxArraySizeOrDefault() {
+        final Integer value = getAsInteger("api.param.max.array.size");
+        return value != null ? value : 100;
     }
 
     /**
      * Returns the maximum allowed length for a password field submitted via the
      * v2 API.
      *
+     * <p>Named {@code ...OrDefault} rather than {@code ...AsInteger}/{@code ...AsLong} on purpose: freegen
+     * emits those two suffixes for every key in {@code fess_config.properties}, and a generated declaration
+     * in {@link FessConfig} plus its {@code SimpleImpl} body would override this default and drop the
+     * fallback below.</p>
+     *
      * @return maximum character length; defaults to {@code 100}
      */
-    default int getPasswordMaxLengthAsInteger() {
+    default int getPasswordMaxLengthOrDefault() {
         final Integer value = getAsInteger("password.max.length");
-        return value != null ? value.intValue() : 100;
+        return value != null ? value : 100;
     }
 
     /**
      * Returns the upper clamp for the {@code facet.size} parameter applied at
      * the search chokepoint.
      *
+     * <p>Named {@code ...OrDefault} rather than {@code ...AsInteger}/{@code ...AsLong} on purpose: freegen
+     * emits those two suffixes for every key in {@code fess_config.properties}, and a generated declaration
+     * in {@link FessConfig} plus its {@code SimpleImpl} body would override this default and drop the
+     * fallback below.</p>
+     *
      * @return maximum facet field size; defaults to {@code 1000}
      */
-    default int getQueryFacetFieldsSizeMaxAsInteger() {
+    default int getQueryFacetFieldsSizeMaxOrDefault() {
         final Integer value = getAsInteger("query.facet.fields.size.max");
-        return value != null ? value.intValue() : 1000;
+        return value != null ? value : 1000;
     }
 
     /**
@@ -2528,9 +2550,14 @@ public interface FessProp {
      * at the search chokepoint. Read as a long because the value (and its default)
      * may exceed the {@code int} range.
      *
+     * <p>Named {@code ...OrDefault} rather than {@code ...AsInteger}/{@code ...AsLong} on purpose: freegen
+     * emits those two suffixes for every key in {@code fess_config.properties}, and a generated declaration
+     * in {@link FessConfig} plus its {@code SimpleImpl} body would override this default and drop the
+     * fallback below.</p>
+     *
      * @return maximum facet minimum document count; defaults to {@code 2147483647}
      */
-    default long getQueryFacetFieldsMinDocCountMaxAsLong() {
+    default long getQueryFacetFieldsMinDocCountMaxOrDefault() {
         final String value = get("query.facet.fields.min_doc_count.max");
         if (value != null) {
             try {
@@ -2547,10 +2574,15 @@ public interface FessProp {
      * accepted by the v2 click API. Read as a long because the value (and its
      * default) exceeds the {@code int} range.
      *
+     * <p>Named {@code ...OrDefault} rather than {@code ...AsInteger}/{@code ...AsLong} on purpose: freegen
+     * emits those two suffixes for every key in {@code fess_config.properties}, and a generated declaration
+     * in {@link FessConfig} plus its {@code SimpleImpl} body would override this default and drop the
+     * fallback below.</p>
+     *
      * @return maximum accepted {@code rt}; defaults to {@code 9999999999999}
      */
-    default long getApiV2ClickMaxRtAsLong() {
-        final String value = get("api.v2.click.max.rt");
+    default long getApiClickMaxTimestampOrDefault() {
+        final String value = get("api.click.max.timestamp");
         if (value != null) {
             try {
                 return Long.parseLong(value.trim());

--- a/src/main/java/org/codelibs/fess/mylasta/direction/sponsor/FessMultipartRequestHandler.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/sponsor/FessMultipartRequestHandler.java
@@ -209,7 +209,7 @@ public class FessMultipartRequestHandler implements MultipartRequestHandler {
     //                                                                   =================
     protected void mappingParameter(final HttpServletRequest request, final List<DiskFileItem> items) {
         showFieldLoggingTitle();
-        for (DiskFileItem item : items) {
+        for (final DiskFileItem item : items) {
             if (item.isFormField()) {
                 showFormFieldParameter(item);
                 addTextParameter(request, item);
@@ -336,7 +336,7 @@ public class FessMultipartRequestHandler implements MultipartRequestHandler {
     //                                                                           =========
     @Override
     public void rollback() {
-        for (MultipartFormFile formFile : elementsFile.values()) {
+        for (final MultipartFormFile formFile : elementsFile.values()) {
             formFile.destroy();
         }
     }

--- a/src/main/java/org/codelibs/fess/opensearch/client/CrawlerEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/CrawlerEngineClient.java
@@ -37,7 +37,6 @@ public class CrawlerEngineClient extends FesenClient {
      * Creates a new instance of CrawlerEngineClient.
      */
     public CrawlerEngineClient() {
-        super();
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -422,12 +422,11 @@ public class SearchEngineClient implements Client {
                 final String knnEngine =
                         fessConfig.getSystemProperty(ChunkVectorHelper.KNN_ENGINE_PROPERTY, ChunkVectorHelper.DEFAULT_KNN_ENGINE);
                 if (isUnsupportedEmbeddedEngine(true, knnEngine)) {
-                    logger.warn(
-                            "content_chunker.search.knn.engine is set to '{}', but the embedded OpenSearch's bundled k-NN plugin "
-                                    + "has no JNI native libraries for it: index creation will succeed, then every document write is "
-                                    + "silently dropped by an uncaught error, and searches will return zero hits. Set "
-                                    + "content_chunker.search.knn.engine=lucene, or use Docker or an external OpenSearch instead.",
-                            knnEngine);
+                    logger.warn("""
+                            content_chunker.search.knn.engine is set to '{}', but the embedded OpenSearch's bundled k-NN plugin \
+                            has no JNI native libraries for it: index creation will succeed, then every document write is \
+                            silently dropped by an uncaught error, and searches will return zero hits. Set \
+                            content_chunker.search.knn.engine=lucene, or use Docker or an external OpenSearch instead.""", knnEngine);
                 }
                 break;
             }
@@ -752,11 +751,12 @@ public class SearchEngineClient implements Client {
             }
         } catch (final Exception e) {
             if (isMissingKnnPluginError(e)) {
-                logger.warn("Failed to create index: index={}, path={}. This looks like the OpenSearch cluster is missing the "
-                        + "opensearch-knn plugin -- every shipped index now declares \"index.knn\": true and a "
-                        + "\"knn_vector\" field unconditionally. Install opensearch-knn on every node and restart; Fess "
-                        + "cannot start against this cluster otherwise, and the failure this triggers next (loading this "
-                        + "index's mapping) will not repeat this diagnosis.", index, indexConfigFile, e);
+                logger.warn("""
+                        Failed to create index: index={}, path={}. This looks like the OpenSearch cluster is missing the \
+                        opensearch-knn plugin -- every shipped index now declares "index.knn": true and a \
+                        "knn_vector" field unconditionally. Install opensearch-knn on every node and restart; Fess \
+                        cannot start against this cluster otherwise, and the failure this triggers next (loading this \
+                        index's mapping) will not repeat this diagnosis.""", index, indexConfigFile, e);
             } else {
                 logger.warn("Failed to create index: index={}, path={}", index, indexConfigFile, e);
             }
@@ -1256,10 +1256,10 @@ public class SearchEngineClient implements Client {
      * @return {@code true} when none of the known job-process markers are set
      */
     protected boolean isWebappProcess() {
-        return !(Constants.TRUE.equalsIgnoreCase(System.getProperty("fess." + Constants.EXECUTE_TYPE_CRAWLER + ".process"))
-                || Constants.TRUE.equalsIgnoreCase(System.getProperty("fess." + Constants.EXECUTE_TYPE_THUMBNAIL + ".process"))
-                || Constants.TRUE.equalsIgnoreCase(System.getProperty("fess." + Constants.EXECUTE_TYPE_SUGGEST + ".process"))
-                || Constants.TRUE.equalsIgnoreCase(System.getProperty("fess." + Constants.EXECUTE_TYPE_CHUNK + ".process")));
+        return (!Constants.TRUE.equalsIgnoreCase(System.getProperty("fess." + Constants.EXECUTE_TYPE_CRAWLER + ".process"))
+                && !Constants.TRUE.equalsIgnoreCase(System.getProperty("fess." + Constants.EXECUTE_TYPE_THUMBNAIL + ".process"))
+                && !Constants.TRUE.equalsIgnoreCase(System.getProperty("fess." + Constants.EXECUTE_TYPE_SUGGEST + ".process"))
+                && !Constants.TRUE.equalsIgnoreCase(System.getProperty("fess." + Constants.EXECUTE_TYPE_CHUNK + ".process")));
     }
 
     /**
@@ -1334,7 +1334,7 @@ public class SearchEngineClient implements Client {
             if (aliasConfigDir.isDirectory()) {
                 stream(aliasConfigDir.listFiles((dir, name) -> name.endsWith(".json"))).of(stream -> stream.forEach(f -> {
                     String aliasName = f.getName().replaceFirst(".json$", "");
-                    if (index.equals(DOC_INDEX)) {
+                    if (DOC_INDEX.equals(index)) {
                         if ("fess.search".equals(aliasName)) {
                             aliasName = fessConfig.getIndexDocumentSearchIndex();
                         } else if ("fess.update".equals(aliasName)) {
@@ -1587,12 +1587,9 @@ public class SearchEngineClient implements Client {
             if (cause instanceof OpenSearchStatusException) {
                 final RestStatus status = ((OpenSearchStatusException) cause).status();
                 switch (status) {
-                case UNAUTHORIZED:
-                    logger.warn("[{}] Unauthorized access: {}", i, SystemUtil.getSearchEngineHttpAddress(), cause);
-                    break;
-                default:
-                    logger.debug("[{}][{}] Failed to access to Fesen ({})", i, status, SystemUtil.getSearchEngineHttpAddress(), cause);
-                    break;
+                case UNAUTHORIZED -> logger.warn("[{}] Unauthorized access: {}", i, SystemUtil.getSearchEngineHttpAddress(), cause);
+                default -> logger.debug("[{}][{}] Failed to access to Fesen ({})", i, status, SystemUtil.getSearchEngineHttpAddress(),
+                        cause);
                 }
             } else if (logger.isDebugEnabled()) {
                 logger.debug("[{}] Failed to access to Fesen ({})", i, SystemUtil.getSearchEngineHttpAddress(), cause);
@@ -2511,11 +2508,12 @@ public class SearchEngineClient implements Client {
                         AggregationBuilders.terms(Constants.FACET_FIELD_PREFIX + encodedField).field(f);
                 termsBuilder.order(facetInfo.getBucketOrder());
                 if (facetInfo.size != null) {
-                    final int maxFacetSize = fessConfig.getQueryFacetFieldsSizeMaxAsInteger();
+                    final int maxFacetSize = fessConfig.getQueryFacetFieldsSizeMaxOrDefault();
                     termsBuilder.size(clampFacetSize(facetInfo.size, maxFacetSize));
                 }
                 if (facetInfo.minDocCount != null) {
-                    termsBuilder.minDocCount(clampMinDocCount(facetInfo.minDocCount, fessConfig.getQueryFacetFieldsMinDocCountMaxAsLong()));
+                    termsBuilder
+                            .minDocCount(clampMinDocCount(facetInfo.minDocCount, fessConfig.getQueryFacetFieldsMinDocCountMaxOrDefault()));
                 }
                 if (facetInfo.missing != null) {
                     termsBuilder.missing(facetInfo.missing);
@@ -3540,8 +3538,8 @@ public class SearchEngineClient implements Client {
      * @throws UnsupportedOperationException always thrown as this operation is not implemented
      */
     @Override
-    public void searchView(org.opensearch.action.admin.indices.view.SearchViewAction.Request request,
-            ActionListener<SearchResponse> listener) {
+    public void searchView(final org.opensearch.action.admin.indices.view.SearchViewAction.Request request,
+            final ActionListener<SearchResponse> listener) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
@@ -3553,7 +3551,7 @@ public class SearchEngineClient implements Client {
      * @throws UnsupportedOperationException always thrown as this operation is not implemented
      */
     @Override
-    public ActionFuture<SearchResponse> searchView(org.opensearch.action.admin.indices.view.SearchViewAction.Request request) {
+    public ActionFuture<SearchResponse> searchView(final org.opensearch.action.admin.indices.view.SearchViewAction.Request request) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
@@ -3565,8 +3563,8 @@ public class SearchEngineClient implements Client {
      * @throws UnsupportedOperationException always thrown as this operation is not implemented
      */
     @Override
-    public void listViewNames(org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request,
-            ActionListener<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listener) {
+    public void listViewNames(final org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request,
+            final ActionListener<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listener) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
@@ -3579,7 +3577,7 @@ public class SearchEngineClient implements Client {
      */
     @Override
     public ActionFuture<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listViewNames(
-            org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request) {
+            final org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/DataConfig.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/DataConfig.java
@@ -321,11 +321,14 @@ public class DataConfig extends BsDataConfig implements CrawlingConfig {
         }
 
         // AuthSchemeType
-        if (Constants.BASIC.equals(scheme)) {
+        switch (scheme) {
+        case Constants.BASIC:
             config.setAuthSchemeType(AuthSchemeType.BASIC);
-        } else if (Constants.DIGEST.equals(scheme)) {
+            break;
+        case Constants.DIGEST:
             config.setAuthSchemeType(AuthSchemeType.DIGEST);
-        } else if (Constants.NTLM.equals(scheme)) {
+            break;
+        case Constants.NTLM: {
             config.setAuthSchemeType(AuthSchemeType.NTLM);
             // Pass jcifs.* properties via formParameters for NTLM configuration
             final Map<String, String> jcifsParams = paramMap.entrySet()
@@ -335,13 +338,20 @@ public class DataConfig extends BsDataConfig implements CrawlingConfig {
             if (!jcifsParams.isEmpty()) {
                 config.setNtlmParameters(jcifsParams);
             }
-        } else if (Constants.FORM.equals(scheme)) {
+            break;
+        }
+        case Constants.FORM: {
             config.setAuthSchemeType(AuthSchemeType.FORM);
             final Map<String, String> formParams = paramMap.entrySet()
                     .stream()
                     .filter(e -> e.getKey().startsWith(prefix))
                     .collect(Collectors.toMap(e -> e.getKey().substring(prefix.length()), Entry::getValue));
             config.setFormParameters(formParams);
+            break;
+        }
+        case null:
+        default:
+            break;
         }
 
         // Credentials

--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/WebAuthentication.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/WebAuthentication.java
@@ -66,11 +66,14 @@ public class WebAuthentication extends BsWebAuthentication {
 
         // AuthSchemeType の設定
         final String scheme = getProtocolScheme();
-        if (Constants.BASIC.equals(scheme)) {
+        switch (scheme) {
+        case Constants.BASIC:
             config.setAuthSchemeType(AuthSchemeType.BASIC);
-        } else if (Constants.DIGEST.equals(scheme)) {
+            break;
+        case Constants.DIGEST:
             config.setAuthSchemeType(AuthSchemeType.DIGEST);
-        } else if (Constants.NTLM.equals(scheme)) {
+            break;
+        case Constants.NTLM: {
             config.setAuthSchemeType(AuthSchemeType.NTLM);
             // Pass jcifs.* properties via formParameters for NTLM configuration
             final Map<String, String> jcifsParams = new HashMap<>();
@@ -82,9 +85,15 @@ public class WebAuthentication extends BsWebAuthentication {
             if (!jcifsParams.isEmpty()) {
                 config.setNtlmParameters(jcifsParams);
             }
-        } else if (Constants.FORM.equals(scheme)) {
+            break;
+        }
+        case Constants.FORM:
             config.setAuthSchemeType(AuthSchemeType.FORM);
             config.setFormParameters(ParameterUtil.parse(getParameters()));
+            break;
+        case null:
+        default:
+            break;
         }
 
         // Credentials の設定

--- a/src/main/java/org/codelibs/fess/opensearch/query/KnnQueryBuilder.java
+++ b/src/main/java/org/codelibs/fess/opensearch/query/KnnQueryBuilder.java
@@ -93,6 +93,7 @@ public class KnnQueryBuilder extends AbstractQueryBuilder<KnnQueryBuilder> {
      * @param filter the filter query
      * @return this builder
      */
+    @Override
     public KnnQueryBuilder filter(final QueryBuilder filter) {
         this.filter = filter;
         return this;

--- a/src/main/java/org/codelibs/fess/query/BooleanQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/BooleanQueryCommand.java
@@ -36,7 +36,6 @@ public class BooleanQueryCommand extends QueryCommand {
      * Default constructor for BooleanQueryCommand.
      */
     public BooleanQueryCommand() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(BooleanQueryCommand.class);

--- a/src/main/java/org/codelibs/fess/query/BoostQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/BoostQueryCommand.java
@@ -33,7 +33,6 @@ public class BoostQueryCommand extends QueryCommand {
      * Default constructor for BoostQueryCommand.
      */
     public BoostQueryCommand() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(BoostQueryCommand.class);

--- a/src/main/java/org/codelibs/fess/query/DefaultQueryBuilder.java
+++ b/src/main/java/org/codelibs/fess/query/DefaultQueryBuilder.java
@@ -171,7 +171,7 @@ public class DefaultQueryBuilder implements QueryBuilder {
      * @return the query builder
      */
     @Override
-    public QueryBuilder filter(QueryBuilder filter) {
+    public QueryBuilder filter(final QueryBuilder filter) {
         return queryBuilder.filter(filter);
     }
 

--- a/src/main/java/org/codelibs/fess/query/FuzzyQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/FuzzyQueryCommand.java
@@ -43,7 +43,6 @@ public class FuzzyQueryCommand extends QueryCommand {
      * Default constructor.
      */
     public FuzzyQueryCommand() {
-        super();
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/query/MatchAllQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/MatchAllQueryCommand.java
@@ -32,7 +32,6 @@ public class MatchAllQueryCommand extends QueryCommand {
      * Default constructor.
      */
     public MatchAllQueryCommand() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(MatchAllQueryCommand.class);

--- a/src/main/java/org/codelibs/fess/query/PhraseQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/PhraseQueryCommand.java
@@ -39,7 +39,6 @@ public class PhraseQueryCommand extends QueryCommand {
      * Default constructor.
      */
     public PhraseQueryCommand() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(PhraseQueryCommand.class);

--- a/src/main/java/org/codelibs/fess/query/PrefixQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/PrefixQueryCommand.java
@@ -39,7 +39,6 @@ public class PrefixQueryCommand extends QueryCommand {
      * Default constructor.
      */
     public PrefixQueryCommand() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(PrefixQueryCommand.class);

--- a/src/main/java/org/codelibs/fess/query/TermQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/TermQueryCommand.java
@@ -49,7 +49,6 @@ public class TermQueryCommand extends QueryCommand {
      * Default constructor for TermQueryCommand.
      */
     public TermQueryCommand() {
-        super();
     }
 
     private static final String SORT_FIELD = "sort";
@@ -102,14 +101,16 @@ public class TermQueryCommand extends QueryCommand {
         if (fessConfig.getQueryReplaceTermWithPrefixQueryAsBoolean() && text.length() > 1 && text.endsWith("*")) {
             return convertPrefixQuery(fessConfig, context, termQuery, boost, field, text);
         }
-        if (DEFAULT_FIELD.equals(field)) {
+        switch (field) {
+        case DEFAULT_FIELD:
             return convertDefaultTermQuery(fessConfig, context, termQuery, boost, field, text);
-        }
-        if (SORT_FIELD.equals(field)) {
+        case SORT_FIELD:
             return convertSortQuery(fessConfig, context, termQuery, boost, field, text);
-        }
-        if (SITE_FIELD.equals(field)) {
+        case SITE_FIELD:
             return convertSiteQuery(fessConfig, context, termQuery, boost, field, text);
+        case null:
+        default:
+            break;
         }
         if (INURL_FIELD.equals(field)
                 || StringUtil.equals(field, context.getDefaultField()) && fessConfig.getIndexFieldUrl().equals(context.getDefaultField())) {

--- a/src/main/java/org/codelibs/fess/query/TermRangeQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/TermRangeQueryCommand.java
@@ -42,7 +42,6 @@ public class TermRangeQueryCommand extends QueryCommand {
      * Default constructor for TermRangeQueryCommand.
      */
     public TermRangeQueryCommand() {
-        super();
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/query/WildcardQueryCommand.java
+++ b/src/main/java/org/codelibs/fess/query/WildcardQueryCommand.java
@@ -43,7 +43,6 @@ public class WildcardQueryCommand extends QueryCommand {
      * Default constructor.
      */
     public WildcardQueryCommand() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(WildcardQueryCommand.class);

--- a/src/main/java/org/codelibs/fess/rank/fusion/DefaultSearcher.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/DefaultSearcher.java
@@ -59,7 +59,6 @@ public class DefaultSearcher extends RankFusionSearcher {
      * standard OpenSearch queries with response processing and document highlighting.
      */
     public DefaultSearcher() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
@@ -428,7 +428,7 @@ public class RankFusionProcessor implements AutoCloseable {
         if (size == 0 || startPosition >= size) {
             return Collections.emptyList();
         }
-        int fromIndex = Math.max(0, startPosition);
+        final int fromIndex = Math.max(0, startPosition);
         int toIndex = fromIndex + pageSize;
         if (toIndex >= size) {
             toIndex = size;
@@ -507,7 +507,6 @@ public class RankFusionProcessor implements AutoCloseable {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Failed to parse float value: {}", s);
                 }
-                return 0.0f;
             }
         }
         return 0.0f;

--- a/src/main/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcher.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcher.java
@@ -146,7 +146,6 @@ public class SemanticChunkSearcher extends DefaultSearcher {
      * Default constructor.
      */
     public SemanticChunkSearcher() {
-        super();
     }
 
     /**
@@ -284,10 +283,10 @@ public class SemanticChunkSearcher extends DefaultSearcher {
             return;
         }
         if (exactModeWarned.compareAndSet(false, true)) {
-            logger.warn(
-                    "Semantic chunk search is falling back to the exact vector scan: the live index was not created with "
-                            + "index.knn and an ANN method on {}. Every plain-text query now scans all stored chunk vectors. "
-                            + "Recreate or reindex the index with {}=true so the ANN setting and method are baked in.",
+            logger.warn("""
+                    Semantic chunk search is falling back to the exact vector scan: the live index was not created with \
+                    index.knn and an ANN method on {}. Every plain-text query now scans all stored chunk vectors. \
+                    Recreate or reindex the index with {}=true so the ANN setting and method are baked in.""",
                     Constants.CONTENT_CHUNK_VECTOR_FIELD, SEARCH_ENABLED_PROPERTY);
         } else if (logger.isDebugEnabled()) {
             logger.debug("Semantic chunk search still using the exact vector scan.");

--- a/src/main/java/org/codelibs/fess/score/ScoreBooster.java
+++ b/src/main/java/org/codelibs/fess/score/ScoreBooster.java
@@ -42,7 +42,6 @@ public abstract class ScoreBooster {
      * Constructor.
      */
     public ScoreBooster() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ScoreBooster.class);

--- a/src/main/java/org/codelibs/fess/score/ScoreUpdater.java
+++ b/src/main/java/org/codelibs/fess/score/ScoreUpdater.java
@@ -29,7 +29,6 @@ public class ScoreUpdater {
      * Constructor.
      */
     public ScoreUpdater() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ScoreUpdater.class);

--- a/src/main/java/org/codelibs/fess/script/ScriptEngineFactory.java
+++ b/src/main/java/org/codelibs/fess/script/ScriptEngineFactory.java
@@ -31,7 +31,6 @@ public class ScriptEngineFactory {
      * Constructor.
      */
     public ScriptEngineFactory() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(ScriptEngineFactory.class);

--- a/src/main/java/org/codelibs/fess/script/groovy/GroovyEngine.java
+++ b/src/main/java/org/codelibs/fess/script/groovy/GroovyEngine.java
@@ -79,7 +79,6 @@ public class GroovyEngine extends AbstractScriptEngine {
      * Default constructor for GroovyEngine.
      */
     public GroovyEngine() {
-        super();
         buildScriptCache();
     }
 
@@ -190,7 +189,7 @@ public class GroovyEngine extends AbstractScriptEngine {
                 }
                 final GroovyClassLoader classLoader = new GroovyClassLoader(parentClassLoader);
                 try {
-                    final Class<? extends Script> scriptClass = (Class<? extends Script>) classLoader.parseClass(template);
+                    final Class<? extends Script> scriptClass = classLoader.parseClass(template);
                     return new CachedScript(scriptClass, classLoader);
                 } catch (final Exception e) {
                     try {

--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -392,9 +392,10 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                     // Redirecting would send the user straight back here in the same state, so
                     // this is where the loop has to stop. Returning null makes SsoAction show the
                     // SSO error message and fall back to the local login form.
-                    logger.warn("Received an Entra ID authentication response without a session."
-                            + " The session cookie was not sent back with the callback request."
-                            + " See tomcat.sameSiteCookies in tomcat_config.properties.");
+                    logger.warn("""
+                            Received an Entra ID authentication response without a session.\
+                             The session cookie was not sent back with the callback request.\
+                             See tomcat.sameSiteCookies in tomcat_config.properties.""");
                     return null;
                 }
                 // The browser did return a session id and the container rejected it, so cookies

--- a/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
@@ -170,13 +170,13 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
      * @param base64String the Base64 string to decode
      * @return the decoded bytes, or null if input is null
      */
-    protected byte[] decodeBase64(String base64String) {
+    protected byte[] decodeBase64(final String base64String) {
         if (base64String == null) {
             return null;
         }
         try {
             return BASE64_DECODER.decode(base64String);
-        } catch (IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             if (e.getCause() instanceof DecodingException) {
                 return BASE64URL_DECODER.decode(base64String.trim());
             }

--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -169,7 +169,6 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * Constructor.
      */
     public SamlAuthenticator() {
-        super();
     }
 
     private static final Logger logger = LogManager.getLogger(SamlAuthenticator.class);
@@ -697,10 +696,11 @@ public class SamlAuthenticator implements SsoAuthenticator {
      *            several live logins.
      */
     protected void logUnmatchedSamlResponse(final int pendingCount) {
-        logger.warn("Received a SAML response with no matching AuthnRequest ID in the session ({} pending)."
-                + " The assertion consumer service is a cross-site POST, which does not carry a SameSite=Lax cookie;"
-                + " see tomcat.sameSiteCookies in tomcat_config.properties."
-                + " An IdP-initiated (unsolicited) response is rejected for the same reason.", pendingCount);
+        logger.warn("""
+                Received a SAML response with no matching AuthnRequest ID in the session ({} pending).\
+                 The assertion consumer service is a cross-site POST, which does not carry a SameSite=Lax cookie;\
+                 see tomcat.sameSiteCookies in tomcat_config.properties.\
+                 An IdP-initiated (unsolicited) response is rejected for the same reason.""", pendingCount);
     }
 
     /**
@@ -726,11 +726,11 @@ public class SamlAuthenticator implements SsoAuthenticator {
      *            the session still had in flight before the TTL removed them.
      */
     protected void logUnmatchedSamlResponseAfterExpiry(final int expiredCount) {
-        logger.warn(
-                "Received a SAML response after all {} pending AuthnRequest ID(s) of the session had expired."
-                        + " The session cookie did reach this server, so this is not the SameSite case:"
-                        + " the login took longer to finish at the IdP than {} allows, and starting it again resolves it.",
-                expiredCount, SAML_REQUEST_ID_TTL);
+        logger.warn("""
+                Received a SAML response after all {} pending AuthnRequest ID(s) of the session had expired.\
+                 The session cookie did reach this server, so this is not the SameSite case:\
+                 the login took longer to finish at the IdP than {} allows, and starting it again resolves it.""", expiredCount,
+                SAML_REQUEST_ID_TTL);
     }
 
     /**
@@ -763,11 +763,12 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * reported by that one with a pending count of zero.</p>
      */
     protected void logUnmatchedSamlResponseAfterSessionExpiry() {
-        logger.warn("Received a SAML response after the session it belongs to had expired."
-                + " The browser did return its session cookie, so this is not the SameSite case:"
-                + " the session, and with it the AuthnRequest ID it held, was discarded by the"
-                + " container's session timeout rather than by {}, so raising that value does not help."
-                + " Starting the login again resolves it.", SAML_REQUEST_ID_TTL);
+        logger.warn("""
+                Received a SAML response after the session it belongs to had expired.\
+                 The browser did return its session cookie, so this is not the SameSite case:\
+                 the session, and with it the AuthnRequest ID it held, was discarded by the\
+                 container's session timeout rather than by {}, so raising that value does not help.\
+                 Starting the login again resolves it.""", SAML_REQUEST_ID_TTL);
     }
 
     /**
@@ -827,9 +828,7 @@ public class SamlAuthenticator implements SsoAuthenticator {
         synchronized (session) {
             final Object stored = session.getAttribute(SAML_STATE);
             if (stored instanceof ConcurrentHashMap) {
-                @SuppressWarnings("unchecked")
-                final Map<String, Long> requestIdMap = (Map<String, Long>) stored;
-                return requestIdMap;
+                return (Map<String, Long>) stored;
             }
             final Map<String, Long> concurrentMap = new ConcurrentHashMap<>();
             if (stored instanceof final String requestId && StringUtil.isNotBlank(requestId)) {

--- a/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/spnego/SpnegoAuthenticator.java
@@ -509,7 +509,8 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
          */
         @Override
         public String getInitParameter(final String name) {
-            if (Constants.LOGGER_LEVEL.equals(name)) {
+            switch (name) {
+            case Constants.LOGGER_LEVEL: {
                 final String logLevel = getProperty(SPNEGO_LOGGER_LEVEL, StringUtil.EMPTY);
                 if (StringUtil.isNotBlank(logLevel)) {
                     if (isSupportedLoggerLevel(logLevel)) {
@@ -530,49 +531,42 @@ public class SpnegoAuthenticator implements SsoAuthenticator {
                 // the quietest setting it actually understands.
                 return "7";
             }
-            if (Constants.LOGIN_CONF.equals(name)) {
+            case Constants.LOGIN_CONF:
                 return getResourcePath(getProperty(SPNEGO_LOGIN_CONF, "auth_login.conf"));
-            }
-            if (Constants.KRB5_CONF.equals(name)) {
+            case Constants.KRB5_CONF:
                 return getResourcePath(getProperty(SPNEGO_KRB5_CONF, "krb5.conf"));
-            }
-            if (Constants.CLIENT_MODULE.equals(name)) {
+            case Constants.CLIENT_MODULE:
                 return getProperty(SPNEGO_LOGIN_CLIENT_MODULE, "spnego-client");
-            }
-            if (Constants.SERVER_MODULE.equals(name)) {
+            case Constants.SERVER_MODULE:
                 return getProperty(SPNEGO_LOGIN_SERVER_MODULE, "spnego-server");
-            }
-            if (Constants.PREAUTH_USERNAME.equals(name)) {
+            case Constants.PREAUTH_USERNAME:
                 // Empty by default so that keytab-based server login is used when the server login
                 // module is configured for it (the library only uses a keytab when both preauth
                 // username and password are empty).
                 return getProperty(SPNEGO_PREAUTH_USERNAME, StringUtil.EMPTY);
-            }
-            if (Constants.PREAUTH_PASSWORD.equals(name)) {
+            case Constants.PREAUTH_PASSWORD:
                 return getProperty(SPNEGO_PREAUTH_PASSWORD, StringUtil.EMPTY);
-            }
-            if (Constants.ALLOW_BASIC.equals(name)) {
+            case Constants.ALLOW_BASIC:
                 // SECURITY NOTE: Basic authentication is enabled by default for compatibility.
                 // For production, consider setting spnego.allow.basic to false.
                 return getProperty(SPNEGO_ALLOW_BASIC, "true");
-            }
-            if (Constants.ALLOW_UNSEC_BASIC.equals(name)) {
+            case Constants.ALLOW_UNSEC_BASIC:
                 // SECURITY: unsecure basic authentication is disabled by default so that basic
                 // credentials are never offered over plain HTTP. When false, basic auth is only
                 // offered over HTTPS. Enable only if you fully understand the risk.
                 return getProperty(SPNEGO_ALLOW_UNSECURE_BASIC, "false");
-            }
-            if (Constants.PROMPT_NTLM.equals(name)) {
+            case Constants.PROMPT_NTLM:
                 return getProperty(SPNEGO_PROMPT_NTLM, "true");
-            }
-            if (Constants.ALLOW_LOCALHOST.equals(name)) {
+            case Constants.ALLOW_LOCALHOST:
                 // SECURITY: localhost bypass is disabled by default. When enabled, the spnego library
                 // authenticates same-host requests as the server OS user without Kerberos verification,
                 // which is unsafe behind a same-host reverse proxy. Opt in explicitly if required.
                 return getProperty(SPNEGO_ALLOW_LOCALHOST, "false");
-            }
-            if (Constants.ALLOW_DELEGATION.equals(name)) {
+            case Constants.ALLOW_DELEGATION:
                 return getProperty(SPNEGO_ALLOW_DELEGATION, "false");
+            case null:
+            default:
+                break;
             }
             // NOTE: spnego.exclude.dirs is deliberately not mapped. Only SpnegoHttpFilter consumes it,
             // and Fess calls SpnegoAuthenticator#authenticate directly instead of installing that

--- a/src/main/java/org/codelibs/fess/storage/GcsStorageClient.java
+++ b/src/main/java/org/codelibs/fess/storage/GcsStorageClient.java
@@ -92,18 +92,16 @@ public class GcsStorageClient implements StorageClient {
             if (logger.isDebugEnabled()) {
                 logger.debug("Using custom GCS endpoint: {}", endpoint);
             }
-        } else {
-            // Production: use credentials file or default credentials
-            if (StringUtil.isNotBlank(credentialsPath)) {
-                try (FileInputStream fis = new FileInputStream(credentialsPath)) {
-                    final GoogleCredentials credentials = GoogleCredentials.fromStream(fis);
-                    builder.setCredentials(credentials);
-                } catch (final IOException e) {
-                    throw new StorageException("Failed to load GCS credentials from " + credentialsPath, e);
-                }
+        } else // Production: use credentials file or default credentials
+        if (StringUtil.isNotBlank(credentialsPath)) {
+            try (FileInputStream fis = new FileInputStream(credentialsPath)) {
+                final GoogleCredentials credentials = GoogleCredentials.fromStream(fis);
+                builder.setCredentials(credentials);
+            } catch (final IOException e) {
+                throw new StorageException("Failed to load GCS credentials from " + credentialsPath, e);
             }
-            // If no credentials path, uses default credentials (GOOGLE_APPLICATION_CREDENTIALS env var)
         }
+        // If no credentials path, uses default credentials (GOOGLE_APPLICATION_CREDENTIALS env var)
 
         this.storage = builder.build().getService();
     }
@@ -239,12 +237,11 @@ public class GcsStorageClient implements StorageClient {
     public void setObjectTags(final String objectName, final Map<String, String> tags) {
         try {
             final Blob blob = storage.get(BlobId.of(bucket, objectName));
-            if (blob != null) {
-                // GCS uses metadata instead of tags
-                blob.toBuilder().setMetadata(tags).build().update();
-            } else {
+            if (blob == null) {
                 throw new StorageException("Object not found: " + objectName);
             }
+            // GCS uses metadata instead of tags
+            blob.toBuilder().setMetadata(tags).build().update();
         } catch (final StorageException e) {
             throw e;
         } catch (final Exception e) {

--- a/src/main/java/org/codelibs/fess/storage/StorageClientFactory.java
+++ b/src/main/java/org/codelibs/fess/storage/StorageClientFactory.java
@@ -86,14 +86,11 @@ public final class StorageClientFactory {
             type = parseStorageType(typeStr);
         }
 
-        switch (type) {
-        case GCS:
-            return new GcsStorageClient(fessConfig.getStorageProjectId(), bucket, endpoint, fessConfig.getStorageCredentialsPath());
-        case S3:
-        case S3_COMPAT:
-        default:
-            return new S3StorageClient(endpoint, accessKey, secretKey, bucket, fessConfig.getStorageRegion());
-        }
+        return switch (type) {
+        case GCS -> new GcsStorageClient(fessConfig.getStorageProjectId(), bucket, endpoint, fessConfig.getStorageCredentialsPath());
+        case S3, S3_COMPAT -> new S3StorageClient(endpoint, accessKey, secretKey, bucket, fessConfig.getStorageRegion());
+        default -> new S3StorageClient(endpoint, accessKey, secretKey, bucket, fessConfig.getStorageRegion());
+        };
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/taglib/FessFunctions.java
+++ b/src/main/java/org/codelibs/fess/taglib/FessFunctions.java
@@ -130,7 +130,7 @@ public class FessFunctions {
     public static String html(final boolean isOpen) {
         if (isOpen) {
             return "<html lang=\"" + LaRequestUtil.getOptionalRequest().map(req -> {
-                if (req.getAttribute(LastaWebKey.USER_LOCALE_KEY) instanceof Locale locale) {
+                if (req.getAttribute(LastaWebKey.USER_LOCALE_KEY) instanceof final Locale locale) {
                     return locale;
                 }
                 return Locale.ENGLISH;

--- a/src/main/java/org/codelibs/fess/theme/StaticThemeInstaller.java
+++ b/src/main/java/org/codelibs/fess/theme/StaticThemeInstaller.java
@@ -403,7 +403,8 @@ public class StaticThemeInstaller {
             long lastRawCount = 0L;
             final byte[] buffer = new byte[8192];
             while ((entry = zis.getNextEntry()) != null) {
-                if (++entries > maxEntries) {
+                entries++;
+                if (entries > maxEntries) {
                     throw new InstallException(InstallException.Code.ENTRY_LIMIT, "Too many entries (>" + maxEntries + ")");
                 }
                 final String name = entry.getName();
@@ -572,7 +573,7 @@ public class StaticThemeInstaller {
         }
         int retentionDays = DEFAULT_ATTIC_RETENTION_DAYS;
         if (atticRetentionDaysOverride != null) {
-            retentionDays = atticRetentionDaysOverride.intValue();
+            retentionDays = atticRetentionDaysOverride;
         } else if (fessConfig != null) {
             try {
                 final Integer cfg = fessConfig.getThemeUploadAtticRetentionDaysAsInteger();

--- a/src/main/java/org/codelibs/fess/theme/StaticThemeResponder.java
+++ b/src/main/java/org/codelibs/fess/theme/StaticThemeResponder.java
@@ -131,7 +131,7 @@ public class StaticThemeResponder {
         // HTTP status so proxies and CDNs see the correct status without parsing X-Fess-Error-Code.
         // When a ?message_key query parameter is present, inject an error detail meta tag so the
         // SPA can surface the specific error message.
-        final boolean isErrorRoute = requestPath != null && (requestPath.equals("/error") || requestPath.startsWith("/error/"));
+        final boolean isErrorRoute = requestPath != null && ("/error".equals(requestPath) || requestPath.startsWith("/error/"));
         final String messageKey = resolveMessageKey(req);
 
         if (isErrorRoute) {
@@ -227,31 +227,22 @@ public class StaticThemeResponder {
         }
         // Extract the kind segment after "/error/"
         final String kind;
-        if (uri.equals("/error")) {
+        if ("/error".equals(uri) || !uri.startsWith("/error/")) {
             kind = "";
-        } else if (uri.startsWith("/error/")) {
+        } else {
             // Take only the first path segment after /error/ (ignore trailing /...),
             // and normalise to lower-case for case-insensitive matching.
             final String rest = uri.substring("/error/".length());
             final int slash = rest.indexOf('/');
             kind = (slash < 0 ? rest : rest.substring(0, slash)).toLowerCase(Locale.ROOT);
-        } else {
-            kind = "";
         }
-        switch (kind) {
-        case "":
-        case "error":
-        case "system":
-            return 500;
-        case "badrequest":
-            return 400;
-        case "notfound":
-            return 404;
-        case "busy":
-            return 429;
-        default:
-            return 500;
-        }
+        return switch (kind) {
+        case "", "error", "system" -> 500;
+        case "badrequest" -> 400;
+        case "notfound" -> 404;
+        case "busy" -> 429;
+        default -> 500;
+        };
     }
 
     /**
@@ -269,11 +260,8 @@ public class StaticThemeResponder {
             return null;
         }
         final String raw = req.getParameter("message_key");
-        if (raw == null || raw.isEmpty()) {
-            return null;
-        }
         // Allowlist: letters, digits, dots, underscores, hyphens only.
-        if (!MESSAGE_KEY_PATTERN.matcher(raw).matches()) {
+        if (raw == null || raw.isEmpty() || !MESSAGE_KEY_PATTERN.matcher(raw).matches()) {
             return null;
         }
         return raw;
@@ -356,11 +344,8 @@ public class StaticThemeResponder {
         }
         final Path candidate = theme.getBasePath().resolve(path).normalize();
         // Re-check containment after normalization.
-        if (!candidate.startsWith(theme.getBasePath())) {
-            return null;
-        }
         // Reject symlinks (NOFOLLOW_LINKS): a symlink could escape the theme sandbox.
-        if (!Files.isRegularFile(candidate, LinkOption.NOFOLLOW_LINKS)) {
+        if (!candidate.startsWith(theme.getBasePath()) || !Files.isRegularFile(candidate, LinkOption.NOFOLLOW_LINKS)) {
             return null;
         }
         final String fname = candidate.getFileName() != null ? candidate.getFileName().toString() : "";
@@ -388,10 +373,7 @@ public class StaticThemeResponder {
      * @return {@code true} if the file must not be served
      */
     static boolean isBlockedFilename(final String filename) {
-        if (filename == null || filename.isEmpty()) {
-            return true;
-        }
-        if (filename.startsWith(".")) {
+        if (filename == null || filename.isEmpty() || filename.startsWith(".")) {
             return true;
         }
         final String lower = filename.toLowerCase(Locale.ROOT);

--- a/src/main/java/org/codelibs/fess/theme/ThemeManifest.java
+++ b/src/main/java/org/codelibs/fess/theme/ThemeManifest.java
@@ -120,7 +120,7 @@ public final class ThemeManifest {
                 checkFieldLength("supportedLocales[" + i + "]", locales.get(i));
             }
             b.supportedLocales = locales;
-        } else if (loc instanceof String s) {
+        } else if (loc instanceof final String s) {
             b.supportedLocales = List.of(checkFieldLength("supportedLocales", s));
         }
         b.entry = checkFieldLength("entry", str(raw, "entry"));
@@ -177,16 +177,7 @@ public final class ThemeManifest {
         if (e == null) {
             return false; // null entry will default to index.html
         }
-        if (e.startsWith("/")) {
-            return true;
-        }
-        if (e.contains("..")) {
-            return true;
-        }
-        if (e.contains("\\")) {
-            return true;
-        }
-        if (e.contains("\0")) {
+        if (e.startsWith("/") || e.contains("..") || e.contains("\\") || e.contains("\0")) {
             return true;
         }
         if (e.contains(":")) {

--- a/src/main/java/org/codelibs/fess/thumbnail/impl/CommandGenerator.java
+++ b/src/main/java/org/codelibs/fess/thumbnail/impl/CommandGenerator.java
@@ -65,7 +65,6 @@ public class CommandGenerator extends BaseThumbnailGenerator {
      * Default constructor for CommandGenerator.
      */
     public CommandGenerator() {
-        super();
     }
 
     /**
@@ -237,10 +236,7 @@ public class CommandGenerator extends BaseThumbnailGenerator {
             }
 
             if (p.waitFor(commandTimeout + commandDestroyTimeout, TimeUnit.MILLISECONDS)) {
-                if (task.isExecuted()) {
-                    // Process was killed by the timer.
-                    logger.warn("{} was timed out and destroyed.", getName());
-                } else {
+                if (!task.isExecuted()) {
                     // Process finished normally.
                     final int exitValue = p.exitValue();
                     if (exitValue != 0) {
@@ -252,6 +248,8 @@ public class CommandGenerator extends BaseThumbnailGenerator {
                     }
                     return exitValue;
                 }
+                // Process was killed by the timer.
+                logger.warn("{} was timed out and destroyed.", getName());
             } else {
                 // This is a secondary timeout, a safety net.
                 logger.warn("{} is unresponsive and could not be terminated within the safety timeout.", getName());
@@ -366,10 +364,8 @@ public class CommandGenerator extends BaseThumbnailGenerator {
                 } catch (final Exception e) {
                     logger.warn("Failed to stop destroyer.", e);
                 }
-            } else {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Process {} is already executed.", p);
-                }
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("Process {} is already executed.", p);
             }
         }
 

--- a/src/main/java/org/codelibs/fess/thumbnail/impl/EmptyGenerator.java
+++ b/src/main/java/org/codelibs/fess/thumbnail/impl/EmptyGenerator.java
@@ -28,7 +28,6 @@ public class EmptyGenerator extends BaseThumbnailGenerator {
      * Default constructor.
      */
     public EmptyGenerator() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/thumbnail/impl/HtmlTagBasedGenerator.java
+++ b/src/main/java/org/codelibs/fess/thumbnail/impl/HtmlTagBasedGenerator.java
@@ -58,7 +58,6 @@ public class HtmlTagBasedGenerator extends BaseThumbnailGenerator {
      * Default constructor for HtmlTagBasedGenerator.
      */
     public HtmlTagBasedGenerator() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/timer/HotThreadMonitorTarget.java
+++ b/src/main/java/org/codelibs/fess/timer/HotThreadMonitorTarget.java
@@ -40,7 +40,6 @@ public class HotThreadMonitorTarget extends MonitorTarget {
      * Default constructor for HotThreadMonitorTarget.
      */
     public HotThreadMonitorTarget() {
-        super();
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/timer/SystemMonitorTarget.java
+++ b/src/main/java/org/codelibs/fess/timer/SystemMonitorTarget.java
@@ -53,7 +53,6 @@ public class SystemMonitorTarget extends MonitorTarget {
      * Constructs a new system monitor target.
      */
     public SystemMonitorTarget() {
-        super();
     }
 
     @Override

--- a/src/main/java/org/codelibs/fess/util/DocList.java
+++ b/src/main/java/org/codelibs/fess/util/DocList.java
@@ -42,7 +42,6 @@ public class DocList extends ArrayList<Map<String, Object>> {
      * Creates a new empty document list with zero content size and processing time.
      */
     public DocList() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/util/GsaConfigParser.java
+++ b/src/main/java/org/codelibs/fess/util/GsaConfigParser.java
@@ -128,7 +128,6 @@ public class GsaConfigParser extends DefaultHandler {
      * Default constructor for GsaConfigParser.
      */
     public GsaConfigParser() {
-        super();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/util/OriginUtil.java
+++ b/src/main/java/org/codelibs/fess/util/OriginUtil.java
@@ -65,12 +65,9 @@ public final class OriginUtil {
         // "https://example.com\r\n..." slip through as a clean origin. Edge CR/LF/TAB
         // must be detected by the control-char scan below and rejected.
         final String value = stripSpaces(originOrUrl);
-        if (value.isEmpty()) {
-            return null;
-        }
         // Browsers emit the literal "null" for opaque origins (e.g. sandboxed
         // iframes, data: URLs). It is never a trustworthy same-origin value.
-        if ("null".equalsIgnoreCase(value)) {
+        if (value.isEmpty() || "null".equalsIgnoreCase(value)) {
             return null;
         }
         // Reject any remaining whitespace or control character. A well-formed

--- a/src/main/java/org/codelibs/fess/util/WebApiUtil.java
+++ b/src/main/java/org/codelibs/fess/util/WebApiUtil.java
@@ -82,7 +82,7 @@ public final class WebApiUtil {
             path = path.substring(contextPath.length());
         }
         // SearchApiV2Manager#matches accepts the prefix itself or any sub-path of it.
-        if (path.equals(API_V2_PATH_PREFIX) || path.startsWith(API_V2_PATH_PREFIX + "/")) {
+        if (API_V2_PATH_PREFIX.equals(path) || path.startsWith(API_V2_PATH_PREFIX + "/")) {
             return true;
         }
         // SearchEngineApiManager#matches accepts a plain prefix match: the access token is

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1256,11 +1256,11 @@ paging.search.page.size=10
 # Maximum size of search results per page.
 paging.search.page.max.size=100
 # Maximum length of a v2 API string query parameter (q, sort, sdh). OWASP API4:2023.
-api.v2.param.max.length=1000
+api.param.max.length=1000
 # Maximum number of values for a v2 API repeatable query parameter.
-api.v2.param.max.array.size=100
+api.param.max.array.size=100
 # Maximum click-log timestamp (rt, epoch ms) accepted by the v2 click API. OWASP API4:2023.
-api.v2.click.max.rt=9999999999999
+api.click.max.timestamp=9999999999999
 
 # searchlog
 searchlog.agg.shard.size=-1
@@ -1771,4 +1771,4 @@ theme.api.login.rate.limit.max.entries=100000
 # event stream but defeats intermediaries (nginx default proxy_read_timeout
 # is 60s) that drop idle connections during long LLM phases. Set <=0 to
 # disable. Unit: milliseconds.
-api.v2.chat.stream.keepalive.interval.ms=15000
+api.chat.stream.keepalive.interval.ms=15000

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandlerTest.java
@@ -545,7 +545,7 @@ public class ChatStreamHandlerTest extends UnitFessTestCase {
             private static final long serialVersionUID = 1L;
 
             @Override
-            public Integer getApiV2ChatStreamKeepaliveIntervalMsAsInteger() {
+            public Integer getApiChatStreamKeepaliveIntervalMsAsInteger() {
                 throw new RuntimeException("not configured");
             }
         };

--- a/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
@@ -1122,7 +1122,7 @@ public class SystemHelperTest extends UnitFessTestCase {
             }
 
             @Override
-            public int getPasswordMaxLengthAsInteger() {
+            public int getPasswordMaxLengthOrDefault() {
                 // Explicit override: avoids getAsInteger NPE in slim test harness.
                 return 100;
             }

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
@@ -720,7 +720,7 @@ public class FessPropTest extends UnitFessTestCase {
         final FessConfig fessConfig = new FessConfig.SimpleImpl() {
             @Override
             public String getSystemProperty(final String key, final String defaultValue) {
-                if ("api.v2.chat.rate.limit.per.user.per.minute".equals(key)) {
+                if ("api.chat.rate.limit.per.user.per.minute".equals(key)) {
                     return "0";
                 }
                 return defaultValue;
@@ -735,7 +735,7 @@ public class FessPropTest extends UnitFessTestCase {
         final FessConfig fessConfig = new FessConfig.SimpleImpl() {
             @Override
             public String getSystemProperty(final String key, final String defaultValue) {
-                if ("api.v2.chat.rate.limit.per.user.per.minute".equals(key)) {
+                if ("api.chat.rate.limit.per.user.per.minute".equals(key)) {
                     return "bad-value";
                 }
                 return defaultValue;
@@ -747,12 +747,42 @@ public class FessPropTest extends UnitFessTestCase {
     @Test
     public void test_apiV2InputBoundGetters_defaults() {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        assertEquals(1000, fessConfig.getApiV2ParamMaxLengthAsInteger());
-        assertEquals(100, fessConfig.getApiV2ParamMaxArraySizeAsInteger());
-        assertEquals(100, fessConfig.getPasswordMaxLengthAsInteger());
-        assertEquals(1000, fessConfig.getQueryFacetFieldsSizeMaxAsInteger());
-        assertEquals(2147483647L, fessConfig.getQueryFacetFieldsMinDocCountMaxAsLong());
-        assertEquals(9999999999999L, fessConfig.getApiV2ClickMaxRtAsLong());
+        assertEquals(1000, fessConfig.getApiParamMaxLengthOrDefault());
+        assertEquals(100, fessConfig.getApiParamMaxArraySizeOrDefault());
+        assertEquals(100, fessConfig.getPasswordMaxLengthOrDefault());
+        assertEquals(1000, fessConfig.getQueryFacetFieldsSizeMaxOrDefault());
+        assertEquals(2147483647L, fessConfig.getQueryFacetFieldsMinDocCountMaxOrDefault());
+        assertEquals(9999999999999L, fessConfig.getApiClickMaxTimestampOrDefault());
+    }
+
+    /**
+     * A blank value in fess_config.properties reads back as null (getAsInteger) or as an
+     * unparsable string (get), and every caller unboxes the result into a primitive. These
+     * getters therefore must fall back to their documented default rather than hand a null
+     * to the caller. See the naming note on the FessProp methods: an ...AsInteger/...AsLong
+     * name here would be overridden by the generated FessConfig and drop the fallback.
+     */
+    @Test
+    public void test_apiV2InputBoundGetters_fallBackOnBlankValue() {
+        final FessConfig fessConfig = new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Integer getAsInteger(final String propertyKey) {
+                return null; // DfTypeUtil.toInteger("") is null
+            }
+
+            @Override
+            public String get(final String propertyKey) {
+                return ""; // blank value, as written by a hand-edited properties file
+            }
+        };
+        assertEquals(1000, fessConfig.getApiParamMaxLengthOrDefault());
+        assertEquals(100, fessConfig.getApiParamMaxArraySizeOrDefault());
+        assertEquals(100, fessConfig.getPasswordMaxLengthOrDefault());
+        assertEquals(1000, fessConfig.getQueryFacetFieldsSizeMaxOrDefault());
+        assertEquals(2147483647L, fessConfig.getQueryFacetFieldsMinDocCountMaxOrDefault());
+        assertEquals(9999999999999L, fessConfig.getApiClickMaxTimestampOrDefault());
     }
 
     @Test


### PR DESCRIPTION
## Summary

A mechanical cleanup sweep, a catch-up regeneration of the generated config
interface, and a config-key namespace fix.

| Part | Files | Nature |
|---|---|---|
| Redundant `super();` removal | 261 | Provably a no-op; these files change nothing else |
| Java 21 control-flow modernization | 87 | if-chain → switch, colon-switch → arrow/expression switch, `instanceof` pattern variables, De Morgan merges, redundant casts / `.intValue()` dropped, log concatenation → text blocks |
| `FessConfig` regeneration | 1 | Eight keys that already existed in `fess_config.properties`, plus refreshed javadoc |
| `api.v2.*` → `api.*` key rename | 10 | See below |

## FessProp fallbacks: the reason for the `...OrDefault` rename

`FessConfig.java` had drifted stale, so the regeneration adds accessors for
keys that were already shipping. Five of those collide with hand-written
tolerant defaults in `FessProp` (added in #3162).

A generated declaration in `FessConfig` plus its `SimpleImpl` body **overrides
the interface default** (JLS 9.4.1.3 re-abstraction; a class method always beats
an interface default). That silently made the fallbacks unreachable:

| `password.max.length=` (blank) | before | after regeneration alone |
|---|---|---|
| `getPasswordMaxLength…()` | `100` | `null` → NPE at the call sites that unbox it |

The affected accessors are therefore renamed in `FessProp` to `...OrDefault`,
a suffix freegen never emits, so a future regeneration cannot collide with them
again. The reason is recorded in each method's javadoc, and
`FessPropTest#test_apiV2InputBoundGetters_fallBackOnBlankValue` pins the
behavior — that test fails with an NPE if the fallback is removed.

Default installs were never affected: all keys ship with values, and the six new
`defaultMap` entries now also cover a *missing* key, which previously threw.

## BREAKING: `api.v2.*` configuration keys renamed to `api.*`

The API version belongs in the endpoint path, not in a settings key.

```
api.v2.param.max.length                    -> api.param.max.length
api.v2.param.max.array.size                -> api.param.max.array.size
api.v2.click.max.rt                        -> api.click.max.timestamp
api.v2.chat.stream.keepalive.interval.ms   -> api.chat.stream.keepalive.interval.ms
api.v2.chat.rate.limit.per.user.per.minute -> api.chat.rate.limit.per.user.per.minute
```

These shipped in 15.7.0. An existing override under an old key is no longer read
and the documented default applies instead. The `org.codelibs.fess.api.v2`
package and the `/api/v2` endpoint path are unchanged.

Docs referencing the old keys need a follow-up in `fess-docs` (15.8 only; the
15.7 pages document released behavior and should stay):

- `<lang>/15.8/api/api-chat.rst` — `api.v2.chat.rate.limit.per.user.per.minute`
- `<lang>/15.8/user/search-additional.rst` — `api.v2.param.max.array.size`, `api.v2.param.max.length`

## Also fixed

`CsrfRequirement` had lost the `return true;` from its `/chat/sessions/` arm,
leaving `if (subPath.startsWith("/chat/sessions/")) {}`. Behavior was unchanged
because the arm fell through to the secure default, but the explicit rule is
restored.

## Verification

- **Tests**: 7252 pass, 0 failures. `master` at the same commit runs 7251 with 0
  failures — identical, plus the one new regression test.
- **CI gates**: `javadoc:jar` (the gate in `maven.yml`), `formatter:validate`,
  and `license:check` all pass.
- **Bytecode diff vs `master`**, over every changed class: string literals,
  method/field signatures with access flags, and method/field references were
  extracted from both builds and diffed. The only differences are the intended
  new accessors and expected compiler artifacts (`SwitchBootstraps` call sites
  replacing `$SwitchMap` lookups, lambda renumbering, `StringConcatFactory` →
  `StringBuilder`). **No log message, prompt, or error string changed** — every
  text-block conversion is byte-identical.
- Behavior of each non-mechanical hunk was reviewed individually, including the
  vendored `BCrypt` (differential-tested old vs new) and the escaping paths in
  the index export formatters.
