### PR TITLE
fix(admin): mask the SAML SP private key in System Info and bug reports

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoAction.java
@@ -208,8 +208,28 @@ public class AdminSysteminfoAction extends FessAdminAction {
                 || "app.cipher.key".equals(key) //
                 || "content_chunker.embedding.opensearch.password".equals(key) //
                 || isSsoClientCredential(key) //
+                || isPrivateKeyMaterial(key) //
                 || isEmbeddingApiKey(key) //
                 || isLlmApiKey(key);
+    }
+
+    /**
+     * Checks if a key holds private key material, e.g. {@code saml.sp.privatekey} or
+     * {@code saml.keystore.key.password}. Matching on the {@code .privatekey} /
+     * {@code .key.password} shape, instead of listing every key by name, means a future
+     * setting that carries a private key is masked by default.
+     *
+     * <p>The SAML SP private key was rendered in cleartext under System Info &gt; Config Info,
+     * and was also copied verbatim into the bug report that users paste into public issues.
+     * That key signs this SP's AuthnRequests and decrypts the assertions an IdP encrypts for
+     * it, so disclosing it is worse than disclosing a client secret: whoever holds it can mint
+     * messages this SP will treat as its own and read assertions intended for it.
+     *
+     * @param key the property key to check
+     * @return true if the key matches the private key material shape
+     */
+    protected static boolean isPrivateKeyMaterial(final String key) {
+        return key != null && (key.endsWith(".privatekey") || key.endsWith(".key.password"));
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/systeminfo/AdminSysteminfoActionTest.java
@@ -90,6 +90,17 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_isMaskedValue_masksPrivateKeyMaterial() {
+        // The SAML SP private key signs this SP's AuthnRequests and decrypts the assertions an
+        // IdP encrypts for it. It lives in conf/system.properties next to saml.sp.x509cert and
+        // was rendered in cleartext on the admin screen and in the bug report.
+        assertTrue(AdminSysteminfoAction.isMaskedValue("saml.sp.privatekey"));
+        assertTrue(AdminSysteminfoAction.isMaskedValue("saml.keystore.key.password"));
+        // The rule matches on shape, so a private key added under another name is masked too.
+        assertTrue(AdminSysteminfoAction.isMaskedValue("something.else.privatekey"));
+    }
+
+    @Test
     public void test_isMaskedValue_doesNotMaskOrdinaryKeys() {
         // Other content_chunker.embedding.* keys are plain diagnostic config, not credentials,
         // and must stay visible on the admin screen.
@@ -108,6 +119,14 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         assertFalse(AdminSysteminfoAction.isMaskedValue("rag.llm.openai.retry.max"));
         assertFalse(AdminSysteminfoAction.isMaskedValue("rag.chat.enabled"));
 
+        // Certificates are public by definition -- the IdP's is published in its metadata and
+        // the SP's is published in /sso/metadata -- so masking them would only make the admin
+        // screen less useful for diagnosing a trust problem.
+        assertFalse(AdminSysteminfoAction.isMaskedValue("saml.idp.x509cert"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("saml.sp.x509cert"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("saml.sp.base.url"));
+        assertFalse(AdminSysteminfoAction.isMaskedValue("saml.keystore.alias"));
+
         // The rest of the Entra ID settings are plain configuration, not credentials.
         assertFalse(AdminSysteminfoAction.isMaskedValue("entraid.tenant"));
         assertFalse(AdminSysteminfoAction.isMaskedValue("entraid.authority"));
@@ -123,6 +142,8 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         ComponentUtil.getSystemProperties().setProperty("rag.llm.openai.api.key", "sk-chat-secret");
         ComponentUtil.getSystemProperties().setProperty("entraid.client.secret", "entraid-super-secret");
         ComponentUtil.getSystemProperties().setProperty("entraid.tenant", "contoso.onmicrosoft.com");
+        ComponentUtil.getSystemProperties().setProperty("saml.sp.privatekey", "MIIEvgIBADANBgkq-private-key");
+        ComponentUtil.getSystemProperties().setProperty("saml.sp.x509cert", "MIIDGTCCAgGg-public-cert");
         ComponentUtil.getSystemProperties().setProperty("content_chunker.embedding.dimension", "768");
 
         final List<Map<String, String>> itemList = AdminSysteminfoAction.getBugReportItems();
@@ -134,8 +155,10 @@ public class AdminSysteminfoActionTest extends UnitFessTestCase {
         assertEquals(MASKED_VALUE, findValue(itemList, "content_chunker.embedding.opensearch.password"));
         assertEquals(MASKED_VALUE, findValue(itemList, "rag.llm.openai.api.key"));
         assertEquals(MASKED_VALUE, findValue(itemList, "entraid.client.secret"));
+        assertEquals(MASKED_VALUE, findValue(itemList, "saml.sp.privatekey"));
 
         // An ordinary diagnostic key is unaffected and keeps its real value.
+        assertEquals("MIIDGTCCAgGg-public-cert", findValue(itemList, "saml.sp.x509cert"));
         assertEquals("768", findValue(itemList, "content_chunker.embedding.dimension"));
         assertEquals("contoso.onmicrosoft.com", findValue(itemList, "entraid.tenant"));
     }


### PR DESCRIPTION
## Problem

`saml.sp.privatekey` was rendered in cleartext under **System Info > Config Info**, and copied verbatim into the **bug report** textarea that users paste into public issues.

`isMaskedValue` covered the proxy / LDAP / SPNEGO passwords, the cipher key, the embedding and LLM API keys, and the `<provider>.client.id` / `.client.secret` SSO shape — but nothing matched a private key.

That key signs this SP's AuthnRequests and decrypts the assertions an IdP encrypts for it, so disclosing it is worse than disclosing a client secret: whoever holds it can mint messages this SP treats as its own and read assertions intended for it.

## Change

Mask on the `.privatekey` / `.key.password` shape rather than by name, matching how the SSO, embedding and LLM rules in this class already work, so a private key added under another name is masked by default. `saml.keystore.key.password` is covered by the same rule.

Certificates stay visible — the IdP's is published in its metadata and the SP's in `/sso/metadata` — so masking them would only make the screen less useful for diagnosing a trust problem.

## Verification

- `AdminSysteminfoActionTest`: 7 tests green. Reverting the one-line call in `isMaskedValue` turns 2 of them red (`expected: <true> but was: <false>` and `expected: <XXXXXXXX> but was: <...private-key>`), so they are not vacuous.
- Confirmed on a running server against a live IdP: before the change the page and both textareas contained the PKCS#8 key body; after it, `saml.sp.privatekey=XXXXXXXX` while `saml.sp.x509cert` keeps its real value.
- Related suites green: 328 tests across `Saml*`, `Sso*`, `SystemHelper`, `PermissionHelper`, `RoleQueryHelper`, `AdminSysteminfo*`.
