### PR TITLE
fix(sso): refuse a SAML LogoutRequest whose NameID names nobody

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -1280,9 +1280,16 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * outgoing message rather than parse anything.</p>
      *
      * <p>Anything that is not a clear mismatch keeps the previous behaviour of ending the session:
-     * no user logged in, a user who did not come from SAML, a NameID that cannot be read. Failing
-     * the other way would let an unreadable NameID keep sessions alive, which is the failure mode
-     * this method exists to avoid making worse.</p>
+     * no user logged in, a user who did not come from SAML, a message whose NameID cannot be read
+     * at all. Those are properties of this deployment or of a message java-saml is about to reject
+     * anyway, not values a sender chooses.</p>
+     *
+     * <p>A NameID that is read but empty is not one of them. It is the sender's own input, so
+     * treating it as "cannot tell" would hand back exactly the bypass this method exists to close:
+     * java-saml requires the {@code <saml:NameID>} element to be present but does not require it to
+     * carry anything, so {@code <saml:NameID/>} parses, names nobody, and would end any session it
+     * reached. It is therefore compared like any other value and, naming nobody, never matches. No
+     * IdP is lost by this: one that ends a session says whose.</p>
      *
      * @param request The HTTP request carrying the SAML logout message.
      * @param settings The SAML settings, used to parse the LogoutRequest the way java-saml
@@ -1298,7 +1305,8 @@ public class SamlAuthenticator implements SsoAuthenticator {
             return false;
         }
         final String logoutRequestNameId = getLogoutRequestNameId(request, settings);
