### PR TITLE
fix(api): stop reporting a caller's credential as a v2 server error

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -44,6 +44,7 @@ import org.codelibs.fess.api.v2.handlers.SearchHandler;
 import org.codelibs.fess.api.v2.handlers.SuggestWordsHandler;
 import org.codelibs.fess.api.v2.handlers.UiConfigHandler;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
+import org.codelibs.fess.exception.InvalidAccessTokenException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
@@ -295,6 +296,18 @@ public class SearchApiV2Manager extends BaseApiManager {
             case "/related-queries" -> relatedQueriesHandler.handle(request, response);
             case "/related-content" -> relatedContentHandler.handle(request, response);
             default -> ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.NOT_FOUND, "endpoint not found: " + sub);
+            }
+        } catch (final InvalidAccessTokenException e) {
+            // The request presented a credential we could not accept: an access token that is not
+            // registered or has expired, or none at all where api.access.token.required demands
+            // one. That is a refusal, not a server fault, and the generic handler below turned it
+            // into a 500. The envelope carries no detail from the exception because its message
+            // describes the caller's own credential.
+            if (logger.isDebugEnabled()) {
+                logger.debug("/api/v2 rejected the access token for {}", sub, e);
+            }
+            if (!response.isCommitted()) {
+                ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.AUTH_REQUIRED, "invalid access token");
             }
         } catch (final IOException e) {
             // Streaming handlers can disconnect mid-write (broken pipe, client abort). Once

--- a/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
+import org.codelibs.fess.exception.InvalidAccessTokenException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -203,6 +204,13 @@ public class V2EnvelopeWriter {
      * committed (e.g. SSE or NDJSON handlers that flushed before the failure),
      * the method returns silently to avoid corrupting the in-flight body.</p>
      *
+     * <p>Every handler funnels its unexpected failures here, which makes this the one place that
+     * can tell the caller's fault from ours. An {@link InvalidAccessTokenException} is the
+     * caller's: the request presented an access token that is not registered or has expired, or
+     * none at all where {@code api.access.token.required} demands one. Reporting that as a 500
+     * both misleads the caller and writes a stack trace per request; classifying it here rather
+     * than in each handler keeps a handler added later from reintroducing it.</p>
+     *
      * @param res the HTTP response to write to
      * @param cause the cause to log (may be null; only logged, never written to wire)
      * @param logger the caller's logger to use for WARN-level logging
@@ -211,6 +219,16 @@ public class V2EnvelopeWriter {
      */
     public void writeInternalError(final HttpServletResponse res, final Throwable cause, final Logger logger, final String contextTag)
             throws IOException {
+        if (cause instanceof InvalidAccessTokenException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("v2 rejected the access token: {}", contextTag, cause);
+            }
+            if (res.isCommitted()) {
+                return;
+            }
+            writeError(res, V2ErrorCode.AUTH_REQUIRED, "invalid access token");
+            return;
+        }
         if (cause != null) {
             logger.warn("v2 internal error: {}", contextTag, cause);
         } else {

--- a/src/main/java/org/codelibs/fess/app/service/AccessTokenService.java
+++ b/src/main/java/org/codelibs/fess/app/service/AccessTokenService.java
@@ -152,7 +152,7 @@ public class AccessTokenService {
                 final String name = accessToken.getParameterName();
                 stream(request.getParameterValues(name)).of(stream -> stream.filter(StringUtil::isNotBlank).forEach(permissionSet::add));
                 return OptionalEntity.of(permissionSet);
-            }).orElseThrow(() -> new InvalidAccessTokenException("invalid_token", "Invalid token: " + token));
+            }).orElseThrow(() -> new InvalidAccessTokenException("invalid_token", "The access token is not registered."));
         }
         return OptionalEntity.empty();
     }

