### PR TITLE
fix(search): filter by the guest roles when a logged-in user resolved no permission

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/RoleQueryHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/RoleQueryHelper.java
@@ -145,6 +145,7 @@ public class RoleQueryHelper {
      */
     public Set<String> build(final SearchRequestType searchRequestType) {
         final Set<String> roleSet = new HashSet<>();
+        final boolean[] loggedIn = { false };
         final HttpServletRequest request = LaRequestUtil.getOptionalRequest().orElse(null);
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final boolean isApiRequest =
@@ -181,16 +182,17 @@ public class RoleQueryHelper {
 
             final RequestManager requestManager = ComponentUtil.getRequestManager();
             try {
-                findUserBean(requestManager)
-                        .ifPresent(fessUserBean -> stream(fessUserBean.getPermissions()).of(stream -> stream.forEach(roleSet::add)))
-                        .orElse(() -> {
-                            if (isApiRequest && ComponentUtil.getFessConfig().getApiAccessTokenRequiredAsBoolean()) {
-                                throw new InvalidAccessTokenException("invalid_token", "Access token is requried.");
-                            }
-                            if (!hasAccessToken || roleSet.isEmpty()) {
-                                roleSet.addAll(fessConfig.getSearchGuestRoleList());
-                            }
-                        });
+                findUserBean(requestManager).ifPresent(fessUserBean -> {
+                    loggedIn[0] = true;
+                    stream(fessUserBean.getPermissions()).of(stream -> stream.forEach(roleSet::add));
+                }).orElse(() -> {
+                    if (isApiRequest && ComponentUtil.getFessConfig().getApiAccessTokenRequiredAsBoolean()) {
+                        throw new InvalidAccessTokenException("invalid_token", "Access token is requried.");
+                    }
+                    if (!hasAccessToken || roleSet.isEmpty()) {
+                        roleSet.addAll(fessConfig.getSearchGuestRoleList());
+                    }
+                });
             } catch (final RuntimeException e) {
                 try {
                     requestManager.findLoginManager(FessUserBean.class).ifPresent(LoginManager::logout);
@@ -199,10 +201,30 @@ public class RoleQueryHelper {
                 }
                 throw e;
             }
+
         }
 
         if (defaultRoleList != null) {
             roleSet.addAll(defaultRoleList);
+        }
+
+        // An empty set is read downstream as "role based search is not in use" and the role filter
+        // is then not applied at all, so a user whose permissions resolved to nothing would be
+        // answered from the whole index -- more than the anonymous visitor this same method gives
+        // the guest roles to. Nothing in the permission resolution guarantees a non-empty result:
+        // ldap.role.search.user.enabled withholds the user's own permission, and a member of no
+        // group then contributes none at all.
+        //
+        // Checked after the default permissions above, so a deployment that configures them keeps
+        // exactly what it configured and gains nothing here. Falling back to the guest roles keeps
+        // the two ends consistent, and a deployment that really has opted out of role based search
+        // has an empty guest list too, so the filter is still skipped for logged-in and anonymous
+        // callers alike.
+        if (loggedIn[0] && roleSet.isEmpty()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("No permission is resolved for the logged-in user. Falling back to the guest roles.");
+            }
+            roleSet.addAll(ComponentUtil.getFessConfig().getSearchGuestRoleList());
         }
 
         if (logger.isDebugEnabled()) {

--- a/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/RoleQueryHelperTest.java
@@ -492,6 +492,148 @@ public class RoleQueryHelperTest extends UnitFessTestCase {
         }
     }
 
+    /**
+     * The same invariant from the other end: a request that <em>does</em> carry a logged-in user
+     * whose permissions resolved to nothing.
+     *
+     * <p>The anonymous branch above backfills the guest roles, but the present branch only copies
+     * {@code FessUserBean#getPermissions}, and nothing guarantees that array is non-empty:
+     * {@code ldap.role.search.user.enabled=false} withholds the user's own permission, and an
+     * account belonging to no group then contributes none at all. An empty set is read by
+     * {@code QueryHelper#buildRoleQuery} and {@code SearchHelper} as "role based search is not in
+     * use" -- they skip the filter entirely -- so an empty set here answers the caller from the
+     * whole index, which is strictly more than the anonymous visitor gets.
+     */
+    @Test
+    public void test_build_loggedInWithNoPermissions_fallsBackToGuestRole() {
+        final RoleQueryHelper roleQueryHelper = new RoleQueryHelper() {
+            @Override
+            protected long getCurrentTime() {
+                return System.currentTimeMillis();
+            }
+
+            @Override
+            protected boolean processAccessToken(final HttpServletRequest request, final Set<String> roleSet, final boolean isApiRequest) {
+                return false;
+            }
+
+            @Override
+            protected org.dbflute.optional.OptionalThing<org.codelibs.fess.mylasta.action.FessUserBean> findUserBean(
+                    final org.lastaflute.web.servlet.request.RequestManager requestManager) {
+                // A logged-in user carrying no permission at all. Resolved here rather than through
+                // the container for the same reason as the anonymous test above.
+                return org.dbflute.optional.OptionalThing
+                        .of(new org.codelibs.fess.mylasta.action.FessUserBean(new org.codelibs.fess.entity.FessUser() {
+                            private static final long serialVersionUID = 1L;
+
+                            @Override
+                            public String getName() {
+                                return "no-permission-user";
+                            }
+
+                            @Override
+                            public String[] getRoleNames() {
+                                return org.codelibs.core.lang.StringUtil.EMPTY_STRINGS;
+                            }
+
+                            @Override
+                            public String[] getGroupNames() {
+                                return org.codelibs.core.lang.StringUtil.EMPTY_STRINGS;
+                            }
+
+                            @Override
+                            public String[] getPermissions() {
+                                return org.codelibs.core.lang.StringUtil.EMPTY_STRINGS;
+                            }
+
+                            @Override
+                            public boolean isEditable() {
+                                return false;
+                            }
+                        }));
+            }
+        };
+        roleQueryHelper.init();
+
+        getMockRequest();
+
+        final Set<String> roleSet = roleQueryHelper.build(SearchRequestType.JSON);
+
+        assertFalse(roleSet.isEmpty(), "a logged-in user with no permissions must not produce an empty role set "
+                + "(the role filter would be skipped and the whole index returned): " + roleSet);
+
+        final List<String> guestRoleList = ComponentUtil.getFessConfig().getSearchGuestRoleList();
+        assertFalse(guestRoleList.isEmpty(), "search.guest.role must be non-empty; emptying it fails the role filter open");
+        for (final String guestRole : guestRoleList) {
+            assertTrue(roleSet.contains(guestRole),
+                    "a logged-in user with no permissions must fall back to guest role '" + guestRole + "': " + roleSet);
+        }
+    }
+
+    /**
+     * The fallback must not reach a user who does have permissions: adding the guest roles to
+     * everyone would hand every logged-in account whatever the guest role can read.
+     */
+    @Test
+    public void test_build_loggedInWithPermissions_keepsOnlyItsOwn() {
+        final RoleQueryHelper roleQueryHelper = new RoleQueryHelper() {
+            @Override
+            protected long getCurrentTime() {
+                return System.currentTimeMillis();
+            }
+
+            @Override
+            protected boolean processAccessToken(final HttpServletRequest request, final Set<String> roleSet, final boolean isApiRequest) {
+                return false;
+            }
+
+            @Override
+            protected org.dbflute.optional.OptionalThing<org.codelibs.fess.mylasta.action.FessUserBean> findUserBean(
+                    final org.lastaflute.web.servlet.request.RequestManager requestManager) {
+                return org.dbflute.optional.OptionalThing
+                        .of(new org.codelibs.fess.mylasta.action.FessUserBean(new org.codelibs.fess.entity.FessUser() {
+                            private static final long serialVersionUID = 1L;
+
+                            @Override
+                            public String getName() {
+                                return "permitted-user";
+                            }
+
+                            @Override
+                            public String[] getRoleNames() {
+                                return org.codelibs.core.lang.StringUtil.EMPTY_STRINGS;
+                            }
+
+                            @Override
+                            public String[] getGroupNames() {
+                                return org.codelibs.core.lang.StringUtil.EMPTY_STRINGS;
+                            }
+
+                            @Override
+                            public String[] getPermissions() {
+                                return new String[] { "1permitted-user" };
+                            }
+
+                            @Override
+                            public boolean isEditable() {
+                                return false;
+                            }
+                        }));
+            }
+        };
+        roleQueryHelper.init();
+
+        getMockRequest();
+
+        final Set<String> roleSet = roleQueryHelper.build(SearchRequestType.JSON);
+
+        assertTrue(roleSet.contains("1permitted-user"), "the user's own permission must survive: " + roleSet);
+        for (final String guestRole : ComponentUtil.getFessConfig().getSearchGuestRoleList()) {
+            assertFalse(roleSet.contains(guestRole),
+                    "a user with permissions must not also receive guest role '" + guestRole + "': " + roleSet);
+        }
+    }
+
     @Test
     public void test_build_withRequest() {
         final RoleQueryHelper roleQueryHelper = new RoleQueryHelper() {


### PR DESCRIPTION
## Problem

`RoleQueryHelper#build` copies the permissions of the logged-in user and nothing more. The branch a few lines above, for a request with no user, backfills the guest roles — the logged-in branch has no equivalent, and nothing guarantees that the copied array is non-empty:

- `ldap.role.search.user.enabled=false` withholds the user's own permission, and an account that belongs to no group then contributes nothing at all.
- `ldap.base.dn` unset short-circuits `LdapUser#getPermissions` to an empty array.

An empty set is not read downstream as "this caller may see nothing". All three consumers skip the filter entirely when it is empty:

```java
// QueryHelper#buildRoleQuery, SearchHelper#getDocumentByDocId, SearchHelper#getDocumentListByDocIds
if (!roleSet.isEmpty()) {
    queryHelper.buildRoleQuery(roleSet, boolQuery);
}
```

So the request is answered from the whole index — every role-restricted document included, which is strictly more than the same deployment gives an anonymous visitor.

`ldap.role.search.user.enabled` is the reachable path in 15.8 specifically. Before #3311 that setting could not withhold anything, because `LdapUser` added the user's own permission unconditionally, so the set was never empty by that route. #3311 made the setting work as documented, which is correct — and made this reachable.

## Measured

Directory user in no group, `ldap.role.search.user.enabled=false`, everything else as shipped:

| | permissions at login | documents returned |
|---|---|---|
| before | *(none)* | every document in the index, including the ones restricted to the admin role and to other users |
| after | *(none)* | only what the guest role reaches |
| control: a user who does have a group and a role | its own two permissions | unchanged, exactly the documents those two reach |

## Change

Fall back to the guest roles when a user is logged in and resolved no permission, so the two ends of the same method agree. Applied after the default permissions are added, so a deployment that configures `role.search.default.permissions` keeps exactly what it configured and gains nothing.

A deployment that has genuinely opted out of role based search has an empty guest role list as well, and keeps its unfiltered behaviour for logged-in and anonymous callers alike.

## Tests

`RoleQueryHelperTest` gains the mirror of the existing anonymous case — a logged-in user whose permissions resolve to nothing must not produce an empty role set — plus a guard that the fallback does not reach a user who does have permissions.
