### PR TITLE
fix(ldap): let ldap.role.search.user.enabled withhold the user's own permission

### DIFF
--- a/src/main/java/org/codelibs/fess/ldap/LdapUser.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapUser.java
@@ -141,19 +141,25 @@ public class LdapUser implements FessUser {
                 final LdapManager ldapManager = ComponentUtil.getLdapManager();
                 // Appended to both writes, not just the synchronous one. LdapManager derives its own
                 // user entry through getCanonicalLdapName, which drops a NetBIOS "DOMAIN\" prefix,
-                // and adds it only when ldap.role.search.user.enabled is set -- so a lazy write that
-                // carried only what LdapManager collected would hand back a strictly smaller set
-                // than the synchronous result, and the user would silently lose their own
-                // permission at the moment the nested-group walk succeeded.
-                final String userPermission = fessConfig.getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName());
+                // so the two are not always the same string -- and a lazy write that carried only
+                // what LdapManager collected would hand back a strictly smaller set than the
+                // synchronous result, the user losing their own permission at the moment the
+                // nested-group walk succeeded.
+                //
+                // Both writes are also gated on ldap.role.search.user.enabled, which is what that
+                // setting has always claimed to control. Adding it here regardless made the setting
+                // unable to withhold anything.
+                final String[] userPermissions = fessConfig.isLdapRoleSearchUserEnabled()
+                        ? new String[] { fessConfig.getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName()) }
+                        : StringUtil.EMPTY_STRINGS;
                 final String[] directPermissions =
                         distinct(ArrayUtils.addAll(ldapManager.getRoles(this, baseDn, accountFilter, groupFilter, roles -> {
-                            permissions = distinct(ArrayUtils.addAll(roles, userPermission));
+                            permissions = distinct(ArrayUtils.addAll(roles, userPermissions));
                             // Written after the permissions it describes, so a reader that sees the
                             // flag cannot see the set it replaced.
                             nestedRolesPublished = true;
                             ComponentUtil.getActivityHelper().permissionChanged(OptionalThing.of(new FessUserBean(this)));
-                        }), userPermission));
+                        }), userPermissions));
                 if (!nestedRolesPublished) {
                     permissions = directPermissions;
                 }

