### PR TITLE
fix(ldap): name a group permission from its sAMAccountName, not from a slice of it

### DIFF
--- a/src/main/java/org/codelibs/fess/ldap/LdapManager.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapManager.java
@@ -517,7 +517,7 @@ public class LdapManager {
             final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
             sAMAccountGroupNameSet.stream().forEach(groupName -> {
                 getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
-                    roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
+                    roleSet.add(systemHelper.getSearchRoleByDirectoryGroup(normalizePermissionName(sAMAccountGroupName)));
                 });
             });
             processSubRoles(ldapUser, bindDn, subRoleSet, groupFilter, roleSet);
@@ -636,7 +636,7 @@ public class LdapManager {
             try (DirContextHolder holder = getDirContext(() -> env)) {
                 sAMAccountGroupNameSet.forEach(groupName -> {
                     getSAMAccountGroupName(bindDn, groupName).ifPresent(sAMAccountGroupName -> {
-                        roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(sAMAccountGroupName)));
+                        roleSet.add(systemHelper.getSearchRoleByDirectoryGroup(normalizePermissionName(sAMAccountGroupName)));
                     });
                 });
             }


### PR DESCRIPTION
## What this changes

Stacked on #3309.

With `ldap.samaccountname.group` enabled, a group's permission is named from the
`sAMAccountName` the directory holds for that group. Two call sites still pass
that name through `getCanonicalLdapName` -- the step that drops everything up to
the first backslash so that a `DOMAIN\name` typed at the login form matches. A
name read out of a directory entry is not qualified that way, so the step can
only remove characters that belong to the name.

## Not a reachable defect

Active Directory does not accept a backslash in a `sAMAccountName`, so no
directory this path reads can currently produce a name for the step to cut.
This is consistency: after #3292, #3299 and the parent PR, these are the last
two places where a directory-supplied name is still re-read as a typed one, and
leaving them inconsistent with the rest invites the distinction being lost
again.

## Verification

`mvn test`: 7346 tests, 0 failures.
