### PR TITLE
fix(sso): ignore an Entra ID permission field that is not a string

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -1078,6 +1078,40 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Field names from {@code entraid.permission.fields} that Microsoft Graph does not answer with
+     * a string. Reported once each, because the alternative is one warning per group per login.
+     */
+    protected final Set<String> unusablePermissionFields = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Reads one of the fields named by {@code entraid.permission.fields} out of a Microsoft Graph
+     * object as a permission value.
+     *
+     * <p>Only a string can be one: a permission is matched against the {@code role} field of a
+     * document, which holds strings. Graph answers with the type the directory schema gives the
+     * field, so naming {@code securityEnabled} or {@code groupTypes} yields a boolean or an array.
+     * Casting those threw {@link ClassCastException} out of the middle of the membership loop,
+     * where the surrounding {@code catch} turned one mistyped field name into "no groups at all"
+     * for every user in the tenant. Skipping the value keeps the rest of the memberships, and the
+     * warning says which field is at fault.
+     *
+     * @param source The Graph object to read from.
+     * @param name The configured field name.
+     * @return The value, or null when the field is absent or is not a string.
+     */
+    protected String getPermissionFieldValue(final Map<String, Object> source, final String name) {
+        final Object value = source.get(name);
+        if (value == null || value instanceof String) {
+            return (String) value;
+        }
+        if (unusablePermissionFields.add(name)) {
+            logger.warn("entraid.permission.fields names {}, which Microsoft Graph answers with {} rather than a string. "
+                    + "It cannot be a permission value and is ignored.", name, value.getClass().getSimpleName());
+        }
+        return null;
+    }
+
+    /**
      * Adds a group or role name to the specified list.
      * @param list The list to add the group or role name to.
      * @param value The group or role name value.
@@ -1166,7 +1200,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                         logger.warn("id is empty: {}", memberOf);
                     }
                     for (final String name : names) {
-                        final String value = (String) memberOf.get(name);
+                        final String value = getPermissionFieldValue(memberOf, name);
                         if (StringUtil.isNotBlank(value)) {
                             if (logger.isDebugEnabled()) {
                                 logger.debug("{} is a member of {}", name, value);
@@ -1622,7 +1656,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
                 final String[] names = fessConfig.getEntraIdPermissionFields();
                 final int initialSize = groupList.size();
                 for (final String name : names) {
-                    final String value = (String) contentMap.get(name);
+                    final String value = getPermissionFieldValue(contentMap, name);
                     if (StringUtil.isNotBlank(value)) {
                         groupList.add(value);
                         if (logger.isDebugEnabled()) {

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -1122,6 +1123,56 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
                 logs.detach();
                 fessConfig.setSystemProperty("entraid.state.ttl", "");
             }
+        }
+    }
+
+    @Test
+    public void test_getPermissionFieldValue_ignoresAFieldThatIsNotAString() {
+        // entraid.permission.fields is a list of Graph field names, and the documentation does not
+        // say the field has to hold a string. securityEnabled and groupTypes are the two most
+        // plausible wrong answers -- they are on every group object -- and both used to throw
+        // ClassCastException out of the middle of processDirectMemberOf, where the catch turned a
+        // single mistyped field name into "no group permissions at all" for the whole tenant.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Map<String, Object> group = new HashMap<>();
+        group.put("displayName", "Engineering");
+        group.put("securityEnabled", Boolean.TRUE);
+        group.put("groupTypes", Arrays.asList("Unified"));
+
+        final LogCapturingAppender logs = LogCapturingAppender.attach(EntraIdAuthenticator.class);
+        try {
+            assertEquals("Engineering", authenticator.getPermissionFieldValue(group, "displayName"));
+            assertNull(authenticator.getPermissionFieldValue(group, "securityEnabled"));
+            assertNull(authenticator.getPermissionFieldValue(group, "groupTypes"));
+            // Absent is not a misconfiguration worth a warning: a group without a mail address is
+            // the normal case for a security group.
+            assertNull(authenticator.getPermissionFieldValue(group, "mail"));
+
+            assertEquals(logs.warnings().toString(), 2L,
+                    logs.warnings().stream().filter(m -> m.contains("entraid.permission.fields")).count());
+            assertTrue(logs.warnings().toString(), logs.warnings().stream().anyMatch(m -> m.contains("securityEnabled")));
+            assertTrue(logs.warnings().toString(), logs.warnings().stream().anyMatch(m -> m.contains("groupTypes")));
+        } finally {
+            logs.detach();
+        }
+    }
+
+    @Test
+    public void test_getPermissionFieldValue_warnsOncePerFieldName() {
+        // The read runs once per group per login, so warning every time would bury the rest of the
+        // log under a message that says the same thing.
+        final EntraIdAuthenticator authenticator = new EntraIdAuthenticator();
+        final Map<String, Object> group = new HashMap<>();
+        group.put("securityEnabled", Boolean.TRUE);
+
+        final LogCapturingAppender logs = LogCapturingAppender.attach(EntraIdAuthenticator.class);
+        try {
+            for (int i = 0; i < 5; i++) {
+                assertNull(authenticator.getPermissionFieldValue(group, "securityEnabled"));
+            }
+            assertEquals(logs.warnings().toString(), 1L, logs.warnings().stream().filter(m -> m.contains("securityEnabled")).count());
+        } finally {
+            logs.detach();
         }
     }
 


### PR DESCRIPTION
> Stacked on #3295. Review only the last commit; the base branch carries the first change.

## Problem

`entraid.permission.fields` names Microsoft Graph fields whose values become
permission values, and the value was read with a plain cast to `String`. Graph
answers with whatever type the directory schema gives the field, so a name such as
`securityEnabled` or `groupTypes` -- both present on every group object -- comes
back as a boolean or an array and the cast throws `ClassCastException`.

The throw lands in the `catch` around the whole membership loop in
`processDirectMemberOf`, which abandons the read and returns false. The user keeps
only what was collected before the first group was reached, the resolution is
reported as failed, and the search screen tells them their group and role
permissions could not be fully loaded.

One mistyped field name in `system.properties` therefore removes group permissions
from every user in the tenant, and the log shows only a `ClassCastException` with no
mention of the setting that caused it. The same cast in `processGroup` escapes its
narrower `catch (IOException | CurlException)` and surfaces as a cache-loader
failure instead.

## Verified against a live tenant

With `entraid.permission.fields=mail,securityEnabled`, a user who normally matches
six permission-scoped documents matched two, the search screen showed the
"could not be fully loaded" message, and the log held three `ClassCastException`s
plus `Failed to access groups/roles in Entra ID.`

With `entraid.permission.fields=mail,noSuchField` the same user matched all six and
saw no message -- a field name that does not exist was already harmless, so the
failure is specific to a field whose value is not a string.

## Change

Read the field through a helper that returns the value only when it is a string, and
warns once per field name naming the field and the type Graph actually returned. An
absent field stays silent: a security group without a mail address is the normal
case, not a misconfiguration.

## Tests

- `test_getPermissionFieldValue_ignoresAFieldThatIsNotAString`
- `test_getPermissionFieldValue_warnsOncePerFieldName`

Both fail when the raw cast is restored.
