### PR TITLE
fix(api): decide admin API access on the token, not on a request parameter

### DIFF
--- a/src/main/java/org/codelibs/fess/app/service/AccessTokenService.java
+++ b/src/main/java/org/codelibs/fess/app/service/AccessTokenService.java
@@ -131,29 +131,78 @@ public class AccessTokenService {
     }
 
     /**
-     * Get the permissions.
+     * Get the permissions a request carries: the ones the registered token was issued with, plus
+     * the ones the caller named in the token's own request parameter.
+     *
+     * <p>These are the permissions a search is filtered by, which is what the request parameter
+     * exists for -- an application that embeds Fess passes the end user's permissions per request
+     * rather than issuing a token each. Anything that decides what the CALLER may do, rather than
+     * which documents it may see, has to read {@link #getTokenPermissions(HttpServletRequest)}
+     * instead.
+     *
      * @param request The request.
      * @return The permissions.
      */
     public OptionalEntity<Set<String>> getPermissions(final HttpServletRequest request) {
+        return resolvePermissions(request, true);
+    }
+
+    /**
+     * Get only the permissions the registered token itself was issued with.
+     *
+     * <p>The request parameter is deliberately not read. Its values come from the caller, so a set
+     * that included them could be raised by the caller to any permission at all -- which is exactly
+     * what it is for while the set decides which documents come back, and exactly what it must not
+     * do while the set decides whether the administration API answers.
+     *
+     * @param request The request.
+     * @return The permissions the token carries.
+     */
+    public OptionalEntity<Set<String>> getTokenPermissions(final HttpServletRequest request) {
+        return resolvePermissions(request, false);
+    }
+
+    /**
+     * Resolves the registered token and collects its permissions.
+     *
+     * @param request The request.
+     * @param withRequestParameter Whether to add the values of the token's request parameter.
+     * @return The permissions, empty when the request carries no token.
+     */
+    protected OptionalEntity<Set<String>> resolvePermissions(final HttpServletRequest request, final boolean withRequestParameter) {
         final String token = ComponentUtil.getAccessTokenHelper().getAccessTokenFromRequest(request);
         if (StringUtil.isNotBlank(token)) {
             return accessTokenBhv.selectEntity(cb -> {
                 cb.query().setToken_Term(token);
-            }).map(accessToken -> {
-                final Set<String> permissionSet = new HashSet<>();
-                final Long expiredTime = accessToken.getExpiredTime();
-                if (expiredTime != null && expiredTime.longValue() > 0
-                        && expiredTime.longValue() < ComponentUtil.getSystemHelper().getCurrentTimeAsLong()) {
-                    throw new InvalidAccessTokenException("invalid_token",
-                            "The token is expired(" + FessFunctions.formatDate(FessFunctions.date(expiredTime)) + ").");
-                }
-                stream(accessToken.getPermissions()).of(stream -> stream.forEach(permissionSet::add));
-                final String name = accessToken.getParameterName();
-                stream(request.getParameterValues(name)).of(stream -> stream.filter(StringUtil::isNotBlank).forEach(permissionSet::add));
-                return OptionalEntity.of(permissionSet);
-            }).orElseThrow(() -> new InvalidAccessTokenException("invalid_token", "The access token is not registered."));
+            })
+                    .map(accessToken -> OptionalEntity.of(collectPermissions(accessToken, request, withRequestParameter)))
+                    .orElseThrow(() -> new InvalidAccessTokenException("invalid_token", "The access token is not registered."));
         }
         return OptionalEntity.empty();
