### PR TITLE
fix(auth): trim the entries of authentication.admin.users

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -1350,14 +1350,21 @@ public interface FessProp {
      * matches, and FessLoginAssist keeps such a name off the LDAP path -- so where the comparison
      * ignores case the same account cannot come back in under a different spelling.
      *
+     * <p>Each entry is trimmed. A comma-separated list is ordinarily written with a space after the
+     * comma, and the untrimmed entry is compared as " name", which no user name can equal: every
+     * entry but the first would stop reserving anything, silently, in the direction that lets a
+     * directory account of that name log in. Every other comma list this interface parses -- the LDAP
+     * object classes, the additional sort fields, the trusted proxies -- already trims. Blank entries
+     * are dropped for the same reason: a trailing comma cannot be allowed to reserve the empty name.
+     *
      * @param username the name to test, as the user typed it or the provider asserted it
      * @return true when the name is reserved
      */
     default boolean isAdminUser(final String username) {
-        if (isAdminUserNameIgnoreCase()) {
-            return split(getAuthenticationAdminUsers(), ",").get(stream -> stream.anyMatch(s -> s.equalsIgnoreCase(username)));
-        }
-        return split(getAuthenticationAdminUsers(), ",").get(stream -> stream.anyMatch(s -> s.equals(username)));
+        final boolean ignoreCase = isAdminUserNameIgnoreCase();
+        return split(getAuthenticationAdminUsers(), ",").get(stream -> stream.map(String::trim)
+                .filter(StringUtil::isNotBlank)
+                .anyMatch(s -> ignoreCase ? s.equalsIgnoreCase(username) : s.equals(username)));
     }
 
     boolean isLdapAdminEnabled();

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
@@ -212,6 +212,54 @@ public class FessPropTest extends UnitFessTestCase {
     }
 
     /**
+     * A comma-separated list is ordinarily written with a space after the comma. Untrimmed, every
+     * entry but the first is compared as " name" and reserves nothing -- and for SSO that is the
+     * fail-open direction: the account logs in and is handed the permission named after it.
+     */
+    @Test
+    public void test_isAdminUser_trimsEachEntry() {
+        FessProp.propMap.clear();
+        setLdapProviderUrl("ldap://localhost:389/");
+        final FessConfig fessConfig = createAdminUsersConfig("admin, operator , backup", "auto");
+
+        assertTrue(fessConfig.isAdminUser("admin"));
+        assertTrue(fessConfig.isAdminUser("operator"));
+        assertTrue(fessConfig.isAdminUser("backup"));
+        // The space is not part of any name, so it must not become part of one either.
+        assertFalse(fessConfig.isAdminUser(" operator"));
+        assertFalse(fessConfig.isAdminUser("operator "));
+    }
+
+    /**
+     * The exact comparison reads the same list, so it has to trim the same way.
+     */
+    @Test
+    public void test_isAdminUser_trimsEachEntryWithExactComparison() {
+        FessProp.propMap.clear();
+        setLdapProviderUrl(null);
+        final FessConfig fessConfig = createAdminUsersConfig("admin, operator", "false");
+
+        assertTrue(fessConfig.isAdminUser("operator"));
+        assertFalse(fessConfig.isAdminUser("OPERATOR"));
+        assertFalse(fessConfig.isAdminUser(" operator"));
+    }
+
+    /**
+     * A trailing comma leaves an empty entry, which must reserve nothing rather than the empty name.
+     */
+    @Test
+    public void test_isAdminUser_dropsBlankEntries() {
+        FessProp.propMap.clear();
+        setLdapProviderUrl("ldap://localhost:389/");
+        final FessConfig fessConfig = createAdminUsersConfig("admin,,  ,", "auto");
+
+        assertTrue(fessConfig.isAdminUser("admin"));
+        assertFalse(fessConfig.isAdminUser(""));
+        assertFalse(fessConfig.isAdminUser(" "));
+        assertFalse(fessConfig.isAdminUser(null));
+    }
+
+    /**
      * isLdapAdminEnabled refuses to make a reserved name editable in the directory, and reads the same
      * comparison -- so the switch moves that decision too.
      */


### PR DESCRIPTION
## Problem

For SSO `authentication.admin.users` is a **block list**. `SpnegoAuthenticator#resolveCredential`
resolves no credential for a name it matches, `FessLoginAssist#resolveCredential` keeps such a name
off the LDAP path, and `isLdapAdminEnabled(String)` refuses to synchronise it to the directory.

`isAdminUser` split the value on `,` and compared the pieces as they came:

```java
split(getAuthenticationAdminUsers(), ",").get(stream -> stream.anyMatch(s -> s.equals(username)));
```

A comma-separated list is ordinarily written with a space after the comma:

```properties
authentication.admin.users=admin, operator
```

The second entry is then compared as `" operator"`, which no user name can equal. **Every entry
after the first stops reserving anything**, and the direction it fails in is open: the directory
account of that name logs in through SSO and is handed the permission named after it — the
permission the documents of the account the name was meant to reserve carry.

## Measured

On a running instance with SPNEGO and a directory (shipped `authentication.admin.users.ignore.case=auto`):

| `authentication.admin.users` | login as the second entry | permissions | documents read |
|---|---|---|---|
| `admin, bob` (one space) | **succeeds** | `1bob｜2dev` | the group's documents |
| `admin,bob` (control) | refused (`LOGIN_FAILURE`) | — | — |
| after this change, both | refused | — | — |

## Change

Trim each entry and drop the blank ones, so a trailing comma cannot reserve the empty name either.
Every other comma list `FessProp` parses — the LDAP object classes, the additional sort fields, the
trusted proxies — already trims; this one decides who is refused.

## What changes for a deployment that already has a space in the list

`isAdminUser` has four call sites, and they do not all move in the same direction — the same
asymmetry #3316 documented for the case comparison:

| call site | effect of the entry now matching |
|---|---|
| `SpnegoAuthenticator#resolveCredential` | refuses the SSO login (the point of this PR) |
| `FessLoginAssist#resolveCredential` | keeps the name off the LDAP path |
| `FessProp#isLdapAdminEnabled(String)` | stops synchronising the name to the directory |
| `FessSearchAction` → `adminUser` | **shows the admin link** for a logged-in local user of that name |

The first three refuse more. The fourth is a widening, and display-only: reaching an admin screen is
decided by `authentication.admin.roles` in `FessAdminAction`, not by this setting, so the link can
appear for a user the screens still turn away.

Nothing changes for a list written without spaces, which includes the shipped
`authentication.admin.users=admin`. Worth a release note for the deployments where it does.

## Tests

Three cases added to `FessPropTest` (trimming under both comparisons, and blank entries). All three
fail on the current `master` and pass with the change. `mvn test`: 7369 green.
