### PR TITLE
fix(api): honor login.required on the /api/v2 surface

### DIFF
--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -29,6 +29,18 @@ info:
     `403 forbidden` (not `401 auth_required`). `/auth/login` is exempt from
     CSRF since no token can exist prior to login.
 
+    **Login requirement.** When the administrator enables `login.required`,
+    every endpoint answers `401 auth_required` unless the request carries an
+    authenticated session. Only `GET /health`, `GET /auth/me`,
+    `POST /auth/login`, `POST /auth/logout` and `GET /ui/config` stay
+    reachable, so that a client can still probe the service and complete the
+    login flow. The policy is default-deny: an endpoint introduced later is
+    gated until it is listed as reachable before login. While
+    `login.required` is disabled — the default — no endpoint returns
+    `401 auth_required` on this ground, and the individual `401` responses
+    documented below apply only to the endpoints that require a user
+    regardless of the setting.
+
     `/chat/stream` emits Server-Sent Events (`text/event-stream`).
     `/documents/all` emits NDJSON (`application/x-ndjson`); each line is a
     `{"data": {...}}` object except the final line on a mid-stream failure,
@@ -42,7 +54,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 15.7.0
+  version: 15.8.0
 externalDocs:
   description: API Documentation
   url: https://fess.codelibs.org/15.7/api/
@@ -234,6 +246,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SearchResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '500': { $ref: '#/components/responses/InternalServerError' }
 
@@ -327,6 +340,7 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '500': { $ref: '#/components/responses/InternalServerError' }
 
@@ -370,6 +384,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuggestWordsResponse'
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '500': { $ref: '#/components/responses/InternalServerError' }
 
@@ -385,6 +400,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LabelsResponse'
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '500': { $ref: '#/components/responses/InternalServerError' }
 
@@ -421,6 +437,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PopularWordsResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '500': { $ref: '#/components/responses/InternalServerError' }
 
@@ -442,6 +459,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RelatedQueriesResponse'
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '500': { $ref: '#/components/responses/InternalServerError' }
 
@@ -464,6 +482,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RelatedContentResponse'
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '500': { $ref: '#/components/responses/InternalServerError' }
 
@@ -666,6 +685,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClickResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
@@ -705,6 +725,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ChatResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '413': { $ref: '#/components/responses/PayloadTooLarge' }
@@ -771,6 +792,7 @@ paths:
                   event: done
                   data: {"session_id":"abc"}
         '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '413': { $ref: '#/components/responses/PayloadTooLarge' }
@@ -806,6 +828,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ChatClearResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
@@ -860,6 +883,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/FavoriteGetResponse'
         '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
         '404': { $ref: '#/components/responses/NotFound' }
         '405': { $ref: '#/components/responses/MethodNotAllowed' }
         '500': { $ref: '#/components/responses/InternalServerError' }

--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -43,7 +43,10 @@ import org.codelibs.fess.api.v2.handlers.ScrollSearchHandler;
 import org.codelibs.fess.api.v2.handlers.SearchHandler;
 import org.codelibs.fess.api.v2.handlers.SuggestWordsHandler;
 import org.codelibs.fess.api.v2.handlers.UiConfigHandler;
+import org.codelibs.fess.app.web.base.login.FessLoginAssist;
+import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
@@ -229,6 +232,15 @@ public class SearchApiV2Manager extends BaseApiManager {
                 return;
             }
         }
+        // Layer 3: honor app login.required. The v1 actions redirect an anonymous caller to
+        // the login page; without this the v2 surface answered every request anonymously, so
+        // the setting stopped short of the endpoint the single-page application searches with.
+        // The policy table is default-deny, so an endpoint added later is gated until it is
+        // explicitly listed as reachable before login.
+        if (ComponentUtil.getV2LoginRequirement().requiresLogin(sub) && isLoginRequiredForAnonymous(sub, response)) {
+            return;
+        }
+
         try {
             // Path components that vary (docId) are matched before the static switch so the
             // exhaustive switch below can keep its readable shape. Order is important:
@@ -314,6 +326,48 @@ public class SearchApiV2Manager extends BaseApiManager {
             // information the SPA must not see.
             ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INTERNAL_ERROR, "internal error");
         }
