### PR TITLE
fix(sso): report an OpenID Connect callback failure instead of a system error

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
@@ -130,8 +130,22 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
                     if (logger.isDebugEnabled()) {
                         logger.debug("code: {}, state(request): {}, state(session): {}", code, reqState, sesState);
                     }
-                    if (sesState.equals(reqState) && StringUtil.isNotBlank(code)) {
-                        return processCallback(request, code);
+                    if (sesState.equals(reqState)) {
+                        final String error = request.getParameter("error");
+                        if (StringUtil.isNotBlank(error)) {
+                            // The provider answered this login with an error response (RFC 6749 section
+                            // 4.1.2.1). Falling through to a new authorization request would either bounce
+                            // between the two servers until the browser gives up, when the provider keeps
+                            // refusing, or hand back a code and log the user in anyway, when it refuses only
+                            // because the user declined the consent. Report it instead, so the caller shows
+                            // the login error.
+                            logger.warn("The OpenID provider rejected the authorization request: error={}, error_description={}", error,
+                                    request.getParameter("error_description"));
+                            return null;
+                        }
+                        if (StringUtil.isNotBlank(code)) {
+                            return processCallback(request, code);
+                        }
                     }
                 }
             }
@@ -195,7 +209,18 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
         try {
             final TokenResponse tr = getTokenUrl(code);
 
-            final String[] jwt = ((String) tr.get("id_token")).split("\\.");
+            // Everything below reads a document the provider controls. Each malformed shape has to end
+            // as a returned null, which the caller turns into the SSO login error, and not as a thrown
+            // RuntimeException, which leaves the browser on a system error page.
+            if (!(tr.get("id_token") instanceof final String idToken) || StringUtil.isBlank(idToken)) {
+                logger.warn("The token response carries no id_token, so there is no user to log in.");
+                return null;
+            }
+            final String[] jwt = idToken.split("\\.");
+            if (jwt.length != 3) {
+                logger.warn("The id_token is not a JWT: it has {} dot-separated segments instead of 3.", jwt.length);
+                return null;
+            }
             final String jwtHeader = new String(decodeBase64(jwt[0]), Constants.UTF_8_CHARSET);
             final String jwtClaim = new String(decodeBase64(jwt[1]), Constants.UTF_8_CHARSET);
             final String jwtSignature = new String(decodeBase64(jwt[2]), Constants.UTF_8_CHARSET);
@@ -225,8 +250,20 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
             }
             parseJwtClaim(jwtClaim, attributes);
 
