### PR TITLE
fix(sso): read the LogoutRequest NameID without parsing the message twice

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -59,7 +59,6 @@ import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
 import org.codelibs.saml2.core.util.Util;
-import org.codelibs.saml2.servlet.ServletUtils;
 import org.dbflute.optional.OptionalEntity;
 import org.dbflute.optional.OptionalThing;
 import org.lastaflute.core.message.UserMessages;
@@ -1406,30 +1405,41 @@ public class SamlAuthenticator implements SsoAuthenticator {
     /**
      * Returns the NameID carried by the incoming LogoutRequest, or null when it cannot be read.
      *
-     * <p>The message is parsed with java-saml rather than by hand. {@code /sso/logout} is
-     * anonymous, so hand-parsing the base64 {@code SAMLRequest} here would put an XML parser --
+     * <p>The message is decoded and parsed with java-saml rather than by hand. {@code /sso/logout}
+     * is anonymous, so hand-parsing the base64 {@code SAMLRequest} here would put an XML parser --
      * and therefore an XXE surface -- in front of an unauthenticated sender, whereas
-     * {@link LogoutRequest} decodes and loads it through the hardened path the library already
-     * uses. The arguments mirror {@code LogoutRequest.isValid()} exactly, including the allowed
-     * key transport algorithms, so an encrypted NameID is read here under the same restrictions it
-     * would be read under a moment later and this adds no decryption the message was not going to
-     * get anyway.</p>
+     * {@code Util.base64decodedInflated} and {@code Util.loadXML} are the hardened path the
+     * library uses on the same bytes a moment later. The arguments mirror
+     * {@code LogoutRequest.isValid()} exactly, including the allowed key transport algorithms, so
+     * an encrypted NameID is read here under the same restrictions it would be read under a moment
+     * later and this adds no decryption the message was not going to get anyway.</p>
+     *
+     * <p>It parses once. Constructing a {@link LogoutRequest} to reach the decoded XML would parse
+     * it a second time, because that constructor loads the document itself and then discards it,
+     * and a parse that fails is not free: java-saml logs the failure with its stack trace, so each
+     * extra parse of a message that will not parse writes another ~90 lines to the log. This
+     * endpoint is anonymous and, because SAML requires {@code SameSite=none}, reachable cross-site
+     * with the victim's cookie attached, which is exactly when this method runs -- so the second
+     * parse fell on the sessions an attacker targets.</p>
      *
      * <p>Nothing here is allowed to abort the logout. A malformed message, an {@code EncryptedID}
      * with no SP private key configured to open it, an unreadable NameID: all of them mean "cannot
      * tell", which {@link #isLogoutRequestForAnotherUser} turns back into the previous behaviour.
-     * Constructing the {@link LogoutRequest} touches no replay cache -- only {@code isValid()}
-     * registers a message ID -- so parsing it twice does not make java-saml reject its own copy as
-     * a replay.</p>
+     * Parsing here touches no replay cache -- only {@code isValid()} registers a message ID -- so
+     * reading the NameID does not make java-saml reject its own copy as a replay.</p>
      *
      * @param request The HTTP request carrying the LogoutRequest.
      * @param settings The SAML settings.
      * @return The NameID of the LogoutRequest, or null when it cannot be read.
      */
     protected String getLogoutRequestNameId(final HttpServletRequest request, final Saml2Settings settings) {
+        final String logoutRequestMessage = request.getParameter("SAMLRequest");
+        if (StringUtil.isBlank(logoutRequestMessage)) {
+            // a LogoutResponse, or no SAML message at all: there is no LogoutRequest to read
+            return null;
+        }
         try {
-            final LogoutRequest logoutRequest = new LogoutRequest(settings, ServletUtils.makeHttpRequest(request));
-            final Document document = Util.loadXML(logoutRequest.getLogoutRequestXml());
+            final Document document = Util.loadXML(Util.base64decodedInflated(logoutRequestMessage));
             if (document == null) {
                 // Util.loadXML answers unparsable XML, and anything holding an ENTITY, with null
                 return null;

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -1685,6 +1685,33 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getLogoutRequestNameId_parsesTheMessageOnce() throws Exception {
+        // A message that does not parse is not free to look at: java-saml answers null and logs
+        // the failure with its stack trace, so every parse of one writes about ninety lines. The
+        // endpoint is anonymous and, because SAML requires SameSite=none, reachable cross-site
+        // with a victim's cookie attached, which is the only case in which this method runs at
+        // all -- so a second parse would land on precisely the sessions an attacker aims at.
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final LogCapturingAppender library = LogCapturingAppender.attach("org.codelibs.saml2.core.util.Util");
+        try {
+            setUpSlo(systemProperties);
+            final Saml2Settings settings = authenticator.getSettings();
+
+            final MockletHttpServletRequest notXml = getMockRequest();
+            notXml.setParameter("SAMLRequest", "................");
+
+            assertNull(authenticator.getLogoutRequestNameId(notXml, settings));
+            // one failed parse, one warning: reaching the XML through a LogoutRequest instead
+            // parses it a second time and doubles this
+            assertEquals(1, library.warnings().size());
+        } finally {
+            library.detach();
+            tearDownSlo(systemProperties);
+        }
+    }
+
+    @Test
     public void test_getSessionSamlNameId_ignoresAUserThatDidNotComeFromSaml() throws Exception {
         // A local or LDAP login carries a user name, not a NameID, and comparing the two would
         // reject every legitimate single logout on a mixed-authentication deployment.


### PR DESCRIPTION
> **Stacked on #3303.** Base is `fix/saml-report-refusal-reason`, so merge that first;
> this branch's own commit is the single-parse change only. The workflows here run on
> `pull_request` to `master` and `*.x` only, so a stacked PR shows no checks until its base
> becomes `master` — verified locally instead: with both branches applied,
> `org.codelibs.fess.sso.**` is 322 tests green against java-saml **3.1.1 and
> 3.1.2-SNAPSHOT** alike.
>
> The earlier green check on this PR was recorded before `fess-parent` moved to
> java-saml `3.1.2-SNAPSHOT`, and would not reproduce on its own: without #3303,
> `test_getLoginCredential_answersTheOlderOfTwoPendingRequestIds` fails with
> `expected: <2> but was: <0>` against that library.

## What

`getLogoutRequestNameId` reached the decoded XML of an incoming LogoutRequest by
constructing a `LogoutRequest`, then loaded the same XML again with `Util.loadXML`.
That is two parses of every logout message. This reads it once.

## Why it matters

A parse that fails is not free. `Util.loadXML` answers `null` and logs the failure
with its stack trace, so a message that will not parse costs about ninety log lines
per parse.

`/sso/logout` is anonymous, and because SAML requires `SameSite=none` it is reachable
cross-site with the victim's session cookie attached. That is also the only situation
in which this check runs at all — it returns early unless the session is a SAML
session — so the second parse landed exactly on the sessions an attacker would aim at.

Measured with an unparsable `SAMLRequest` of about 190 bytes:

| request | log lines | log bytes |
| --- | --- | --- |
| anonymous | 194 | 17.5 KB |
| session logged in through SAML, before | 385 | 34.8 KB |
| session logged in through SAML, after | 287 | 25.9 KB |

The remaining volume is the library parsing the message on its own; this change
removes only the parse we added. For context, the trace has already moved to `debug`
on java-saml's master, which takes the same request to about six lines — that is a
separate release, and this change is independent of it.

## How

- Decode with `Util.base64decodedInflated` and load with `Util.loadXML`, which is the
  same hardened path the library uses on those bytes a moment later, so no XML parser
  of our own is placed in front of an unauthenticated sender.
- A blank `SAMLRequest` now returns `null` directly. That is also more accurate: with
  nothing to parse, the `LogoutRequest` constructor builds a fresh *outgoing* message
  whose NameID is the IdP entity ID rather than anything the incoming message named.

## Behaviour

Unchanged. A LogoutRequest naming another user, or naming nobody, still leaves the
session alone; one naming the holder still ends it. Verified end to end against a real
IdP for all three cases plus the empty-NameID variants, before and after the change.

## Tests

`SamlAuthenticatorTest` 69 tests, `org.codelibs.fess.sso.**` 321 tests, all green.

The new test pins the parse count through the library's own warning rather than
through an internal call count, and is not vacuous: against the previous
implementation it fails with `expected: <1> but was: <2>`.