+    }
+
+    /**
+     * Rejects an anonymous caller when {@code login.required} is enabled.
+     *
+     * <p>Mirrors the v1 actions, which redirect to the login page instead of answering. A
+     * browser follows that redirect; an API client cannot, so the v2 surface reports the same
+     * decision as {@code 401 auth_required}.</p>
+     *
+     * <p>A failure to resolve the caller is reported as an internal error rather than being
+     * treated as "anonymous" or as "signed in": the former turns a broken dependency into a
+     * misleading session-expired message for a user who is in fact signed in, and the latter
+     * would open the very hole this gate closes.</p>
+     *
+     * @param sub the v2 sub-path, used for logging only
+     * @param response the response to write the error envelope to
+     * @return {@code true} when an error envelope was written and dispatch must stop
+     * @throws IOException if the error envelope cannot be written
+     */
+    protected boolean isLoginRequiredForAnonymous(final String sub, final HttpServletResponse response) throws IOException {
+        try {
+            if (!ComponentUtil.getFessConfig().isLoginRequired()) {
+                return false;
+            }
+        } catch (final RuntimeException e) {
+            logger.warn("/api/v2{}: could not read login.required", sub, e);
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2" + sub);
+            return true;
+        }
+        final OptionalThing<FessUserBean> userBean;
+        try {
+            userBean = ComponentUtil.getComponent(FessLoginAssist.class).getSavedUserBean();
+        } catch (final RuntimeException e) {
+            logger.warn("/api/v2{}: could not resolve the current user", sub, e);
+            ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2" + sub);
+            return true;
+        }
+        if (userBean.isPresent()) {
+            return false;
+        }
+        ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.AUTH_REQUIRED, "login required");
+        return true;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRequirement.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginRequirement.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+/**
+ * Static decision table for the {@code login.required} gate on the {@code /api/v2} surface.
+ *
+ * <p>{@code login.required} promises that search requires a login. The v1 actions honor it
+ * ({@code SearchAction}, {@code GoAction}, {@code CacheAction}, {@code ThumbnailAction},
+ * {@code OsddAction}, {@code HelpAction} and {@code RootAction} all redirect to the login page),
+ * but on the v2 surface only {@code /api/v2/cache/{docId}} did. Every other v2 endpoint answered
+ * anonymously, so {@code GET /api/v2/search} returned every document carrying the guest role —
+ * and {@code role.search.default.display.permissions} seeds exactly that role into each crawl
+ * configuration created from the admin UI, so in a default installation that is the whole
+ * corpus.</p>
+ *
+ * <p><strong>Default policy: a login is REQUIRED for every sub-path.</strong> Exemptions are
+ * listed explicitly in {@link #requiresLogin}, so an endpoint added to
+ * {@code SearchApiV2Manager.process} without a corresponding entry here inherits the safe
+ * default rather than being silently reachable by anonymous callers.</p>
+ *
+ * <p>The exempt set is the minimum a browser needs to render the login page and authenticate:
+ * the health probe, the three anonymous-capable auth endpoints and the UI configuration the
+ * single-page application reads before it knows whether anyone is signed in. Note that this
+ * table describes the policy only; it applies solely when {@code login.required} is enabled.</p>
+ *
+ * <p><strong>Maintenance contract:</strong> whenever a new endpoint is added to
+ * {@code SearchApiV2Manager.process}, decide whether it is reachable before login and extend
+ * {@code LoginRequirementCompleteCoverageTest} to pin that decision.</p>
+ */
+public class LoginRequirement {
+
+    /**
+     * Creates a login requirement evaluator. Registered as the DI component
+     * {@code v2LoginRequirement} and obtained via
+     * {@link org.codelibs.fess.util.ComponentUtil#getV2LoginRequirement()}.
+     */
+    public LoginRequirement() {
+        // default constructor
+    }
+
+    /**
+     * Returns whether the given v2 sub-path may only be served to an authenticated user
+     * while {@code login.required} is enabled.
+     *
+     * <p>A {@code null} sub-path is treated as unknown and therefore gated, matching the
+     * secure default applied to every path that is not explicitly exempt.</p>
+     *
+     * @param subPath the v2 sub-path (e.g. {@code /search}, {@code /auth/login})
+     * @return {@code true} if the request must carry an authenticated user
+     */
+    public boolean requiresLogin(final String subPath) {
+        if (subPath == null) {
+            return true;
+        }
+        return switch (subPath) {
+        // Liveness/readiness probing must stay reachable: monitoring runs without a session.
+        case "/health" -> false;
+        // The single-page application calls these before it can know whether anyone is signed
+        // in. /auth/me answers "nobody" for an anonymous caller, and /ui/config carries the
+        // login_required flag the page needs in order to show the login form at all.
+        case "/auth/me", "/auth/login", "/auth/logout", "/ui/config" -> false;
+        // Secure default: everything else — search, scroll, suggest, labels, popular words,
+        // related queries/content, chat, click, favorites, cache and any endpoint added later
+        // — is served only to an authenticated user.
+        default -> true;
+        };
+    }
+}

