### PR TITLE
fix(sso): tell an administrator how to accept a repeated SAML attribute name

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -133,6 +133,14 @@ import jakarta.servlet.http.HttpSession;
  * saml.default.groups=user
  * saml.default.roles=user
  * </pre>
+ * <p>An assertion that carries the same attribute name on more than one element is refused, and
+ * the login fails before any of the mapping above is reached. An IdP that emits one
+ * {@code <Attribute>} element per value produces such an assertion -- Keycloak does unless the
+ * {@code single} option of its role and group mappers is enabled -- and the repeats are accepted
+ * and merged only with:</p>
+ * <pre>
+ * saml.security.allow_duplicated_attribute_name=true
+ * </pre>
  *
  * <h2>Security Settings (Production)</h2>
  * <p>For production environments, consider enabling these security features:</p>
@@ -484,7 +492,11 @@ public class SamlAuthenticator implements SsoAuthenticator {
                             // request can be repeated for the whole TTL. A stack trace per attempt
                             // would let an unauthenticated client fill the log; SsoAction already
                             // makes this split for SsoStateException.
-                            logger.warn("Authentication failed: {}", describeSamlFailure(e));
+                            if (isDuplicatedAttributeName(e)) {
+                                logDuplicatedAttributeName();
+                            } else {
+                                logger.warn("Authentication failed: {}", describeSamlFailure(e));
+                            }
                             if (logger.isDebugEnabled()) {
                                 logger.debug("Authentication failed.", e);
                             }
@@ -769,6 +781,58 @@ public class SamlAuthenticator implements SsoAuthenticator {
                  the session, and with it the AuthnRequest ID it held, was discarded by the\
                  container's session timeout rather than by {}, so raising that value does not help.\
                  Starting the login again resolves it.""", SAML_REQUEST_ID_TTL);
+    }
+
+    /**
+     * Returns whether the given failure is the library refusing an assertion that carries the same
+     * attribute name more than once.
+     *
+     * <p>Matched on {@link ValidationException#DUPLICATED_ATTRIBUTE_NAME_FOUND} rather than on the
+     * message, which is the library's to change.</p>
+     *
+     * @param e The failure that ended the login.
+     * @return True if the assertion repeated an attribute name.
+     */
+    protected boolean isDuplicatedAttributeName(final SAMLException e) {
+        return e instanceof final ValidationException ve && ve.getErrorCode() == ValidationException.DUPLICATED_ATTRIBUTE_NAME_FOUND;
+    }
+
+    /**
+     * Logs the one line reported when the IdP put the same attribute name on more than one
+     * element of the assertion.
+     *
+     * <p>Told apart from the generic failure line because the generic one -- "Found an Attribute
+     * element with duplicated Name" -- names a fact about the XML and leaves an administrator with
+     * nothing to change. The setting that accepts the repeats exists, but nothing in Fess mentions
+     * it, so without this line the deployment is a dead end.</p>
+     *
+     * <p>It is worth its own line because of how it is reached rather than how rare it is: this
+     * refusal happens in {@code Auth#processResponse} after {@code SamlResponse#isValid} has
+     * already returned true, while the attributes are being read, so the signature, the
+     * InResponseTo comparison and the replay check all passed. An administrator who is told only
+     * that an assertion was refused reasonably suspects the certificate or the clock, none of
+     * which is involved.</p>
+     *
+     * <p>Keycloak is named because it is listed as a supported IdP and produces this on a stock
+     * configuration: its role and group mappers emit one {@code <Attribute>} element per value
+     * unless their {@code single} option is enabled, and every Keycloak account carries several
+     * default realm roles, so every login of every user fails. The failure does not depend on
+     * Fess mapping those attributes -- a deployment that sets no
+     * {@code saml.attribute.role.name} at all fails identically, because the refusal is in the
+     * library, before Fess is given anything to map.</p>
+     *
+     * <p>The pending AuthnRequest ID is not consumed by this failure, so a login retried after the
+     * IdP or Fess is reconfigured still has its ID to match against.</p>
+     */
+    protected void logDuplicatedAttributeName() {
+        logger.warn("""
+                The IdP repeated an attribute name in the SAML assertion, which is refused, so the login failed\
+                 while the attributes were being read; the assertion itself passed validation and no group or\
+                 role was mapped. An IdP that emits one <Attribute> element per value produces this: Keycloak\
+                 does unless the "single" option of its role and group mappers is enabled, and every Keycloak\
+                 account carries several default roles. Either aggregate each attribute into a single element\
+                 at the IdP, or set {}=true in system.properties to accept the repeats and merge their values.""",
+                SAML_PREFIX + "security.allow_duplicated_attribute_name");
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -1107,6 +1107,52 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getLoginCredential_duplicatedAttributeNameNamesTheSettingThatAcceptsIt() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            final MockletHttpServletRequest request = postRawSamlResponse(authenticator, BROKEN_XML);
+            // what an IdP that emits one <Attribute> element per value produces; the library
+            // raises it from getAttributes(), after the assertion has already validated
+            final RuntimeException failure = new ValidationException("Found an Attribute element with duplicated Name",
+                    ValidationException.DUPLICATED_ATTRIBUTE_NAME_FOUND);
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                assertNull(failingAuthenticator(failure).getLoginCredential());
+
+                assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+                final String warning = appender.warnings().get(0);
+                // the setting is the whole point of the line: without it an administrator is told
+                // a fact about the XML and has nothing to change
+                assertTrue(warning, warning.contains("saml.security.allow_duplicated_attribute_name"));
+                // and it must not be mistaken for the two cookie/timing diagnoses
+                assertFalse(warning, warning.contains("tomcat.sameSiteCookies"));
+                assertFalse(warning, warning.contains("saml.request.id.ttl"));
+                appender.eventsAt(Level.WARN).forEach(e -> assertNull(e.getThrown(), e.getMessage().getFormattedMessage()));
+            } finally {
+                appender.detach();
+            }
+            // the ID is still there, so the login works as soon as either side is reconfigured
+            assertEquals(1, pendingRequestIds(request.getSession(false)).size());
+        } finally {
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
+    public void test_isDuplicatedAttributeName_matchesOnlyThatErrorCode() throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+
+        assertTrue(authenticator
+                .isDuplicatedAttributeName(new ValidationException("duplicated", ValidationException.DUPLICATED_ATTRIBUTE_NAME_FOUND)));
+        // the code a retried candidate produces, which processSamlResponse handles on its own
+        assertFalse(authenticator.isDuplicatedAttributeName(new ValidationException("mismatch", ValidationException.WRONG_INRESPONSETO)));
+        assertFalse(authenticator.isDuplicatedAttributeName(new SAMLException("not a validation failure")));
+    }
+
+    @Test
     public void test_hasExpiredSession_needsASessionIdThatIsNoLongerValid() throws Exception {
         final SamlAuthenticator authenticator = new SamlAuthenticator();
         // one request, walked through the three states, because getMockRequest() hands out the


### PR DESCRIPTION
## Problem

An assertion that carries the same attribute name on more than one element is refused by
java-saml, and the login failed with nothing but the fact:

```
Authentication failed: ValidationException: Found an Attribute element with duplicated Name
```

The setting that accepts the repeats and merges their values exists —
`saml.security.allow_duplicated_attribute_name`, which reaches the library's
`onelogin.saml2.security.allow_duplicated_attribute_name` through the usual `saml.` prefix
mapping — but nothing in Fess mentions it, so the deployment is a dead end.

This is not a rare shape. **Keycloak is listed as a supported IdP in the documentation and
produces it on a stock configuration**: its role and group mappers emit one `<Attribute>` element
per value unless their `single` option is enabled, and every Keycloak account carries several
default realm roles (`default-roles-*`, `offline_access`, `uma_authorization`,
`manage-account`, …). Every login of every user therefore fails.

The failure does not depend on Fess mapping those attributes either — a deployment that sets no
`saml.attribute.role.name` at all fails identically, because the refusal happens inside the
library before Fess is given anything to map.

It is also raised from `Auth#processResponse` *after* `SamlResponse#isValid` has already returned
true, while the attributes are being read, so the signature, the InResponseTo comparison and the
replay check all passed. An administrator told only that an assertion was refused reasonably
suspects the certificate or the clock, none of which is involved.

## Change

Give that one failure its own warning, naming both remedies:

```
The IdP repeated an attribute name in the SAML assertion, which is refused, so the login failed
while the attributes were being read; the assertion itself passed validation and no group or role
was mapped. An IdP that emits one <Attribute> element per value produces this: Keycloak does
unless the "single" option of its role and group mappers is enabled, and every Keycloak account
carries several default roles. Either aggregate each attribute into a single element at the IdP,
or set saml.security.allow_duplicated_attribute_name=true in system.properties to accept the
repeats and merge their values.
```

It is matched on `ValidationException#DUPLICATED_ATTRIBUTE_NAME_FOUND`, not on the library's
message text, and split out the same way the SameSite / TTL / expired-session diagnoses already
are. The pending AuthnRequest ID is not consumed by this failure, so a login retried after either
side is reconfigured still has its ID to match against.

The class javadoc gains the same note next to the existing attribute-mapping settings.

## Verification

Against a real Keycloak 26.4 with its **default** role list mapper and a stock Fess SAML
configuration:

- before the change, the login fails with the bare `Found an Attribute element with duplicated
  Name` line;
- after the change, the login fails with the new line, and following its instruction —
  setting `saml.security.allow_duplicated_attribute_name=true` — makes the same login succeed
  with the repeated values merged and group/role permissions mapped as expected.

Both new tests were mutation-checked: dropping the branch, and matching the wrong error code,
each turn the suite red.

```
mvn -o test -Dtest=SamlAuthenticatorTest          → 56/56
mvn -o test -Dtest='org.codelibs.fess.sso.**'     → 288/288
mvn -o clean javadoc:jar                          → no errors
```

## Follow-up (not in this PR)

Documentation for the same problem is being prepared separately for `fess-docs`, since Keycloak
is advertised as supported there.

Whether `saml.security.allow_duplicated_attribute_name` should simply default to `true` is a
separate question worth deciding on its own: java-saml merges the repeated values into one list,
which is what Fess wants, but that changes a security default and is not something this PR
assumes.
