### PR TITLE
fix(sso): report a refused SAML logout message without a stack trace

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -1211,8 +1211,14 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 final String redirectUrl = auth.processSLO(false, null, true);
                 final List<String> errors = auth.getErrors();
                 if (!errors.isEmpty()) {
+                    // java-saml refused the message the sender supplied -- a replayed ID, a bad
+                    // signature, a missing NameID, XML that will not parse. The endpoint is
+                    // anonymous and, because SAML requires SameSite=none, reachable cross-site, so
+                    // this is a rejected request rather than a fault: an SsoStateException gets it
+                    // logged without a stack trace, the way getLoginCredential already treats a
+                    // callback it did not start.
                     final String msg = String.join(", ", errors);
-                    throw processFailure("Failed to log out.", msg);
+                    throw processFailure("Failed to log out.", msg, new SsoStateException(msg));
                 }
                 if (StringUtil.isNotBlank(redirectUrl)) {
                     // an IdP-initiated LogoutRequest: send our LogoutResponse back to the IdP

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -1292,6 +1292,34 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getLogoutResponse_rejectsAnUnusableLogoutMessageWithoutAStackTrace() throws Exception {
+        // The message here is one the sender supplied and java-saml refused. /sso/logout is
+        // anonymous and, because SAML requires SameSite=none, reachable cross-site, so an
+        // unauthenticated client can repeat this at will; a stack trace per attempt would let it
+        // fill the log. The cause is what SsoAction branches on to log the message alone.
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            systemProperties.setProperty("saml.idp.single_logout_service.url", "https://idp.example.com/slo");
+            final MockletHttpServletRequest request = getMockRequest();
+            // a LogoutRequest with no NameID: java-saml parses it and then refuses it
+            final String xml = "<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\""
+                    + " xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_nonameid\" Version=\"2.0\""
+                    + " IssueInstant=\"2026-01-01T00:00:00Z\"/>";
+            request.setParameter("SAMLRequest", Base64.getEncoder().encodeToString(xml.getBytes(StandardCharsets.UTF_8)));
+
+            authenticator.getResponse(SsoResponseType.LOGOUT);
+            fail("SsoMessageException should be thrown");
+        } catch (final SsoMessageException e) {
+            assertTrue(String.valueOf(e.getCause()), e.getCause() instanceof SsoStateException);
+        } finally {
+            systemProperties.remove("saml.idp.single_logout_service.url");
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
     public void test_containsSamlLogoutMessage() throws Exception {
         final SamlAuthenticator authenticator = new SamlAuthenticator();
 


### PR DESCRIPTION
Independent of #3262 — this is on `master` today and applies on its own.

## The problem

`/sso/logout` is anonymous and, because SAML requires `tomcat.sameSiteCookies=none`, reachable
cross-site, so an unauthenticated client can send it whatever it likes as often as it likes.

When java-saml refuses the message — a replayed request ID, a signature that does not verify,
a missing NameID, XML that will not parse — `getLogoutResponse` reports it with the two-argument
`processFailure`, whose cause is an `SsoProcessException`. `SsoAction.logout` only recognises
`SsoStateException` as client-caused, so everything else falls to `logger.warn("Failed to log
out.", e)` and gets a full stack trace.

Measured against a running server, sending a LogoutRequest with no NameID and no session cookie:

| | per request |
|---|---|
| request body | ~190 bytes |
| log lines | **90** |
| log bytes | **8646** |
| amplification | **~46x** |

`rate.limit.enabled` is `false` by default, so nothing bounds the repetition.

## The change

The same endpoint already makes this distinction for a visit that carries no SAML message at
all, and `getLoginCredential` makes it for a callback that matches no login this server started
(#3272). A message the sender supplied and the library refused belongs in that category too:
it is a rejected request, not a fault. Give it an `SsoStateException` cause so `SsoAction` logs
the reason alone — which is all an operator can act on anyway, since java-saml has already
logged what it objected to.

After the change, the same 20 requests produce **4.0 lines and 889 bytes each**, and those
lines are java-saml's own message-only WARNs plus one from Fess:

```
WARN  Errors found when validating SAML response with schema: [...]
WARN  Invalid SAML Logout Request. Not match the saml-schema-protocol-2.0.xsd
WARN  processSLO error. invalid_logout_request
```

The generic `catch (Exception e)` below it is deliberately left alone: an exception from there
can be a real server-side fault, and its stack trace is worth having.

## Verification

- `mvn -o clean test -Dtest=SamlAuthenticatorTest` → `Tests run: 57, Failures: 0, Errors: 0`
- `mvn -o test -Dtest='*Saml*,*Sso*'` → `Tests run: 180, Failures: 0, Errors: 0`
- `mvn -o formatter:format license:format` → no further changes
- Reverting only the changed line fails
  `test_getLogoutResponse_rejectsAnUnusableLogoutMessageWithoutAStackTrace`
  (`SsoProcessException: invalid_logout_request ==> expected: <true> but was: <false>`), so the
  test is not vacuous. Note the neighbouring `containsSamlLogoutMessage` branch throws the same
  expression, so a mutation has to target this line specifically.
