### PR TITLE
fix(sso): report SP metadata that could not be signed instead of publishing it unsigned

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -1183,6 +1183,32 @@ public class SamlAuthenticator implements SsoAuthenticator {
      *
      * @return The metadata response.
      */
+    /**
+     * Warns when metadata signing was asked for but cannot happen.
+     *
+     * <p>{@code Saml2Settings#getSPMetadata()} signs with the SP key and certificate and swallows
+     * any failure at debug level, returning the unsigned document. So with
+     * {@code saml.security.sign_metadata=true} and no key material, {@code /sso/metadata} answers
+     * 200 with unsigned metadata and nothing says the request was dropped. An operator who turned
+     * signing on has no way to tell it is not happening.</p>
+     *
+     * <p>This is reported rather than refused: the metadata is still correct, only unsigned, and
+     * an IdP that does not check the signature keeps working. Refusing would turn a working
+     * deployment into a broken one on upgrade.</p>
+     *
+     * @param settings The SAML settings.
+     */
+    protected void warnIfMetadataCannotBeSigned(final Saml2Settings settings) {
+        if (settings.getSignMetadata() && (settings.getSPkey() == null || settings.getSPcert() == null)) {
+            logger.warn(
+                    "saml.security.sign_metadata is enabled but the SP metadata cannot be signed, so it is published unsigned. "
+                            + "Signing needs both saml.sp.privatekey and saml.sp.x509cert; missing: {}.",
+                    settings.getSPkey() == null
+                            ? (settings.getSPcert() == null ? "saml.sp.privatekey, saml.sp.x509cert" : "saml.sp.privatekey")
+                            : "saml.sp.x509cert");
+        }
+    }
+
     protected ActionResponse getMetadataResponse() {
         return LaRequestUtil.getOptionalRequest().map(request -> {
             if (logger.isDebugEnabled()) {
@@ -1198,6 +1224,7 @@ public class SamlAuthenticator implements SsoAuthenticator {
                     final String msg = String.join(", ", settingsErrors);
                     throw processFailure("Failed to process metadata.", msg);
                 }
+                warnIfMetadataCannotBeSigned(settings);
                 final String metadata = settings.getSPMetadata();
                 final List<String> errors = Saml2Settings.validateMetadata(metadata);
                 if (!errors.isEmpty()) {

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -232,6 +232,53 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_warnIfMetadataCannotBeSigned_reportsSilentlyUnsignedMetadata() throws Exception {
+        final SamlAuthenticator authenticator = createAuthenticator();
+        final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            // signing not requested: nothing to report whatever the key material is
+            authenticator.warnIfMetadataCannotBeSigned(authenticator.getSettings());
+            assertTrue(appender.warnings().toString(), appender.warnings().stream().noneMatch(w -> w.contains("sign_metadata")));
+
+            systemProperties.setProperty("saml.security.sign_metadata", "true");
+            authenticator.warnIfMetadataCannotBeSigned(authenticator.getSettings());
+
+            // getSPMetadata() swallows the signing failure at debug level and returns the
+            // unsigned document, so without this warning the downgrade is invisible
+            final String bothMissing = lastWarning(appender, "sign_metadata");
+            assertTrue(bothMissing, bothMissing.contains("saml.sp.privatekey, saml.sp.x509cert"));
+
+            systemProperties.setProperty("saml.sp.privatekey", generateSpPrivateKey());
+            authenticator.warnIfMetadataCannotBeSigned(authenticator.getSettings());
+            final String certMissing = lastWarning(appender, "sign_metadata");
+            assertTrue(certMissing, certMissing.contains("missing: saml.sp.x509cert."));
+        } finally {
+            systemProperties.remove("saml.security.sign_metadata");
+            systemProperties.remove("saml.sp.privatekey");
+            appender.detach();
+        }
+    }
+
+    /**
+     * The most recent captured warning containing {@code needle}, or the whole capture
+     * rendered as text so a failing assertion says what was logged instead.
+     *
+     * @param appender the capturing appender
+     * @param needle the substring to look for
+     * @return the matching warning, or the full capture when nothing matched
+     */
+    private static String lastWarning(final LogCapturingAppender appender, final String needle) {
+        String found = null;
+        for (final String w : appender.warnings()) {
+            if (w.contains(needle)) {
+                found = w;
+            }
+        }
+        return found != null ? found : ("no warning contained " + needle + ": " + appender.warnings());
+    }
+
+    @Test
     public void test_logSecurityWarnings_reportsUnrestrictedKeyTransport() throws Exception {
         final SamlAuthenticator authenticator = createAuthenticator();
         final DynamicProperties systemProperties = ComponentUtil.getSystemProperties();


### PR DESCRIPTION
Stacked on #3306, which is stacked on #3305 — review those first. CI does not start for a PR whose base is not `master`; all three commits were verified locally (`SamlAuthenticatorTest` 72 green, plus 328 across the related suites).

## Problem

`Saml2Settings#getSPMetadata()` signs the document with the SP key and certificate and swallows any failure at **debug** level, returning the unsigned metadata. So with `saml.security.sign_metadata=true` and no key material, `GET /sso/metadata` answers **200 with unsigned metadata** and nothing tells the operator the request was dropped.

Measured on the shipped build:

| `sign_metadata` | SP key | SP cert | status | signed | reported |
| --- | --- | --- | --- | --- | --- |
| `true` | — | — | 200 | no | nothing |
| `true` | — | set | 200 | no | nothing |
| `true` | set | — | 200 | no | nothing |
| `true` | set | set | 200 | **yes** | — |

2662 bytes unsigned against 4986 signed, same endpoint, no difference an operator would notice.

This behaviour is identical in java-saml 3.1.1 and 3.1.2-SNAPSHOT, so it is not a regression from the version bump — it has simply never been visible.

## Change

Warn before generating the metadata, naming whichever of `saml.sp.privatekey` / `saml.sp.x509cert` is missing.

Reported rather than refused, deliberately: the metadata is still correct, only unsigned, and an IdP that does not check the signature keeps working. Refusing would turn a working deployment into a broken one on upgrade. If you would rather this fail closed with a 500, say so — `getMetadataResponse()` already signals a misconfigured SP that way for `checkSPSettings()` failures, so the alternative is a one-line change.

The check reads the preconditions (`getSPkey()` / `getSPcert()`) rather than inspecting the produced XML: deterministic and testable. A signing failure from some other cause would still be silent, which is a smaller gap than the one being closed.

## Verification

Live, against a real IdP, after the change: the three degraded configurations each log the warning and name the missing setting; key + cert logs nothing and produces a signed document; `sign_metadata` unset logs nothing.

`SamlAuthenticatorTest`: 72 green. Neutralising the condition turns the new test red with the captured log in the message (`no warning contained sign_metadata: [...]`).

## Note for the record

An earlier round of this verification recorded that this configuration returned `500` + `sp_cert_not_found_and_required`, i.e. that it already failed closed. That measurement was contaminated: `saml.security.authnrequest_signed` was still `true` from a previous case, and that is what makes `checkSPSettings()` demand a certificate. With `sign_metadata` alone, the result is the 200 documented above.
