### PR TITLE
fix(sso): stop a SAML LogoutResponse from ending a session it never belonged to

### DIFF
--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -1290,7 +1290,10 @@ public class SamlAuthenticator implements SsoAuthenticator {
                 // it is still answered with an ordinary LogoutResponse: an error would tell an
                 // unauthenticated sender whether it guessed a live session, and would leave a
                 // confused-but-legitimate IdP with no way of finishing its own logout.
-                final boolean keepLocalSession = isLogoutRequestForAnotherUser(request, settings);
+                //
+                // A LogoutResponse never ends a session at all; see isLogoutResponse.
+                final boolean keepLocalSession = isLogoutResponse(request) || isLogoutRequestForAnotherUser(request, settings);
+                warnIfLogoutResponseReachedALiveLogin(request);
                 // stay=true keeps java-saml from committing the servlet response itself
                 final String redirectUrl = auth.processSLO(keepLocalSession, null, true);
                 final List<String> errors = auth.getErrors();
@@ -1318,6 +1321,83 @@ public class SamlAuthenticator implements SsoAuthenticator {
     }
 
     /**
+     * Returns whether the incoming logout message is a LogoutResponse, in which case it must not
+     * end the local session.
+     *
+     * <p>A LogoutResponse is the answer to a LogoutRequest this SP sent, and {@code LogoutAction}
+     * has already ended the local login by the time one can arrive: it asks the SSO manager for
+     * the redirect URL and then calls {@code logout()}, which invalidates the session. Whatever
+     * session the answer lands on is therefore a fresh one, so invalidating it ends nothing that
+     * was still running -- and that is the only thing a legitimate LogoutResponse gave up here.</p>
+     *
+     * <p>What it costs is the rest of the deployment. {@code /sso/logout} is anonymous and,
+     * because SAML requires {@code SameSite=none}, reachable cross-site with the victim's session
+     * cookie attached. {@code Auth#processSLO} is given no request ID to bind the answer to -- the
+     * SP has none to give, having just discarded the session that would have held it -- so
+     * java-saml skips the {@code InResponseTo} comparison, and with the shipped
+     * {@code saml.security.want_messages_signed=false} every remaining check is conditional on an
+     * attribute the sender may simply omit: {@code Issuer}, {@code Destination}, and the
+     * {@code InResponseTo} attribute itself. A LogoutResponse carrying nothing but a Success
+     * status was therefore enough to invalidate any session it was pointed at -- a SAML login, a
+     * local one, or a login still in flight, whose pending AuthnRequest ID went with the session
+     * and left the user unable to log in while the page kept firing. No signature, no guess, and
+     * nothing in the log.</p>
+     *
+     * <p>This is the same exposure {@link #isLogoutRequestForAnotherUser} closes for the other
+     * kind of message, where the NameID is what costs the sender a guess. A LogoutResponse carries
+     * no NameID, so there is nothing to compare -- and nothing that needs comparing, because there
+     * is nothing left for it to end.</p>
+     *
+     * @param request The HTTP request carrying the SAML logout message.
+     * @return true if the message is a LogoutResponse.
+     */
+    protected boolean isLogoutResponse(final HttpServletRequest request) {
+        return StringUtil.isBlank(request.getParameter("SAMLRequest")) && StringUtil.isNotBlank(request.getParameter("SAMLResponse"));
+    }
+
+    /**
+     * Reports a LogoutResponse that reached a session which is still logged in.
+     *
+     * <p>The legitimate answer arrives after {@code LogoutAction} has ended the login, so this
+     * says nothing on the path a logout actually takes. It says something on the one it does not:
+     * a LogoutResponse aimed at a live login answers a logout that was never started, which is
+     * either a stale replay out of a browser's history or a request forged to end somebody's
+     * session. Reporting it is what makes the attempt visible; the session is kept either way.</p>
+     *
+     * <p>One bounded line and no stack trace, for the reason the rest of this endpoint gives: it
+     * is anonymous, so a rejected message must not let an unauthenticated client fill the log.
+     * Nothing the sender supplied is echoed, because nothing in the message was validated.</p>
+     *
+     * @param request The HTTP request carrying the SAML logout message.
+     */
+    protected void warnIfLogoutResponseReachedALiveLogin(final HttpServletRequest request) {
+        if (!isLogoutResponse(request) || !isLoggedIn()) {
+            return;
+        }
+        logger.warn("A SAML LogoutResponse reached a session that is still logged in, so it is answered without ending it."
+                + " A LogoutResponse answers a LogoutRequest this server sent, and this server had not sent one:"
+                + " the message is a replay or was forged to end the session. An IdP that starts a logout sends a LogoutRequest instead.");
+    }
+
+    /**
+     * Returns whether this session is logged in, answering false when that cannot be determined.
+     *
+     * @return true if a user is logged in.
+     */
+    protected boolean isLoggedIn() {
+        try {
+            return getSavedUserBean().isPresent();
+        } catch (final Exception e) {
+            // this endpoint has to keep working for a request that reaches it outside a login
+            // scope, so being unable to look at the session means "cannot tell", not "fail"
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to read the session user.", e);
+            }
+            return false;
+        }
+    }
+
+    /**
      * Returns whether an IdP-initiated LogoutRequest names somebody other than the user this
      * session is logged in as, in which case the session must survive it.
      *
@@ -1330,10 +1410,11 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * comparison as well. The NameID is the one element java-saml insists on, so it is the one
      * thing left worth checking, and comparing it with the session costs an attacker the guess.</p>
      *
-     * <p>A LogoutResponse the IdP is answering ({@code SAMLResponse}) is left alone: it is the
-     * reply to a LogoutRequest this SP itself sent, so it carries no NameID to compare, and
-     * constructing a {@link LogoutRequest} from such a request would silently build a fresh
-     * outgoing message rather than parse anything.</p>
+     * <p>A LogoutResponse the IdP is answering ({@code SAMLResponse}) is left alone here: it
+     * carries no NameID to compare, and constructing a {@link LogoutRequest} from such a request
+     * would silently build a fresh outgoing message rather than parse anything.
+     * {@link #isLogoutResponse(HttpServletRequest)} keeps the session for that kind of message
+     * instead, on the ground that there is nothing left for it to end.</p>
      *
      * <p>Anything that is not a clear mismatch keeps the previous behaviour of ending the session:
      * no user logged in, a user who did not come from SAML, a message whose NameID cannot be read

--- a/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/org/codelibs/fess/sso/saml/SamlAuthenticatorTest.java
@@ -1907,6 +1907,90 @@ public class SamlAuthenticatorTest extends UnitFessTestCase {
         }
     }
 
+    @Test
+    public void test_isLogoutResponse() throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator();
+        // getMockRequest() hands out the one request of this test, so each step overwrites the
+        // parameter the previous one set rather than starting from a clean request.
+        final MockletHttpServletRequest request = getMockRequest();
+
+        // No logout message at all.
+        assertFalse(authenticator.isLogoutResponse(request));
+
+        request.setParameter("SAMLResponse", "   ");
+        assertFalse(authenticator.isLogoutResponse(request));
+
+        request.setParameter("SAMLResponse", "PHNhbWxwOkxvZ291dFJlc3BvbnNlIC8+");
+        assertTrue(authenticator.isLogoutResponse(request));
+
+        // Auth#processSLO reads SAMLResponse first, but a request carrying both has to be treated
+        // as the LogoutRequest it also is: the NameID comparison is what guards that branch, and
+        // an IdP-initiated logout does end the session.
+        request.setParameter("SAMLRequest", "PHNhbWxwOkxvZ291dFJlcXVlc3QgLz4=");
+        assertFalse(authenticator.isLogoutResponse(request));
+
+        request.setParameter("SAMLRequest", "");
+        assertTrue(authenticator.isLogoutResponse(request));
+    }
+
+    @Test
+    public void test_warnIfLogoutResponseReachedALiveLogin_reportsOnlyTheLoginThatIsStillLive() throws Exception {
+        final boolean[] loggedIn = { true };
+        final SamlAuthenticator authenticator = new SamlAuthenticator() {
+            @Override
+            protected boolean isLoggedIn() {
+                return loggedIn[0];
+            }
+        };
+        final MockletHttpServletRequest request = getMockRequest();
+        final LogCapturingAppender appender = LogCapturingAppender.attach(SamlAuthenticator.class);
+        try {
+            // A LogoutRequest is the other branch, reported by its own NameID comparison.
+            request.setParameter("SAMLRequest", "PHNhbWxwOkxvZ291dFJlcXVlc3QgLz4=");
+            authenticator.warnIfLogoutResponseReachedALiveLogin(request);
+            assertEquals(String.valueOf(appender.warnings()), 0, appender.warnings().size());
+
+            // The legitimate answer arrives after LogoutAction has ended the login, so the path a
+            // logout actually takes stays silent.
+            request.setParameter("SAMLRequest", "");
+            request.setParameter("SAMLResponse", "PHNhbWxwOkxvZ291dFJlc3BvbnNlIC8+");
+            loggedIn[0] = false;
+            authenticator.warnIfLogoutResponseReachedALiveLogin(request);
+            assertEquals(String.valueOf(appender.warnings()), 0, appender.warnings().size());
+
+            // A LogoutResponse aimed at a live login answers a logout that was never started.
+            loggedIn[0] = true;
+            authenticator.warnIfLogoutResponseReachedALiveLogin(request);
+
+            final List<String> warnings = appender.warnings();
+            assertEquals(String.valueOf(warnings), 1, warnings.size());
+            final String message = warnings.get(0);
+            assertTrue(message, message.contains("LogoutResponse"));
+            assertTrue(message, message.contains("still logged in"));
+            // The endpoint is anonymous and nothing in the message was validated: one bounded
+            // line, no stack trace, and nothing the sender supplied.
+            assertFalse(message, message.contains("PHNhbWxwOkxvZ291dFJlc3BvbnNlIC8+"));
+            assertEquals(String.valueOf(appender.errors()), 0, appender.errors().size());
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_isLoggedIn_answersFalseWhenTheSessionCannotBeRead() throws Exception {
+        final SamlAuthenticator authenticator = new SamlAuthenticator() {
+            @Override
+            protected OptionalThing<FessUserBean> getSavedUserBean() {
+                throw new IllegalStateException("no login scope");
+            }
+        };
+
+        // /sso/logout has to keep working for a request that reaches it outside a login scope, so
+        // "cannot tell" must not become "fail" -- and must not become "logged in" either, which
+        // would report every legitimate logout.
+        assertFalse(authenticator.isLoggedIn());
+    }
+
     /** A user that did not authenticate through SAML, as a local or LDAP login leaves behind. */
     private static class LocalUser implements FessUser {
 


### PR DESCRIPTION
## What

`/sso/logout` accepted an unsigned, unsolicited SAML `LogoutResponse` and ended
whatever session the request carried. This keeps the session for that kind of
message, and reports one bounded line when the message reached a login that was
still live.

## Why

`/sso/logout` is anonymous, and because SAML requires `SameSite=none` on the
session cookie it is reachable cross-site with the victim's cookie attached.

`Auth#processSLO` was given `null` as the request ID, so java-saml skipped the
`InResponseTo` comparison. With the shipped `saml.security.want_messages_signed=false`
every remaining check is conditional on an attribute the sender may simply omit:
`Issuer`, `Destination`, and the `InResponseTo` attribute itself. A
`LogoutResponse` containing nothing but a `Success` status therefore passed
validation, and `processSLO` invalidated the session.

The SP has no request ID to give: `LogoutAction` asks the SSO manager for the
redirect URL and then calls `logout()`, which invalidates the session that would
have held it. So the binding cannot be restored by storing the ID there.

Measured on a Keycloak-backed setup, against `master`:

| | before | after |
|---|---|---|
| live SAML login, forged `LogoutResponse` | session ended, `0` log lines | session kept, `1` WARN |
| local (non-SAML) login | session ended | session kept |
| login still in flight | session ended, and the pending AuthnRequest ID with it, so the login could not complete | login completes |
| SP-initiated SLO round trip | login ended | login ended, no WARN |
| `LogoutRequest` naming the session's own user | session ended | session ended |
| `LogoutRequest` naming another user | session kept (#3262) | session kept |

The impact is denial of service rather than escalation: an attacker ends
sessions and, while the request keeps being made, prevents logins from
completing. `saml.security.want_messages_signed=true` already prevented it,
which is why the start-up banner recommends it — but the shipped default did not.

## How

- A `LogoutResponse` no longer ends the local session. Nothing is lost by that:
  a legitimate one answers a `LogoutRequest` this SP sent, and by the time it can
  arrive `LogoutAction` has already ended the login, so the session it lands on
  is a fresh one. This is the same exposure the NameID comparison closes for a
  `LogoutRequest` (#3262); a `LogoutResponse` carries no NameID, and needs none,
  because there is nothing left for it to end.
- A `LogoutResponse` that reaches a session which is still logged in is reported.
  That never happens on the path a logout actually takes, so the legitimate round
  trip stays silent. The line is bounded, carries no stack trace and echoes
  nothing the sender supplied — an anonymous endpoint must not let an
  unauthenticated client fill the log.
- A request carrying both parameters stays on the `LogoutRequest` branch, decided
  the same way round as `Auth#processSLO` reads them.

## Tests

`SamlAuthenticatorTest` 75 tests green (3 added), and 235 green across the
related SSO/exception suites.

Verified end to end against a Keycloak IdP: the forged message is refused and
reported, a login in flight completes afterwards, the SP-initiated SLO round trip
still ends the login without a warning, and both `LogoutRequest` cases behave as
before. Reverting the change turns six of those assertions red, so they are not
vacuous.
