### PR TITLE
fix(sso): name a permission from the provider's own name, not a slice of it

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
@@ -176,16 +176,16 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                 if (logger.isDebugEnabled()) {
                     logger.debug("homeAccountId={}, username={}", homeAccountId, username);
                 }
-                permissionSet.add(systemHelper.getSearchRoleByUser(homeAccountId));
-                permissionSet.add(systemHelper.getSearchRoleByUser(username));
+                permissionSet.add(systemHelper.getSearchRoleByDirectoryUser(homeAccountId));
+                permissionSet.add(systemHelper.getSearchRoleByDirectoryUser(username));
                 if (ComponentUtil.getFessConfig().isEntraIdUseDomainServices() && username.indexOf('@') >= 0) {
                     final String[] values = username.split("@");
                     if (values.length > 1) {
-                        permissionSet.add(systemHelper.getSearchRoleByUser(values[0]));
+                        permissionSet.add(systemHelper.getSearchRoleByDirectoryUser(values[0]));
                     }
                 }
-                stream(groups).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByGroup(s))));
-                stream(roles).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByRole(s))));
+                stream(groups).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByDirectoryGroup(s))));
+                stream(roles).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByDirectoryRole(s))));
                 permissions = permissionSet.stream().filter(StringUtil::isNotBlank).distinct().toArray(n -> new String[n]);
             }
             return permissions;

--- a/src/main/java/org/codelibs/fess/app/web/base/login/OpenIdConnectCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/OpenIdConnectCredential.java
@@ -173,9 +173,9 @@ public class OpenIdConnectCredential implements LoginCredential, FessCredential 
             if (permissions == null) {
                 final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
                 final Set<String> permissionSet = new HashSet<>();
-                permissionSet.add(systemHelper.getSearchRoleByUser(name));
-                stream(groups).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByGroup(s))));
-                stream(roles).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByRole(s))));
+                permissionSet.add(systemHelper.getSearchRoleByDirectoryUser(name));
+                stream(groups).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByDirectoryGroup(s))));
+                stream(roles).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByDirectoryRole(s))));
                 permissions = permissionSet.toArray(new String[permissionSet.size()]);
             }
             return permissions;

--- a/src/main/java/org/codelibs/fess/app/web/base/login/SamlCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/SamlCredential.java
@@ -221,9 +221,9 @@ public class SamlCredential implements LoginCredential, FessCredential {
             if (permissions == null) {
                 final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
                 final Set<String> permissionSet = new HashSet<>();
-                permissionSet.add(systemHelper.getSearchRoleByUser(nameId));
-                stream(groups).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByGroup(s))));
-                stream(roles).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByRole(s))));
+                permissionSet.add(systemHelper.getSearchRoleByDirectoryUser(nameId));
+                stream(groups).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByDirectoryGroup(s))));
+                stream(roles).of(stream -> stream.forEach(s -> permissionSet.add(systemHelper.getSearchRoleByDirectoryRole(s))));
                 permissions = permissionSet.toArray(new String[permissionSet.size()]);
             }
             return permissions;

