### PR TITLE
fix(search): stop reporting a search that never ran as a complete result

### DIFF
--- a/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
@@ -209,8 +209,7 @@ public class RankFusionProcessor implements AutoCloseable {
         }
         if (availableSearchers.length == 0) {
             logger.warn("No searchers available for query: {}", query);
-            return createResponseList(Collections.emptyList(), 0, Relation.EQUAL_TO.toString(), 0, false, null, params.getStartPosition(),
-                    params.getPageSize(), 0);
+            return createDegradedResponseList(params, params.getPageSize());
         }
         if (availableSearchers.length == 1) {
             return searchWithMainSearcher(availableSearchers[0], query, params, userBean);
@@ -299,8 +298,7 @@ public class RankFusionProcessor implements AutoCloseable {
         final int rankConstant = fessConfig.getRankFusionRankConstantAsInteger();
         if (searchers.length == 0) {
             logger.warn("searchWithMultipleSearchers called with empty searcher array");
-            return createResponseList(Collections.emptyList(), 0, Relation.EQUAL_TO.toString(), 0, false, null, params.getStartPosition(),
-                    params.getPageSize(), 0);
+            return createDegradedResponseList(params, params.getPageSize());
         }
         final int size = windowSize / searchers.length;
         if (logger.isDebugEnabled()) {
@@ -468,9 +466,30 @@ public class RankFusionProcessor implements AutoCloseable {
             throw e;
         } catch (final Exception e) {
             logger.warn("Main searcher failed to execute search for query: {}", query, e);
-            return createResponseList(Collections.emptyList(), 0, Relation.EQUAL_TO.toString(), 0, false, null, params.getStartPosition(),
-                    pageSize, 0);
+            return createDegradedResponseList(params, pageSize);
         }
+    }
+
+    /**
+     * Creates the empty response returned when a search could not actually be executed.
+     * <p>
+     * Distinct from an ordinary zero-hit result: here the query never reached a searcher, or the
+     * searcher threw. Both used to be reported with {@code partialResults} set to {@code false},
+     * which tells every consumer -- the search UI, {@code /api/v1/documents}, {@code
+     * /api/v2/search}, and any MCP or other API client on top of them -- that this is a complete
+     * result set that happens to contain nothing. A caller then cannot distinguish "no document
+     * matches" from "the search engine is unreachable", and an automated one will report the
+     * former. The same flag is already set for a timeout, which is the milder version of exactly
+     * this condition.
+     * </p>
+     *
+     * @param params search request parameters, for the start position
+     * @param pageSize the page size to report
+     * @return an empty response list flagged as partial
+     */
+    protected QueryResponseList createDegradedResponseList(final SearchRequestParams params, final int pageSize) {
+        return createResponseList(Collections.emptyList(), 0, Relation.EQUAL_TO.toString(), 0, true, null, params.getStartPosition(),
+                pageSize, 0);
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorErrorHandlingTest.java
+++ b/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorErrorHandlingTest.java
@@ -29,6 +29,7 @@ import org.codelibs.fess.exception.FessSystemException;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.rank.fusion.SearchResult.SearchResultBuilder;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.QueryResponseList;
 import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
 
@@ -148,6 +149,42 @@ public class RankFusionProcessorErrorHandlingTest extends UnitFessTestCase {
             // Should return empty results without crashing
             final List<Map<String, Object>> results = processor.search("*", new TestSearchRequestParams(0, 10, 0), OptionalThing.empty());
             assertNotNull(results);
+            assertTrue(results.isEmpty());
+            // ...and must say so. A caller that cannot tell this from a genuine zero-hit result
+            // will report "no document matches" while the search engine is unreachable.
+            assertTrue("a search that never ran must not be reported as complete", ((QueryResponseList) results).isPartialResults());
+        }
+    }
+
+    /**
+     * Test that a search with no searcher at all is also flagged as partial.
+     */
+    @Test
+    public void test_noSearchersAvailable_isPartial() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            processor.init();
+
+            final List<Map<String, Object>> results = processor.search("*", new TestSearchRequestParams(0, 10, 0), OptionalThing.empty());
+            assertNotNull(results);
+            assertTrue(results.isEmpty());
+            assertTrue("a query that reached no searcher must not be reported as complete",
+                    ((QueryResponseList) results).isPartialResults());
+        }
+    }
+
+    /**
+     * Test that an ordinary zero-hit search is NOT flagged as partial.
+     */
+    @Test
+    public void test_genuineZeroHits_isNotPartial() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            processor.setSearcher(new TestSearcher(0));
+            processor.init();
+
+            final List<Map<String, Object>> results = processor.search("*", new TestSearchRequestParams(0, 10, 0), OptionalThing.empty());
+            assertNotNull(results);
+            assertTrue(results.isEmpty());
+            assertFalse("a search that ran and matched nothing is a complete result", ((QueryResponseList) results).isPartialResults());
         }
     }
 


### PR DESCRIPTION
Found while verifying the MCP plugin for 15.8, but the flag is consumed by the search UI, `/api/v1/documents` and `/api/v2/search` alike, so this is not MCP-specific and targets **15.9**.

## The bug

`RankFusionProcessor` returns an empty list in three places where the query never actually reached a working searcher:

| line | condition |
|---|---|
| `search` | no searcher is available |
| `searchWithMultipleSearchers` | the searcher array is empty |
| `searchWithMainSearcher` | the main searcher threw |

All three passed `partialResults=false` to `createResponseList` — which tells every consumer that this is a **complete** result set that happens to contain nothing.

## Measurement

On a running 15.8 instance with the search engine stopped, a search answered:

```
HTTP 200, zero hits, no error, partial=false
   server log: WARN  Main searcher failed to execute search for query: mcpcorpus
```

A caller cannot distinguish *"no document matches"* from *"the search engine is unreachable"* — and an automated one reports the former. An LLM client did exactly that during verification: it answered that no documents matched, while the index was simply down.

## Why `partialResults` is the right signal

The same flag is **already set for a timeout**, which is the milder version of exactly this condition. So the semantics are established rather than new, and every existing consumer already knows how to read it.

The `catch` immediately above the failure path already reasons about this problem for refusals:

> These say the request was refused, not that the searcher broke. Swallowing one and returning an empty list would report a refusal as a successful search of nothing

The generic `catch` was simply left behind.

## The fix

The three sites now share `createDegradedResponseList` so they cannot drift apart.

## Tests

- `test_allSearchersFail` is strengthened from *"does not crash"* to *"says it did not complete"*
- `test_noSearchersAvailable_isPartial` covers the no-searcher path
- `test_genuineZeroHits_isNotPartial` pins that an **ordinary empty result is still not partial**, so the change cannot quietly widen
- The two positive tests go red with the main-code change reverted; 101 tests in `org.codelibs.fess.rank.fusion` pass with it
