### PR TITLE
fix(api): answer an unauthorized admin API request with 401

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/api/FessApiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/FessApiAction.java
@@ -32,6 +32,7 @@ import org.lastaflute.web.validation.VaMessenger;
 
 import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Abstract base class for Fess API actions that provides common functionality
@@ -82,7 +83,8 @@ public abstract class FessApiAction extends FessBaseAction {
 
     /**
      * Pre-processes API requests by checking access authorization before executing the action.
-     * If access is not allowed, returns an unauthorized error response.
+     * If access is not allowed, returns an unauthorized error response with HTTP 401 so that
+     * a rejected call is distinguishable from a successful one by status alone.
      *
      * @param runtime the action runtime context containing request information
      * @return ActionResponse with unauthorized error if access denied, otherwise delegates to parent
@@ -92,7 +94,7 @@ public abstract class FessApiAction extends FessBaseAction {
         if (!isAccessAllowed()) {
             return asJson(new ApiErrorResponse().message(getMessage(messages -> messages.addErrorsUnauthorizedRequest(GLOBAL)))
                     .status(Status.UNAUTHORIZED)
-                    .result());
+                    .result()).httpStatus(HttpServletResponse.SC_UNAUTHORIZED);
         }
         return super.godHandPrologue(runtime);
     }

--- a/src/test/java/org/codelibs/fess/app/web/api/FessApiActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/api/FessApiActionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.api;
+
+import org.codelibs.fess.app.web.api.ApiResult.ApiErrorResponse;
+import org.codelibs.fess.app.web.api.ApiResult.Status;
+import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.mylasta.action.FessMessages;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.lastaflute.web.response.ActionResponse;
+import org.lastaflute.web.response.JsonResponse;
+import org.lastaflute.web.validation.VaMessenger;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public class FessApiActionTest extends UnitFessTestCase {
+
+    private static final String UNAUTHORIZED_MESSAGE = "Unauthorized request.";
+
+    @Override
+    protected void setUp(final TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        // the result bean stamps the product version through this helper
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+    }
+
+    /**
+     * Stands in for a concrete API action so that the prologue can be driven without a
+     * container. The message lookup is stubbed out because the behaviour under test is
+     * the response itself, not the wording of the message.
+     */
+    private static class TestApiAction extends FessApiAction {
+
+        @Override
+        protected boolean isAccessAllowed() {
+            return false;
+        }
+
+        @Override
+        protected String getMessage(final VaMessenger<FessMessages> validationMessagesLambda) {
+            return UNAUTHORIZED_MESSAGE;
+        }
+    }
+
+    private ActionResponse prologueOfDeniedRequest() {
+        return new TestApiAction().godHandPrologue(null);
+    }
+
+    /**
+     * A denied request must carry 401. Leaving the status unset makes the container send
+     * 200, so a client that only inspects the HTTP status cannot tell a rejected call
+     * from a successful one.
+     */
+    @Test
+    public void test_godHandPrologue_deniedUsesUnauthorizedStatus() {
+        final ActionResponse response = prologueOfDeniedRequest();
+
+        assertTrue(response instanceof JsonResponse);
+        final JsonResponse<?> jsonResponse = (JsonResponse<?>) response;
+        assertTrue(jsonResponse.getHttpStatus().isPresent());
+        assertEquals(Integer.valueOf(HttpServletResponse.SC_UNAUTHORIZED), jsonResponse.getHttpStatus().get());
+    }
+
+    /**
+     * The response body is the published part of the contract, so the status code change
+     * must leave it alone. Clients reading response.status keep seeing UNAUTHORIZED.
+     */
+    @Test
+    public void test_godHandPrologue_deniedKeepsResponseBody() {
+        final Object bean = ((JsonResponse<?>) prologueOfDeniedRequest()).getJsonBean();
+
+        assertTrue(bean instanceof ApiResult);
+        final ApiResult result = (ApiResult) bean;
+        assertEquals(Status.UNAUTHORIZED.getId(), result.response.status);
+        assertTrue(result.response instanceof ApiErrorResponse);
+        assertEquals(UNAUTHORIZED_MESSAGE, ((ApiErrorResponse) result.response).message);
+    }
+}


### PR DESCRIPTION
## Problem

An unauthorized request to `/api/admin/*` is answered with **HTTP 200**:

```
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/api/admin/webconfig/settings
200
$ curl -s http://localhost:8080/api/admin/webconfig/settings
{"response":{"message":"Unauthorized request.","version":"15.8","status":3}}
```

The same 200 comes back whether the `Authorization` header is missing, malformed, or
carries a token that no longer exists.

`FessApiAction.godHandPrologue` builds the error bean but never sets an HTTP status, so
the container falls back to 200:

```java
if (!isAccessAllowed()) {
    return asJson(new ApiErrorResponse().message(...)
            .status(Status.UNAUTHORIZED)
            .result());        // no httpStatus
}
```

`FessApiFailureHook` does answer 401 for `LoginUnauthorizedException`, but the prologue
rejects the request before the failure hook is reached, so that path never covers the
access token check.

The practical consequence is that a client cannot use the HTTP status to decide whether
its credentials work. Any check shaped like "200 means the token is good" silently accepts
an invalid token, and the failure only surfaces later when the caller tries to read a field
that an error body does not have.

## Change

Set `401` on the response returned by the prologue. One line plus the import; the rejection
logic itself is untouched.

## Compatibility

**This changes the HTTP status of an existing endpoint**, which is why it targets 15.9.0
rather than 15.8.

- The **response body is unchanged**: `response.status` stays `3` (`UNAUTHORIZED`) and the
  message is the same. Clients that read the body are unaffected.
- Clients that treat any `200` as success now see `401` and need to handle it. That is the
  point of the change, but it is a visible difference for existing integrations.

This behaviour has been in place since #920 (2017), so it is not a regression in a recent
release — it is a long-standing gap being closed.

## Tests

`FessApiActionTest` is added with two cases:

- `test_godHandPrologue_deniedUsesUnauthorizedStatus` — the denied response carries 401.
  Verified to fail before the change (`getHttpStatus()` was empty) and pass after, so the
  assertion is not vacuous.
- `test_godHandPrologue_deniedKeepsResponseBody` — the body still reports `UNAUTHORIZED`
  with the same message, pinning the part of the contract that must not move.
