### PR TITLE
fix(sso): key the Entra ID parent group cache by the permission fields it used

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticator.java
@@ -301,8 +301,9 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
     protected long groupCacheExpiry = 10 * 60L;
 
     /**
-     * Maximum number of groups kept in {@link #groupCache}. The cache is keyed by group id, so a
-     * tenant with many groups would otherwise grow it without bound until every entry expired.
+     * Maximum number of groups kept in {@link #groupCache}. The cache is keyed by group id and the
+     * configured permission fields, so a tenant with many groups would otherwise grow it without
+     * bound until every entry expired.
      */
     protected int maxGroupCacheSize = 10000;
 
@@ -1356,7 +1357,8 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             return new Pair<>(StringUtil.EMPTY_STRINGS, StringUtil.EMPTY_STRINGS);
         }
         // Check if cached
-        final Pair<String[], String[]> cachedResult = groupCache.getIfPresent(id);
+        final String cacheKey = buildGroupCacheKey(id);
+        final Pair<String[], String[]> cachedResult = groupCache.getIfPresent(cacheKey);
         if (cachedResult != null) {
             if (logger.isDebugEnabled()) {
                 logger.debug("[getParentGroup] Cache HIT for id: {}, groups: {}, roles: {}", id, cachedResult.getFirst().length,
@@ -1383,7 +1385,7 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             return new Pair<>(StringUtil.EMPTY_STRINGS, StringUtil.EMPTY_STRINGS);
         }
         try {
-            return groupCache.get(id, () -> loadParentGroup(user, id, depth, failed));
+            return groupCache.get(cacheKey, () -> loadParentGroup(user, id, depth, failed));
         } catch (final ExecutionException | UncheckedExecutionException e) {
             failed.set(true);
             // A loader that throws leaves nothing in the cache, which is the point: a throttled or
@@ -1399,6 +1401,29 @@ public class EntraIdAuthenticator implements SsoAuthenticator {
             }
             return new Pair<>(StringUtil.EMPTY_STRINGS, StringUtil.EMPTY_STRINGS);
         }
+    }
+
+    /**
+     * The key {@link #groupCache} stores a parent group lookup under.
+     *
+     * <p>What is cached is not the raw Graph answer: {@link #processGroup} has already turned it
+     * into the permission values that {@code entraid.permission.fields} selects. Keying it by
+     * group id alone meant a change to that setting was ignored for the rest of the cache TTL, and
+     * only for nested groups -- direct memberships are read from Graph on every login, so they
+     * picked the new setting up immediately. A user was then granted permissions derived from the
+     * new setting for the groups they belong to directly and from the old one for the groups above
+     * them.
+     *
+     * <p>Narrowing the setting is the case that matters. The documentation warns that
+     * {@code displayName} is neither domain-qualified nor unique and can match documents it should
+     * not; removing it once that has happened left every nested group granting it for up to ten
+     * more minutes.
+     *
+     * @param id The group id.
+     * @return The cache key.
+     */
+    protected String buildGroupCacheKey(final String id) {
+        return id + '\n' + String.join(",", ComponentUtil.getFessConfig().getEntraIdPermissionFields());
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/entraid/EntraIdAuthenticatorTest.java
@@ -906,6 +906,36 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getParentGroup_doesNotServeAnEntryBuiltFromAnotherPermissionFieldSetting() {
+        // The cached pair holds the permission values entraid.permission.fields selected, not the
+        // raw Graph answer. Keyed by group id alone, a change to the setting was ignored for
+        // nested groups until the entry expired -- while direct memberships, which are read from
+        // Graph on every login, picked it up at once. Narrowing the setting is the case that
+        // matters: displayName is neither domain-qualified nor unique, and removing it once it has
+        // matched the wrong documents must not keep granting it for another ten minutes.
+        final ScriptedAuthenticator authenticator = newScriptedAuthenticator();
+        authenticator.parents.put("group-a", new String[] { "group-b" });
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        try {
+            fessConfig.setSystemProperty("entraid.permission.fields", "mail");
+            authenticator.getParentGroup(null, "group-a", 0);
+            assertEquals(1, authenticator.lookups.stream().filter("group-a"::equals).count());
+
+            fessConfig.setSystemProperty("entraid.permission.fields", "mail,displayName");
+            authenticator.getParentGroup(null, "group-a", 0);
+
+            // Read again rather than served from the entry the old setting produced.
+            assertEquals(2, authenticator.lookups.stream().filter("group-a"::equals).count());
+            // The entry the first setting produced is still addressable under its own key, so the
+            // two settings do not evict each other.
+            fessConfig.setSystemProperty("entraid.permission.fields", "mail");
+            assertNotNull(authenticator.groupCache.getIfPresent(authenticator.buildGroupCacheKey("group-a")));
+        } finally {
+            fessConfig.setSystemProperty("entraid.permission.fields", "");
+        }
+    }
+
+    @Test
     public void test_getParentGroup_doesNotCacheAFailedLookup() {
         // A throttled or briefly unreachable Graph used to leave an empty result in the cache,
         // so the user silently lost their parent-group permissions for the whole cache TTL.
@@ -914,7 +944,7 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
         final Pair<String[], String[]> failed = authenticator.getParentGroup(null, "group-a", 0);
         assertEquals(0, failed.getFirst().length);
-        assertNull(authenticator.groupCache.getIfPresent("group-a"));
+        assertNull(authenticator.groupCache.getIfPresent(authenticator.buildGroupCacheKey("group-a")));
 
         authenticator.failing.remove("group-a");
         authenticator.parents.put("group-a", new String[] { "group-b" });
@@ -933,7 +963,7 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
         final Pair<String[], String[]> result = authenticator.getParentGroup(null, "group-a", 0);
 
         assertEquals(0, result.getFirst().length);
-        assertNotNull(authenticator.groupCache.getIfPresent("group-a"));
+        assertNotNull(authenticator.groupCache.getIfPresent(authenticator.buildGroupCacheKey("group-a")));
     }
 
     @Test
@@ -971,7 +1001,7 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
         assertEquals(0, result.getFirst().length);
         assertEquals(0, result.getSecond().length);
-        assertNull(authenticator.groupCache.getIfPresent("group-a"));
+        assertNull(authenticator.groupCache.getIfPresent(authenticator.buildGroupCacheKey("group-a")));
     }
 
     @Test
@@ -1054,7 +1084,7 @@ public class EntraIdAuthenticatorTest extends UnitFessTestCase {
 
         assertEquals(0, throttled.getFirst().length);
         assertTrue(authenticator.lookups.isEmpty());
-        assertNull(authenticator.groupCache.getIfPresent("group-a"), "a skipped walk must not be cached");
+        assertNull(authenticator.groupCache.getIfPresent(authenticator.buildGroupCacheKey("group-a")), "a skipped walk must not be cached");
 
         clock.addAndGet(60_000L);
         final Pair<String[], String[]> recovered = authenticator.getParentGroup(null, "group-a", 0);


### PR DESCRIPTION
> Stacked on #3296 (which is stacked on #3295). Review only the last commit.

## Problem

`groupCache` does not hold Microsoft Graph's answer. `processGroup` has already
turned it into the permission values that `entraid.permission.fields` selects, so an
entry is only valid for the setting in force when it was written.

It was keyed by group id alone. For the rest of the ten minute TTL a change to that
setting was therefore ignored for nested groups, while direct memberships -- read
from Graph on every login -- picked it up at once. The user ended up holding
permissions derived from the new setting for the groups they belong to directly and
from the old one for every group above them.

Narrowing the setting is the case that matters. The documentation warns that
`displayName` is neither domain-qualified nor unique and can match documents it was
never meant to; removing it once that has happened left every nested group still
granting it for up to another ten minutes.

## Verified against a live tenant

A user logged in with `entraid.permission.fields=mail,displayName`, which resolved a
nested parent group to both its object id and its display name. The setting was then
narrowed to `mail` and the user logged in again: the direct memberships correctly
carried only ids and mail addresses, while `Cache HIT ... groups: 2` served the
parent group's display name from the entry the previous setting had written. It
disappeared only after the cache was emptied.

## Change

Key the cache by the group id and the configured fields together. Entries written
under different settings no longer serve each other, and neither evicts the other.

## Tests

- `test_getParentGroup_doesNotServeAnEntryBuiltFromAnotherPermissionFieldSetting`

Fails when the key is reduced back to the group id. The existing cache tests were
updated to address entries through the same key helper.
