### PR TITLE
fix(ldap): fold the user's own permission name, not the prefix in front of it

### DIFF
--- a/src/main/java/org/codelibs/fess/ldap/LdapManager.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapManager.java
@@ -418,11 +418,10 @@ public class LdapManager {
      */
     public String[] getRoles(final LdapUser ldapUser, final String bindDn, final String accountFilter, final String groupFilter,
             final Consumer<String[]> lazyLoading) {
-        final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
         final Set<String> roleSet = new HashSet<>();
 
         if (fessConfig.isLdapRoleSearchUserEnabled()) {
-            roleSet.add(normalizePermissionName(getUserSearchRole(ldapUser, systemHelper)));
+            roleSet.add(getUserPermissionName(ldapUser));
         }
 
         // LDAP: cn=%s
@@ -644,7 +643,19 @@ public class LdapManager {
     }
 
     /**
-     * Names the user's own permission from the name this user logged in with.
+     * Names the permission that stands for this user themselves.
+     *
+     * <p>The one place that name is spelled. {@link LdapUser#getPermissions()} needs it too -- it
+     * appends the user's own permission to both the synchronous result and the nested-group walk's
+     * later write, so that the lazy write does not hand back a strictly smaller set -- and building
+     * it there from its parts instead let the two spellings diverge, putting two permissions for
+     * one identity into the same set.
+     *
+     * <p>Folding applies to the name, never to a string the prefix is already part of. The prefix
+     * marks which kind of permission this is; it is not a character of anybody's name, and it is
+     * configurable to a letter -- {@code role.search.role.prefix} ships as {@code R}. Every other
+     * permission {@code ldap.lowercase.permission.name} touches has been folded that way since the
+     * setting was added.
      *
      * <p>{@code getCanonicalLdapName} drops everything up to the first backslash, which is what
      * turns a NetBIOS-qualified {@code DOMAIN\alice} typed at the login form into the {@code alice}
@@ -655,14 +666,15 @@ public class LdapManager {
      * what {@code getLeafCommonName} closed for group and role names.
      *
      * @param ldapUser the user logging in
-     * @param systemHelper the helper that joins a prefix to a name
-     * @return the user's own search role
+     * @return the user's own permission name
      */
-    protected String getUserSearchRole(final LdapUser ldapUser, final SystemHelper systemHelper) {
+    public String getUserPermissionName(final LdapUser ldapUser) {
+        final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
+        final String name = normalizePermissionName(ldapUser.getName());
         if (ldapUser.isNameFromProvider()) {
-            return systemHelper.getSearchRoleByDirectoryUser(ldapUser.getName());
+            return systemHelper.getSearchRoleByDirectoryUser(name);
         }
-        return systemHelper.getSearchRoleByUser(ldapUser.getName());
+        return systemHelper.getSearchRoleByUser(name);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ldap/LdapUser.java
+++ b/src/main/java/org/codelibs/fess/ldap/LdapUser.java
@@ -139,19 +139,24 @@ public class LdapUser implements FessUser {
             final String groupFilter = fessConfig.getLdapGroupFilter();
             if (StringUtil.isNotBlank(baseDn) && StringUtil.isNotBlank(accountFilter)) {
                 final LdapManager ldapManager = ComponentUtil.getLdapManager();
-                // Appended to both writes, not just the synchronous one. LdapManager derives its own
-                // user entry through getCanonicalLdapName, which drops a NetBIOS "DOMAIN\" prefix,
-                // so the two are not always the same string -- and a lazy write that carried only
-                // what LdapManager collected would hand back a strictly smaller set than the
-                // synchronous result, the user losing their own permission at the moment the
-                // nested-group walk succeeded.
+                // Appended to both writes, not just the synchronous one: a lazy write that carried
+                // only what the nested-group walk collected would hand back a strictly smaller set
+                // than the synchronous result, the user losing their own permission at the moment
+                // that walk succeeded.
+                //
+                // Taken from LdapManager rather than assembled here from the prefix and the name.
+                // Only LdapManager knows whether this name was asserted by a provider -- which
+                // decides whether a backslash in it is a NetBIOS qualifier to drop or a character
+                // of the name -- and it is the one place that decides how far folding reaches.
+                // Assembling it here produced a second, differently spelled permission for the
+                // same identity, in the same set as the first.
                 //
                 // Both writes are also gated on ldap.role.search.user.enabled, which is what that
                 // setting has always claimed to control. Adding it here regardless made the setting
                 // unable to withhold anything.
-                final String[] userPermissions = fessConfig.isLdapRoleSearchUserEnabled()
-                        ? new String[] { fessConfig.getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName()) }
-                        : StringUtil.EMPTY_STRINGS;
+                final String[] userPermissions =
+                        fessConfig.isLdapRoleSearchUserEnabled() ? new String[] { ldapManager.getUserPermissionName(this) }
+                                : StringUtil.EMPTY_STRINGS;
                 final String[] directPermissions =
                         distinct(ArrayUtils.addAll(ldapManager.getRoles(this, baseDn, accountFilter, groupFilter, roles -> {
                             permissions = distinct(ArrayUtils.addAll(roles, userPermissions));

--- a/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapManagerTest.java
@@ -153,7 +153,7 @@ public class LdapManagerTest extends UnitFessTestCase {
      */
     @SuppressWarnings("serial")
     @Test
-    public void test_getUserSearchRole_assertedNameKeepsItsBackslash() {
+    public void test_getUserPermissionName_assertedNameKeepsItsBackslash() {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             public boolean isLdapIgnoreNetbiosName() {
                 return true;
@@ -162,18 +162,60 @@ public class LdapManagerTest extends UnitFessTestCase {
             public String getRoleSearchUserPrefix() {
                 return "1";
             }
+
+            public boolean isLdapLowercasePermissionName() {
+                return false;
+            }
         });
         final LdapManager ldapManager = new LdapManager();
         ldapManager.init();
-        final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
 
         // Typed at the login form: the NetBIOS domain is dropped, as it always was.
-        assertEquals("1alice", ldapManager.getUserSearchRole(new LdapUser(new Hashtable<>(), "EXAMPLE\\alice"), systemHelper));
+        assertEquals("1alice", ldapManager.getUserPermissionName(new LdapUser(new Hashtable<>(), "EXAMPLE\\alice")));
         // Asserted by an identity provider: the whole name is the name.
-        assertEquals("1zz\\alice", ldapManager.getUserSearchRole(new LdapUser(new Hashtable<>(), "zz\\alice", true), systemHelper));
+        assertEquals("1zz\\alice", ldapManager.getUserPermissionName(new LdapUser(new Hashtable<>(), "zz\\alice", true)));
         // A name with no backslash reads the same either way.
-        assertEquals("1alice", ldapManager.getUserSearchRole(new LdapUser(new Hashtable<>(), "alice"), systemHelper));
-        assertEquals("1alice", ldapManager.getUserSearchRole(new LdapUser(new Hashtable<>(), "alice", true), systemHelper));
+        assertEquals("1alice", ldapManager.getUserPermissionName(new LdapUser(new Hashtable<>(), "alice")));
+        assertEquals("1alice", ldapManager.getUserPermissionName(new LdapUser(new Hashtable<>(), "alice", true)));
+    }
+
+    /**
+     * The user's own permission has one spelling, and folding reaches the name only.
+     *
+     * <p>This class built it as {@code normalizePermissionName(prefix + name)} while LdapUser built
+     * it as {@code prefix + normalizePermissionName(name)}, and both landed in the same set. The
+     * two agree only while the prefix has no case of its own -- the shipped user prefix is "1" --
+     * and diverge as soon as it has one, which a prefix may: {@code role.search.role.prefix} ships
+     * as "R". Folding the joined string is also what no other permission does; the group, role and
+     * SID-derived names have all folded the name alone since the setting was added.
+     */
+    @SuppressWarnings("serial")
+    @Test
+    public void test_getUserPermissionName_foldsTheNameNotThePrefix() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public boolean isLdapIgnoreNetbiosName() {
+                return true;
+            }
+
+            @Override
+            public String getRoleSearchUserPrefix() {
+                return "U";
+            }
+
+            @Override
+            public boolean isLdapLowercasePermissionName() {
+                return true;
+            }
+        });
+        final LdapManager ldapManager = new LdapManager();
+        ldapManager.init();
+
+        // One spelling for one identity: "Ualice" here and "Ualice" in LdapUser, not "ualice" here.
+        assertEquals("Ualice", ldapManager.getUserPermissionName(new LdapUser(new Hashtable<>(), "Alice")));
+        assertEquals("Ualice", ldapManager.getUserPermissionName(new LdapUser(new Hashtable<>(), "EXAMPLE\\Alice")));
+        // And the asserted-name distinction survives folding.
+        assertEquals("Uzz\\alice", ldapManager.getUserPermissionName(new LdapUser(new Hashtable<>(), "zz\\Alice", true)));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/ldap/LdapUserTest.java
+++ b/src/test/java/org/codelibs/fess/ldap/LdapUserTest.java
@@ -219,6 +219,13 @@ public class LdapUserTest extends UnitFessTestCase {
             public String normalizePermissionName(String name) {
                 return name.toLowerCase();
             }
+
+            @Override
+            public String getUserPermissionName(final LdapUser user) {
+                // LdapUser takes the whole permission name from LdapManager instead of
+                // joining the prefix to it, so the stub spells what it used to build.
+                return "U" + normalizePermissionName(user.getName());
+            }
         }, "ldapManager");
 
         ComponentUtil.register(new ActivityHelper() {
@@ -294,6 +301,13 @@ public class LdapUserTest extends UnitFessTestCase {
             public String normalizePermissionName(String name) {
                 return "user";
             }
+
+            @Override
+            public String getUserPermissionName(final LdapUser user) {
+                // LdapUser takes the whole permission name from LdapManager instead of
+                // joining the prefix to it, so the stub spells what it used to build.
+                return "U" + normalizePermissionName(user.getName());
+            }
         }, "ldapManager");
 
         ComponentUtil.register(new ActivityHelper() {
@@ -355,6 +369,13 @@ public class LdapUserTest extends UnitFessTestCase {
             @Override
             public String normalizePermissionName(String name) {
                 return name;
+            }
+
+            @Override
+            public String getUserPermissionName(final LdapUser user) {
+                // LdapUser takes the whole permission name from LdapManager instead of
+                // joining the prefix to it, so the stub spells what it used to build.
+                return "U" + normalizePermissionName(user.getName());
             }
         }, "ldapManager");
 
@@ -434,6 +455,13 @@ public class LdapUserTest extends UnitFessTestCase {
             @Override
             public String normalizePermissionName(String name) {
                 return name;
+            }
+
+            @Override
+            public String getUserPermissionName(final LdapUser user) {
+                // LdapUser takes the whole permission name from LdapManager instead of
+                // joining the prefix to it, so the stub spells what it used to build.
+                return "U" + normalizePermissionName(user.getName());
             }
         }, "ldapManager");
 
@@ -622,6 +650,13 @@ public class LdapUserTest extends UnitFessTestCase {
             public String normalizePermissionName(final String name) {
                 return name;
             }
+
+            @Override
+            public String getUserPermissionName(final LdapUser user) {
+                // LdapUser takes the whole permission name from LdapManager instead of
+                // joining the prefix to it, so the stub spells what it used to build.
+                return "1" + normalizePermissionName(user.getName());
+            }
         }, "ldapManager");
 
         ComponentUtil.register(new ActivityHelper() {
@@ -689,6 +724,13 @@ public class LdapUserTest extends UnitFessTestCase {
             @Override
             public String normalizePermissionName(final String name) {
                 return name;
+            }
+
+            @Override
+            public String getUserPermissionName(final LdapUser user) {
+                // LdapUser takes the whole permission name from LdapManager instead of
+                // joining the prefix to it, so the stub spells what it used to build.
+                return "1" + normalizePermissionName(user.getName());
             }
         }, "ldapManager");
 
@@ -765,6 +807,13 @@ public class LdapUserTest extends UnitFessTestCase {
             @Override
             public String normalizePermissionName(final String name) {
                 return name;
+            }
+
+            @Override
+            public String getUserPermissionName(final LdapUser user) {
+                // LdapUser takes the whole permission name from LdapManager instead of
+                // joining the prefix to it, so the stub spells what it used to build.
+                return "1" + normalizePermissionName(user.getName());
             }
         }, "ldapManager");
 


### PR DESCRIPTION
Stacked on #3316.

## Problem

The permission that stands for the user themselves is needed in two places, and they built it differently.

```java
// LdapManager#getRoles
roleSet.add(normalizePermissionName(getUserSearchRole(ldapUser, systemHelper)));   // normalize(prefix + name)

// LdapUser#getPermissions
fessConfig.getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName())   // prefix + normalize(name)
```

Both land in the same set, so wherever the two expressions differ, one login carries two permissions for one identity.

### `LdapManager` is the one that is wrong

`ldap.lowercase.permission.name` arrived in be91848 (`fix #2510`, shipped in 13.10.2) folding **the name**, with the prefix joined afterwards -- at every site it touched:

```java
roleSet.add(systemHelper.getSearchRoleByRole(normalizePermissionName(name)));    // R + fold(name)
roleSet.add(systemHelper.getSearchRoleByGroup(normalizePermissionName(name)));   // 2 + fold(name)
... getRoleSearchUserPrefix() + ldapManager.normalizePermissionName(getName())   // 1 + fold(name)
```

Twelve days later, 5b28be6 (`fix #2514` "User permission is not normalized on LdapManager", shipped in 13.10.3) added the missing normalization to the user branch by wrapping a call that had **already joined the prefix**:

```diff
-roleSet.add(systemHelper.getSearchRoleByUser(ldapUser.getName()));
+roleSet.add(normalizePermissionName(systemHelper.getSearchRoleByUser(ldapUser.getName())));
```

That line is the only place in Fess where a search-role prefix is folded. `SambaHelper#createSearchRole` folds the account name and prepends the SID type; `PermissionHelper#encode`, which turns a crawl configuration's `{user}alice` into the value indexed on the document, folds nothing at all. So once `role.search.user.prefix` has a case of its own, the searcher's own name could not match the name their documents are indexed under -- independently of the second builder.

## Measured

`role.search.user.prefix=U`, one SSO login:

| | permissions |
|---|---|
| `ldap.lowercase.permission.name=false` | `Uname` plus the group and role permissions |
| `ldap.lowercase.permission.name=true`, before | **`uname` and `Uname`** plus the group and role permissions |

`Uname` is also what a document permitted to `{user}name` carries, at either setting. The group permission, which has only one builder, folds to a single spelling in the same run -- that is the control.

## Second difference: whose name it is

Only `LdapManager` consults `LdapUser#isNameFromProvider`, which decides whether a backslash in the name is a NetBIOS qualifier to drop or a character of the name -- the distinction #3309 introduced. `LdapUser` dropped nothing, so a name typed at the login form produced the canonicalised permission *and* the name as typed. This half is not reachable on every directory: it needs a bind template that passes the typed string through and a directory that accepts a NetBIOS-qualified simple bind, which the directory used here refuses. It is closed by construction rather than by measurement.

## Change

Name it once, in `LdapManager#getUserPermissionName`: fold the name, then join the prefix, keeping #3309's asserted-name distinction. Both callers read it from there, and `getUserSearchRole` folds into it -- it had no other caller. No behaviour change for the shipped prefixes, where the two expressions already agreed.

`mvn test` 7355 passing. The new test fails against the previous implementation with `expected: <Ualice> but was: <ualice>`.
