### PR TITLE
chore(auth): trim the entries of authentication.admin.roles

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessProp.java
@@ -856,10 +856,22 @@ public interface FessProp {
 
     String getAuthenticationAdminRoles();
 
+    /**
+     * The roles that make a user an administrator.
+     *
+     * <p>Each entry is trimmed and the blank ones are dropped, for the same reason
+     * {@link #isAdminUser(String)} does it: a list written with a space after the comma compared its
+     * second entry as " name", which no role name can equal. That direction is closed rather than
+     * open -- the administrator simply stops being one, on every screen at once -- but it is just as
+     * silent, and the two halves of authentication.admin.* should not disagree about what a list is.
+     *
+     * @return the role names
+     */
     default String[] getAuthenticationAdminRolesAsArray() {
         String[] roles = (String[]) propMap.get(AUTHENTICATION_ADMIN_ROLES);
         if (roles == null) {
-            roles = getAuthenticationAdminRoles().split(",");
+            roles = split(getAuthenticationAdminRoles(), ",")
+                    .get(stream -> stream.map(String::trim).filter(StringUtil::isNotBlank).toArray(n -> new String[n]));
             propMap.put(AUTHENTICATION_ADMIN_ROLES, roles);
         }
         return roles;

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessPropTest.java
@@ -260,6 +260,29 @@ public class FessPropTest extends UnitFessTestCase {
     }
 
     /**
+     * The other half of authentication.admin.*: a role list written with a space after the comma
+     * lost every entry but the first, and with it the administrator's access to every admin screen.
+     */
+    @Test
+    public void test_getAuthenticationAdminRolesAsArray_trimsEachEntry() {
+        FessProp.propMap.clear();
+        final FessConfig fessConfig = new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getAuthenticationAdminRoles() {
+                return "admin, operator ,, ";
+            }
+        };
+
+        final String[] roles = fessConfig.getAuthenticationAdminRolesAsArray();
+
+        assertEquals(2, roles.length);
+        assertEquals("admin", roles[0]);
+        assertEquals("operator", roles[1]);
+    }
+
+    /**
      * isLdapAdminEnabled refuses to make a reserved name editable in the directory, and reads the same
      * comparison -- so the switch moves that decision too.
      */


### PR DESCRIPTION
> Stacked on 3320.

## Problem

The other half of the setting pair. `authentication.admin.roles` was split on `,` and used as it
came:

```java
roles = getAuthenticationAdminRoles().split(",");
```

so `authentication.admin.roles=admin, operator` compares its second entry as `" operator"`, which no
role name can equal.

This one **fails closed** — the user simply stops being an administrator, on the admin screens, the
admin link, `/api/v2/auth/me` and the role-filter exemption at once — so it is not the security hole
the same omission was in `authentication.admin.users`. It is just as silent, though, and the two
halves of `authentication.admin.*` should not disagree about what a comma-separated list is.

## Change

Trim each entry and drop the blank ones, matching `isAdminUser`.

## What changes for a deployment that already has a space in the list

The direction here is the opposite of #3319's: the entry starts matching, so **users holding that
role become administrators** — on the admin screens, the admin link, `/api/v2/auth/me` and the
role-filter exemption in `QueryHelper`. That is what writing the role asked for, and until now the
setting silently did not deliver it, but it is a widening for such a deployment and belongs in a
release note.

Dropping the blank entries changes nothing on its own: `hasRoles` matches a user role against the
accepted ones, so neither `[""]` (what `"".split(",")` produced) nor `[]` matches anything.

Nothing changes for a list written without spaces, which includes the shipped
`authentication.admin.roles=admin`.

## Tests

One case added to `FessPropTest`; it fails on the current `master` and passes with the change.
`mvn test`: 7369 green.
