### PR TITLE
fix(ldap): name a permission from the directory entry, not from a slice of its DN

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -773,14 +773,52 @@ public class SystemHelper {
     }
 
     /**
-     * Creates a search role string.
+     * Gets the search role for a group named by a directory entry's own DN.
+     *
+     * @param name The group name, exactly as the entry carries it.
+     * @return The search role.
+     */
+    public String getSearchRoleByDirectoryGroup(final String name) {
+        return buildSearchRole(ComponentUtil.getFessConfig().getRoleSearchGroupPrefix(), name);
+    }
+
+    /**
+     * Gets the search role for a role named by a directory entry's own DN.
+     *
+     * @param name The role name, exactly as the entry carries it.
+     * @return The search role.
+     */
+    public String getSearchRoleByDirectoryRole(final String name) {
+        return buildSearchRole(ComponentUtil.getFessConfig().getRoleSearchRolePrefix(), name);
+    }
+
+    /**
+     * Creates a search role string from a name a user supplied.
      *
      * @param type The type of the role.
      * @param name The name of the role.
      * @return The search role string.
      */
     protected String createSearchRole(final String type, final String name) {
-        final String value = type + ComponentUtil.getFessConfig().getCanonicalLdapName(name);
+        return buildSearchRole(type, ComponentUtil.getFessConfig().getCanonicalLdapName(name));
+    }
+
+    /**
+     * Joins a permission prefix to an already-final name.
+     *
+     * <p>Split out from {@link #createSearchRole(String, String)} so that a name read out of a
+     * directory entry can skip {@code getCanonicalLdapName}. That canonicalisation exists to drop
+     * the {@code DOMAIN\} prefix from a name a user typed at login; a group's own name is not
+     * NetBIOS-qualified, so running it there would let a backslash inside the name rewrite the
+     * permission to whatever follows the backslash -- naming one group's permission from another
+     * group's entry.
+     *
+     * @param type The type of the role.
+     * @param name The final name.
+     * @return The search role string.
+     */
+    protected String buildSearchRole(final String type, final String name) {
+        final String value = type + name;
         if (logger.isDebugEnabled()) {
             logger.debug("Search Role: {}:{}={}", type, name, value);
         }

--- a/src/main/java/org/codelibs/fess/ldap/LdapManager.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapManager.java
@@ -47,6 +47,8 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.ModificationItem;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -638,13 +640,15 @@ public class LdapManager {
         if (StringUtil.isNotBlank(name)) {
             final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
             final boolean isRole = entryDn.toLowerCase(Locale.ROOT).indexOf("ou=role") != -1;
+            // The directory variants: the name already came out of this entry's own DN, so it must
+            // not be re-read as a NetBIOS-qualified "DOMAIN\name" and truncated to its tail.
             if (isRole) {
                 if (fessConfig.isLdapRoleSearchRoleEnabled()) {
-                    roleSet.add(systemHelper.getSearchRoleByRole(normalizePermissionName(name)));
+                    roleSet.add(systemHelper.getSearchRoleByDirectoryRole(normalizePermissionName(name)));
                     return fessConfig.getRoleSearchRolePrefix();
                 }
             } else if (fessConfig.isLdapRoleSearchGroupEnabled()) {
-                roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(name)));
+                roleSet.add(systemHelper.getSearchRoleByDirectoryGroup(normalizePermissionName(name)));
                 return fessConfig.getRoleSearchGroupPrefix();
             }
         }
