### PR TITLE
fix(sso): name a permission from the asserted user name, not from a slice of it

### DIFF
--- a/src/main/java/org/codelibs/fess/ldap/LdapManager.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapManager.java
@@ -340,7 +340,9 @@ public class LdapManager {
             final Hashtable<String, String> env = createSearchEnv();
             try (DirContextHolder holder = getDirContext(() -> env)) {
                 final DirContext context = holder.get();
-                final LdapUser ldapUser = createLdapUser(username, env);
+                // This overload is the SSO entry point -- no password, because an identity provider
+                // already authenticated the user and asserted this name.
+                final LdapUser ldapUser = createLdapUser(username, env, true);
                 if (!allowEmptyGroupAndRole(ldapUser)) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Login failed. No permissions. {}", context);
@@ -388,7 +390,20 @@ public class LdapManager {
      * @return a new LdapUser instance
      */
     protected LdapUser createLdapUser(final String username, final Hashtable<String, String> env) {
-        return new LdapUser(env, username);
+        return createLdapUser(username, env, false);
+    }
+
+    /**
+     * Creates an LDAP user.
+     *
+     * @param username the user name
+     * @param env the LDAP environment
+     * @param nameFromProvider whether an identity provider asserted the name rather than a user
+     *            typing it at the login form
+     * @return the LDAP user
+     */
+    protected LdapUser createLdapUser(final String username, final Hashtable<String, String> env, final boolean nameFromProvider) {
+        return new LdapUser(env, username, nameFromProvider);
     }
 
     /**
@@ -407,7 +422,7 @@ public class LdapManager {
         final Set<String> roleSet = new HashSet<>();
 
         if (fessConfig.isLdapRoleSearchUserEnabled()) {
-            roleSet.add(normalizePermissionName(systemHelper.getSearchRoleByUser(ldapUser.getName())));
+            roleSet.add(normalizePermissionName(getUserSearchRole(ldapUser, systemHelper)));
         }
 
         // LDAP: cn=%s
@@ -626,6 +641,28 @@ public class LdapManager {
                 });
             }
         }
+    }
+
+    /**
+     * Names the user's own permission from the name this user logged in with.
+     *
+     * <p>{@code getCanonicalLdapName} drops everything up to the first backslash, which is what
+     * turns a NetBIOS-qualified {@code DOMAIN\alice} typed at the login form into the {@code alice}
+     * the documents are indexed under. A name an identity provider asserted is not qualified that
+     * way, so running it through the same step takes the tail of a backslash that belongs to the
+     * name -- and hands the account holding it the permission of whatever follows. The account
+     * does not have to be able to reach that permission any other way, so this is the user half of
+     * what {@code getLeafCommonName} closed for group and role names.
+     *
+     * @param ldapUser the user logging in
+     * @param systemHelper the helper that joins a prefix to a name
+     * @return the user's own search role
+     */
+    protected String getUserSearchRole(final LdapUser ldapUser, final SystemHelper systemHelper) {
+        if (ldapUser.isNameFromProvider()) {
+            return systemHelper.getSearchRoleByDirectoryUser(ldapUser.getName());
+        }
+        return systemHelper.getSearchRoleByUser(ldapUser.getName());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ldap/LdapUser.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapUser.java
@@ -42,6 +42,17 @@ public class LdapUser implements FessUser {
     protected String name;
 
     /**
+     * Whether {@link #name} was asserted by an identity provider rather than typed at a login form.
+     *
+     * <p>Decides whether the user permission may be re-read as a NetBIOS-qualified {@code
+     * DOMAIN\name}. A name typed at the login form may carry that qualifier and dropping it is what
+     * makes the permission match the documents; a name an identity provider asserted carries the
+     * account's own characters, so taking the tail of a backslash inside it names a different
+     * account's permission.
+     */
+    protected final boolean nameFromProvider;
+
+    /**
      * Whether the nested-group walk has already published its result.
      *
      * <p>Guards the synchronous write below. {@link LdapManager#getRoles} schedules that walk and
@@ -88,8 +99,30 @@ public class LdapUser implements FessUser {
      * @param name The name of the user.
      */
     public LdapUser(final Hashtable<String, String> env, final String name) {
+        this(env, name, false);
+    }
+
+    /**
+     * Constructs a new LDAP user.
+     *
+     * @param env The environment for LDAP connection.
+     * @param name The name of the user.
+     * @param nameFromProvider Whether the name was asserted by an identity provider rather than
+     *            typed at a login form.
+     */
+    public LdapUser(final Hashtable<String, String> env, final String name, final boolean nameFromProvider) {
         this.env = env;
         this.name = name;
+        this.nameFromProvider = nameFromProvider;
+    }
+
+    /**
+     * Returns whether this user's name was asserted by an identity provider.
+     *
+     * @return true when the name came from a provider, false when a user typed it.
+     */
+    public boolean isNameFromProvider() {
+        return nameFromProvider;
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
@@ -145,6 +145,37 @@ public class LdapManagerTest extends UnitFessTestCase {
         assertNull(ldapManager.getSearchRoleName("CN=broken\\q,DC=example,DC=com"));
     }
 
+    /**
+     * A name a user typed at a login form may be NetBIOS-qualified, and dropping the domain half
+     * is what makes it match the documents.  A name an identity provider asserted carries no such
+     * qualifier, so reading one out of it takes the tail of a backslash that is part of the name --
+     * naming the permission after a different account.
+     */
+    @SuppressWarnings("serial")
+    @Test
+    public void test_getUserSearchRole_assertedNameKeepsItsBackslash() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            public boolean isLdapIgnoreNetbiosName() {
+                return true;
+            }
+
+            public String getRoleSearchUserPrefix() {
+                return "1";
+            }
+        });
+        final LdapManager ldapManager = new LdapManager();
+        ldapManager.init();
+        final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
+
+        // Typed at the login form: the NetBIOS domain is dropped, as it always was.
+        assertEquals("1alice", ldapManager.getUserSearchRole(new LdapUser(new Hashtable<>(), "EXAMPLE\\alice"), systemHelper));
+        // Asserted by an identity provider: the whole name is the name.
+        assertEquals("1zz\\alice", ldapManager.getUserSearchRole(new LdapUser(new Hashtable<>(), "zz\\alice", true), systemHelper));
+        // A name with no backslash reads the same either way.
+        assertEquals("1alice", ldapManager.getUserSearchRole(new LdapUser(new Hashtable<>(), "alice"), systemHelper));
+        assertEquals("1alice", ldapManager.getUserSearchRole(new LdapUser(new Hashtable<>(), "alice", true), systemHelper));
+    }
+
     @Test
     public void test_replaceWithUnderscores() {
         LdapManager ldapManager = new LdapManager();


### PR DESCRIPTION
## What this fixes

A permission is a prefix character followed by a name. The user half of that name
is built by `getCanonicalLdapName`, which drops everything up to the first
backslash.

That is correct for a name typed at the login form: the backslash separates a
NetBIOS domain from the account, and dropping it is what makes the permission
match the name the documents are indexed under. It is wrong for a name an
identity provider asserted, where the backslash is one of the account's own
characters. Cutting there names the permission after whatever follows the
backslash -- that is, after a different account.

An account whose asserted name is `<anything>\<victim>` therefore received
`<user-prefix><victim>` in addition to its own permission, and read the victim's
documents. It needed nothing granted to it in Fess and no other permission of
its own.

This is the user half of what #3292 closed for group and role names, and the
same distinction #3299 drew for the other identity providers, whose credentials
already name the user permission from the asserted name
(`getSearchRoleByDirectoryUser`). The path that resolves a provider-authenticated
user through the directory was the one still missing it.

## How

The single-argument `LdapManager#login` is the SSO entry point -- it takes no
password because a provider already authenticated the user -- so the `LdapUser`
it builds is marked as carrying a provider-asserted name. `getRoles` then joins
the prefix to that name unchanged. The two-argument overload, which serves the
login form, keeps dropping the NetBIOS domain exactly as before.

## Verification

- New unit test `test_getUserSearchRole_assertedNameKeepsItsBackslash` pins both
  directions: a typed `DOMAIN\name` still resolves to `name`, an asserted
  `<anything>\<name>` keeps both halves. Without the change it fails with
  `expected: <1zz\alice> but was: <1alice>`.
- `mvn test`: 7346 tests, 0 failures.
- Reproduced end to end against a live directory before the change (the account
  held the victim's permission and returned the victim's document) and confirmed
  gone after it, with the ordinary accounts' permissions and results unchanged.
