### PR TITLE
fix(sso): refuse an Entra ID state TTL that expires every login

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -1793,12 +1793,23 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
      */
     protected long getStateTtl() {
         final String value = getEntraIdProperty(ENTRAID_STATE_TTL, AAD_STATE_TTL, DEFAULT_STATE_TTL);
+        final long ttl;
         try {
-            return Long.parseLong(value.trim());
+            ttl = Long.parseLong(value.trim());
         } catch (final NumberFormatException e) {
             logger.warn("Invalid {}: {}. Using {} seconds.", ENTRAID_STATE_TTL, value, DEFAULT_STATE_TTL);
             return Long.parseLong(DEFAULT_STATE_TTL);
         }
+        if (ttl <= 0L) {
+            // removeExpiredStates drops a state once (now - created) / 1000 exceeds this value, so
+            // a non-positive TTL expires every login attempt before the user can finish signing in
+            // at Microsoft. The callback then reports "could not validate state", which names
+            // neither this setting nor the reason, and no login on the server can ever succeed.
+            logger.warn("Invalid {}: {}. A login cannot outlive a state that expires immediately. Using {} seconds.", ENTRAID_STATE_TTL,
+                    value, DEFAULT_STATE_TTL);
+            return Long.parseLong(DEFAULT_STATE_TTL);
+        }
+        return ttl;
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -1103,6 +1103,41 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getStateTtl_fallsBackWhenTheConfiguredValueIsNotPositive() {
+        // Long.parseLong accepts "0" and "-1", so these used to be taken at face value.
+        // removeExpiredStates then dropped every state one second after it was created, and the
+        // user -- who spends longer than that signing in at Microsoft -- came back to
+        // "could not validate state" on every attempt. Nothing in the log named the setting, so
+        // the server looked broken rather than misconfigured.
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        for (final String value : new String[] { "0", "-1" }) {
+            final LogCapturingAppender logs = LogCapturingAppender.attach(EntraIdAuthenticator.class);
+            try {
+                fessConfig.setSystemProperty("entraid.state.ttl", value);
+
+                assertEquals(3600L, new EntraIdAuthenticator().getStateTtl());
+                assertTrue(logs.warnings().toString(),
+                        logs.warnings().stream().anyMatch(m -> m.contains("entraid.state.ttl") && m.contains(value)));
+            } finally {
+                logs.detach();
+                fessConfig.setSystemProperty("entraid.state.ttl", "");
+            }
+        }
+    }
+
+    @Test
+    public void test_getStateTtl_keepsAPositiveValue() {
+        // The guard must not round a deliberately short expiry up to the default.
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        try {
+            fessConfig.setSystemProperty("entraid.state.ttl", "1");
+            assertEquals(1L, new EntraIdAuthenticator().getStateTtl());
+        } finally {
+            fessConfig.setSystemProperty("entraid.state.ttl", "");
+        }
+    }
+
+    @Test
     public void test_addGroupOrRoleName() {
         EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
         List<String> list = new ArrayList<>();


### PR DESCRIPTION
## Problem

`entraid.state.ttl` is parsed with `Long.parseLong`, which accepts `0` and negative
values. `removeExpiredStates` then drops a pending authorization as soon as
`(now - created) / 1000` exceeds it, so every attempt expires about a second after
the authorization request is built -- long before anyone finishes signing in at
Microsoft.

The callback fails state validation. The browser lands back on the login form with
`SSO login process failed.`, and the log says only:

```
Failed to process SSO login: could not validate state
```

which names neither the setting nor the reason. No login on the server can succeed
and nothing points at the one line of configuration responsible.

## Verified against a live tenant

With `entraid.state.ttl=0`, a real authorization code returned two seconds later is
rejected at state validation. With the default `3600`, the same request gets past
state validation and reaches the token exchange -- so the failure is the TTL, not
the callback.

## Change

Treat a non-positive value the way a non-numeric one is already treated: warn,
naming the key and the value, and fall back to the 3600 second default. A positive
value, however short, is still honoured.

## Tests

- `test_getStateTtl_fallsBackWhenTheConfiguredValueIsNotPositive` -- `0` and `-1`
  both fall back and warn naming the key and the value
- `test_getStateTtl_keepsAPositiveValue` -- the guard does not round a deliberately
  short expiry up to the default

Both fail when the guard is removed.