@@ -727,25 +731,63 @@ public class LdapManager {
     /**
      * Extracts the role name from an LDAP entry DN.
      *
+     * <p>The name is taken as an RDN value rather than by cutting the DN text at the first comma.
+     * A comma is legal inside a CN and appears in the DN escaped ({@code CN=sales\,EMEA}); cutting
+     * on it stops inside the name and yields a prefix of it, so two entries whose names share a
+     * prefix collapse onto one permission -- and a name whose prefix happens to be a privileged
+     * one is granted that privilege.
+     *
      * @param entryDn the LDAP entry DN
-     * @return the extracted role name, or null if not found
+     * @return the extracted role name, or null if the DN names no CN or cannot be parsed
      */
     protected String getSearchRoleName(final String entryDn) {
         if (entryDn == null) {
             return null;
         }
-        int start = entryDn.toLowerCase(Locale.ROOT).indexOf("cn=");
-        if (start == -1) {
+        final String value = getLeafCommonName(entryDn);
+        if (value == null) {
             return null;
         }
-        start += 3;
-
-        final int end = entryDn.indexOf(',', start);
-        final String value = end == -1 ? entryDn.substring(start) : entryDn.substring(start, end);
         if (fessConfig.isLdapGroupNameWithUnderscores()) {
             return replaceWithUnderscores(value);
         }
         return value;
+    }
+
+    /**
+     * Returns the value of the CN nearest the leaf of a DN.
+     *
+     * <p>Searches from the leaf so that it keeps naming the entry itself, which is what reading the
+     * first {@code cn=} in the DN text did. Returns null rather than falling back to a text scan
+     * when the DN does not parse: the DN comes from the directory through
+     * {@code SearchResult#getNameInNamespace()}, so a parse failure means the value cannot be
+     * trusted to name what it appears to name, and contributing no permission is the safe outcome.
+     *
+     * @param entryDn the LDAP entry DN
+     * @return the CN value, or null when the DN carries no CN or cannot be parsed
+     */
+    protected String getLeafCommonName(final String entryDn) {
+        try {
+            final LdapName name = new LdapName(entryDn);
+            final List<Rdn> rdns = name.getRdns();
+            for (int i = rdns.size() - 1; i >= 0; i--) {
+                // toAttributes(), not getValue(): getValue() on a multi-valued RDN such as
+                // "CN=a+OU=b" returns whichever half came first, which need not be the CN.
+                final Attribute cn = rdns.get(i).toAttributes().get("cn");
+                if (cn != null) {
+                    final Object cnValue = cn.get();
+                    if (cnValue != null) {
+                        return cnValue.toString();
+                    }
+                }
+            }
+        } catch (final NamingException | IllegalArgumentException e) {
+            // IllegalArgumentException as well as InvalidNameException: Rdn#unescapeValue reports a
+            // malformed escape by throwing unchecked, and letting that out of here would turn one
+            // unparseable group DN into a failed login rather than one missing permission.
+            logger.warn("Failed to read a common name from DN: {}", entryDn, e);
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
@@ -73,15 +73,76 @@ public class LdapManagerTest extends UnitFessTestCase {
         assertEquals("aaa", ldapManager.getSearchRoleName("cn=aaa"));
         assertEquals("aaa", ldapManager.getSearchRoleName("CN=aaa"));
         assertEquals("aaa", ldapManager.getSearchRoleName("cn=aaa,du=test"));
-        assertEquals("aaa\\bbb", ldapManager.getSearchRoleName("cn=aaa\\bbb"));
-        assertEquals("aaa\\bbb", ldapManager.getSearchRoleName("cn=aaa\\bbb,du=test"));
-        assertEquals("aaa\\bbb\\ccc", ldapManager.getSearchRoleName("cn=aaa\\bbb\\ccc"));
-        assertEquals("aaa\\bbb\\ccc", ldapManager.getSearchRoleName("cn=aaa\\bbb\\ccc,du=test\""));
+        // A backslash inside a CN reaches this method escaped, the way a directory writes it into
+        // a DN.  It must survive here: stripping it is getCanonicalLdapName's job, and only for a
+        // name a user typed.
+        assertEquals("aaa\\bbb", ldapManager.getSearchRoleName("cn=aaa\\\\bbb"));
+        assertEquals("aaa\\bbb", ldapManager.getSearchRoleName("cn=aaa\\\\bbb,du=test"));
+        assertEquals("aaa\\bbb\\ccc", ldapManager.getSearchRoleName("cn=aaa\\\\bbb\\\\ccc"));
+        assertEquals("aaa\\bbb\\ccc", ldapManager.getSearchRoleName("cn=aaa\\\\bbb\\\\ccc,du=test"));
 
         assertNull(ldapManager.getSearchRoleName(null));
         assertNull(ldapManager.getSearchRoleName(""));
         assertNull(ldapManager.getSearchRoleName(" "));
         assertNull(ldapManager.getSearchRoleName("aaa"));
+    }
+
+    /**
+     * A comma is legal inside a CN and a directory escapes it in the DN.  Reading the DN as text
+     * and cutting at the first comma stops inside the name and hands back a prefix of it, so
+     * "sales,EMEA" and "sales,APAC" both become the permission of the unrelated group "sales" --
+     * and a group named after a privileged name gains that privilege.
+     */
+    @SuppressWarnings("serial")
+    @Test
+    public void test_getSearchRoleName_escapedComma() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            public boolean isLdapIgnoreNetbiosName() {
+                return true;
+            }
+
+            public boolean isLdapGroupNameWithUnderscores() {
+                return false;
+            }
+        });
+        final LdapManager ldapManager = new LdapManager();
+        ldapManager.init();
+
+        assertEquals("sales,EMEA", ldapManager.getSearchRoleName("CN=sales\\,EMEA,CN=Users,DC=example,DC=com"));
+        assertEquals("sales,APAC", ldapManager.getSearchRoleName("CN=sales\\,APAC,CN=Users,DC=example,DC=com"));
+        assertEquals("admin,decoy", ldapManager.getSearchRoleName("CN=admin\\,decoy,OU=Role,DC=example,DC=com"));
+        // The hex form of the same escape has to read the same way.
+        assertEquals("sales,EMEA", ldapManager.getSearchRoleName("CN=sales\\2CEMEA,CN=Users,DC=example,DC=com"));
+        // Other escapes a CN can legally carry.
+        assertEquals("a+b", ldapManager.getSearchRoleName("CN=a\\+b,CN=Users,DC=example,DC=com"));
+        assertEquals(" pad ", ldapManager.getSearchRoleName("CN=\\ pad\\ ,CN=Users,DC=example,DC=com"));
+    }
+
+    /**
+     * The CN nearest the leaf names the entry itself.  A DN whose leaf RDN is not a CN must not
+     * report a container further up as the entry's name unless that container is the only CN.
+     */
+    @SuppressWarnings("serial")
+    @Test
+    public void test_getSearchRoleName_leafCommonName() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            public boolean isLdapIgnoreNetbiosName() {
+                return true;
+            }
+
+            public boolean isLdapGroupNameWithUnderscores() {
+                return false;
+            }
+        });
+        final LdapManager ldapManager = new LdapManager();
+        ldapManager.init();
+
+        assertEquals("leaf", ldapManager.getSearchRoleName("CN=leaf,CN=Users,DC=example,DC=com"));
+        assertEquals("Users", ldapManager.getSearchRoleName("OU=sub,CN=Users,DC=example,DC=com"));
+        // A multi-valued RDN must report its CN half, not whichever half sorts first.
+        assertEquals("multi", ldapManager.getSearchRoleName("OU=other+CN=multi,DC=example,DC=com"));
+        // A DN the provider cannot parse contributes no permission rather than a guessed one.
+        assertNull(ldapManager.getSearchRoleName("CN=broken\\q,DC=example,DC=com"));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`LdapManager#getSearchRoleName` read the entry DN as text: everything between the first `cn=` and the next comma.

