### PR TITLE
feat(config): report a search-role prefix that cannot work

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -181,6 +181,7 @@ public class SystemHelper {
         }
         updateSystemProperties();
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        reportSearchRolePrefixProblems(fessConfig);
         filterPathEncoding = fessConfig.getPathEncoding();
         supportedLanguages = fessConfig.getSupportedLanguagesAsArray();
         langItemsCache = CacheBuilder.newBuilder()
@@ -740,6 +741,76 @@ public class SystemHelper {
             return permission.startsWith(ComponentUtil.getFessConfig().getRoleSearchUserPrefix());
         }
         return false;
+    }
+
+    /**
+     * Reports any search-role prefix that is not usable.
+     *
+     * <p>A permission is a prefix character followed by a name, and the prefix is what says whether
+     * the name is a user, a group, a role or a denial. Reading one back is a one-character
+     * operation ({@link org.codelibs.fess.ldap.LdapUser#getRoleNames()}), so a prefix that is not
+     * exactly one character does not round-trip.
+     *
+     * <p>Both ways of getting it wrong grant access rather than withhold it, which is why this is
+     * reported at ERROR:
+     *
+     * <ul>
+     * <li>An empty prefix matches every permission, so every group and user name is also read as a
+     * role name. A member of a group named in {@code authentication.admin.roles} -- {@code admin}
+     * by default -- is then an administrator. Measured: a user holding only the group {@code dev}
+     * was reported as {@code roles=[bob, dev] admin=true}.</li>
+     * <li>Two prefixes that are the same collapse the distinction they exist to draw: with the role
+     * prefix set to the group prefix, holding a group is holding the role of that name; with the
+     * denied prefix set to another, a denial is read as a grant.</li>
+     * </ul>
+     *
+     * <p>A prefix longer than one character fails the other way -- the rest of it stays on the
+     * front of the name, so nothing matches, and an LDAP-authenticated administrator loses the
+     * admin UI -- and is caught by the same length check.
+     *
+     * <p>Reports rather than throws. An exception raised from this {@link PostConstruct} does not
+     * stop the server: it is swallowed without reaching any log, and the rest of this method is
+     * skipped, so the only thing throwing would achieve is to disable initialisation silently.
+     * ERROR is the level that reaches an operator.
+     *
+     * @param fessConfig The configuration to check.
+     * @return The problems found, in the order they were checked; empty when the prefixes are usable.
+     */
+    protected List<String> validateSearchRolePrefixes(final FessConfig fessConfig) {
+        final Map<String, String> prefixes = new LinkedHashMap<>(4);
+        prefixes.put("role.search.user.prefix", fessConfig.getRoleSearchUserPrefix());
+        prefixes.put("role.search.group.prefix", fessConfig.getRoleSearchGroupPrefix());
+        prefixes.put("role.search.role.prefix", fessConfig.getRoleSearchRolePrefix());
+        prefixes.put("role.search.denied.prefix", fessConfig.getRoleSearchDeniedPrefix());
+
+        final List<String> problems = new ArrayList<>();
+        for (final Map.Entry<String, String> entry : prefixes.entrySet()) {
+            final String value = entry.getValue();
+            if (value == null || value.length() != 1) {
+                problems.add(entry.getKey() + " must be exactly one character, but is "
+                        + (value == null ? "not set" : "\"" + value + "\" (" + value.length() + " characters)"));
+            }
+        }
+
+        final Map<String, String> seen = new LinkedHashMap<>(4);
+        for (final Map.Entry<String, String> entry : prefixes.entrySet()) {
+            final String previous = seen.putIfAbsent(entry.getValue(), entry.getKey());
+            if (previous != null) {
+                problems.add("Search role prefixes must differ, but " + previous + " and " + entry.getKey() + " are both \""
+                        + entry.getValue() + "\"");
+            }
+        }
+        return problems;
+    }
+
+    /**
+     * Checks the search-role prefixes and reports every problem at ERROR.
+     *
+     * @param fessConfig The configuration to check.
+     */
+    protected void reportSearchRolePrefixProblems(final FessConfig fessConfig) {
+        validateSearchRolePrefixes(fessConfig).forEach(problem -> logger
+                .error("{} Group and role permissions will not be applied as configured until this is corrected.", problem));
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SystemHelperTest.java
@@ -102,6 +102,79 @@ public class SystemHelperTest extends UnitFessTestCase {
         ComponentUtil.register(systemHelper, "systemHelper");
     }
 
+    /** Builds a config whose four search-role prefixes are exactly the given values. */
+    @SuppressWarnings("serial")
+    private FessConfig prefixConfig(final String user, final String group, final String role, final String denied) {
+        return new FessConfig.SimpleImpl() {
+            @Override
+            public String getRoleSearchUserPrefix() {
+                return user;
+            }
+
+            @Override
+            public String getRoleSearchGroupPrefix() {
+                return group;
+            }
+
+            @Override
+            public String getRoleSearchRolePrefix() {
+                return role;
+            }
+
+            @Override
+            public String getRoleSearchDeniedPrefix() {
+                return denied;
+            }
+        };
+    }
+
+    private void assertOnlyProblem(final List<String> problems, final String expected) {
+        assertEquals(problems.toString(), 1, problems.size());
+        assertTrue(problems.get(0), problems.get(0).contains(expected));
+    }
+
+    @Test
+    public void test_validateSearchRolePrefixes_shipped() {
+        assertEquals(Collections.emptyList(), systemHelper.validateSearchRolePrefixes(prefixConfig("1", "2", "R", "D")));
+    }
+
+    @Test
+    public void test_validateSearchRolePrefixes_mustBeOneCharacter() {
+        // Empty matches every permission, so a group name is read as a role name too: a member of
+        // the group named in authentication.admin.roles becomes an administrator.
+        assertOnlyProblem(systemHelper.validateSearchRolePrefixes(prefixConfig("1", "2", "", "D")),
+                "role.search.role.prefix must be exactly one character");
+        assertOnlyProblem(systemHelper.validateSearchRolePrefixes(prefixConfig("", "2", "R", "D")),
+                "role.search.user.prefix must be exactly one character");
+        // Longer than one character fails the other way -- the remainder stays on the name -- and
+        // is caught by the same check.
+        assertOnlyProblem(systemHelper.validateSearchRolePrefixes(prefixConfig("1", "2", "R_", "D")),
+                "role.search.role.prefix must be exactly one character");
+        assertOnlyProblem(systemHelper.validateSearchRolePrefixes(prefixConfig("1", "G_", "R", "D")),
+                "role.search.group.prefix must be exactly one character");
+        assertOnlyProblem(systemHelper.validateSearchRolePrefixes(prefixConfig("1", "2", "R", null)),
+                "role.search.denied.prefix must be exactly one character");
+    }
+
+    @Test
+    public void test_validateSearchRolePrefixes_mustDiffer() {
+        // Role set to the group prefix: holding a group becomes holding the role of that name.
+        assertOnlyProblem(systemHelper.validateSearchRolePrefixes(prefixConfig("1", "2", "2", "D")),
+                "role.search.group.prefix and role.search.role.prefix are both \"2\"");
+        // Denied set to another prefix: a denial is read as a grant.
+        assertOnlyProblem(systemHelper.validateSearchRolePrefixes(prefixConfig("1", "2", "R", "R")),
+                "role.search.role.prefix and role.search.denied.prefix are both \"R\"");
+    }
+
+    @Test
+    public void test_validateSearchRolePrefixes_reportsEveryProblem() {
+        // One report per problem: an operator fixing one should not have to restart to find the next.
+        final List<String> problems = systemHelper.validateSearchRolePrefixes(prefixConfig("R_", "2", "2", "D"));
+        assertEquals(problems.toString(), 2, problems.size());
+        assertTrue(problems.get(0), problems.get(0).contains("role.search.user.prefix must be exactly one character"));
+        assertTrue(problems.get(1), problems.get(1).contains("are both"));
+    }
+
     @Test
     public void test_getUsername() {
         assertEquals("guest", systemHelper.getUsername());


### PR DESCRIPTION
> Stacked on #3292. Review that one first; this branch targets it, so the diff shown here is only the second commit.
>
> **CI note:** `.github/workflows/maven.yml` triggers only on pull requests targeting `master` or `*.x`, so no checks run while this PR targets #3292's branch. Verified locally on this branch: `mvn test` — 7324 tests, 0 failures. Retargeting to `master` after #3292 merges will start the normal run.
>
> **Replaces the original contents of this PR.** It previously proposed stripping the permission prefix by its configured length. That was wrong: a single character is the specification, and `substring(1)` is correct. What was missing is anything that says so when the configuration disagrees.

## Problem

A permission is a prefix character followed by a name, and the prefix is what says whether the name is a user, a group, a role or a denial:

```
1alice      user alice
2sales      group sales
Radmin      role admin
Dbob        denied for bob
```

Reading one back is a one-character operation (`LdapUser#getRoleNames`), so a prefix that is not exactly one character does not round-trip. All four are configurable in `fess_config.properties`, and nothing checked them.

**Both ways of getting it wrong grant access rather than withhold it.** Measured against a live directory, on a user whose only membership is the *group* `dev`, with `authentication.admin.roles=dev`:

| `role.search.role.prefix` | `/api/v2/auth/me` | |
|---|---|---|
| `R` (shipped) | `roles=[] groups=['dev'] admin=false` | correct |
| *(empty)* | `roles=['bob', 'dev'] admin=true` | every name is also a role name |
| `2` (= the group prefix) | `roles=['dev'] admin=true` | holding a group is holding the role |

An empty prefix matches every permission, so every group and user name is read as a role name too — a member of the group named in `authentication.admin.roles` (`admin` by default) becomes an administrator. Two prefixes set to the same character collapse the distinction they exist to draw; with the denied prefix equal to another, a denial is read as a grant.

A prefix longer than one character fails the other way — the remainder stays on the front of every name, so `authentication.admin.roles` matches nothing and an LDAP-authenticated administrator loses the admin UI (`roles=["_admin"] admin=false` with `R_`).

## Change

`SystemHelper#init` checks all four prefixes and reports each problem at ERROR, naming the setting. One line per problem, so fixing one does not require a restart to find the next.

**Reports rather than throws.** An exception raised from that `@PostConstruct` does not stop the server. Measured with a temporary probe on either side of the check: the probe before it logged, the probe after it did not — so the exception is raised — and yet the server answered `302`, the admin UI worked, and **nothing appeared in any log or on stdout**. Lasta Di swallows it and skips the rest of `init()`. Throwing there would only disable initialisation silently, so ERROR — which is what a Fess deployment escalates — is the level that actually reaches an operator.

## Tests

`mvn test` — 7324 tests, 0 failures.

New in `SystemHelperTest`: the shipped set reports nothing; each of the four settings is named when it is empty, absent, or longer than one character; a role prefix equal to the group prefix and a denied prefix equal to the role prefix are each reported naming both settings; and two independent problems produce two reports.

Verified end to end on a running server: the shipped prefixes start silently; empty, colliding, and two-character prefixes each start and log exactly one ERROR naming the setting; two problems at once log two.