--- a/src/main/java/org/codelibs/fess/util/ComponentUtil.java
+++ b/src/main/java/org/codelibs/fess/util/ComponentUtil.java
@@ -29,6 +29,7 @@ import org.codelibs.fess.api.WebApiManagerFactory;
 import org.codelibs.fess.api.v2.SessionCsrfTokenManager;
 import org.codelibs.fess.api.v2.V2EnvelopeWriter;
 import org.codelibs.fess.api.v2.handlers.CsrfRequirement;
+import org.codelibs.fess.api.v2.handlers.LoginRequirement;
 import org.codelibs.fess.api.v2.handlers.DocIdValidator;
 import org.codelibs.fess.api.v2.handlers.LoginRateLimiter;
 import org.codelibs.fess.api.v2.handlers.UserPayloads;
@@ -165,6 +166,8 @@ public final class ComponentUtil {
     private static final String V2_USER_PAYLOADS = "v2UserPayloads";
 
     private static final String V2_CSRF_REQUIREMENT = "v2CsrfRequirement";
+
+    private static final String V2_LOGIN_REQUIREMENT = "v2LoginRequirement";
 
     private static final String V2_DOC_ID_VALIDATOR = "v2DocIdValidator";
 
@@ -829,6 +832,14 @@ public final class ComponentUtil {
      */
     public static CsrfRequirement getV2CsrfRequirement() {
         return getComponent(V2_CSRF_REQUIREMENT);
+    }
+
+    /**
+     * Gets the v2 login requirement component.
+     * @return The v2 login requirement component.
+     */
+    public static LoginRequirement getV2LoginRequirement() {
+        return getComponent(V2_LOGIN_REQUIREMENT);
     }
 
     /**

--- a/src/main/resources/fess_api.xml
+++ b/src/main/resources/fess_api.xml
@@ -14,6 +14,7 @@
 	<component name="v2JsonBody" class="org.codelibs.fess.api.v2.handlers.V2JsonBody"/>
 	<component name="v2UserPayloads" class="org.codelibs.fess.api.v2.handlers.UserPayloads"/>
 	<component name="v2CsrfRequirement" class="org.codelibs.fess.api.v2.handlers.CsrfRequirement"/>
+	<component name="v2LoginRequirement" class="org.codelibs.fess.api.v2.handlers.LoginRequirement"/>
 	<component name="v2DocIdValidator" class="org.codelibs.fess.api.v2.handlers.DocIdValidator"/>
 	<component name="sseResponseHelper" class="org.codelibs.fess.helper.SseResponseHelper"/>
 

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerLoginRequiredTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerLoginRequiredTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.codelibs.core.misc.DynamicProperties;
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.api.v2.handlers.LoginRequirement;
+import org.codelibs.fess.app.web.base.login.FessLoginAssist;
+import org.codelibs.fess.mylasta.action.FessUserBean;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Pins the {@code login.required} gate on the {@code /api/v2} surface.
+ *
+ * <p>Before this gate existed, {@code GET /api/v2/search} answered anonymously even with
+ * {@code login.required} enabled, while the v1 {@code SearchAction} redirected the same caller
+ * to the login page. These tests drive {@code SearchApiV2Manager.process} directly and assert
+ * the decision the gate reaches, rather than accepting any of several outcomes — the property
+ * is set explicitly so that a regression cannot hide behind a permissive assertion.</p>
+ */
+public class SearchApiV2ManagerLoginRequiredTest extends UnitFessTestCase {
+
+    @Override
+    protected boolean isUseOneTimeContainer() {
+        // login.required lives in DynamicProperties, which is a JVM-lifetime singleton in the
+        // test container; a one-time container keeps this test from leaking the flag.
+        return true;
+    }
+
+    @BeforeEach
+    public void registerComponents() {
+        final LoginRequirement requirement = new LoginRequirement();
+        ComponentUtil.register(requirement, "v2LoginRequirement");
+        ComponentUtil.register(requirement, LoginRequirement.class.getCanonicalName());
+        // The test container has no HTTP session, so resolve the caller through a stub that
+        // reports "nobody is signed in" — the state an anonymous request actually produces.
+        final FessLoginAssist anonymous = new FessLoginAssist() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public OptionalThing<FessUserBean> getSavedUserBean() {
+                return OptionalThing.empty();
+            }
+        };
+        ComponentUtil.register(anonymous, "fessLoginAssist");
+        ComponentUtil.register(anonymous, FessLoginAssist.class.getCanonicalName());
+    }
+
+    @Override
+    protected void tearDown(final TestInfo testInfo) throws Exception {
+        ComponentUtil.getSystemProperties().remove(Constants.LOGIN_REQUIRED_PROPERTY);
+        super.tearDown(testInfo);
+    }
+
+    private static void setLoginRequired(final boolean value) {
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        systemProperties.setProperty(Constants.LOGIN_REQUIRED_PROPERTY, Boolean.toString(value));
+    }
+
+    @Test
+    public void test_search_isRejectedForAnonymousWhenLoginRequired() throws Exception {
+        setLoginRequired(true);
+        final CapturingResponse res = process("/api/v2/search");
+        assertEquals(401, res.status);
+        assertTrue(res.body().contains("\"code\":\"auth_required\""), res.body());
+    }
+
+    @Test
+    public void test_scrollSearch_isRejectedForAnonymousWhenLoginRequired() throws Exception {
+        setLoginRequired(true);
+        final CapturingResponse res = process("/api/v2/documents/all");
+        assertEquals(401, res.status);
+        assertTrue(res.body().contains("\"code\":\"auth_required\""), res.body());
+    }
+
+    @Test
+    public void test_indexDerivedEndpoints_areRejectedForAnonymousWhenLoginRequired() throws Exception {
+        setLoginRequired(true);
+        for (final String path : new String[] { "/api/v2/labels", "/api/v2/popular-words", "/api/v2/suggest-words",
+                "/api/v2/related-queries", "/api/v2/related-content" }) {
+            final CapturingResponse res = process(path);
+            assertEquals(401, res.status, path);
+            assertTrue(res.body().contains("\"code\":\"auth_required\""), path + " -> " + res.body());
+        }
+    }
+
+    @Test
+    public void test_health_staysReachableWhenLoginRequired() throws Exception {
+        setLoginRequired(true);
+        final CapturingResponse res = process("/api/v2/health");
+        assertFalse(res.body().contains("\"code\":\"auth_required\""), res.body());
+    }
+
+    @Test
+    public void test_loginFlowEndpoints_stayReachableWhenLoginRequired() throws Exception {
+        setLoginRequired(true);
+        for (final String path : new String[] { "/api/v2/auth/me", "/api/v2/ui/config" }) {
+            final CapturingResponse res = process(path);
+            assertFalse(res.body().contains("\"code\":\"auth_required\""), path + " -> " + res.body());
+        }
+    }
+
+    @Test
+    public void test_search_isNotGatedWhenLoginIsNotRequired() throws Exception {
+        setLoginRequired(false);
+        final CapturingResponse res = process("/api/v2/search");
+        // The handler itself needs a search engine that the unit container does not provide,
+        // so the request may still fail — but never with the authentication decision.
+        assertFalse(res.body().contains("\"code\":\"auth_required\""), res.body());
+    }
+
+    private CapturingResponse process(final String servletPath) throws Exception {
+        final SearchApiV2Manager manager = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final CapturingResponse res = new CapturingResponse();
+        manager.process(request(servletPath), res, nopChain());
+        return res;
+    }
+
+    private static HttpServletRequest request(final String servletPath) {
+        final InvocationHandler h = (proxy, method, args) -> switch (method.getName()) {
+        case "getServletPath" -> servletPath;
+        case "getMethod" -> "GET";
+        case "getRequestURI" -> servletPath;
+        case "getParameterMap" -> java.util.Collections.emptyMap();
+        case "getParameterNames" -> java.util.Collections.enumeration(java.util.Collections.emptyList());
+        case "getRemoteAddr" -> "127.0.0.1";
+        case "toString" -> "StubRequest[" + servletPath + "]";
+        case "hashCode" -> System.identityHashCode(proxy);
+        case "equals" -> proxy == args[0];
+        default -> defaultValue(method.getReturnType());
+        };
+        return (HttpServletRequest) Proxy.newProxyInstance(SearchApiV2ManagerLoginRequiredTest.class.getClassLoader(),
+                new Class<?>[] { HttpServletRequest.class }, h);
+    }
+
+    private static Object defaultValue(final Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return Boolean.FALSE;
+        }
+        if (type == int.class) {
+            return Integer.valueOf(0);
+        }
+        if (type == long.class) {
+            return Long.valueOf(0L);
+        }
+        return null;
+    }
+
+    private static FilterChain nopChain() {
+        return new FilterChain() {
+            @Override
+            public void doFilter(final ServletRequest req, final ServletResponse res) {
+                // no downstream filter in these tests
+            }
+        };
+    }
+
+    /** Minimal response that records the status and buffers whatever the envelope writer emits. */
+    private static class CapturingResponse implements HttpServletResponse {
+
+        int status = 200;
+
+        private final StringWriter writer = new StringWriter();
+
+        private final PrintWriter printWriter = new PrintWriter(writer);
+
+        String body() {
+            printWriter.flush();
+            return writer.toString();
+        }
+
+        @Override
+        public void setStatus(final int sc) {
+            this.status = sc;
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        @Override
+        public PrintWriter getWriter() {
+            return printWriter;
+        }
+
+        @Override
+        public void sendError(final int sc, final String msg) {
+            this.status = sc;
+        }
+
+        @Override
+        public void sendError(final int sc) {
+            this.status = sc;
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() {
+            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            return new ServletOutputStream() {
+                @Override
+                public void write(final int b) {
+                    buffer.write(b);
+                }
+
+                @Override
+                public boolean isReady() {
+                    return true;
+                }
+
+                @Override
+                public void setWriteListener(final WriteListener listener) {
+                    // not used
+                }
+            };
+        }
+
+        // --- everything below is unused by these tests ---
+
+        @Override
+        public void addCookie(final jakarta.servlet.http.Cookie cookie) {
+        }
+
+        @Override
+        public boolean containsHeader(final String name) {
+            return false;
+        }
+
+        @Override
+        public String encodeURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeRedirectURL(final String url) {
+            return url;
+        }
+
+        @Override
+        public void sendRedirect(final String location) throws IOException {
+        }
+
+        @Override
+        public void sendRedirect(final String location, final int sc, final boolean clearBuffer) throws IOException {
+        }
+
+        @Override
+        public void setDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void addDateHeader(final String name, final long date) {
+        }
+
+        @Override
+        public void setHeader(final String name, final String value) {
+        }
+
+        @Override
+        public void addHeader(final String name, final String value) {
+        }
+
+        @Override
+        public void setIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public void addIntHeader(final String name, final int value) {
+        }
+
+        @Override
+        public String getHeader(final String name) {
+            return null;
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaders(final String name) {
+            return java.util.Collections.emptyList();
+        }
+
+        @Override
+        public java.util.Collection<String> getHeaderNames() {
+            return java.util.Collections.emptyList();
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterEncoding(final String charset) {
+        }
+
+        @Override
+        public void setContentLength(final int len) {
+        }
+
+        @Override
+        public void setContentLengthLong(final long len) {
+        }
+
+        @Override
+        public void setContentType(final String type) {
+        }
+
+        @Override
+        public void setBufferSize(final int size) {
+        }
+
+        @Override
+        public int getBufferSize() {
+            return 0;
+        }
+
+        @Override
+        public void flushBuffer() {
+        }
+
+        @Override
+        public void resetBuffer() {
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void setLocale(final java.util.Locale loc) {
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return java.util.Locale.getDefault();
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRequirementCompleteCoverageTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRequirementCompleteCoverageTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Coverage-completeness test for {@link LoginRequirement}.
+ *
+ * <p>Enumerates every sub-path dispatched by {@code SearchApiV2Manager.process} and pins
+ * whether it may be served to an anonymous caller while {@code login.required} is enabled.
+ * The list is hand-maintained rather than reflection-derived: the dispatch table is a switch
+ * statement, and extracting it dynamically would restate the implementation instead of
+ * checking it.</p>
+ *
+ * <p><strong>Maintenance contract:</strong> when a new endpoint is added to
+ * {@code SearchApiV2Manager.process}, add it here with an explicit decision and update
+ * {@link #EXPECTED_ENTRY_COUNT}. Forgetting to do so is safe — the endpoint inherits the
+ * default-deny policy — but this test makes the omission visible.</p>
+ */
+public class LoginRequirementCompleteCoverageTest {
+
+    /**
+     * Every dispatched sub-path paired with whether it requires an authenticated user
+     * while {@code login.required} is enabled.
+     */
+    private static final Map<String, Boolean> ENDPOINT_DECISIONS;
+
+    /** Must equal {@code ENDPOINT_DECISIONS.size()}. */
+    private static final int EXPECTED_ENTRY_COUNT = 18;
+
+    static {
+        final Map<String, Boolean> m = new LinkedHashMap<>();
+
+        // --- Reachable before login: the probe, the login flow, and the configuration the
+        // single-page application reads in order to render the login form. ---
+        m.put("/health", false);
+        m.put("/auth/me", false);
+        m.put("/auth/login", false);
+        m.put("/auth/logout", false);
+        m.put("/ui/config", false);
+
+        // --- Search and everything derived from the index. ---
+        m.put("/search", true);
+        m.put("/documents/all", true);
+        m.put("/suggest-words", true);
+        m.put("/labels", true);
+        m.put("/popular-words", true);
+        m.put("/related-queries", true);
+        m.put("/related-content", true);
+        m.put("/cache/abc123", true);
+
+        // --- Per-user state and generative endpoints. ---
+        m.put("/auth/password", true);
+        m.put("/click", true);
+        m.put("/favorites", true);
+        m.put("/documents/abc123/favorite", true);
+        m.put("/chat", true);
+
+        ENDPOINT_DECISIONS = Collections.unmodifiableMap(m);
+    }
+
+    @Test
+    public void test_entryCounts_matchExpectedEntryCount() {
+        assertTrue(ENDPOINT_DECISIONS.size() == EXPECTED_ENTRY_COUNT, "ENDPOINT_DECISIONS has " + ENDPOINT_DECISIONS.size()
+                + " entries but EXPECTED_ENTRY_COUNT=" + EXPECTED_ENTRY_COUNT + "; update the constant when adding or removing endpoints");
+    }
+
+    @Test
+    public void test_everyEndpointHasDeliberateLoginDecision() {
+        final List<String> failures = new ArrayList<>();
+        for (final Map.Entry<String, Boolean> entry : ENDPOINT_DECISIONS.entrySet()) {
+            final boolean actual = new LoginRequirement().requiresLogin(entry.getKey());
+            if (actual != entry.getValue().booleanValue()) {
+                failures.add(String.format("  subPath=%-35s expected requiresLogin=%b, got=%b", entry.getKey(), entry.getValue(), actual));
+            }
+        }
+        if (!failures.isEmpty()) {
+            fail("LoginRequirement decision mismatch for the following endpoints:\n" + String.join("\n", failures)
+                    + "\n\nFor each mismatch, either:\n"
+                    + "  (a) update LoginRequirement.requiresLogin() to reflect the intended decision, or\n"
+                    + "  (b) update this test's ENDPOINT_DECISIONS table if the intended decision changed.");
+        }
+    }
+
+    @Test
+    public void test_exemptSetIsExactlyTheLoginFlowAndTheProbe() {
+        // A regression here means an endpoint became anonymously reachable. Any addition to
+        // this set widens what an unauthenticated caller can read and must be deliberate.
+        final List<String> exempt = new ArrayList<>();
+        for (final Map.Entry<String, Boolean> entry : ENDPOINT_DECISIONS.entrySet()) {
+            if (!entry.getValue().booleanValue()) {
+                exempt.add(entry.getKey());
+            }
+        }
+        Collections.sort(exempt);
+        assertEquals(List.of("/auth/login", "/auth/logout", "/auth/me", "/health", "/ui/config"), exempt);
+    }
+}

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRequirementTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginRequirementTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.api.v2.handlers;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the {@code login.required} decision table.
+ */
+public class LoginRequirementTest extends UnitFessTestCase {
+
+    private final LoginRequirement requirement = new LoginRequirement();
+
+    @Test
+    public void test_searchIsGated() {
+        assertTrue(requirement.requiresLogin("/search"));
+    }
+
+    @Test
+    public void test_scrollSearchIsGated() {
+        assertTrue(requirement.requiresLogin("/documents/all"));
+    }
+
+    @Test
+    public void test_indexDerivedEndpointsAreGated() {
+        assertTrue(requirement.requiresLogin("/labels"));
+        assertTrue(requirement.requiresLogin("/popular-words"));
+        assertTrue(requirement.requiresLogin("/suggest-words"));
+        assertTrue(requirement.requiresLogin("/related-queries"));
+        assertTrue(requirement.requiresLogin("/related-content"));
+    }
+
+    @Test
+    public void test_healthIsExempt() {
+        assertFalse(requirement.requiresLogin("/health"));
+    }
+
+    @Test
+    public void test_endpointsTheLoginPageNeedsAreExempt() {
+        assertFalse(requirement.requiresLogin("/auth/me"));
+        assertFalse(requirement.requiresLogin("/auth/login"));
+        assertFalse(requirement.requiresLogin("/auth/logout"));
+        assertFalse(requirement.requiresLogin("/ui/config"));
+    }
+
+    @Test
+    public void test_passwordChangeIsGated() {
+        // Changing a password is an authenticated operation; it is deliberately NOT part of
+        // the anonymous /auth/* subset.
+        assertTrue(requirement.requiresLogin("/auth/password"));
+    }
+
+    @Test
+    public void test_unknownPathFallsBackToGated() {
+        // A path added to the dispatcher without an entry here must inherit the secure default
+        // rather than becoming anonymously reachable.
+        assertTrue(requirement.requiresLogin("/some-endpoint-added-later"));
+    }
+
+    @Test
+    public void test_nullPathIsGated() {
+        assertTrue(requirement.requiresLogin(null));
+    }
+
+    @Test
+    public void test_exemptionsAreExactMatchesNotPrefixes() {
+        // "/health" is exempt but "/healthz" or "/auth/mel" must not inherit the exemption.
+        assertTrue(requirement.requiresLogin("/healthz"));
+        assertTrue(requirement.requiresLogin("/auth/mel"));
+        assertTrue(requirement.requiresLogin("/ui/config/extra"));
+    }
+}

--- a/src/test/resources/test_app.xml
+++ b/src/test/resources/test_app.xml
@@ -15,6 +15,7 @@
 	<component name="v2JsonBody" class="org.codelibs.fess.api.v2.handlers.V2JsonBody" />
 	<component name="v2UserPayloads" class="org.codelibs.fess.api.v2.handlers.UserPayloads" />
 	<component name="v2CsrfRequirement" class="org.codelibs.fess.api.v2.handlers.CsrfRequirement" />
+	<component name="v2LoginRequirement" class="org.codelibs.fess.api.v2.handlers.LoginRequirement" />
 	<component name="v2DocIdValidator" class="org.codelibs.fess.api.v2.handlers.DocIdValidator" />
 	<component name="sseResponseHelper" class="org.codelibs.fess.helper.SseResponseHelper" />
 </components>


### PR DESCRIPTION
## Problem

`login.required` is documented as making search require a login ("検索機能をログインを必須にするかを指定します"), and every v1 action honors it — `SearchAction`, `RootAction`, `GoAction`, `CacheAction`, `ThumbnailAction`, `OsddAction` and `HelpAction` all redirect an anonymous caller to the login page. On the `/api/v2` surface only `/cache/{docId}` did.

Measured against a running 15.8.0-SNAPSHOT with `login.required=true` and SPNEGO SSO configured, before this change:

| request (anonymous) | result |
|---|---|
| `GET /search/?q=…` (v1) | `302 → /sso/` |
| `GET /api/v2/cache/{docId}` | `401 auth_required` |
| `GET /api/v2/search?q=…` | **`200` with documents** |
| `GET /api/v2/popular-words` | **`200`** |
| `GET /api/v2/labels` | **`200`** |

The role filter still applies, so an anonymous caller receives only documents carrying the guest role — but `role.search.default.display.permissions` defaults to `{role}guest` and seeds the permissions field of every crawl configuration created from the admin UI (`webconfig`, `fileconfig`, `dataconfig`, `labeltype`, `elevateword` create forms and `AdminWizardAction`). In a default installation that is the whole corpus, so `/api/v2/search` is the search the setting was supposed to close.

This is not a 15.8 regression: `fess-15.7.0` has the same asymmetry (`CacheHandler` checks, `SearchHandler` does not). It matters more now because the static theme's single-page application searches through `/api/v2/search`.

## Change

`LoginRequirement` is a decision table in the same shape as `CsrfRequirement`, registered as `v2LoginRequirement`, applied as a third layer in `SearchApiV2Manager.process` after the Origin and CSRF layers.

The table is **default-deny**. Only these stay reachable while `login.required` is enabled:

- `/health` — monitoring runs without a session
- `/auth/me`, `/auth/login`, `/auth/logout` — the login flow itself
- `/ui/config` — carries the `login_required` flag the SPA needs in order to render the login form

Everything else — search, scroll, suggest, labels, popular words, related queries/content, chat, click, favorites, cache, and any endpoint added later — requires an authenticated user. An endpoint added to the dispatcher without an entry here inherits the gate rather than becoming anonymously reachable.

A caller that cannot be resolved is reported as `internal_error`, not treated as anonymous (which would mislead a signed-in user into thinking their session expired) and not treated as signed in (which would reopen the hole). This mirrors what `CacheHandler` already does; its own check is left in place so the handler stays correct when called directly.

`CacheHandler`'s existing check is now redundant with the central gate. It is intentionally left alone: it keeps the handler self-contained and its unit tests meaningful.

## OpenAPI

`src/main/config/openapi/v2/openapi-user.yaml` described twelve operations as unable to answer `401`, which the gate changes: `searchV2`, `scrollSearchV2`, `suggestWordsV2`, `labelsV2`, `popularWordsV2`, `relatedQueriesV2`, `relatedContentV2`, `clickV2`, `chatV2`, `chatStreamV2`, `chatClearSessionV2` and `favoriteGetV2`. Each gains the existing `Unauthorized` response. The five operations that stay reachable before login are unchanged, as are the operations that already documented `401` because they need a user regardless of the setting (`authPasswordV2`, `favoritesListV2`, `favoritePostV2`, `cacheV2`).

`info.description` gains a paragraph on the gate, placed beside the existing note about CSRF running before authentication because the two interact: an unauthenticated state-changing request without a token is still rejected as `403 forbidden` by the CSRF layer before the login gate can report `401`.

`info.version` is bumped to `15.8.0`. It had not moved since v2 was introduced, so the document still claimed to describe a contract that no longer answers `401` on these paths. `redocly lint` reports the same 21 errors and 1 warning before and after, so the change introduces no new spec problems.

## Verification

Same environment, after the change:

| request (anonymous, `login.required=true`) | result |
|---|---|
| `GET /api/v2/search?q=…` | `401 auth_required` |
| `GET /api/v2/documents/all` | `401 auth_required` |
| `GET /api/v2/labels` | `401 auth_required` |
| `GET /api/v2/popular-words` | `401 auth_required` |
| `GET /api/v2/health` | `200` |
| `GET /api/v2/auth/me` | `200 {"authenticated":false}` |
| `GET /api/v2/ui/config` | `200` |

After a SPNEGO login against an Active Directory domain, three users still see exactly their permitted documents (`alice`→`1alice`/`2sales`, `bob`→`2dev`, `carol`→`2all-staff`), and with `login.required=false` an anonymous search returns the guest-visible document as before.

`mvn test`: 7278 tests, 0 failures, 0 errors.

New tests: `LoginRequirementTest` (9), `LoginRequirementCompleteCoverageTest` (3, pins every dispatched sub-path and the exact exempt set), `SearchApiV2ManagerLoginRequiredTest` (6, drives `process` with the property set explicitly and asserts the exact status rather than accepting a range of outcomes).
