### PR TITLE
fix(sso): accept a single-valued OpenID Connect groups claim

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/login/OpenIdConnectCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/OpenIdConnectCredential.java
@@ -61,6 +61,15 @@ public class OpenIdConnectCredential implements LoginCredential, FessCredential 
      * @return the user groups
      */
     public String[] getUserGroups() {
+        if (attributes.get("groups") instanceof final String singleGroup) {
+            // A provider that collapses a single-valued claim to a bare JSON string still named a
+            // group. DocumentUtil answers null when a String is asked for as a String[], which is the
+            // same answer it gives for a claim that was never sent, so this used to be indistinguishable
+            // from an absent claim and the user silently got oic.default.groups instead of their own
+            // group. An empty value is treated like an empty array: the claim was sent, so the default
+            // does not apply.
+            return StringUtil.isBlank(singleGroup) ? StringUtil.EMPTY_STRINGS : new String[] { singleGroup.trim() };
+        }
         String[] userGroups = DocumentUtil.getValue(attributes, "groups", String[].class);
         if (userGroups == null) {
             userGroups = getDefaultGroupsAsArray();

--- a/src/test/java/org/codelibs/fess/app/web/base/login/OpenIdConnectCredentialTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/OpenIdConnectCredentialTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.base.login;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+/**
+ * Unit tests for {@link OpenIdConnectCredential}, covering the shapes an OpenID provider can give
+ * the {@code groups} claim and how {@code oic.default.groups} applies to each of them.
+ */
+public class OpenIdConnectCredentialTest extends UnitFessTestCase {
+
+    private static final String DEFAULT_GROUPS_KEY = "oic.default.groups";
+
+    @Override
+    protected void setUp(final TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        // The system properties component outlives a single test class, so the key is set on the one
+        // the code actually reads and removed again below rather than swapped for a fresh instance.
+        ComponentUtil.getSystemProperties().setProperty(DEFAULT_GROUPS_KEY, "fallback");
+    }
+
+    @Override
+    protected void tearDown(final TestInfo testInfo) throws Exception {
+        ComponentUtil.getSystemProperties().remove(DEFAULT_GROUPS_KEY);
+        super.tearDown(testInfo);
+    }
+
+    private static String[] groupsOf(final Object claim) {
+        final Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", "user@example.com");
+        if (claim != null) {
+            attributes.put("groups", claim);
+        }
+        return new OpenIdConnectCredential(attributes).getUserGroups();
+    }
+
+    @Test
+    public void test_getUserGroups_fromArrayClaim() {
+        assertEquals(List.of("dev", "sales"), List.of(groupsOf(List.of("dev", "sales"))));
+    }
+
+    @Test
+    public void test_getUserGroups_fromSingleValuedStringClaim() {
+        // Some providers emit a single-valued claim as a bare string rather than a one-element array.
+        // That group used to be dropped and oic.default.groups substituted for it.
+        assertEquals(List.of("dev"), List.of(groupsOf("dev")));
+    }
+
+    @Test
+    public void test_getUserGroups_fromSingleValuedStringClaim_isTrimmed() {
+        assertEquals(List.of("dev"), List.of(groupsOf("  dev  ")));
+    }
+
+    @Test
+    public void test_getUserGroups_fromBlankStringClaim() {
+        // The claim was sent, so the default does not apply -- the same rule as an empty array.
+        assertEquals(0, groupsOf("").length);
+        assertEquals(0, groupsOf("   ").length);
+    }
+
+    @Test
+    public void test_getUserGroups_fromEmptyArrayClaim() {
+        assertEquals(0, groupsOf(List.of()).length);
+    }
+
+    @Test
+    public void test_getUserGroups_withoutClaimUsesTheDefault() {
+        assertEquals(List.of("fallback"), List.of(groupsOf(null)));
+    }
+
+    @Test
+    public void test_getUserId_fromEmailClaim() {
+        final Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", "user@example.com");
+        assertEquals("user@example.com", new OpenIdConnectCredential(attributes).getUserId());
+    }
+
+    @Test
+    public void test_getUserId_withoutEmailClaim() {
+        assertNull(new OpenIdConnectCredential(new HashMap<>()).getUserId());
+    }
+}


### PR DESCRIPTION
## What

When an OpenID provider emits a single-valued `groups` claim as a bare JSON string rather
than a one-element array, that group was silently discarded and the user was given
`oic.default.groups` instead. They then searched with the permissions of a different group,
with nothing in the log to say so.

`OpenIdConnectCredential.getUserGroups()` asks `DocumentUtil` for the claim as a `String[]`.
`DocumentUtil.getValue` handles a `List` and a `String[]`, and otherwise falls through to
`convertObj`, which has no `String` -> `String[]` conversion and returns null. Null is also
what it returns for a claim that was never sent, so the two cases were indistinguishable and
the absent-claim fallback ran.

Emitting a single-valued claim as a scalar is a real provider behaviour, and `groups` is the
claim most likely to be single-valued in practice: a user who belongs to exactly one group.

## Change

A `String` claim is read as the single group it names, trimmed. A blank one is treated the
same way an empty array already is: the claim was sent, so `oic.default.groups` does not
apply. Array claims and absent claims keep their current behaviour.

## Tests

New `OpenIdConnectCredentialTest` covering every shape the claim can take: array,
single-valued string, whitespace-padded string, blank string, empty array, and absent. Three
of the eight fail on the current `master` — the single-valued string cases resolve to the
default group, and the blank string does too.

Verified end to end against a real OpenID provider that the array claim, the empty-groups
fallback and the permission set built from them are unchanged.
