### PR TITLE
fix(sso): report why a SAML response was refused

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -222,6 +222,14 @@ public class SamlAuthenticator implements SsoAuthenticator {
     protected static final int MAX_LOGGED_NAME_ID_LENGTH = 64;
 
     /**
+     * Upper bound on the length of a rejection reason embedded in a log message. Longer than a
+     * NameID because the reason is a sentence that quotes what it objected to -- an entity ID, a
+     * destination, an audience -- and truncating it to a NameID's length would cut off the part
+     * that identifies the problem.
+     */
+    protected static final int MAX_LOGGED_FAILURE_REASON_LENGTH = 512;
+
+    /**
      * Characters that must not be copied verbatim into a log message. {@code \p{Cntrl}} alone is
      * ASCII-only, so the Unicode break characters a log viewer still renders as a new line are
      * listed explicitly.
@@ -651,8 +659,17 @@ public class SamlAuthenticator implements SsoAuthenticator {
             return null;
         }
         final String errors = String.join(", ", lastAuth.getErrors());
-        if (lastAuth.isDebugActive() && StringUtil.isNotBlank(lastAuth.getLastErrorReason())) {
-            logger.warn("Authentication Failure: {} - Reason: {}", errors, lastAuth.getLastErrorReason());
+        // The reason is reported whatever saml.debug is set to. getErrors() answers a category --
+        // "invalid_response" for a bad signature, an expired assertion, a foreign audience and a
+        // replay alike -- so on its own it tells an administrator only that the login failed. The
+        // detail used to reach the log anyway because java-saml logged it at warn as well; it now
+        // leaves that to whoever calls it, and getLastErrorReason() carries it either way.
+        final String reason = lastAuth.getLastErrorReason();
+        if (StringUtil.isNotBlank(reason)) {
+            // The reason quotes the message it objected to -- an issuer, a destination, an
+            // audience -- and this endpoint is anonymous, so the quoted part is a sender's own
+            // input and is bounded and stripped of control characters like any other.
+            logger.warn("Authentication Failure: {} - Reason: {}", errors, sanitizeForLog(reason, MAX_LOGGED_FAILURE_REASON_LENGTH));
         } else {
             logger.warn("Authentication Failure: {}", errors);
         }
@@ -1332,7 +1349,19 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * @return A value safe to embed in a log message.
      */
     protected static String sanitizeForLog(final String value) {
-        final String bounded = value.length() > MAX_LOGGED_NAME_ID_LENGTH ? value.substring(0, MAX_LOGGED_NAME_ID_LENGTH) + "..." : value;
+        return sanitizeForLog(value, MAX_LOGGED_NAME_ID_LENGTH);
+    }
+
+    /**
+     * Bounds a value to {@code maxLength} and strips its control characters so that it can be
+     * embedded in a log message.
+     *
+     * @param value The value to embed in a log message.
+     * @param maxLength The number of characters to keep before truncating.
+     * @return A value safe to embed in a log message.
+     */
+    protected static String sanitizeForLog(final String value, final int maxLength) {
+        final String bounded = value.length() > maxLength ? value.substring(0, maxLength) + "..." : value;
         return LOG_UNSAFE_PATTERN.matcher(bounded).replaceAll("?");
     }
 

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -631,6 +631,44 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_getLoginCredential_reportsWhyTheResponseWasRefused() throws Exception {
+        // getErrors() answers a category: "invalid_response" covers a bad signature, an expired
+        // assertion, a foreign audience, a replay and a rewritten destination alike. On its own it
+        // tells an administrator only that the login failed, so the reason has to reach the log
+        // too -- and not only when saml.debug is on, which is off in every shipped configuration.
+        final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        try {
+            setUpIdp(systemProperties);
+            systemProperties.setProperty("saml.security.want_xml_validation", "false");
+            assertNull(systemProperties.getProperty("saml.debug"));
+            final MockletHttpServletRequest request = getMockRequest();
+            authenticator.getLoginCredential();
+            final String requestId = pendingRequestIds(request.getSession(false)).iterator().next();
+
+            final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+            try {
+                postSamlResponse(request, requestId);
+                assertNull(authenticator.getLoginCredential());
+
+                assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
+                final String failure = appender.warnings().get(0);
+                // measured: "... - Reason: The Assertion must include a Conditions element", which
+                // is the part an administrator can act on. The wording belongs to java-saml, so the
+                // assertion is that a reason follows the category rather than what it says.
+                final String prefix = "Authentication Failure: invalid_response - Reason: ";
+                assertTrue(failure, failure.startsWith(prefix));
+                assertTrue(failure, failure.length() > prefix.length());
+            } finally {
+                appender.detach();
+            }
+        } finally {
+            systemProperties.remove("saml.security.want_xml_validation");
+            tearDownIdp(systemProperties);
+        }
+    }
+
+    @Test
     public void test_getLoginCredential_answersTheOlderOfTwoPendingRequestIds() throws Exception {
         final SamlAuthenticator authenticator = createAuthenticatorWithControlledClock();
         final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
@@ -648,28 +686,27 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertEquals(2, pending.size(), String.valueOf(pending));
 
             final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
-            // java-saml reports each rejected candidate itself, which is how a test can see that
-            // the response was tried against more than the newest pending ID
-            final LogCapturingAppender samlAppender = LogCapturingAppender.attach("org.codelibs.saml2.core.authn.SamlResponse");
             try {
                 // the first tab's assertion comes back while the second tab's AuthnRequest is the
                 // most recent one, which is the case that used to fail both logins
                 postSamlResponse(request, olderRequestId);
                 assertNull(authenticator.getLoginCredential());
 
-                final List<String> samlWarnings = samlAppender.warnings();
-                assertEquals(2, samlWarnings.size(), String.valueOf(samlWarnings));
-                // the newest ID is tried first and rejected on InResponseTo alone
-                assertTrue(samlWarnings.get(0), samlWarnings.get(0).contains("does not match the ID of the AuthNRequest"));
-                assertTrue(samlWarnings.get(0), samlWarnings.get(0).contains(olderRequestId));
-                // the older ID then matched, so the response was rejected on its own merits, which
-                // is as far as an unsigned response can get
-                assertFalse(samlWarnings.get(1), samlWarnings.get(1).contains("does not match the ID of the AuthNRequest"));
                 assertEquals(1, appender.warnings().size(), String.valueOf(appender.warnings()));
-                assertFalse(appender.warnings().get(0), appender.warnings().get(0).contains("no matching AuthnRequest ID"));
-                assertTrue(appender.warnings().get(0), appender.warnings().get(0).startsWith("Authentication Failure:"));
+                final String failure = appender.warnings().get(0);
+                // reaching the failure line at all means the loop went past the newest pending ID:
+                // a response matching none of them is reported by logUnmatchedSamlResponse instead
+                assertTrue(failure, failure.startsWith("Authentication Failure:"));
+                assertFalse(failure, failure.contains("no matching AuthnRequest ID"));
+                // and the reason reported is the older candidate's own rejection rather than the
+                // InResponseTo mismatch the newest candidate was ruled out on, which is what shows
+                // the response was tried against more than one. Read from our own log line rather
+                // than java-saml's, so that the test does not depend on the level that library
+                // reports a ruled-out candidate at.
+                assertTrue(failure, failure.contains("- Reason:"));
+                assertFalse(failure, failure.contains("does not match the ID of the AuthNRequest"));
+                assertFalse(failure, failure.contains(olderRequestId));
             } finally {
-                samlAppender.detach();
                 appender.detach();
             }
         } finally {
@@ -1687,6 +1724,14 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
         assertEquals("x".repeat(max) + "...", SamlAuthenticator.sanitizeForLog("x".repeat(max + 10)));
         // an ordinary NameID is passed through untouched
         assertEquals("victim@example.com", SamlAuthenticator.sanitizeForLog("victim@example.com"));
+
+        // a rejection reason quotes the message it objected to, so it is sender-supplied in the
+        // same way and gets the same treatment at a bound that leaves the sentence readable
+        final int reasonMax = SamlAuthenticator.MAX_LOGGED_FAILURE_REASON_LENGTH;
+        assertTrue(String.valueOf(reasonMax), reasonMax > max);
+        assertEquals("Invalid issuer in the Assertion/Response. Was '?ERROR forged'",
+                SamlAuthenticator.sanitizeForLog("Invalid issuer in the Assertion/Response. Was '\nERROR forged'", reasonMax));
+        assertEquals("y".repeat(reasonMax) + "...", SamlAuthenticator.sanitizeForLog("y".repeat(reasonMax + 1), reasonMax));
     }
 
     @Test


### PR DESCRIPTION
## Why now

`fess-parent` now pins `java-saml` `3.1.2-SNAPSHOT`, and that release moves two log
lines from warn to debug: `SamlResponse#isValid` and `Auth#processResponse`. Both
changes are right — the library hands the failure back through `getErrors()`,
`getLastErrorReason()` and `getLastValidationException()`, and says what reaches an
operator is for the caller to decide. We are the caller, and we were not deciding.

Two things follow, and this PR is both of them.

## 1. A failed login stops saying why

`getErrors()` answers a category. `invalid_response` is what all of these come back as:

| what happened | what `getLastErrorReason()` says |
| --- | --- |
| the assertion was edited | `Signature validation failed. SAML Response rejected` |
| it was meant for another SP | `... is not a valid audience for this Response` |
| it had expired | `Could not validate timestamp: expired. Check system clock` |
| it was replayed | `The Assertion was already processed (replay detected): ID_...` |
| it came from another IdP | `Invalid issuer in the Assertion/Response. Was '...', but expected '...'` |
| its Destination was rewritten | `The response was received at ... instead of ...` |

Only the right-hand column tells an administrator what to do next, and it was logged
only when `saml.debug` was on — off in every shipped configuration. It reached the log
anyway while java-saml also logged it at warn; with the upgrade it does not. Every
failed SAML login would read `Authentication Failure: invalid_response` and stop.

So the reason is now reported whatever `saml.debug` is set to. `getLastErrorReason()`
is populated regardless of that switch (`Auth.java`, the failure branch of
`processResponse`), so nothing else has to change to get it.

It is also sanitised. The reason quotes the message it objected to — an issuer, a
destination, an audience — and `/sso/` is anonymous, so that quoted part is a sender's
own input, and an issuer is element text that can carry a line break. It gets the same
bounding and control-character stripping the LogoutRequest NameID already gets, at a
larger bound: the reason is a sentence, and a NameID's 64 characters would cut off the
part that identifies the problem.

## 2. A test that depended on the library's log level

`test_getLoginCredential_answersTheOlderOfTwoPendingRequestIds` proved that a response
was tried against more than the newest pending request id by counting warnings from
`org.codelibs.saml2.core.authn.SamlResponse`. Those warnings are the ones that moved to
debug, so the test fails with `expected: <2> but was: <0>` as soon as the library is
upgraded — reproduced here against a build carrying only that upstream change.

The same fact is visible in our own failure line: the reason reported is the older
candidate's own rejection, not the InResponseTo mismatch the newest candidate was ruled
out on. Reading it from there makes the test independent of what level the library logs
a ruled-out candidate at, which is what made it brittle in the first place.

## Tests

`org.codelibs.fess.sso.**` — 321 tests, green against **both** `3.1.1` and
`3.1.2-SNAPSHOT`, so this does not depend on the upgrade landing.

Neither test is vacuous: putting the `saml.debug` gate back fails both of them with
`Authentication Failure: invalid_response ==> expected: <true> but was: <false>` — the
regression itself, written out.

## Not included

The remaining `saml.debug` behaviour is untouched: it is java-saml's own switch for its
own debug output, and this PR only stops it from deciding whether our failure line
carries a reason.