+    }
+
+    /**
+     * Collects the permissions of a resolved token.
+     *
+     * @param accessToken The registered token.
+     * @param request The request, read only for the token's own parameter.
+     * @param withRequestParameter Whether to add the values of that parameter.
+     * @return The permissions.
+     */
+    protected Set<String> collectPermissions(final AccessToken accessToken, final HttpServletRequest request,
+            final boolean withRequestParameter) {
+        final Set<String> permissionSet = new HashSet<>();
+        final Long expiredTime = accessToken.getExpiredTime();
+        if (expiredTime != null && expiredTime.longValue() > 0
+                && expiredTime.longValue() < ComponentUtil.getSystemHelper().getCurrentTimeAsLong()) {
+            throw new InvalidAccessTokenException("invalid_token",
+                    "The token is expired(" + FessFunctions.formatDate(FessFunctions.date(expiredTime)) + ").");
+        }
+        stream(accessToken.getPermissions()).of(stream -> stream.forEach(permissionSet::add));
+        if (withRequestParameter) {
+            final String name = accessToken.getParameterName();
+            stream(request.getParameterValues(name)).of(stream -> stream.filter(StringUtil::isNotBlank).forEach(permissionSet::add));
+        }
+        return permissionSet;
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/FessApiAdminAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/FessApiAdminAction.java
@@ -44,12 +44,19 @@ public abstract class FessApiAdminAction extends FessApiAction {
      * This method validates the access token and checks if the associated permissions
      * allow admin access according to the Fess configuration.
      *
+     * <p>Only the permissions the token was issued with are consulted. A token may also name a
+     * request parameter through which the caller supplies further permissions, and those are what
+     * a search is filtered by -- but they are chosen by the caller, so admitting them here let any
+     * token whatsoever reach the administration API by naming
+     * {@code api.admin.access.permissions} in that parameter. Granting a token administrative
+     * access is the issuing screen's decision, and it is recorded on the token.
+     *
      * @return true if admin access is allowed, false otherwise
      */
     @Override
     protected boolean isAccessAllowed() {
         try {
-            return accessTokenService.getPermissions(request)
+            return accessTokenService.getTokenPermissions(request)
                     .map(permissions -> fessConfig.isApiAdminAccessAllowed(permissions))
                     .orElse(false);
         } catch (final InvalidAccessTokenException e) {

--- a/src/test/java/org/codelibs/fess/app/service/AccessTokenServiceTest.java
+++ b/src/test/java/org/codelibs/fess/app/service/AccessTokenServiceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.service;
+
+import java.util.Set;
+
+import org.codelibs.fess.opensearch.config.exentity.AccessToken;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * The two permission sets a request carries: the one the token was issued with, and the one the
+ * caller added through the token's request parameter.
+ */
+public class AccessTokenServiceTest extends UnitFessTestCase {
+
+    private AccessToken createToken(final String[] permissions, final String parameterName) {
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setPermissions(permissions);
+        accessToken.setParameterName(parameterName);
+        return accessToken;
+    }
+
+    /**
+     * The request parameter exists so that an application embedding Fess can pass the end user's
+     * permissions per request instead of issuing a token each, so the search-filtering set has to
+     * carry them.
+     */
+    @Test
+    public void test_collectPermissions_searchSetCarriesTheRequestParameter() {
+        final AccessTokenService service = new AccessTokenService();
+        final HttpServletRequest request = getMockRequest();
+        getMockRequest().setParameter("fessPermissions", "2sales");
+
+        final Set<String> permissions =
+                service.collectPermissions(createToken(new String[] { "1guest" }, "fessPermissions"), request, true);
+
+        assertTrue(permissions.contains("1guest"));
+        assertTrue(permissions.contains("2sales"));
+    }
+
+    /**
+     * The set that decides whether the caller may reach the administration API must not, or naming
+     * api.admin.access.permissions in that same parameter raises any token to an administrative one.
+     */
+    @Test
+    public void test_collectPermissions_tokenSetIgnoresTheRequestParameter() {
+        final AccessTokenService service = new AccessTokenService();
+        final HttpServletRequest request = getMockRequest();
+        getMockRequest().setParameter("fessPermissions", "Radmin-api");
+
+        final Set<String> permissions =
+                service.collectPermissions(createToken(new String[] { "1guest" }, "fessPermissions"), request, false);
+
+        assertTrue(permissions.contains("1guest"));
+        assertFalse(permissions.contains("Radmin-api"));
+        assertEquals(1, permissions.size());
+    }
+
+    /**
+     * A token issued WITH the administrative permission still carries it either way: the fix
+     * narrows where the permission may come from, not which permissions exist.
+     */
+    @Test
+    public void test_collectPermissions_tokenSetKeepsItsOwnPermissions() {
+        final AccessTokenService service = new AccessTokenService();
+        final HttpServletRequest request = getMockRequest();
+
+        final Set<String> permissions = service.collectPermissions(createToken(new String[] { "Radmin-api" }, null), request, false);
+
+        assertTrue(permissions.contains("Radmin-api"));
+    }
+
+    /**
+     * A token that names no parameter is unaffected by whatever the caller sends.
+     */
+    @Test
+    public void test_collectPermissions_noParameterName() {
+        final AccessTokenService service = new AccessTokenService();
+        final HttpServletRequest request = getMockRequest();
+        getMockRequest().setParameter("fessPermissions", "Radmin-api");
+
+        final Set<String> permissions = service.collectPermissions(createToken(new String[] { "1guest" }, null), request, true);
+
+        assertEquals(1, permissions.size());
+        assertTrue(permissions.contains("1guest"));
+    }
+}


### PR DESCRIPTION
> Stacked on 3319.

## Problem

An access token may name a **request parameter**, and every value the caller sends in it is added to
the permission set the token resolves to:

```java
stream(accessToken.getPermissions()).of(stream -> stream.forEach(permissionSet::add));
final String name = accessToken.getParameterName();
stream(request.getParameterValues(name)).of(stream -> stream.filter(StringUtil::isNotBlank).forEach(permissionSet::add));
```

That is what the parameter is for: an application embedding Fess passes the end user's permissions
per request instead of issuing a token each, and the search is filtered by the result.

`FessApiAdminAction#isAccessAllowed` decided **admin API access on that same set**. So any issued
token whose configuration names a parameter reached the whole administration API — read and write of
every setting — by sending `api.admin.access.permissions` in that parameter:

```
GET /api/v2/...   ?<parameter>=Radmin-api    filtered search   (intended)
GET /api/admin/...?<parameter>=Radmin-api    200, admin API    (not)
```

## Measured

A token issued with `permissions=["1guest"]` and a parameter name, against `/api/admin/role/settings`:

| request | before | after |
|---|---|---|
| token + `?<parameter>=Radmin-api` | **200, admin payload** | 401 |
| token alone (control) | 401 | 401 |
| parameter alone, no token (control) | 401 | 401 |
| token issued with `Radmin-api` itself | 200 | 200 |

## Change

Split the two sets. `getPermissions` keeps the request parameter, for search filtering.
`getTokenPermissions` returns only what the token was issued with, and the admin gate reads it.

The permission is chosen by the caller, which is acceptable while it only narrows what the caller
may *see* and is not while it decides what the caller may *do*. Granting a token administrative
access stays the issuing screen's decision, recorded on the token itself; a token issued with the
permission is unaffected, and the search path is untouched.

The access token guide already warns that the parameter must only be used where the embedding
application fully controls the request. This closes the part of it a search-scoped token was never
meant to reach.

## Tests

`AccessTokenServiceTest` (new): the search set carries the parameter, the token set does not, a
token's own `Radmin-api` survives either way, and a token naming no parameter ignores it.
`mvn test`: 7369 green.

## Precedent

`fess-webapp-mcp` already treats this channel as a hazard and suppresses it by hand.
`FessTokenAuthenticator#resolvePermissions` hands `AccessTokenService` a request wrapper whose
`getParameterValues` always reports nothing, and its class javadoc names the reason:

> `AccessTokenService#getPermissions(HttpServletRequest)` folds in
> `request.getParameterValues(accessToken.getParameterName())` when the token row declares a
> `parameterName`, letting the caller inject arbitrary extra permission strings through the query
> string.

So a caller that needs "what this token was issued with, and nothing the request added" already
existed outside core and had to build its own answer. `getTokenPermissions` is that answer, and once
this lands the plugin's wrapper can be replaced by a call to it.
