### PR TITLE
fix(sso): warn when SAML assertion decryption accepts any key transport algorithm

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -488,6 +488,19 @@ public class SamlAuthenticator implements SsoAuthenticator {
             // are still ended by it.
             warnings.add("unsigned_logoutrequest_accepted");
         }
+        final Set<String> allowedKeyTransport = settings.getAllowedKeyTransportAlgorithms();
+        if (settings.getSPkey() != null && (allowedKeyTransport == null || allowedKeyTransport.isEmpty())) {
+            // With an SP private key configured, /sso/ decrypts an EncryptedAssertion before it
+            // validates anything: SamlResponse decrypts in its constructor, and processResponse()
+            // only calls isValid() afterwards. The endpoint is anonymous, and an AuthnRequest ID
+            // to quote back is one GET /sso/ away, so an unauthenticated caller can drive the SP
+            // private key through RSA decryption with a ciphertext of their choosing.
+            // java-saml accepts every key transport algorithm when the allow-list is unset, which
+            // includes the RSA-1_5 padding that Bleichenbacher-style attacks target. Fess does not
+            // set it, so say so rather than changing a default that would break an IdP relying on
+            // the old algorithm.
+            warnings.add("key_transport_algorithms_not_restricted");
+        }
         if (!warnings.equals(loggedSecurityWarnings.getAndSet(warnings)) && !warnings.isEmpty()) {
             logger.warn("Insecure SAML settings: {}. See the SAML SSO documentation for the recommended values.",
                     String.join(", ", warnings));

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.sso.saml;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPairGenerator;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.LinkedHashSet;
@@ -211,6 +212,60 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
             assertEquals("https://fess.example.com/sso/metadata", authenticator.getSettings().getSpEntityId());
         } finally {
             systemProperties.remove(BASE_URL_KEY);
+        }
+    }
+
+    /**
+     * Generates a throwaway SP private key in the shape
+     * {@code onelogin.saml2.sp.privatekey} expects: base64 PKCS#8, no PEM header.
+     *
+     * <p>The key is generated rather than checked in so that no private key material
+     * lives in the repository.</p>
+     *
+     * @return the encoded private key
+     * @throws Exception if the key cannot be generated
+     */
+    private static String generateSpPrivateKey() throws Exception {
+        final KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return java.util.Base64.getEncoder().encodeToString(generator.generateKeyPair().getPrivate().getEncoded());
+    }
+
+    @Test
+    public void test_logSecurityWarnings_reportsUnrestrictedKeyTransport() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            // no SP private key: nothing can be decrypted, so the allow-list is moot
+            authenticator.getSettings();
+            assertEquals(1, appender.warnings().size());
+            assertFalse(appender.warnings().get(0), appender.warnings().get(0).contains("key_transport_algorithms_not_restricted"));
+
+            systemProperties.setProperty("saml.sp.privatekey", generateSpPrivateKey());
+            authenticator.getSettings();
+
+            // a key is configured and every key transport algorithm is accepted
+            assertEquals(2, appender.warnings().size());
+            assertTrue(appender.warnings().get(1), appender.warnings().get(1).contains("key_transport_algorithms_not_restricted"));
+
+            systemProperties.setProperty("saml.security.allowed_key_transport_algorithms", "http://www.w3.org/2009/xmlenc11#rsa-oaep");
+            authenticator.getSettings();
+
+            assertEquals(3, appender.warnings().size());
+            assertFalse(appender.warnings().get(2), appender.warnings().get(2).contains("key_transport_algorithms_not_restricted"));
+
+            // a blank value is not a restriction: the library treats an empty set as "accept
+            // everything", so the warning has to come back
+            systemProperties.setProperty("saml.security.allowed_key_transport_algorithms", "");
+            authenticator.getSettings();
+
+            assertEquals(4, appender.warnings().size());
+            assertTrue(appender.warnings().get(3), appender.warnings().get(3).contains("key_transport_algorithms_not_restricted"));
+        } finally {
+            systemProperties.remove("saml.sp.privatekey");
+            systemProperties.remove("saml.security.allowed_key_transport_algorithms");
+            appender.detach();
         }
     }
 


### PR DESCRIPTION
Stacked on #3305 — review that one first. CI does not start for a PR whose base is not `master`, so both commits were verified locally (328 tests green, see below).

## Problem

With an SP private key configured, `/sso/` decrypts an `EncryptedAssertion` **before it validates anything**: `SamlResponse` decrypts in its constructor (`loadXmlFromBase64`), and `Auth.processResponse()` only calls `isValid()` afterwards. The endpoint is anonymous by design, and an AuthnRequest ID to quote back is one `GET /sso/` away.

So an unauthenticated caller can drive the SP private key through RSA decryption with a ciphertext of their choosing. Measured on a running server: three POSTs carrying an `EncryptedAssertion` with garbage ciphertext and **no signature anywhere** each produced `Failed to decrypt an element.` before any validation ran.

java-saml accepts **every** key transport algorithm when `onelogin.saml2.security.allowed_key_transport_algorithms` is unset, and Fess never sets it. That includes RSA-1_5, the padding Bleichenbacher-style attacks target.

To be precise about severity: the HTTP response and the log line are identical for a padding failure and any other decryption failure, so this PR does **not** demonstrate a distinguishing oracle. What it establishes is that the precondition — anonymous, attacker-chosen RSA-1_5 decryption with the SP key — is reachable on shipped defaults, and that nothing tells the operator so.

## Change

Report `key_transport_algorithms_not_restricted` in the existing `Insecure SAML settings` banner, alongside `unsigned_logoutrequest_accepted`, rather than changing the default — restricting it by default would break an IdP that still uses the old algorithm.

The warning is raised only when an SP private key is configured, because without one nothing can be decrypted and the setting is moot. An empty value counts as unrestricted: the library treats an empty set the same as an absent one.

## Verification

Against a real IdP configured to encrypt assertions:

| IdP key transport | `saml.security.allowed_key_transport_algorithms` | Result |
| --- | --- | --- |
| `xmlenc#rsa-1_5` | unset | login **succeeds** |
| `xmlenc#rsa-1_5` | `xmlenc11#rsa-oaep` | login refused |
| `xmlenc11#rsa-oaep` (default) | `xmlenc11#rsa-oaep` | login succeeds |

The banner gains the new entry when a private key is configured and loses it once the allow-list is set; an ordinary login is unaffected either way.

`SamlAuthenticatorTest`: 71 tests green. Removing the single `warnings.add(...)` line turns the new test red (`expected: <2> but was: <1>`). Related suites green: 328 tests across `Saml*`, `Sso*`, `SystemHelper`, `PermissionHelper`, `RoleQueryHelper`, `AdminSysteminfo*`.

The test generates a throwaway RSA key at runtime rather than checking one in, so no private key material lands in the repository.
