### PR TITLE
fix: correct log levels so ERROR means the service is unusable

### DIFF
--- a/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
+++ b/src/main/java/org/codelibs/fess/api/engine/SearchEngineApiManager.java
@@ -250,7 +250,7 @@ public class SearchEngineApiManager extends BaseApiManager {
             } catch (final ClientAbortException e) {
                 logger.debug("Client aborts this request.", e);
             } catch (final IOException e) {
-                logger.error("Failed to read file: path={}, filePath={}", path, filePath);
+                logger.warn("Failed to read file: path={}, filePath={}", path, filePath, e);
                 throw new WebApiException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
             }
         } else {
@@ -260,7 +260,7 @@ public class SearchEngineApiManager extends BaseApiManager {
             } catch (final ClientAbortException e) {
                 logger.debug("Client aborts this request.", e);
             } catch (final IOException e) {
-                logger.error("Failed to read file: path={}, filePath={}", path, filePath);
+                logger.warn("Failed to send a not-found response: path={}", path, e);
                 throw new WebApiException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
             }
         }

--- a/src/main/java/org/codelibs/fess/app/job/AllJobScheduler.java
+++ b/src/main/java/org/codelibs/fess/app/job/AllJobScheduler.java
@@ -103,7 +103,7 @@ public class AllJobScheduler implements LaJobScheduler {
                 try {
                     jobHelper.register(scheduledJob);
                 } catch (final Exception e) {
-                    logger.warn("Failed to update schedule: job={}", scheduledJob, e);
+                    logger.error("Failed to update schedule: job={}", scheduledJob, e);
                 }
             });
             schedulerTime = now;

