### PR TITLE
fix(auth): let a setting decide how authentication.admin.users is compared

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -1336,6 +1336,9 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. admin */
     String AUTHENTICATION_ADMIN_USERS = "authentication.admin.users";
 
+    /** The key of the configuration. e.g. auto */
+    String AUTHENTICATION_ADMIN_USERS_IGNORE_CASE = "authentication.admin.users.ignore.case";
+
     /** The key of the configuration. e.g. admin */
     String AUTHENTICATION_ADMIN_ROLES = "authentication.admin.roles";
 
@@ -6919,6 +6922,14 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
     String getAuthenticationAdminUsers();
+
+    /**
+     * Get the value for the key 'authentication.admin.users.ignore.case'. <br>
+     * The value is, e.g. auto <br>
+     * comment: Whether to match authentication.admin.users without regard to case: auto, true or false. auto ignores case when ldap.provider.url is set.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getAuthenticationAdminUsersIgnoreCase();
 
     /**
      * Get the value for the key 'authentication.admin.roles'. <br>
@@ -12614,6 +12625,10 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
         public String getAuthenticationAdminUsers() {
             return get(FessConfig.AUTHENTICATION_ADMIN_USERS);
+        }
+
+        public String getAuthenticationAdminUsersIgnoreCase() {
+            return get(FessConfig.AUTHENTICATION_ADMIN_USERS_IGNORE_CASE);
         }
 
         public String getAuthenticationAdminRoles() {

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -1318,7 +1318,45 @@ public interface FessProp {
 
     String getAuthenticationAdminUsers();
 
+    String getAuthenticationAdminUsersIgnoreCase();
+
+    /**
+     * Tells whether the names authentication.admin.users reserves are compared without regard to case.
+     *
+     * <p>auto -- the shipped value -- answers that by whether this Fess resolves names through a
+     * directory. With ldap.provider.url set, the reserved names are compared the way a directory
+     * compares an account name: it does not distinguish case in one, and Active Directory issues a
+     * ticket for any casing. Without it neither path that consults the reserved names can reach a
+     * directory -- LdapManager#login returns nothing either way -- so the comparison stays exact, as it
+     * always was. true and false decide it outright.
+     *
+     * @return true when the comparison ignores case
+     */
+    private boolean isAdminUserNameIgnoreCase() {
+        final String value = getAuthenticationAdminUsersIgnoreCase();
+        if (Constants.TRUE.equalsIgnoreCase(value)) {
+            return true;
+        }
+        if (Constants.FALSE.equalsIgnoreCase(value)) {
+            return false;
+        }
+        return StringUtil.isNotBlank(getLdapProviderUrl());
+    }
+
+    /**
+     * Tells whether the given name is one of the names authentication.admin.users reserves.
+     *
+     * <p>For SSO the setting is a block list -- SpnegoAuthenticator resolves no credential for a name it
+     * matches, and FessLoginAssist keeps such a name off the LDAP path -- so where the comparison
+     * ignores case the same account cannot come back in under a different spelling.
+     *
+     * @param username the name to test, as the user typed it or the provider asserted it
+     * @return true when the name is reserved
+     */
     default boolean isAdminUser(final String username) {
+        if (isAdminUserNameIgnoreCase()) {
+            return split(getAuthenticationAdminUsers(), ",").get(stream -> stream.anyMatch(s -> s.equalsIgnoreCase(username)));
+        }
         return split(getAuthenticationAdminUsers(), ",").get(stream -> stream.anyMatch(s -> s.equals(username)));
     }
 

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1105,6 +1105,8 @@ clipboard.copy.icon.enabled=true
 
 # Admin user names for authentication.
 authentication.admin.users=admin
+# Whether to match authentication.admin.users without regard to case: auto, true or false. auto ignores case when ldap.provider.url is set.
+authentication.admin.users.ignore.case=auto
 # Admin role names for authentication.
 authentication.admin.roles=admin
 

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
@@ -94,6 +94,137 @@ public class FessPropTest extends UnitFessTestCase {
         assertEquals("1234567890@fess.codelibs.local", fessConfig.getLdapSecurityPrincipal("12345678901"));
     }
 