--- a/src/main/java/org/codelibs/fess/helper/AccessTokenHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/AccessTokenHelper.java
@@ -57,20 +57,38 @@ public class AccessTokenHelper {
 
     /**
      * Get the access token from the request.
+     *
+     * <p>The Authorization header is read as a Fess access token only when it is addressed to us:
+     * either a bare token with no scheme, or the {@code Bearer} scheme, whose name RFC 7235 makes
+     * case-insensitive. A header naming any other scheme -- the {@code Negotiate} of a SPNEGO
+     * client, a {@code Basic} or {@code Digest} credential -- belongs to that scheme's own
+     * handler, so this request simply carries no access token and the method returns null.
+     * Reporting those as a malformed access token is what made every such API request a 500.</p>
+     *
+     * <p>What is thrown is a header that is ours and unusable: {@code Bearer} with no credential
+     * after it, or with more than one word after it. Neither message quotes the header, because
+     * the part after the scheme is the access token itself and these messages are logged.</p>
+     *
      * @param request The request.
-     * @return The access token.
+     * @return The access token, or null when the request carries none.
      */
     public String getAccessTokenFromRequest(final HttpServletRequest request) {
-        final String token = request.getHeader("Authorization");
-        if (token != null) {
-            final String[] values = token.trim().split(" ");
-            if (values.length == 2 && BEARER.equals(values[0])) {
-                return values[1];
-            }
-            if (values.length == 1 && !BEARER.equals(values[0])) {
+        final String authzHeader = request.getHeader("Authorization");
+        if (authzHeader != null) {
+            final String[] values = authzHeader.trim().split(" ");
+            if (values.length == 1) {
+                if (BEARER.equalsIgnoreCase(values[0])) {
+                    throw new InvalidAccessTokenException("invalid_request", "The Bearer scheme is missing its credential.");
+                }
                 return values[0];
             }
-            throw new InvalidAccessTokenException("invalid_request", "Invalid format: " + token);
+            if (!BEARER.equalsIgnoreCase(values[0])) {
+                return null;
+            }
+            if (values.length == 2) {
+                return values[1];
+            }
+            throw new InvalidAccessTokenException("invalid_request", "The Bearer credential is not a single token.");
         }
         final String name = ComponentUtil.getFessConfig().getApiAccessTokenRequestParameter();
         if (StringUtil.isNotBlank(name)) {

--- a/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
@@ -44,6 +44,7 @@ import org.codelibs.fess.entity.FacetInfo;
 import org.codelibs.fess.entity.GeoInfo;
 import org.codelibs.fess.entity.HighlightInfo;
 import org.codelibs.fess.entity.SearchRequestParams;
+import org.codelibs.fess.exception.InvalidAccessTokenException;
 import org.codelibs.fess.exception.InvalidQueryException;
 import org.codelibs.fess.exception.ResultOffsetExceededException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
@@ -338,6 +339,9 @@ public class RankFusionProcessor implements AutoCloseable {
                 if (e.getCause() instanceof final ResultOffsetExceededException roee) {
                     throw roee;
                 }
+                if (e.getCause() instanceof final InvalidAccessTokenException iate) {
+                    throw iate;
+                }
                 logger.warn("Search operation failed with exception", e.getCause());
                 return SearchResult.create().build();
             }
@@ -457,7 +461,10 @@ public class RankFusionProcessor implements AutoCloseable {
             return createResponseList(searchResult.getDocumentList(), searchResult.getAllRecordCount(),
                     searchResult.getAllRecordCountRelation(), searchResult.getQueryTime(), searchResult.isPartialResults(),
                     searchResult.getFacetResponse(), params.getStartPosition(), pageSize, 0);
-        } catch (final InvalidQueryException | ResultOffsetExceededException e) {
+        } catch (final InvalidQueryException | ResultOffsetExceededException | InvalidAccessTokenException e) {
+            // These say the request was refused, not that the searcher broke. Swallowing one and
+            // returning an empty list would report a refusal as a successful search of nothing,
+            // and would log a stack trace for a caller-supplied credential on every request.
             throw e;
         } catch (final Exception e) {
             logger.warn("Main searcher failed to execute search for query: {}", query, e);

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
@@ -245,6 +245,29 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_process_invalidAccessTokenMapsTo401() throws Exception {
+        // RoleQueryHelper raises this while building the role query, before any handler writes.
+        // The generic catch below it produced a 500, so a request presenting an unusable
+        // credential looked like a server fault.
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        m.labelsHandler = new org.codelibs.fess.api.v2.handlers.LabelsHandler() {
+            @Override
+            public void handle(final jakarta.servlet.http.HttpServletRequest request,
+                    final jakarta.servlet.http.HttpServletResponse response) {
+                throw new org.codelibs.fess.exception.InvalidAccessTokenException("invalid_token", "s3cr3tCredentialDetail");
+            }
+        };
+        final CapturingResponse res = new CapturingResponse();
+        m.process(new StubRequest("/api/v2/labels"), res, new NopChain());
+        assertEquals(401, res.status);
+        final String body = res.body();
+        assertTrue(body.contains("\"status\":1"), body);
+        assertTrue(body.contains("\"code\":\"auth_required\""), body);
+        // The exception message describes the caller's own credential, so it stays out of the wire.
+        assertFalse(body.contains("s3cr3tCredentialDetail"), body);
+    }
+
+    @Test
     public void test_handleHealth_does_not_leak_exception_message() throws Exception {
         // Source-level assertion: the HealthHandler catch block must not pass e.getMessage()
         // to writeError. Uses writeInternalError which logs and emits a generic message.

--- a/src/test/java/org/codelibs/fess/api/v2/V2EnvelopeWriterTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/V2EnvelopeWriterTest.java
@@ -276,6 +276,21 @@ public class V2EnvelopeWriterTest extends UnitFessTestCase {
         assertFalse(body.contains("10.0.0.1"), "should not leak host details: " + body);
     }
 
+    @Test
+    public void test_writeInternalError_classifiesInvalidAccessTokenAs401() throws Exception {
+        // Handlers funnel every unexpected failure here. A credential the caller presented and we
+        // would not accept is theirs, not ours, and used to leave here as a 500 with a stack trace.
+        final CapturingResponse res = new CapturingResponse();
+        final org.apache.logging.log4j.Logger noopLogger = org.apache.logging.log4j.LogManager.getLogger("test-noop");
+        final Exception cause = new org.codelibs.fess.exception.InvalidAccessTokenException("invalid_token", "s3cr3tCredentialDetail");
+        new V2EnvelopeWriter().writeInternalError(res, cause, noopLogger, "/api/v2/search");
+        final String body = res.body();
+        assertEquals(401, res.status);
+        assertTrue(body.contains("\"code\":\"auth_required\""), body);
+        assertFalse(body.contains("internal error"), body);
+        assertFalse(body.contains("s3cr3tCredentialDetail"), body);
+    }
+
     /** Minimal HttpServletResponse stub that captures setContentType/setStatus/getWriter output. */
     private static class CapturingResponse implements HttpServletResponse {
         StringWriter sw = new StringWriter();

--- a/src/test/java/org/codelibs/fess/helper/AccessTokenHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/AccessTokenHelperTest.java
@@ -74,15 +74,37 @@ public class AccessTokenHelperTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_getAccessTokenFromRequest_bad1() {
-        final String token = "INVALID _TOKEN0";
+    public void test_getAccessTokenFromRequest_otherScheme() {
+        // A credential addressed to another authentication scheme is not a malformed access token,
+        // it is simply not one of ours. Throwing here reached the API caller as a 500.
+        for (final String header : new String[] { "Negotiate YIIGxQYGKwYBBQUCoIIG", "Basic dXNlcjpwYXNzd29yZA==", "NTLM TlRMTVNTUAABAAAA",
+                "INVALID _TOKEN0" }) {
+            MockletHttpServletRequest req = getMockRequest();
+            req.addHeader("Authorization", header);
+            assertNull(accessTokenHelper.getAccessTokenFromRequest(req));
+        }
+    }
+
+    @Test
+    public void test_getAccessTokenFromRequest_otherSchemeWithSpaces() {
+        // Digest and friends carry comma-separated parameters, so the header runs to more than two
+        // words. The scheme still says the credential is not ours.
         MockletHttpServletRequest req = getMockRequest();
-        req.addHeader("Authorization", token);
+        req.addHeader("Authorization", "Digest username=\"u\", realm=\"r\", nonce=\"n\"");
+        assertNull(accessTokenHelper.getAccessTokenFromRequest(req));
+    }
+
+    @Test
+    public void test_getAccessTokenFromRequest_doesNotEchoTheCredential() {
+        // The message is logged, and a Bearer credential is an access token.
+        final String secret = "s3cr3tAccessToken";
+        MockletHttpServletRequest req = getMockRequest();
+        req.addHeader("Authorization", "Bearer " + secret + " extra");
         try {
             accessTokenHelper.getAccessTokenFromRequest(req);
             fail();
-        } catch (InvalidAccessTokenException e) {
-            // ok
+        } catch (final InvalidAccessTokenException e) {
+            assertFalse(e.getMessage().contains(secret));
         }
     }
 
@@ -177,26 +199,22 @@ public class AccessTokenHelperTest extends UnitFessTestCase {
 
     @Test
     public void test_getAccessTokenFromRequest_caseInsensitiveBearer() {
+        // RFC 7235 makes the scheme name case-insensitive, and the scheme is what decides whether
+        // the header is addressed to us at all. Without this, "bearer" would fall through to the
+        // other-scheme branch and the token would be ignored without a word.
         final String token = accessTokenHelper.generateAccessToken();
-        MockletHttpServletRequest req = getMockRequest();
-        req.addHeader("Authorization", "bearer " + token);
-        try {
-            accessTokenHelper.getAccessTokenFromRequest(req);
-            fail();
-        } catch (InvalidAccessTokenException e) {
-            // ok
+        for (final String scheme : new String[] { "bearer", "BEARER", "BeArEr" }) {
+            MockletHttpServletRequest req = getMockRequest();
+            req.addHeader("Authorization", scheme + " " + token);
+            assertEquals(token, accessTokenHelper.getAccessTokenFromRequest(req));
         }
     }
 
     @Test
     public void test_getAccessTokenFromRequest_invalidBearerFormat() {
+        // "InvalidBearer" is a different scheme, not a misspelt Bearer.
         MockletHttpServletRequest req = getMockRequest();
         req.addHeader("Authorization", "InvalidBearer token");
-        try {
-            accessTokenHelper.getAccessTokenFromRequest(req);
-            fail();
-        } catch (InvalidAccessTokenException e) {
-            // ok
-        }
+        assertNull(accessTokenHelper.getAccessTokenFromRequest(req));
     }
 }

--- a/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorTest.java
+++ b/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorTest.java
@@ -473,6 +473,30 @@ public class RankFusionProcessorTest extends UnitFessTestCase {
         }
     }
 
+    @Test
+    public void test_mainSearcher_propagatesInvalidAccessToken() throws Exception {
+        // RoleQueryHelper raises this while the query is being built. The generic catch used to
+        // swallow it and return an empty list, which reports a refused request as a successful
+        // search of nothing and logs a stack trace for a caller-supplied credential every time.
+        try (RankFusionProcessor rankFusionProcessor = new RankFusionProcessor()) {
+            rankFusionProcessor.setSearcher(new RankFusionSearcher() {
+                @Override
+                protected SearchResult search(final String query, final SearchRequestParams params,
+                        final OptionalThing<FessUserBean> userBean) {
+                    throw new org.codelibs.fess.exception.InvalidAccessTokenException("invalid_token",
+                            "The access token is not registered.");
+                }
+            });
+            rankFusionProcessor.init();
+            try {
+                rankFusionProcessor.search("*", new TestSearchRequestParams(0, 10, 0), OptionalThing.empty());
+                fail();
+            } catch (final org.codelibs.fess.exception.InvalidAccessTokenException e) {
+                // expected
+            }
+        }
+    }
+
     static class TestMainSearcher extends RankFusionSearcher {
 
         private long allRecordCount;


### PR DESCRIPTION
## Problem

An `Authorization` header that is not a Fess access token makes every `/api/v2` endpoint that builds a role query answer **500**.

`AccessTokenHelper#getAccessTokenFromRequest` reads the header as an access token and nothing else, so any two-word value whose scheme is not `Bearer` is rejected as a malformed access token:

```java
if (values.length == 2 && BEARER.equals(values[0])) { return values[1]; }
if (values.length == 1 && !BEARER.equals(values[0])) { return values[0]; }
throw new InvalidAccessTokenException("invalid_request", "Invalid format: " + token);
```

`RoleQueryHelper#processAccessToken` raises that, and the v2 dispatcher's generic `catch (Exception)` turns it into `internal_error`. `FessApiAdminAction#isAccessAllowed` already catches the same exception and denies access; the v2 surface had no equivalent.

Three consequences, measured on a live SPNEGO deployment:

1. A Kerberos client keeps sending `Authorization: Negotiate …` after `/sso/` has given it a session, so `/search`, `/labels` and `/popular-words` return 500 on every call.
2. With `login.required=false` — the default — the path is reachable **without authenticating at all**. One request wrote **101 log lines and 97 stack frames**.
3. The exception message quotes the raw header. A `Basic` credential therefore lands in the log in a form that decodes straight back:

   ```
   InvalidAccessTokenException: Invalid format: Basic c3ZjX3JlcG9ydDpUcjB1YjRkb3ImMw==
   ```

This is **not a 15.8 regression**: `AccessTokenHelper` is byte-identical to 15.7.0, and the throw has been there since #2801 (2024-01).

## Change

**The scheme decides whether the header is addressed to us.** A scheme other than `Bearer` means the request carries no access token, so the endpoint serves the session as usual. RFC 7235 makes the scheme name case-insensitive, so `bearer` is now accepted rather than silently ignored. What still throws is a header that is ours and unusable: `Bearer` with no credential, or with more than one word after it.

**A credential we will not accept is a refusal, not a fault.** `V2EnvelopeWriter#writeInternalError` is the funnel all 14 handlers route their unexpected failures through, so classifying `InvalidAccessTokenException` there answers 401 for every one of them and keeps a handler added later from reintroducing the 500. This also covers an unregistered or expired token and `api.access.token.required` with none supplied. `SearchApiV2Manager#process` catches it too, for failures raised before a handler runs.

`RankFusionProcessor` already passes `InvalidQueryException` and `ResultOffsetExceededException` through its catch-all; `InvalidAccessTokenException` joins them, because swallowing it reported a refused request as a successful search of nothing — and logged a stack trace for a caller-supplied credential on every request.

**Neither message quotes the header any more.** The part after the scheme is the credential.

### Behaviour

| Request | Before | After |
|---|---|---|
| `Authorization: Negotiate …` (SPNEGO client with a session) | 500 | 200, role-filtered results |
| `Authorization: Basic …` / `NTLM …` / `Digest …` | 500 | served as if no header |
| `Authorization: Bearer <unregistered>` | 500 | 401 `auth_required` |
| `Authorization: Bearer <valid>` | 200 | 200 |
| `Authorization: bearer <valid>` | 500 | 200 |
| `Authorization: Bearer` (no credential) | 500 | 401 |
| No `Authorization` header | unchanged | unchanged |
| Basic credential in the log | present | absent |
| Stack frames per rejected request | 97 | 0 |

`FessApiAdminAction` still denies: a null token yields no permissions, so the outcome is unchanged there.

The one deliberate widening is case-insensitive scheme matching. Without it `bearer <token>` would go from a loud error to being silently ignored, which is worse to diagnose; the token itself is still looked up and must be registered, so nothing is granted that was not before.

## Verification

`mvn test` — **7284 tests, 0 failures**.

Tests added: other-scheme headers yield no token; a Digest header with parameters yields no token; scheme matching is case-insensitive; the thrown message does not contain the credential; `writeInternalError` classifies `InvalidAccessTokenException` as 401 without leaking its message; the dispatcher maps it to 401; `RankFusionProcessor` propagates it instead of returning an empty list. The dispatcher test fails with `expected: <401> but was: <500>` without the fix.

`test_getAccessTokenFromRequest_bad1`, `_caseInsensitiveBearer` and `_invalidBearerFormat` pinned the collateral behaviour of #2801 rather than its intent — that only `Bearer` with no credential should fail — and are restated.

Also verified end to end against a Samba AD domain controller with SPNEGO SSO enabled, in both `login.required` modes: an authenticated client's search returns its role-filtered results, an unusable credential answers 401, no stack frames are written, the Basic credential no longer appears in the log, and SSO login, the no-ticket refusal and the `#3284` anonymous denial are unchanged.