-            return new OpenIdConnectCredential(attributes);
-        } catch (final IOException e) {
+            final OpenIdConnectCredential credential = new OpenIdConnectCredential(attributes);
+            if (StringUtil.isBlank(credential.getUserId())) {
+                // The user id is the email claim. Without it the credential resolves to a user with a
+                // null name, which the login itself accepts and every later request then fails on, so
+                // the session has to be refused here rather than created and left unusable.
+                logger.warn("The ID token has no email claim, which is the user id. Check that {} requests it.", OIC_SCOPE);
+                return null;
+            }
+            return credential;
+        } catch (final IOException | IllegalArgumentException e) {
+            // This endpoint is anonymous, so anyone can drive a failing callback. A message keeps a
+            // misbehaving provider diagnosable; the stack trace stays behind the debug level so an
+            // unauthenticated client cannot fill the log with them.
+            logger.warn("Failed to process the OpenID Connect callback: {}", e.getMessage());
             if (logger.isDebugEnabled()) {
                 logger.debug("Failed to process callback request.", e);
             }

--- a/src/test/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticatorTest.java
@@ -17,6 +17,8 @@ package org.codelibs.fess.sso.oic;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,8 +30,12 @@ import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.lastaflute.web.login.credential.LoginCredential;
+
+import com.google.api.client.auth.oauth2.TokenResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -327,5 +333,140 @@ public class OpenIdConnectAuthenticatorTest extends UnitFessTestCase {
         assertEquals("abc123", attributes.get("nonce"));
         assertEquals("hashvalue", attributes.get("at_hash"));
         assertEquals("codehash", attributes.get("c_hash"));
+    }
+
+    // ===================================================================================
+    //                                                        Callback failure handling
+    //                                                        =========================
+
+    private static String segment(final String json) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String jwtOf(final String claimJson) {
+        return segment("{\"alg\":\"RS256\"}") + "." + segment(claimJson) + "." + segment("signature");
+    }
+
+    private static TokenResponse tokenResponseWith(final Object idToken) {
+        final TokenResponse tr = new TokenResponse();
+        tr.setAccessToken("access-token");
+        tr.setTokenType("Bearer");
+        tr.setExpiresInSeconds(300L);
+        if (idToken != null) {
+            tr.set("id_token", idToken);
+        }
+        return tr;
+    }
+
+    private OpenIdConnectAuthenticator authenticatorReturning(final TokenResponse tr) {
+        return new OpenIdConnectAuthenticator() {
+            @Override
+            protected TokenResponse getTokenUrl(final String code) {
+                return tr;
+            }
+        };
+    }
+
+    private LoginCredential callbackWith(final Object idToken) {
+        return authenticatorReturning(tokenResponseWith(idToken)).processCallback(getMockRequest(), "the-code");
+    }
+
+    @Test
+    public void test_processCallback_acceptsAWellFormedIdToken() {
+        final LoginCredential credential = callbackWith(jwtOf("{\"email\":\"user@example.com\"}"));
+        assertNotNull(credential);
+        assertEquals("{user@example.com}", credential.toString());
+    }
+
+    @Test
+    public void test_processCallback_withoutIdToken() {
+        // A token response that carries no id_token used to reach ((String) null).split and throw.
+        assertNull(callbackWith(null));
+    }
+
+    @Test
+    public void test_processCallback_withNonStringIdToken() {
+        assertNull(callbackWith(Long.valueOf(42)));
+    }
+
+    @Test
+    public void test_processCallback_withBlankIdToken() {
+        assertNull(callbackWith(""));
+    }
+
+    @Test
+    public void test_processCallback_withTwoSegmentIdToken() {
+        // jwt[2] used to throw ArrayIndexOutOfBoundsException, which no caller catches.
+        assertNull(callbackWith("header.claim"));
+    }
+
+    @Test
+    public void test_processCallback_withFourSegmentIdToken() {
+        // A JWE compact serialisation has five segments and is not a signed JWT either.
+        assertNull(callbackWith("a.b.c.d"));
+    }
+
+    @Test
+    public void test_processCallback_withUndecodableSegment() {
+        // decodeBase64 throws IllegalArgumentException, which only the IOException catch used to cover.
+        assertNull(callbackWith("aGVhZGVy.!!!not-base64!!!.c2ln"));
+    }
+
+    @Test
+    public void test_processCallback_withNonJsonClaim() {
+        assertNull(callbackWith(segment("{\"alg\":\"RS256\"}") + "." + segment("not json at all") + "." + segment("s")));
+    }
+
+    @Test
+    public void test_processCallback_withoutEmailClaim() {
+        // The email claim is the user id. A credential without one logs in as a null-named user and
+        // then fails on every later request, so it must not become a session at all.
+        assertNull(callbackWith(jwtOf("{\"sub\":\"1234\",\"groups\":[\"dev\"]}")));
+    }
+
+    @Test
+    public void test_processCallback_withBlankEmailClaim() {
+        assertNull(callbackWith(jwtOf("{\"email\":\"\"}")));
+    }
+
+    @Test
+    public void test_getLoginCredential_withProviderErrorResponse() {
+        // error=access_denied with the state we issued means the provider refused this login. Starting
+        // another authorization request would loop against a provider that keeps refusing, and would
+        // override the user's own refusal against one that does not.
+        final MockletHttpServletRequest request = getMockRequest();
+        request.getSession().setAttribute(OpenIdConnectAuthenticator.OIC_STATE, "the-state");
+        request.setParameter("state", "the-state");
+        request.setParameter("error", "access_denied");
+        request.setParameter("error_description", "The user declined");
+
+        assertNull(authenticator.getLoginCredential());
+        assertNull(request.getSession().getAttribute(OpenIdConnectAuthenticator.OIC_STATE));
+    }
+
+    @Test
+    public void test_getLoginCredential_withErrorForAnotherState() {
+        // A state that is not the one in the session is not this login's error response, so the
+        // existing behaviour -- start a fresh authorization request -- is kept.
+        final MockletHttpServletRequest request = getMockRequest();
+        request.getSession().setAttribute(OpenIdConnectAuthenticator.OIC_STATE, "the-state");
+        request.setParameter("state", "a-different-state");
+        request.setParameter("error", "access_denied");
+
+        final LoginCredential credential = authenticator.getLoginCredential();
+        assertNotNull(credential);
+        assertTrue(credential instanceof ActionResponseCredential);
+    }
+
+    @Test
+    public void test_getLoginCredential_withoutCodeOrError() {
+        // A bare callback with a matching state and neither parameter still restarts the flow.
+        final MockletHttpServletRequest request = getMockRequest();
+        request.getSession().setAttribute(OpenIdConnectAuthenticator.OIC_STATE, "the-state");
+        request.setParameter("state", "the-state");
+
+        final LoginCredential credential = authenticator.getLoginCredential();
+        assertNotNull(credential);
+        assertTrue(credential instanceof ActionResponseCredential);
     }
 }