--- a/src/main/java/org/codelibs/fess/exec/Crawler.java
+++ b/src/main/java/org/codelibs/fess/exec/Crawler.java
@@ -703,7 +703,7 @@ public class Crawler {
 
             return Constants.EXIT_OK;
         } catch (final Throwable t) {
-            logger.warn("Crawl task failed with an exception.", t);
+            logger.error("Crawl task failed with an exception.", t);
             return Constants.EXIT_FAIL;
         } finally {
             pathMappingHelper.removePathMappingList(options.sessionId);

--- a/src/main/java/org/codelibs/fess/indexer/IndexUpdater.java
+++ b/src/main/java/org/codelibs/fess/indexer/IndexUpdater.java
@@ -371,7 +371,7 @@ public class IndexUpdater extends Thread {
             }
         } catch (final ContainerNotAvailableException e) {
             if (logger.isDebugEnabled()) {
-                logger.error("IndexUpdater is terminated.", e);
+                logger.debug("IndexUpdater is terminated.", e);
             } else if (logger.isInfoEnabled()) {
                 logger.info("IndexUpdater is terminated.");
             }
@@ -380,7 +380,7 @@ public class IndexUpdater extends Thread {
             if (ComponentUtil.available()) {
                 logger.error("IndexUpdater is terminated.", t);
             } else if (logger.isDebugEnabled()) {
-                logger.error("IndexUpdater is terminated.", t);
+                logger.debug("IndexUpdater is terminated.", t);
                 org.codelibs.fess.exec.Crawler.addError(t.getClass().getSimpleName());
             } else if (logger.isInfoEnabled()) {
                 logger.info("IndexUpdater is terminated.");

--- a/src/main/java/org/codelibs/fess/job/AggregateLogJob.java
+++ b/src/main/java/org/codelibs/fess/job/AggregateLogJob.java
@@ -49,7 +49,7 @@ public class AggregateLogJob {
         try {
             searchLogHelper.storeSearchLog();
         } catch (final Exception e) {
-            logger.error("Failed to store a search log.", e);
+            logger.warn("Failed to store a search log.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 

--- a/src/main/java/org/codelibs/fess/job/PurgeDocJob.java
+++ b/src/main/java/org/codelibs/fess/job/PurgeDocJob.java
@@ -59,7 +59,7 @@ public class PurgeDocJob {
             searchEngineClient.deleteByQuery(fessConfig.getIndexDocumentUpdateIndex(), queryBuilder);
 
         } catch (final Exception e) {
-            logger.error("Could not delete expired documents: {}", queryBuilder, e);
+            logger.warn("Could not delete expired documents: {}", queryBuilder, e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 

--- a/src/main/java/org/codelibs/fess/job/PurgeLogJob.java
+++ b/src/main/java/org/codelibs/fess/job/PurgeLogJob.java
@@ -67,7 +67,7 @@ public class PurgeLogJob {
         try {
             crawlingInfoService.deleteBefore(systemHelper.getCurrentTimeAsLong());
         } catch (final Exception e) {
-            logger.error("Failed to purge crawling sessions.", e);
+            logger.warn("Failed to purge crawling sessions.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 
@@ -80,7 +80,7 @@ public class PurgeLogJob {
                 resultBuf.append("Skipped to purge search logs.\n");
             }
         } catch (final Exception e) {
-            logger.error("Failed to purge search logs.", e);
+            logger.warn("Failed to purge search logs.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 
@@ -93,7 +93,7 @@ public class PurgeLogJob {
                 resultBuf.append("Skipped to purge click logs.\n");
             }
         } catch (final Exception e) {
-            logger.error("Failed to purge click logs.", e);
+            logger.warn("Failed to purge click logs.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 
@@ -106,7 +106,7 @@ public class PurgeLogJob {
                 resultBuf.append("Skipped to purge favorite logs.\n");
             }
         } catch (final Exception e) {
-            logger.error("Failed to purge favorite logs.", e);
+            logger.warn("Failed to purge favorite logs.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 
@@ -119,7 +119,7 @@ public class PurgeLogJob {
                 resultBuf.append("Skipped to purge job logs.\n");
             }
         } catch (final Exception e) {
-            logger.error("Failed to purge job logs.", e);
+            logger.warn("Failed to purge job logs.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 
@@ -132,7 +132,7 @@ public class PurgeLogJob {
                 resultBuf.append("Skipped to purge user info logs.\n");
             }
         } catch (final Exception e) {
-            logger.error("Failed to purge user info.", e);
+            logger.warn("Failed to purge user info.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 
@@ -140,7 +140,7 @@ public class PurgeLogJob {
         try {
             jobLogService.updateStatus();
         } catch (final Exception e) {
-            logger.error("Failed to purge job logs.", e);
+            logger.warn("Failed to purge job logs.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 

--- a/src/main/java/org/codelibs/fess/job/PurgeThumbnailJob.java
+++ b/src/main/java/org/codelibs/fess/job/PurgeThumbnailJob.java
@@ -50,7 +50,7 @@ public class PurgeThumbnailJob {
             final long count = ComponentUtil.getThumbnailManager().purge(getExpiry());
             return "Deleted " + count + " thumbnail files.";
         } catch (final Exception e) {
-            logger.error("Failed to purge thumbnails.", e);
+            logger.warn("Failed to purge thumbnails.", e);
             return e.getMessage();
         }
     }

--- a/src/main/java/org/codelibs/fess/job/UpdateLabelJob.java
+++ b/src/main/java/org/codelibs/fess/job/UpdateLabelJob.java
@@ -87,7 +87,7 @@ public class UpdateLabelJob {
             });
             resultBuf.append(count).append(" documents").append("\n");
         } catch (final Exception e) {
-            logger.error("Could not update labels.", e);
+            logger.warn("Could not update labels.", e);
             resultBuf.append(e.getMessage()).append("\n");
         }
 


### PR DESCRIPTION
## Background

`ERROR` is not just a log level in Fess. In `src/main/resources/log4j2.xml` the
`org.codelibs` logger is attached directly to `LogNotificationAppender`, whose
`minLevel` defaults to `ERROR`:

```xml
<LogNotificationAppender name="LogNotification"
    minLevel="${sys:fess.log.notification.level:-ERROR}" />
```

So every `logger.error` fires an operator notification. This PR aligns the
levels with that contract:

- **ERROR** — the service is unusable, or the state needs operator intervention
- **WARN** — a retry or the next scheduled run can resolve it

## Changes

### 1. `IndexUpdater` — `logger.error()` guarded by `logger.isDebugEnabled()`

```java
} catch (final ContainerNotAvailableException e) {
    if (logger.isDebugEnabled()) {
        logger.error("IndexUpdater is terminated.", e);   // -> debug
```

Turning debug logging on *raised* the severity, so a normal shutdown emitted a
notification. `ContainerNotAvailableException` is the ordinary stop path. The
four sibling entry points (`Crawler`, `SuggestCreator`, `ThumbnailGenerator`,
`ChunkVectorIndexer`) all use `logger.debug()` in the same idiom. Two
occurrences fixed; the genuine-failure branch (`ComponentUtil.available()`)
stays at ERROR.

### 2. Periodic maintenance jobs — ERROR to WARN (11 sites)

`PurgeLogJob` (7), `PurgeDocJob`, `AggregateLogJob`, `UpdateLabelJob`,
`PurgeThumbnailJob`.

Search stays available and the next scheduled run retries. Every one of these
also appends the message to the job result, which `ScriptExecutorJob` stores in
the job log, so the ERROR was a duplicate notification for something already
visible in Administration > Job Log.

### 3. `AllJobScheduler` — WARN to ERROR

A register failure here is permanent: `schedulerTime = now` runs outside the
`forEach`, so the next poll of `getScheduledJobListAfter(schedulerTime)` never
picks the job up again and it stays dead until it is saved again. This is the
runtime counterpart of `ScheduledJobService#start`, which already uses ERROR
for the same failure at boot.

### 4. `SearchEngineApiManager` — ERROR to WARN, plus two defects

Both handlers dropped the exception, so the stack trace was lost — while the
`WebApiException` they throw is logged *with* its trace at WARN one frame up.
The heavier record carried less information. Now the cause is passed and the
level is WARN.

The second handler is in the not-found branch, where no file is read; its
"Failed to read file" message described the wrong operation. It now reports the
failed `sendError` response.

### 5. `Crawler#doCrawl` — WARN to ERROR

The terminal `catch (Throwable)` for the whole crawl task logged at WARN and
returned `EXIT_FAIL`, so a crawl failure never reached the `logger.error` in
`main()`; even an OOM stopped at WARN. ERROR here also matches
`DataIndexHelper`, which already uses ERROR for the data-crawl equivalent.

## Testing

`mvn clean test` for the touched classes — 132 tests, all passing:

- `PurgeLogJobTest`, `PurgeDocJobTest`, `PurgeThumbnailJobTest`,
  `AggregateLogJobTest`, `UpdateLabelJobTest`
- `IndexUpdaterTest`, `SearchEngineApiManagerTest`, `CrawlerTest`

`mvn formatter:format` and `mvn license:format` produced no further changes.

## Not included

Deliberately left out of this PR, and worth a look separately:

- `IndexUpdater`: `Crawler.addError()` is called in the container-gone branches
  but not in the genuine-failure branch (`ComponentUtil.available()`). That
  looks inverted, but it is a behavior change rather than a log level.
- `AllJobScheduler`: the underlying issue is that `schedulerTime` advances even
  when a job failed to register. Raising the level makes the failure visible,
  but the job is still never retried.
- `HtmlTagBasedGenerator`: the `default:` branch that logs
  "Unknown thumbnail result" is unreachable — the `Result` enum has exactly the
  four values the switch already covers.
- `AllJobSchedulerTest` has no `@Test` methods, so it silently runs nothing.
