### PR TITLE
fix(rate-limit): match a trusted proxy by address, not by spelling

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/TargetOriginResolver.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/TargetOriginResolver.java
@@ -86,7 +86,7 @@ public class TargetOriginResolver {
 
         // (2) Forwarded headers are trusted only when the immediate peer is a trusted proxy.
         final String remoteAddr = request.getRemoteAddr();
-        if (remoteAddr != null && fessConfig.getRateLimitTrustedProxiesAsSet().contains(remoteAddr)) {
+        if (fessConfig.isRateLimitTrustedProxy(remoteAddr)) {
             final String forwarded = reconstructFromForwardedHeaders(request);
             if (forwarded != null) {
                 return Collections.singleton(forwarded);

--- a/src/main/java/org/codelibs/fess/helper/RateLimitHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/RateLimitHelper.java
@@ -130,8 +130,7 @@ public class RateLimitHelper {
      * @return true if the IP is a trusted proxy
      */
     protected boolean isTrustedProxy(final String ip) {
-        final Set<String> trustedProxies = ComponentUtil.getFessConfig().getRateLimitTrustedProxiesAsSet();
-        final boolean trusted = trustedProxies.contains(ip);
+        final boolean trusted = ComponentUtil.getFessConfig().isRateLimitTrustedProxy(ip);
         if (logger.isDebugEnabled() && trusted) {
             logger.debug("Trusted proxy detected: ip={}", ip);
         }

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -19,11 +19,13 @@ import static org.codelibs.core.stream.StreamUtil.split;
 import static org.codelibs.core.stream.StreamUtil.stream;
 
 import java.net.Authenticator;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.Proxy.Type;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2430,6 +2432,9 @@ public interface FessProp {
         return set;
     }
 
+    /** Matches a dotted-quad, so only real IPv4 literals reach InetAddress. */
+    Pattern IPV4_LITERAL_PATTERN = Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
+
     String RATE_LIMIT_TRUSTED_PROXIES_SET = "rateLimitTrustedProxiesSet";
 
     String getRateLimitTrustedProxies();
@@ -2438,11 +2443,61 @@ public interface FessProp {
         @SuppressWarnings("unchecked")
         Set<String> set = (Set<String>) propMap.get(RATE_LIMIT_TRUSTED_PROXIES_SET);
         if (set == null) {
-            set = split(getRateLimitTrustedProxies(), ",")
-                    .get(stream -> stream.map(String::trim).filter(StringUtil::isNotEmpty).collect(Collectors.toSet()));
+            set = split(getRateLimitTrustedProxies(), ",").get(stream -> stream.map(String::trim)
+                    .filter(StringUtil::isNotEmpty)
+                    .map(FessProp::normalizeIpAddress)
+                    .collect(Collectors.toSet()));
             propMap.put(RATE_LIMIT_TRUSTED_PROXIES_SET, set);
         }
         return set;
+    }
+
+    /**
+     * Tells whether {@code ip} is one of the proxies listed in {@code rate.limit.trusted.proxies}.
+     * <p>
+     * Both sides are canonicalised first, because the comparison used to be a plain string match
+     * against {@code getRemoteAddr()} and the two spellings of the IPv6 loopback are not the same
+     * string: the shipped default lists {@code ::1}, while Java renders that address as
+     * {@code 0:0:0:0:0:0:0:1}. A reverse proxy reaching Fess over IPv6 loopback -- which is what
+     * {@code proxy_pass http://localhost:8080} resolves to on a host where {@code localhost}
+     * prefers IPv6 -- was therefore silently untrusted, so every client behind it shared one
+     * rate-limit bucket and the forwarded-header handling never applied.
+     * </p>
+     *
+     * @param ip the peer address to test, may be null
+     * @return true when the peer is a configured trusted proxy
+     */
+    default boolean isRateLimitTrustedProxy(final String ip) {
+        if (StringUtil.isBlank(ip)) {
+            return false;
+        }
+        return getRateLimitTrustedProxiesAsSet().contains(normalizeIpAddress(ip));
+    }
+
+    /**
+     * Canonicalises an IP address literal so that equivalent spellings compare equal.
+     * <p>
+     * Only literals are converted. A value that is neither an IPv4 nor an IPv6 literal is
+     * returned unchanged, so that a hostname left in the configuration can never make this a
+     * DNS lookup on the request path.
+     * </p>
+     *
+     * @param value the configured or observed address
+     * @return the canonical form, or {@code value} when it is not an address literal
+     */
+    static String normalizeIpAddress(final String value) {
+        if (value == null) {
+            return null;
+        }
+        final String trimmed = value.trim();
+        if (trimmed.isEmpty() || !(trimmed.indexOf(':') >= 0 || IPV4_LITERAL_PATTERN.matcher(trimmed).matches())) {
+            return trimmed;
+        }
+        try {
+            return InetAddress.getByName(trimmed).getHostAddress();
+        } catch (final UnknownHostException e) {
+            return trimmed;
+        }
     }
 
     String THEME_API_CSRF_SERVER_ORIGINS_SET = "themeApiCsrfServerOriginsSet";

--- a/src/test/java/org/codelibs/fess/helper/RateLimitHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RateLimitHelperTest.java
@@ -132,6 +132,39 @@ public class RateLimitHelperTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getClientIp_ipv6LoopbackProxy_isTrusted() {
+        // Java renders the IPv6 loopback as 0:0:0:0:0:0:0:1, while the shipped
+        // rate.limit.trusted.proxies lists it as "::1". The comparison used to be a plain string
+        // match, so a reverse proxy on IPv6 loopback -- what proxy_pass http://localhost:8080
+        // resolves to where localhost prefers IPv6 -- was silently untrusted, and every client
+        // behind it shared one rate-limit bucket.
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setRemoteAddr("0:0:0:0:0:0:0:1");
+        request.addHeader("X-Forwarded-For", "203.0.113.50");
+        assertEquals("203.0.113.50", rateLimitHelper.getClientIp(request));
+    }
+
+    @Test
+    public void test_getClientIp_ipv6LoopbackShortForm_isTrusted() {
+        // The same address in the spelling the configuration uses. This one already matched
+        // before the fix -- it is the literal in the shipped default -- and is kept so that
+        // canonicalising the configured side cannot regress it.
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setRemoteAddr("::1");
+        request.addHeader("X-Forwarded-For", "203.0.113.51");
+        assertEquals("203.0.113.51", rateLimitHelper.getClientIp(request));
+    }
+
+    @Test
+    public void test_getClientIp_untrustedIpv6_headersIgnored() {
+        // Control: canonicalising both sides must not make every IPv6 peer trusted.
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setRemoteAddr("2001:db8::1");
+        request.addHeader("X-Forwarded-For", "203.0.113.52");
+        assertEquals("2001:db8::1", rateLimitHelper.getClientIp(request));
+    }
+
+    @Test
     public void test_blockIp() {
         rateLimitHelper.blockIp("192.168.1.100", 1000L);
         assertEquals(1, rateLimitHelper.getBlockedIpCount());

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
@@ -805,4 +805,49 @@ public class FessPropTest extends UnitFessTestCase {
             }
         };
     }
+
+    // ------------------------------------------------------------------
+    // Trusted-proxy address canonicalisation
+
+    @Test
+    public void test_normalizeIpAddress_ipv6LoopbackSpellingsAgree() {
+        // The whole point: the configuration writes "::1", getRemoteAddr() reports
+        // "0:0:0:0:0:0:0:1", and a plain string comparison between them is false.
+        assertEquals(FessProp.normalizeIpAddress("0:0:0:0:0:0:0:1"), FessProp.normalizeIpAddress("::1"));
+    }
+
+    @Test
+    public void test_normalizeIpAddress_ipv4IsUnchanged() {
+        assertEquals("127.0.0.1", FessProp.normalizeIpAddress("127.0.0.1"));
+        assertEquals("192.168.1.100", FessProp.normalizeIpAddress("192.168.1.100"));
+    }
+
+    @Test
+    public void test_normalizeIpAddress_distinctAddressesStayDistinct() {
+        assertFalse(FessProp.normalizeIpAddress("::1").equals(FessProp.normalizeIpAddress("2001:db8::1")));
+        assertFalse(FessProp.normalizeIpAddress("::1").equals(FessProp.normalizeIpAddress("::2")));
+        assertFalse(FessProp.normalizeIpAddress("127.0.0.1").equals(FessProp.normalizeIpAddress("127.0.0.2")));
+    }
+
+    @Test
+    public void test_normalizeIpAddress_nonLiteralIsLeftAlone() {
+        // A hostname must be returned untouched rather than resolved: this runs on the request
+        // path, and a DNS lookup there would be a far worse problem than the one being fixed.
+        assertEquals("proxy.example.com", FessProp.normalizeIpAddress("proxy.example.com"));
+        assertEquals("not an address", FessProp.normalizeIpAddress("not an address"));
+        assertEquals("", FessProp.normalizeIpAddress(""));
+        assertNull(FessProp.normalizeIpAddress(null));
+    }
+
+    @Test
+    public void test_normalizeIpAddress_malformedDottedQuadIsLeftAlone() {
+        // Shaped like IPv4 but not valid; it must come back unchanged, not throw.
+        assertEquals("999.999.999.999", FessProp.normalizeIpAddress("999.999.999.999"));
+    }
+
+    @Test
+    public void test_normalizeIpAddress_trimsSurroundingSpace() {
+        assertEquals("127.0.0.1", FessProp.normalizeIpAddress("  127.0.0.1  "));
+    }
+
 }


### PR DESCRIPTION
Found while verifying the MCP plugin for 15.8, but the defect and its blast radius are in core, so this targets **15.9**.

## The bug

`rate.limit.trusted.proxies` is compared to `getRemoteAddr()` with a plain string match:

```java
final boolean trusted = trustedProxies.contains(ip);   // RateLimitHelper#isTrustedProxy
```

The two spellings of the IPv6 loopback are not the same string. The shipped default lists `::1`; Java renders that address as `0:0:0:0:0:0:0:1`. So a reverse proxy reaching Fess over IPv6 loopback is **silently untrusted** — and that is not an exotic setup: `proxy_pass http://localhost:8080` resolves there on any host where `localhost` prefers IPv6.

The consequences are the opposite of what the setting exists for:

- `X-Forwarded-For` is ignored, so **every client behind the proxy shares one rate-limit bucket** that none of them can influence
- `TargetOriginResolver` falls back to the servlet-observed host instead of the forwarded one

## Measurement

On a running 15.8 instance, `mcp.rate.limit.per.minute=2`, three requests with three distinct `X-Forwarded-For` values:

| reached via | result | meaning |
|---|---|---|
| `http://127.0.0.1:8080` | `200 200 200` | separate buckets — XFF honoured |
| `http://[::1]:8080` | `200 200 429` | one shared bucket — XFF ignored |

Adding `0:0:0:0:0:0:0:1` to the configured list made the second case behave like the first — which confirms the string comparison is the cause, rather than anything about proxy handling.

## The fix

Both sides are canonicalised through `InetAddress` before comparing, so the two spellings agree and an operator who writes `::1` is not punished for it.

Only address literals are converted. Anything else is returned unchanged, so a hostname left in the configuration can never turn this into a **DNS lookup on the request path** — that would be a worse problem than the one being fixed.

The check moves into `FessProp#isRateLimitTrustedProxy` because **both call sites had the same bug**; fixing only `RateLimitHelper` would have left `TargetOriginResolver` broken.

## Tests

- `RateLimitHelperTest`: the long-form IPv6 loopback is now trusted (this one goes red without the fix), the short form stays trusted, and a **non-loopback IPv6 peer stays untrusted** — canonicalising must not make every IPv6 client a trusted proxy
- `FessPropTest`: both spellings normalise equal, distinct addresses stay distinct, hostnames and malformed dotted-quads are returned untouched
- 95 tests across `RateLimitHelperTest`, `FessPropTest`, `FessPropCorsTest`, `TargetOriginResolverTest`, `CsrfRequirementTest` pass
