### PR TITLE
fix(sso): keep tokens and raw signature bytes out of the OpenID Connect debug log

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticator.java
@@ -228,7 +228,10 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
             if (logger.isDebugEnabled()) {
                 logger.debug("jwtHeader={}", jwtHeader);
                 logger.debug("jwtClaim={}", jwtClaim);
-                logger.debug("jwtSignature={}", jwtSignature);
+                // The signature is raw bytes, not text. Writing the decoded string put control and
+                // invalid-UTF-8 bytes straight into fess.log, which makes the file itself count as
+                // binary: grep and the rest of the usual log tooling then skip it silently.
+                logger.debug("jwtSignature: {} encoded characters, not validated", jwt[2].length());
             }
 
             // SECURITY WARNING: JWT signature validation is not implemented.
@@ -246,7 +249,12 @@ public class OpenIdConnectAuthenticator implements SsoAuthenticator {
             attributes.put("jwtsignature", jwtSignature);
 
             if (logger.isDebugEnabled()) {
-                logger.debug("attributes={}", attributes);
+                // Not the whole attribute map: it holds the access token and the refresh token, which
+                // are bearer credentials for the provider. The documentation tells an administrator to
+                // turn this logger up to debug when a login misbehaves, so whatever it prints ends up
+                // in a file that is read, copied into issue reports and shipped to log collectors.
+                logger.debug("tokenType={}, expiresInSeconds={}, refreshToken={}", tr.getTokenType(), tr.getExpiresInSeconds(),
+                        tr.getRefreshToken() == null ? "absent" : "present");
             }
             parseJwtClaim(jwtClaim, attributes);
 

--- a/src/test/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/oic/OpenIdConnectAuthenticatorTest.java
@@ -25,9 +25,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.misc.DynamicProperties;
 import org.codelibs.fess.app.web.base.login.ActionResponseCredential;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
@@ -468,5 +471,67 @@ public class OpenIdConnectAuthenticatorTest extends UnitFessTestCase {
         final LoginCredential credential = authenticator.getLoginCredential();
         assertNotNull(credential);
         assertTrue(credential instanceof ActionResponseCredential);
+    }
+
+    // ===================================================================================
+    //                                                            Debug log confidentiality
+    //                                                            =========================
+
+    private static String segment(final byte[] raw) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw);
+    }
+
+    /**
+     * Drives processCallback with a token response the test controls and returns everything this
+     * class logged while doing it.
+     */
+    private String debugOutputOfCallback(final TokenResponse tr) {
+        final LogCapturingAppender appender = LogCapturingAppender.attach(OpenIdConnectAuthenticator.class.getName(), Level.DEBUG);
+        try {
+            authenticatorReturning(tr).processCallback(getMockRequest(), "the-code");
+        } finally {
+            appender.detach();
+        }
+        final StringBuilder buf = new StringBuilder();
+        for (final LogEvent event : appender.events()) {
+            buf.append(event.getMessage().getFormattedMessage()).append('\n');
+        }
+        return buf.toString();
+    }
+
+    private static TokenResponse secretCarryingTokenResponse() {
+        final TokenResponse tr = new TokenResponse();
+        tr.setAccessToken("ACCESS-TOKEN-MUST-NOT-BE-LOGGED");
+        tr.setRefreshToken("REFRESH-TOKEN-MUST-NOT-BE-LOGGED");
+        tr.setTokenType("Bearer");
+        tr.setExpiresInSeconds(300L);
+        // A signature is raw bytes; these are not valid UTF-8 text.
+        final byte[] signature = { 0x00, 0x01, (byte) 0xC3, (byte) 0x28, (byte) 0xA0, (byte) 0xA1, 0x07 };
+        tr.set("id_token", segment("{\"alg\":\"RS256\"}") + "." + segment("{\"email\":\"user@example.com\"}") + "." + segment(signature));
+        return tr;
+    }
+
+    @Test
+    public void test_processCallback_doesNotLogTheAccessOrRefreshToken() {
+        // The documentation tells administrators to raise this logger to debug when a login
+        // misbehaves, so anything it prints reaches log files, issue reports and log collectors.
+        final String output = debugOutputOfCallback(secretCarryingTokenResponse());
+
+        assertFalse(output.contains("ACCESS-TOKEN-MUST-NOT-BE-LOGGED"), "the access token was logged");
+        assertFalse(output.contains("REFRESH-TOKEN-MUST-NOT-BE-LOGGED"), "the refresh token was logged");
+        // What is actually needed to diagnose a login is still there.
+        assertTrue(output.contains("user@example.com"), "the claim set was not logged");
+        assertTrue(output.contains("Bearer"), "the token type was not logged");
+    }
+
+    @Test
+    public void test_processCallback_doesNotLogRawSignatureBytes() {
+        final String output = debugOutputOfCallback(secretCarryingTokenResponse());
+
+        // A single invalid byte in fess.log makes the whole file count as binary, and grep and the
+        // rest of the usual log tooling then skip it without saying so.
+        assertFalse(output.contains("\u0000"), "a NUL byte reached the log");
+        assertFalse(output.contains("\u0007"), "a control byte reached the log");
+        assertFalse(output.contains("\ufffd"), "an undecodable byte reached the log");
     }
 }


### PR DESCRIPTION
## What

The OpenID Connect troubleshooting section of the documentation tells an administrator to
raise `org.codelibs.fess.sso.oic` to debug when a login misbehaves. Two of the things that
logger then prints do not belong in a log file.

### The access token and the refresh token

`processCallback` logged the whole attribute map, and that map holds `accesstoken` and
`refreshtoken`. Both are bearer credentials for the provider: anyone holding the access token
can call the provider's APIs as that user for its lifetime, and the refresh token keeps
working far longer. They landed in `fess.log`, which gets read, pasted into issue reports and
shipped to log collectors. `CLAUDE.md` already states the rule — do not log secrets
(passwords, tokens, credentials).

### The decoded JWT signature

`jwtSignature` is the signature bytes decoded as if they were UTF-8. They are not text, so the
line carried control characters and replacement characters straight into `fess.log`.

That is not only noise. A single invalid byte makes the whole file count as binary, and
`grep` then skips it and prints nothing — the same output as "no matches". An operator
searching that log for an error silently gets nothing back, and the cost is the entire log
file rather than one line.

## Change

The attribute-map dump is replaced by the token type, the lifetime, and whether a refresh
token was returned — the parts of it that were diagnostically useful. The signature line
reports the encoded length instead of the bytes.

The claim set, which is what actually identifies why a login went wrong (which subject, which
email, which groups), is still logged in full, as is the JWT header.

## Tests

Two tests in `OpenIdConnectAuthenticatorTest` capture this class's debug output for a callback
whose token response carries marked tokens and a deliberately non-UTF-8 signature, then assert
that neither token appears and that no NUL, control or replacement character reaches the log,
while the claim set and the token type still do. Both fail on the current `master`.