+    /**
+     * Builds a config whose only answers are the two keys the admin-user comparison reads.
+     *
+     * @param adminUsers the value of authentication.admin.users
+     * @param ignoreCase the value of authentication.admin.users.ignore.case
+     * @return the config
+     */
+    private FessConfig createAdminUsersConfig(final String adminUsers, final String ignoreCase) {
+        return new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getAuthenticationAdminUsers() {
+                return adminUsers;
+            }
+
+            @Override
+            public String getAuthenticationAdminUsersIgnoreCase() {
+                return ignoreCase;
+            }
+
+            @Override
+            public boolean isLdapAdminEnabled() {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * Sets ldap.provider.url on the running container, which is what auto reads.
+     *
+     * @param url the URL, or null to leave the setting empty
+     */
+    private void setLdapProviderUrl(final String url) {
+        final DynamicProperties systemProps = SingletonLaContainerFactory.getContainer().getComponent("systemProperties");
+        if (url == null) {
+            systemProps.remove(Constants.LDAP_PROVIDER_URL);
+        } else {
+            systemProps.setProperty(Constants.LDAP_PROVIDER_URL, url);
+        }
+    }
+
+    /**
+     * Without a directory the comparison cannot change any outcome: both branches of
+     * FessLoginAssist#resolveCredential end at doAuthenticateLocal, and SpnegoAuthenticator resolves
+     * nothing either way. So auto leaves such an installation comparing exactly, as it always did.
+     */
+    @Test
+    public void test_isAdminUser_autoComparesExactlyWithoutLdap() {
+        FessProp.propMap.clear();
+        setLdapProviderUrl(null);
+        final FessConfig fessConfig = createAdminUsersConfig("admin,operator", "auto");
+
+        assertTrue(fessConfig.isAdminUser("admin"));
+        assertTrue(fessConfig.isAdminUser("operator"));
+        assertFalse(fessConfig.isAdminUser("ADMIN"));
+        assertFalse(fessConfig.isAdminUser("Admin"));
+        assertFalse(fessConfig.isAdminUser("OPERATOR"));
+        assertFalse(fessConfig.isAdminUser("admin2"));
+        assertFalse(fessConfig.isAdminUser(""));
+        assertFalse(fessConfig.isAdminUser(null));
+    }
+
+    /**
+     * A directory does not distinguish case in an account name -- Active Directory issues a ticket for
+     * any casing of one -- so once ldap.provider.url names one, auto compares the reserved names the
+     * way that directory does.
+     */
+    @Test
+    public void test_isAdminUser_autoIgnoresCaseWithLdap() {
+        FessProp.propMap.clear();
+        setLdapProviderUrl("ldap://localhost:389/");
+        final FessConfig fessConfig = createAdminUsersConfig("admin,operator", "auto");
+
+        assertTrue(fessConfig.isAdminUser("admin"));
+        assertTrue(fessConfig.isAdminUser("ADMIN"));
+        assertTrue(fessConfig.isAdminUser("Admin"));
+        assertTrue(fessConfig.isAdminUser("aDmIn"));
+        assertTrue(fessConfig.isAdminUser("OPERATOR"));
+
+        // Only the names it lists, whatever their case: a longer or shorter name is a different one.
+        assertFalse(fessConfig.isAdminUser("admin2"));
+        assertFalse(fessConfig.isAdminUser("adm"));
+        assertFalse(fessConfig.isAdminUser("alice"));
+        assertFalse(fessConfig.isAdminUser(""));
+        assertFalse(fessConfig.isAdminUser(null));
+    }
+
+    /**
+     * true asks for the directory comparison whether or not this Fess resolves names through one.
+     */
+    @Test
+    public void test_isAdminUser_trueIgnoresCaseWithoutLdap() {
+        FessProp.propMap.clear();
+        setLdapProviderUrl(null);
+        final FessConfig fessConfig = createAdminUsersConfig("admin,operator", "true");
+
+        assertTrue(fessConfig.isAdminUser("ADMIN"));
+        assertTrue(fessConfig.isAdminUser("OPERATOR"));
+        assertFalse(fessConfig.isAdminUser("admin2"));
+    }
+
+    /**
+     * false is the way out for an installation that has an account whose name differs from a reserved
+     * one only in case and that must keep logging in.
+     */
+    @Test
+    public void test_isAdminUser_falseComparesExactlyWithLdap() {
+        FessProp.propMap.clear();
+        setLdapProviderUrl("ldap://localhost:389/");
+        final FessConfig fessConfig = createAdminUsersConfig("admin,operator", "false");
+
+        assertTrue(fessConfig.isAdminUser("admin"));
+        assertFalse(fessConfig.isAdminUser("ADMIN"));
+        assertFalse(fessConfig.isAdminUser("Admin"));
+    }
+
+    /**
+     * isLdapAdminEnabled refuses to make a reserved name editable in the directory, and reads the same
+     * comparison -- so the switch moves that decision too.
+     */
+    @Test
+    public void test_isLdapAdminEnabled_readsTheSameComparison() {
+        FessProp.propMap.clear();
+        setLdapProviderUrl("ldap://localhost:389/");
+        assertFalse(createAdminUsersConfig("admin", "auto").isLdapAdminEnabled("ADMIN"));
+        assertTrue(createAdminUsersConfig("admin", "false").isLdapAdminEnabled("ADMIN"));
+        assertTrue(createAdminUsersConfig("admin", "auto").isLdapAdminEnabled("alice"));
+        assertFalse(createAdminUsersConfig("admin", "auto").isLdapAdminEnabled("admin"));
+    }
+
     @Test
     public void test_validateIndexRequiredFields() {
         FessProp.propMap.clear();


### PR DESCRIPTION
Stacked on #3315.

## Problem

For SSO, `authentication.admin.users` is a block list. `SpnegoAuthenticator#resolveCredential` resolves no credential for a name it matches:

```java
if (!ComponentUtil.getFessConfig().isAdminUser(username)) {
    return ComponentUtil.getLdapManager().login(username);
}
return OptionalEntity.empty();
```

`isAdminUser` compared with `String#equals`. Directories that assert those names do not distinguish case in an account name — Active Directory issues a ticket for any casing of one — so the same account was admitted under a different spelling.

## Measured

`authentication.admin.users` naming an account that exists in the directory:

| login | result | permissions | documents |
|---|---|---|---|
| the name as configured | `LOGIN_FAILURE`, no session | — | — |
| the same name, uppercase | **`LOGIN`, session created** | its own, uppercase | its group's documents |
| the same, with `ldap.lowercase.permission.name=true` | **`LOGIN`** | **exactly the blocked name's permission** | its group's documents |

Group and role permissions come from the directory entry and are case-stable, so the bypassing login reads the blocked account's group documents either way.

## Why this is a setting, not a straight change

`isAdminUser` has four call sites, and two of them do more than refuse a login:

| call site | comparison exact (today) | comparison ignoring case |
|---|---|---|
| `SpnegoAuthenticator#resolveCredential` | `ADMIN` logs in through SSO | refused — the point of this change |
| `FessLoginAssist#resolveCredential` | `ADMIN` is authenticated against LDAP | kept off the LDAP path, falls to the local user index and usually fails there |
| `FessProp#isLdapAdminEnabled(String)` → `LdapManager` insert/update/delete/`changePassword`, `LdapUser#isEditable` | `ADMIN` is synchronised to the directory | silently not synchronised |
| `FessSearchAction` → `adminUser` → header/index/advance JSP | admin link hidden for `ADMIN` | admin link shown |

The first revision of this PR claimed the check "can only refuse more than it did, never less". That is wrong: the fourth row widens, and the second and third change behaviour an installation may depend on.

## Change

`authentication.admin.users.ignore.case`, shipped as `auto`:

| value | comparison |
|---|---|
| `auto` (default) | ignores case when `ldap.provider.url` names a directory, exact otherwise |
| `true` / `false` | decided outright. Anything else reads as `auto` |

`auto` costs nothing where there is no directory: without `ldap.provider.url`, neither path that consults the reserved names reaches a directory — the two-argument `LdapManager#login` returns empty at its first guard, the one-argument overload cannot connect — so the comparison cannot change any outcome and stays exact, as it always was. An installation that does resolve names through a directory and has an account whose name differs from a reserved one only in case sets `false` to keep that account logging in.

`ldap.provider.url` is read through `getSystemProperty`, so `auto` follows the admin UI without a restart.