-        if (StringUtil.isBlank(logoutRequestNameId)) {
+        if (logoutRequestNameId == null) {
+            // the message could not be read at all; java-saml is about to fail on the same bytes
             return false;
         }
         if (isSameNameId(sessionNameId, logoutRequestNameId)) {
@@ -1427,7 +1435,8 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * fails whatever the case, and one who does gains nothing from being allowed to change it.</p>
      *
      * @param sessionNameId The NameID this session was logged in with, not blank.
-     * @param logoutRequestNameId The NameID carried by the LogoutRequest, not blank.
+     * @param logoutRequestNameId The NameID carried by the LogoutRequest, never null but possibly
+     *            blank, which the session NameID cannot be and so never matches.
      * @return true if both name the same user.
      */
     protected boolean isSameNameId(final String sessionNameId, final String logoutRequestNameId) {

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -1547,6 +1547,58 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getLogoutResponse_keepsTheSessionWhenTheLogoutRequestNamesNobody() throws Exception {
+        // java-saml insists on the <saml:NameID> element being there but never on it carrying
+        // anything, so an empty one parses and names nobody. Treating that as "cannot tell" would
+        // hand back the whole bypass: the sender picks the value, and an empty element costs it
+        // nothing, so every session would be one crafted URL away from ending again.
+        for (final String nameId : new String[] { "", "   ", "\n" }) {
+            final SamlAuthenticator authenticator = createAuthenticatorLoggedInAs(samlUserBean("victim@example.com"));
+            final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+            try {
+                setUpSlo(systemProperties);
+                final MockletHttpServletRequest request = getMockRequest();
+                request.getSession().setAttribute(SESSION_MARKER, "kept");
+                sendLogoutRequest(request, "_empty" + nameId.length(), nameId);
+                authenticator.getSettings();
+
+                final ActionResponse response = authenticator.getResponse(SsoResponseType.LOGOUT);
+
+                assertEquals("a LogoutRequest that names nobody must not end a session", "kept",
+                        request.getSession(false).getAttribute(SESSION_MARKER));
+                // the IdP still gets an ordinary LogoutResponse: an error would tell an
+                // unauthenticated sender whether it guessed a live session
+                assertTrue(String.valueOf(response), String.valueOf(response).contains("https://idp.example.com/slo?SAMLResponse="));
+            } finally {
+                tearDownSlo(systemProperties);
+            }
+        }
+    }
+
+    @Test
+    public void test_getLogoutRequestNameId_tellsAnEmptyNameIdApartFromAnUnreadableOne() throws Exception {
+        // isLogoutRequestForAnotherUser branches on null, not on blank, so the two have to stay
+        // distinguishable here: null means java-saml is about to fail on the same bytes, while ""
+        // means the message parsed and simply named nobody.
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpSlo(systemProperties);
+            final Saml2Settings settings = authenticator.getSettings();
+
+            final MockletHttpServletRequest empty = getMockRequest();
+            sendLogoutRequest(empty, "_emptyname", "");
+            assertEquals("", authenticator.getLogoutRequestNameId(empty, settings));
+
+            final MockletHttpServletRequest notXml = getMockRequest();
+            notXml.setParameter("SAMLRequest", "................");
+            assertNull(authenticator.getLogoutRequestNameId(notXml, settings));
+        } finally {
+            tearDownSlo(systemProperties);
+        }
+    }
+
+    @Test
     public void test_isLogoutRequestForAnotherUser_leavesALogoutResponseAlone() throws Exception {
         final SamlAuthenticator authenticator = createAuthenticatorLoggedInAs(samlUserBean("victim@example.com"));
         final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
@@ -1615,6 +1667,10 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
         // deployment; a sender that does not know the NameID fails whatever case it picks
         assertTrue(authenticator.isSameNameId("Victim@Example.com", "victim@example.com"));
         assertFalse(authenticator.isSameNameId("victim@example.com", "attacker@example.com"));
+        // a NameID that names nobody is not the session user either, whatever it is padded with
+        assertFalse(authenticator.isSameNameId("victim@example.com", ""));
+        assertFalse(authenticator.isSameNameId("victim@example.com", "   "));
+        assertFalse(authenticator.isSameNameId("victim@example.com", "\n"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #3262 (merged) — this closes a hole in the check it added. Rebased onto master.

## The problem

`isLogoutRequestForAnotherUser` treats a blank NameID as "cannot tell" and falls through to
the previous behaviour of ending the session:

```java
final String logoutRequestNameId = getLogoutRequestNameId(request, settings);
if (StringUtil.isBlank(logoutRequestNameId)) {
    return false;
}
```

That branch does not belong with the others it sits with. Nobody logged in, a session that
did not come from SAML, a message that cannot be parsed at all — those are properties of the
deployment, or of bytes java-saml is about to reject a moment later. **The NameID of the
incoming LogoutRequest is the sender's own input.**

java-saml requires the `<saml:NameID>` element to be present — `LogoutRequest.java:694-696`
throws `NO_NAMEID` when it is absent — but it never requires the element to carry anything.
`getTextContent()` of an empty element is `""`, stored as the Value with no further check
(`LogoutRequest.java:701-705`). So `<saml:NameID/>` parses, names nobody, and reached the
fall-through.

An unsigned LogoutRequest with an empty NameID therefore ended any SAML session whose cookie
the browser attached — which is the entire exposure #3262 exists to close, at no cost to the
sender. No signature, no `Issuer`, no knowledge of the deployment.

## Verified against a live IdP

Before this change, every one of these ended the victim's session:

| LogoutRequest NameID | before | after |
|---|---|---|
| `<saml:NameID/>` | **session ended** | kept |
| `<saml:NameID></saml:NameID>` | **session ended** | kept |
| whitespace only | **session ended** | kept |
| newline only | **session ended** | kept |
| no `Format` attribute, empty | **session ended** | kept |
| another real user | kept | kept |
| unknown user | kept | kept |

And single logout still works, so this is not bought with a false mismatch:

| legitimate single logout | result |
|---|---|
| exact NameID | ends the session |
| NameID in a different case | ends the session |
| NameID with surrounding whitespace | ends the session |
| SP-initiated, via `/logout/` | ends the session |

## The change

Branch on `null` rather than on blank. `null` still means the message could not be read,
which keeps today's behaviour — java-saml is about to fail on the same bytes. A NameID that
*was* read is compared like any other value and, naming nobody, never matches the session
user.

`getLogoutRequestNameId` already distinguishes the two: it returns `null` only when the
message could not be parsed, and the parsed value otherwise. The two new assertions in
`test_getLogoutRequestNameId_tellsAnEmptyNameIdApartFromAnUnreadableOne` pin that, since the
guard now depends on it.

No legitimate single logout is lost by this: an IdP that ends a session says whose.

## Verification

- `mvn -o clean test -Dtest=SamlAuthenticatorTest` → `Tests run: 68, Failures: 0, Errors: 0`
- `mvn -o test -Dtest='*Saml*,*Sso*'` → `Tests run: 191, Failures: 0, Errors: 0`
- `mvn -o formatter:format license:format` → no further changes
- Restoring the `StringUtil.isBlank` guard fails
  `test_getLogoutResponse_keepsTheSessionWhenTheLogoutRequestNamesNobody`
  (`expected: <kept> but was: <null>`), so the test is not vacuous. Re-checked after the rebase.

## Worth knowing

This narrows the exposure, it does not close it — same as #3262. Still ended by a crafted
request: a session whose NameID the sender already knows (with the default `emailAddress`
format, that may be the victim's email address), and any session that did not come from SAML
and so has no NameID to compare. `saml.security.want_messages_signed=true` remains the real
fix, and is still reported as `unsigned_logoutrequest_accepted` in the insecure-settings
warning.