### PR DESCRIPTION
## What

Four shapes of OpenID Connect callback never reached the SSO login error page. Three of
them ended as an HTTP 500 and the system error page; the fourth looped between Fess and
the provider.

### Missing `email` claim: HTTP 500 and a session that stays broken

`OpenIdConnectCredential.getUserId()` reads the `email` claim, so an ID token without one
produced a credential whose user id is null. `FessLoginAssist` accepted it and created the
session; the success callback then recorded the login activity, which computes the search
permissions, and the null name reached `getCanonicalLdapName` -> `name.split(...)` and threw
an NPE.

The session had already been established when that happened, so the failure was not confined
to the callback: every later request from the same browser answered 500 as well. The browser
could not reach the search page or the login page again until its cookies were cleared.

This is reachable with a correctly configured client whenever the provider does not release
the claim — a user account with no mail attribute, or a client whose scopes do not yield it.

### Malformed ID token: HTTP 500 with no log line at all

- fewer than three dot-separated segments: `jwt[2]` threw `ArrayIndexOutOfBoundsException`
- no `id_token` in the token response: `(String) tr.get("id_token")` cast null, then `split`
  threw an NPE
- a segment that is not decodable Base64: `decodeBase64` throws `IllegalArgumentException`,
  which the `IOException` catch did not cover

None of these were logged anywhere, at any level. An operator saw a system error page and had
nothing to go on.

### Provider error response: an infinite redirect loop, or a refusal that is ignored

When the provider answers the authorization request with an error response (RFC 6749 section
4.1.2.1) rather than a code, `getLoginCredential` did not look at the `error` parameter. It
found no code and issued a brand new authorization request.

- Against a provider that keeps refusing (a scope the client is not allowed to request, for
  example), the browser bounces between the two servers until it hits its redirect cap.
- Against one that refuses only because the user declined the consent, the extra round trip
  comes back with a code and the user is logged in anyway. There is no way to say no.

## Change

Each of the four now returns null from the authenticator. `SsoAction` already turns a null
credential into the SSO login error on the login page, so no caller changes.

Each also logs one WARN line naming the cause: which claim is missing, how many segments the
`id_token` had, or the provider's `error` and `error_description`. Stack traces stay behind the
debug level, because the callback endpoint is anonymous and an unauthenticated client must not
be able to fill the log with them.

## Tests

13 tests in `OpenIdConnectAuthenticatorTest`. 9 of them fail on the current `master`:

- `test_processCallback_withoutIdToken` (NPE), `withNonStringIdToken` (ClassCastException),
  `withBlankIdToken` / `withTwoSegmentIdToken` / `withFourSegmentIdToken` /
  `withUndecodableSegment` (IllegalArgumentException, ArrayIndexOutOfBoundsException)
- `withoutEmailClaim` / `withBlankEmailClaim` returned a credential named null
- `test_getLoginCredential_withProviderErrorResponse` returned a fresh authorization redirect

The other four pin behaviour that must not change: a well-formed token still logs in, a claim
segment that is valid Base64 but not JSON was already handled, and an error response carrying
someone else's state, or a callback with neither code nor error, still restarts the flow.

Verified end to end against a real OpenID provider: each case now lands on the login page with
the SSO login error, the session stays usable, and the normal login, the group claim and the
`oic.default.groups` fallback are unchanged.
