### PR TITLE
docs(search): correct what the guest-role fallback claims about an empty guest list

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/RoleQueryHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/RoleQueryHelper.java
@@ -217,9 +217,14 @@ public class RoleQueryHelper {
         //
         // Checked after the default permissions above, so a deployment that configures them keeps
         // exactly what it configured and gains nothing here. Falling back to the guest roles keeps
-        // the two ends consistent, and a deployment that really has opted out of role based search
-        // has an empty guest list too, so the filter is still skipped for logged-in and anonymous
-        // callers alike.
+        // the two ends consistent: this is what an anonymous caller is answered with, and a
+        // logged-in one should never be answered with more.
+        //
+        // The guest roles are never empty -- getSearchGuestRoleList appends <user-prefix>guest
+        // whatever role.search.guest.permissions says -- so this does apply the filter, including
+        // in a deployment that indexes no permissions at all. There, a user who resolves none is
+        // now answered with nothing rather than with everything. That is the point, but it is a
+        // change of behaviour for such a deployment and belongs in the upgrade notes.
         if (loggedIn[0] && roleSet.isEmpty()) {
             if (logger.isDebugEnabled()) {
                 logger.debug("No permission is resolved for the logged-in user. Falling back to the guest roles.");


### PR DESCRIPTION
> Stacked on #3321. Comment only, no behaviour change.

## Problem

The comment on #3314's guest-role fallback says:

> a deployment that really has opted out of role based search has an empty guest list too, so the
> filter is still skipped for logged-in and anonymous callers alike

`getSearchGuestRoleList()` ends with

```java
list.add(getRoleSearchUserPrefix() + Constants.GUEST_USER);
```

so the guest list contains `1guest` whatever `role.search.guest.permissions` says. It is never
empty, and the filter is therefore never skipped.

## Measured

With `role.search.guest.permissions` emptied and a logged-in user resolving no permission: the
search returns the documents carrying `1guest` and nothing else — the filter was applied.

## Why it matters

The fallback itself is right: a logged-in user must not be answered with more than an anonymous one.
But a deployment that indexes no permissions at all now answers such a user with **nothing** where
it used to answer with everything, and that belongs in the upgrade notes rather than in a comment
saying it cannot happen.