--- a/src/test/java/org/codelibs/fess/ldap/LdapUserTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapUserTest.java
@@ -187,6 +187,14 @@ public class LdapUserTest extends UnitFessTestCase {
             public String getRoleSearchUserPrefix() {
                 return "U";
             }
+
+            @Override
+
+            public boolean isLdapRoleSearchUserEnabled() {
+
+                return true;
+
+            }
         });
 
         ComponentUtil.register(new LdapManager() {
@@ -263,6 +271,14 @@ public class LdapUserTest extends UnitFessTestCase {
             public String getRoleSearchUserPrefix() {
                 return "U";
             }
+
+            @Override
+
+            public boolean isLdapRoleSearchUserEnabled() {
+
+                return true;
+
+            }
         });
 
         ComponentUtil.register(new LdapManager() {
@@ -319,6 +335,14 @@ public class LdapUserTest extends UnitFessTestCase {
             @Override
             public String getRoleSearchUserPrefix() {
                 return "U";
+            }
+
+            @Override
+
+            public boolean isLdapRoleSearchUserEnabled() {
+
+                return true;
+
             }
         });
 
@@ -390,6 +414,14 @@ public class LdapUserTest extends UnitFessTestCase {
             @Override
             public String getRoleSearchUserPrefix() {
                 return "U";
+            }
+
+            @Override
+
+            public boolean isLdapRoleSearchUserEnabled() {
+
+                return true;
+
             }
         });
 
@@ -545,6 +577,70 @@ public class LdapUserTest extends UnitFessTestCase {
         assertEquals(FessUser.PermissionState.RESOLVED, ldapUser.getPermissionState());
     }
 
+    /**
+     * {@code ldap.role.search.user.enabled} says whether a user is granted a permission named
+     * after themselves.  Both writes have to honour it: the synchronous one and the one the
+     * nested-group walk publishes.
+     */
+    @Test
+    public void test_getPermissions_userPermissionFollowsTheSwitch() {
+        final AtomicReference<String[]> publishedByCallback = new AtomicReference<>();
+
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getLdapBaseDn() {
+                return "dc=example,dc=com";
+            }
+
+            @Override
+            public String getLdapAccountFilter() {
+                return "(uid=%s)";
+            }
+
+            @Override
+            public String getRoleSearchUserPrefix() {
+                return "1";
+            }
+
+            @Override
+            public boolean isLdapRoleSearchUserEnabled() {
+                return false;
+            }
+        });
+
+        ComponentUtil.register(new LdapManager() {
+            @Override
+            public String[] getRoles(final LdapUser user, final String baseDn, final String accountFilter, final String groupFilter,
+                    final Consumer<String[]> callback) {
+                // What LdapManager returns when the switch is off: groups only.
+                callback.accept(new String[] { "2group1", "2parent1" });
+                publishedByCallback.set(user.permissions);
+                return new String[] { "2group1" };
+            }
+
+            @Override
+            public String normalizePermissionName(final String name) {
+                return name;
+            }
+        }, "ldapManager");
+
+        ComponentUtil.register(new ActivityHelper() {
+            @Override
+            public void permissionChanged(final OptionalThing<FessUserBean> user) {
+                // no-op
+            }
+        }, "activityHelper");
+
+        final String[] permissions = ldapUser.getPermissions();
+        assertFalse("switched off, but " + java.util.Arrays.toString(permissions) + " still names the user",
+                java.util.Arrays.asList(permissions).contains("1testuser"));
+
+        final String[] afterLazyWrite = publishedByCallback.get();
+        assertNotNull(afterLazyWrite);
+        assertFalse("the lazy write re-added it: " + java.util.Arrays.toString(afterLazyWrite),
+                java.util.Arrays.asList(afterLazyWrite).contains("1testuser"));
+    }
+
     @Test
     public void test_getPermissions_lazyWriteKeepsTheUserPermission() {
         // LdapManager derives its own user entry through getCanonicalLdapName, which drops a
@@ -569,6 +665,14 @@ public class LdapUserTest extends UnitFessTestCase {
             @Override
             public String getRoleSearchUserPrefix() {
                 return "1";
+            }
+
+            @Override
+
+            public boolean isLdapRoleSearchUserEnabled() {
+
+                return true;
+
             }
         });
 
@@ -639,6 +743,14 @@ public class LdapUserTest extends UnitFessTestCase {
             @Override
             public String getRoleSearchUserPrefix() {
                 return "1";
+            }
+
+            @Override
+
+            public boolean isLdapRoleSearchUserEnabled() {
+
+                return true;
+
             }
         });
 


### PR DESCRIPTION
## What this changes

Stacked on #3310.

`ldap.role.search.user.enabled` says whether a user is granted a permission
named after themselves. It has not been able to withhold one since **10.1.0**:
`LdapManager#getRoles` consults the setting, but `LdapUser#getPermissions`
appended the same permission to the result regardless, so turning the setting
off changed nothing observable.

Measured before this change, with the setting off: the user's permissions and
their search results were byte-for-byte identical to the shipped default.

## History

| | |
|---|---|
| Setting added | 2016-02-18 (#361), first shipped in 10.0.1 |
| Unconditional append introduced | 2016-04-30 (#494, role-based search refactoring), 10.1.0 |

So it worked for roughly one minor version and has been inert for the ~10
releases since. The released 15.7.x code is identical to master here, so this
is not a 15.8 regression.

## How

Both writes now honour the setting -- the synchronous one and the one the
nested-group walk publishes. Keeping them in step is what the existing comment
in that method is about: a write that carried only what `LdapManager` collected
would hand back a strictly smaller set than the synchronous pass, and the user
would lose their own permission at the moment the walk succeeded.

## Behaviour change on upgrade

A deployment that has the setting off has been running with the permission
granted anyway. After this change its users lose the permission named after
themselves, so documents permissioned to an individual user stop matching for
that user. Leaving the setting at its shipped value of `true` keeps today's
behaviour. This is noted in the upgrade documentation (fess-docs PR to follow).

## Verification

- New unit test `test_getPermissions_userPermissionFollowsTheSwitch` pins both
  writes. Without the change it fails with
  `switched off, but [2group1, 2parent1, 1testuser] still names the user`.
- Six existing tests in `LdapUserTest` had to stub the new getter, because
  `FessConfig.SimpleImpl` throws on any getter a test did not override.
- `mvn test`: 7347 tests, 0 failures.