```java
int start = entryDn.toLowerCase(Locale.ROOT).indexOf("cn=") + 3;
final int end = entryDn.indexOf(',', start);
final String value = end == -1 ? entryDn.substring(start) : entryDn.substring(start, end);
```

A comma is legal inside a CN, and the directory writes it into the DN escaped. The cut therefore lands *inside* the name and returns a prefix of it, ending in the escape's backslash. `getCanonicalLdapName` — which exists to drop a NetBIOS `DOMAIN\` prefix from a name a user typed — then splits on that backslash and removes it, leaving the bare prefix as the whole permission.

| entry DN | permission before | permission after |
|---|---|---|
| `CN=sales\,EMEA,CN=Users,…` | `2sales` | `2sales,EMEA` |
| `CN=sales\,APAC,CN=Users,…` | `2sales` | `2sales,APAC` |
| `CN=admin\,x,OU=Role,…` | `Radmin` | `Radmin,x` |

Two consequences:

- **Cross-group document access.** Any group whose name begins with another group's name followed by a comma collapses onto that group's permission and reads its documents. This also fires by accident: `Sales, EMEA` and `Sales, APAC` are ordinary group names and both become `2Sales`.
- **Privilege escalation.** When the shared prefix is a privileged name, the collapse grants the privilege. A group named `admin,<anything>` below an OU whose DN contains `ou=role` yields `Radmin`, which the shipped `authentication.admin.roles=admin` accepts. Creating a group in a delegated OU is a routine, non-administrative Active Directory right, so the person who does this need never have been granted anything in Fess.

Both require `ldap.ignore.netbios.name`, whose shipped default is `true`. Not a 15.8 regression — `fess-15.7.0` carries the same parse and the same default.

## Change

- `getSearchRoleName` takes the leaf CN as an **RDN value** (`javax.naming.ldap.LdapName`), which respects the escaping the directory applied. It searches from the leaf so it keeps naming the entry itself, as reading the first `cn=` did.
- A DN that does not parse contributes **no** permission rather than a guessed one, and is logged. `Rdn#unescapeValue` reports a malformed escape by throwing *unchecked*, so that is caught too — otherwise one unparseable group DN would fail the whole login instead of costing one permission.
- `updateSearchRoles` builds the permission through two new `SystemHelper` methods that skip `getCanonicalLdapName`. Once the RDN is unescaped correctly, a backslash inside a group's own name would otherwise rewrite the permission to whatever follows it; a group's name is not NetBIOS-qualified, so that canonicalisation does not belong on this path. `createSearchRole` — the login-name path — is unchanged.

## Tests

`mvn test` — 7320 tests, 0 failures.

New in `LdapManagerTest`: escaped commas in both the `\,` and `\2C` forms, other legal CN escapes (`\+`, leading/trailing space), a leaf CN below a non-CN RDN, a multi-valued RDN, and an unparseable DN.

The four existing assertions that passed a backslash *unescaped* (`cn=aaa\bbb`) now pass the escaped form a directory actually emits (`cn=aaa\\bbb`) and keep their expected values — the intent, that this layer does not strip a backslash, is unchanged.

Verified end to end against a live Active Directory domain controller: a user whose only membership is the decoy group is no longer reported as an administrator, is refused the admin screens, and reads none of the real group's documents; users with ordinary group and role memberships — including one holding 60 groups — resolve exactly as before.