--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -844,6 +844,16 @@ public class SystemHelper {
     }
 
     /**
+     * Gets the search role for a user named by an identity provider.
+     *
+     * @param name The user name, exactly as the provider asserted it.
+     * @return The search role.
+     */
+    public String getSearchRoleByDirectoryUser(final String name) {
+        return buildSearchRole(ComponentUtil.getFessConfig().getRoleSearchUserPrefix(), name);
+    }
+
+    /**
      * Gets the search role for a group named by a directory entry's own DN.
      *
      * @param name The group name, exactly as the entry carries it.

--- a/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
@@ -124,6 +124,44 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getPermissions_doesNotCollapseAGroupNameOnABackslash() {
+        // getCanonicalLdapName drops everything up to the first backslash, because a name a user
+        // types at login may be NetBIOS-qualified as DOMAIN\name. An identity provider's group
+        // name is not, so running it through that truncation let one group's name produce another
+        // group's permission: with entraid.permission.fields=displayName, a tenant user who can
+        // create a security group -- the Entra ID default -- names it "x\finance" and receives
+        // the permission of the unrelated group "finance", and with it every document that group
+        // can read. Verified end to end against a live tenant before this fix.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdUser user = newUser();
+        user.setGroups(new String[] { "x\\finance" });
+        user.setRoles(new String[] { "y\\admin" });
+
+        final List<String> permissions = Arrays.asList(user.getPermissions());
+
+        assertTrue(permissions.toString(), permissions.contains("2x\\finance"));
+        assertFalse(permissions.toString(), permissions.contains("2finance"));
+        assertTrue(permissions.toString(), permissions.contains("Ry\\admin"));
+        assertFalse(permissions.toString(), permissions.contains("Radmin"));
+    }
+
+    @Test
+    public void test_getPermissions_doesNotCollapseAUserNameOnABackslash() {
+        // The same truncation applied to the name the provider asserted for the user itself.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdUser user = newUser();
+        user.setGroups(new String[0]);
+        user.setRoles(new String[0]);
+
+        final List<String> permissions = Arrays.asList(user.getPermissions());
+
+        // The account username is taro@contoso.onmicrosoft.com, so nothing is truncated here; the
+        // assertion that matters is that the value arrives whole and prefixed.
+        assertTrue(permissions.toString(), permissions.contains("1taro@contoso.onmicrosoft.com"));
+        assertTrue(permissions.toString(), permissions.contains("1home-account-id"));
+    }
+
+    @Test
     public void test_getPermissions_doesNotPinAStaleValueWhenTheAsyncLookupLands() throws Exception {
         // The membership resolution scheduled at login runs on a TimeoutManager thread while the
         // user is already logged in and searching. getPermissions() is a check-then-act -- read
@@ -135,7 +173,7 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
         final CountDownLatch asyncTaskIsDone = new CountDownLatch(1);
         ComponentUtil.register(new SystemHelper() {
             @Override
-            public String getSearchRoleByGroup(final String name) {
+            public String getSearchRoleByDirectoryGroup(final String name) {
                 if ("direct-group".equals(name)) {
                     // The reader has read `groups` and is now mid-computation.
                     readerIsInside.countDown();
@@ -145,7 +183,7 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
                         Thread.currentThread().interrupt();
                     }
                 }
-                return super.getSearchRoleByGroup(name);
+                return super.getSearchRoleByDirectoryGroup(name);
             }
         }, "systemHelper");
 


### PR DESCRIPTION
Same defect class as #3292, in the paths that commit did not reach. **Verified end to end against a live Entra ID tenant.**

## The bug

The SSO credentials build permissions with `getSearchRoleByUser` / `getSearchRoleByGroup` / `getSearchRoleByRole`, which run the name through `getCanonicalLdapName`. With the shipped `ldap.ignore.netbios.name=true` that drops everything up to the first backslash:

```java
final String[] values = name.split("\\\\");
...
return String.join("\\", Arrays.copyOfRange(values, 1, values.length));
```

The truncation is for a name a **user types at login** (`DOMAIN\name`). A name an **identity provider asserts** is not qualified that way, so a backslash inside it rewrites the permission to whatever follows it. `SystemHelper`'s own javadoc says exactly this — it is why `buildSearchRole` was split out in #3292.

## Exploit

Preconditions: `entraid.permission.fields` includes `displayName` — the setting `config/sso-entraid.rst` tells operators to add, because security groups carry no `mail`.

1. Attacker is an ordinary tenant user. Entra ID lets users create security groups by default, and the creator is a member.
2. They create a group named `x\finance`. **Microsoft Graph accepts a backslash in `displayName`** (confirmed).
3. Fess computes `2` + `canonical("x\finance")` = **`2finance`** — byte-identical to the permission members of the unrelated group `finance` hold.
4. `role` is a `keyword` field matched with a term query, so it is an exact collision. The attacker reads every document ACL'd to `finance`.

No privilege beyond an ordinary account is required.

### Live result, before the fix

A user belonging **only** to `x\finance`, and to no group named `finance`:

```
groups      : ['3a1daae0-...', 'zzz\finance']
permissions : [... , '2finance' , ...]
record_count = 1 -> ['doc-finance']      # a document ACL'd 2finance
```

The tenant objects were deleted after the test.

## The fix

Build the permission through the directory variants, which skip the canonicalisation, and add `getSearchRoleByDirectoryUser` for the name the provider asserts for the user. **Entra ID, OpenID Connect and SAML** all carry the defect and all three are changed.

## Two consequences worth stating

- A name configured in `entraid.default.groups` / `entraid.default.roles` is no longer truncated either, because it reaches the same list. An operator who wrote `DOMAIN\name` there must now write the name they actually want.
- `PermissionHelper.encode` still canonicalises, because it converts an ACL string an administrator wrote for a file crawl, where `DOMAIN\` really is a NetBIOS prefix. So a document ACL'd `{group}x\finance` still encodes to `2finance` and no longer matches a group genuinely named that.

Both only affect names containing a backslash.

## Tests

- `test_getPermissions_doesNotCollapseAGroupNameOnABackslash` — a group `x\finance` yields `2x\finance` and **not** `2finance`; a role `y\admin` yields `Ry\admin` and **not** `Radmin`
- `test_getPermissions_doesNotCollapseAUserNameOnABackslash`

Reverting only the group line reproduces the live observation exactly.

Seven affected suites, 319 tests, all green. Javadoc clean. One existing test intercepted the group method to drive a race; it now intercepts the directory variant.
