### PR TITLE
fix: hand the proxy credentials over in the shape the crawler clients read

### DIFF
--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/CrawlingConfig.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/CrawlingConfig.java
@@ -18,12 +18,13 @@ package org.codelibs.fess.opensearch.config.exentity;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import org.apache.http.auth.UsernamePasswordCredentials;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.crawler.client.CrawlerClientFactory;
 import org.codelibs.fess.crawler.client.ftp.FtpClient;
 import org.codelibs.fess.crawler.client.http.HcHttpClient;
+import org.codelibs.fess.crawler.client.http.config.CredentialsConfig;
+import org.codelibs.fess.crawler.client.http.config.WebAuthenticationConfig;
 import org.codelibs.fess.crawler.client.smb.SmbClient;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
@@ -50,6 +51,23 @@ public interface CrawlingConfig {
 
     Map<String, String> getConfigParameterMap(ConfigName name);
 
+    /**
+     * Creates the credentials to authenticate with the proxy, in the library-independent shape the
+     * crawler clients read them in.
+     *
+     * @param username the proxy user name
+     * @param password the proxy password
+     * @return the proxy credentials
+     */
+    static WebAuthenticationConfig createProxyCredentials(final String username, final String password) {
+        final CredentialsConfig credentials = new CredentialsConfig();
+        credentials.setUsername(username);
+        credentials.setPassword(password);
+        final WebAuthenticationConfig config = new WebAuthenticationConfig();
+        config.setCredentials(credentials);
+        return config;
+    }
+
     default void initializeDefaultHttpProxy(final Map<String, Object> paramMap) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final String proxyHost = fessConfig.getHttpProxyHost();
@@ -60,7 +78,7 @@ public interface CrawlingConfig {
             final String proxyUsername = fessConfig.getHttpProxyUsername();
             final String proxyPassword = fessConfig.getHttpProxyPassword();
             if (proxyUsername != null && proxyPassword != null) {
-                paramMap.put(HcHttpClient.PROXY_CREDENTIALS_PROPERTY, new UsernamePasswordCredentials(proxyUsername, proxyPassword));
+                paramMap.put(HcHttpClient.PROXY_CREDENTIALS_PROPERTY, createProxyCredentials(proxyUsername, proxyPassword));
             }
 
         }

--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/DataConfig.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/DataConfig.java
@@ -26,7 +26,6 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
@@ -193,7 +192,8 @@ public class DataConfig extends BsDataConfig implements CrawlingConfig {
             final String proxyUsername = paramMap.get(CRAWLER_WEB_PREFIX + "proxyUsername");
             final String proxyPassword = paramMap.get(CRAWLER_WEB_PREFIX + "proxyPassword");
             if (proxyUsername != null && proxyPassword != null) {
-                factoryParamMap.put(HcHttpClient.PROXY_CREDENTIALS_PROPERTY, new UsernamePasswordCredentials(proxyUsername, proxyPassword));
+                factoryParamMap.put(HcHttpClient.PROXY_CREDENTIALS_PROPERTY,
+                        CrawlingConfig.createProxyCredentials(proxyUsername, proxyPassword));
             }
         } else {
             initializeDefaultHttpProxy(factoryParamMap);

--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/WebConfig.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/WebConfig.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
-import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
@@ -208,7 +207,7 @@ public class WebConfig extends BsWebConfig implements CrawlingConfig {
         if (StringUtil.isNotBlank(proxyHost) && StringUtil.isNotBlank(proxyPort)) {
             // proxy credentials
             if (paramMap.get(Param.Client.PROXY_USERNAME) != null && paramMap.get(Param.Client.PROXY_PASSWORD) != null) {
-                paramMap.put(HcHttpClient.PROXY_CREDENTIALS_PROPERTY, new UsernamePasswordCredentials(
+                paramMap.put(HcHttpClient.PROXY_CREDENTIALS_PROPERTY, CrawlingConfig.createProxyCredentials(
                         paramMap.remove(Param.Client.PROXY_USERNAME).toString(), paramMap.remove(Param.Client.PROXY_PASSWORD).toString()));
             }
         } else {

--- a/src/test/java/org/codelibs/fess/opensearch/config/exentity/WebConfigTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/config/exentity/WebConfigTest.java
@@ -26,6 +26,7 @@ import org.codelibs.fess.app.service.RequestHeaderService;
 import org.codelibs.fess.app.service.WebAuthenticationService;
 import org.codelibs.fess.crawler.client.CrawlerClientFactory;
 import org.codelibs.fess.crawler.client.http.HcHttpClient;
+import org.codelibs.fess.crawler.client.http.config.CredentialsConfig;
 import org.codelibs.fess.crawler.client.http.config.WebAuthenticationConfig;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -105,6 +106,89 @@ public class WebConfigTest extends UnitFessTestCase {
         assertEquals("Mozilla/5.0 (compatible; Fess/98.76; +http://fess.codelibs.org/bot.html)", initParamMap.get("userAgent"));
         assertEquals(0, ((WebAuthenticationConfig[]) initParamMap.get(HcHttpClient.AUTHENTICATIONS_PROPERTY)).length);
         assertTrue(Boolean.valueOf(initParamMap.get("robotsTxtEnabled").toString()).booleanValue());
+    }
+
+    /**
+     * The proxy credentials reach the crawler clients in the library-independent shape they read them
+     * in. Handing over the HTTP library's own credentials instead failed the crawl outright, because
+     * the clients cast the value to their own library's type.
+     */
+    @Test
+    public void test_initializeClientFactoryWithProxyCredentials() {
+        final Map<String, String> systemPropMap = new HashMap<>();
+        FessProp.propMap.clear();
+        FessConfig fessConfig = new FessConfig.SimpleImpl() {
+            @Override
+            public String getSystemProperty(final String key, final String defaultValue) {
+                return systemPropMap.getOrDefault(key, defaultValue);
+            }
+
+            @Override
+            public boolean isCrawlerIgnoreRobotsTxt() {
+                return false;
+            }
+
+            @Override
+            public String getHttpProxyHost() {
+                return "proxy.example.com";
+            }
+
+            @Override
+            public String getHttpProxyPort() {
+                return "8080";
+            }
+
+            @Override
+            public String getHttpProxyUsername() {
+                return "proxyuser";
+            }
+
+            @Override
+            public String getHttpProxyPassword() {
+                return "proxypass";
+            }
+        };
+        ComponentUtil.setFessConfig(fessConfig);
+        SystemHelper systemHelper = new SystemHelper() {
+            @Override
+            public String getProductVersion() {
+                return "98.76";
+            }
+        };
+        ComponentUtil.register(systemHelper, "systemHelper");
+        WebAuthenticationService webAuthenticationService = new WebAuthenticationService() {
+            @Override
+            public List<WebAuthentication> getWebAuthenticationList(final String webConfigId) {
+                return Collections.emptyList();
+            }
+        };
+        ComponentUtil.register(webAuthenticationService, WebAuthenticationService.class.getCanonicalName());
+        RequestHeaderService requestHeaderService = new RequestHeaderService() {
+            @Override
+            public List<RequestHeader> getRequestHeaderList(final String webConfigId) {
+                return Collections.emptyList();
+            }
+        };
+        ComponentUtil.register(requestHeaderService, RequestHeaderService.class.getCanonicalName());
+
+        final SetOnce<Map<String, Object>> initParamMapSet = new SetOnce<>();
+        WebConfig webConfig = new WebConfig();
+        CrawlerClientFactory crawlerClientFactory = webConfig.initializeClientFactory(() -> new CrawlerClientFactory() {
+            public void setInitParameterMap(final Map<String, Object> params) {
+                initParamMapSet.set(params);
+            }
+        });
+        assertNotNull(crawlerClientFactory);
+        Map<String, Object> initParamMap = initParamMapSet.get();
+        assertNotNull(initParamMap);
+        assertEquals("proxy.example.com", initParamMap.get(HcHttpClient.PROXY_HOST_PROPERTY));
+        assertEquals("8080", initParamMap.get(HcHttpClient.PROXY_PORT_PROPERTY));
+
+        final Object proxyCredentials = initParamMap.get(HcHttpClient.PROXY_CREDENTIALS_PROPERTY);
+        assertTrue(proxyCredentials instanceof WebAuthenticationConfig);
+        final CredentialsConfig credentials = ((WebAuthenticationConfig) proxyCredentials).getCredentials();
+        assertEquals("proxyuser", credentials.getUsername());
+        assertEquals("proxypass", credentials.getPassword());
     }
 
     @Test


### PR DESCRIPTION
## Problem

`CrawlingConfig#initializeDefaultHttpProxy`, `WebConfig` and `DataConfig` all configured the `proxyCredentials` init parameter as an HC4 `org.apache.http.auth.UsernamePasswordCredentials`. The crawler clients read that parameter as their own library's type:

- `Hc5HttpClient` — the default since the HttpComponents 5.x migration — as an HC5 `Credentials`
- `PlaywrightClient` as an HC5 `UsernamePasswordCredentials`

`AbstractCrawlerClient#getInitParameter` casts unchecked, and the `checkcast` lands at the call site, outside its own `try`. So the mismatch was not ignored and did not stay confined to the proxy:

```
java.lang.ClassCastException: class org.apache.http.auth.UsernamePasswordCredentials
  cannot be cast to class org.apache.hc.client5.http.auth.Credentials
```

Any crawl configured to go through an authenticated proxy fails — for the Playwright client, while the browser context is being created, so every URL fails.

## Fix

Hand the credentials over as a `WebAuthenticationConfig`, the library-independent shape `webAuthentications` already uses, built by one static factory the three call sites share. Nothing else about the parameter map changes; `proxyHost` and `proxyPort` are still separate parameters.

With this, no HttpComponents type is put into a crawler init parameter from the crawling configuration any more.

## Tests

`WebConfigTest#test_initializeClientFactoryWithProxyCredentials` (new) pins the shape the parameter map carries when a proxy user name and password are configured.

`mvn test -Dtest=WebConfigTest` is green.

## Depends on

- codelibs/fess-crawler#187 — teaches `Hc5HttpClient` / `Hc4HttpClient` to read the configuration shape. It also keeps accepting what this PR replaces, so the two can land in either order.
- codelibs/fess-crawler-playwright#68 — the same read in the Playwright client.
