### PR TITLE
fix(search): stop a restored search query from failing the login it follows

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
@@ -199,14 +199,50 @@ public class SsoAction extends FessLoginAction {
      * @return Optional HtmlResponse containing the redirect to search page with parameters,
      *         or empty if no search parameters were found
      */
+    /**
+     * Resolves how long a query string {@link #redirectToSearchPage()} may build.
+     *
+     * <p>The bound exists because the container has one: a longer {@code Location} cannot be
+     * written and the login fails with an empty 500. It is configurable because the container's
+     * bound is configurable too -- {@code tomcat.maxHttpHeaderSize} in
+     * {@code tomcat_config.properties}, which the SPNEGO documentation asks deployments with large
+     * Kerberos tickets to raise. Raise the two together.</p>
+     *
+     * <p>The generated accessor answers null for a <em>blank</em> value, and this is read on the
+     * login path, so a blank one falls back to the shipped default rather than throwing.</p>
+     *
+     * @return the maximum encoded query-string length to build
+     */
+    protected int getMaxRestoredQueryLength() {
+        final Integer value = fessConfig.getCookieSearchParameterMaxRestoredLengthAsInteger();
+        return value != null ? value : 4096;
+    }
+
     protected OptionalThing<HtmlResponse> redirectToSearchPage() {
         final RequestParameter[] searchParameters = searchHelper.getSearchParameters();
         if (searchParameters.length > 0) {
             final List<String> paramList = new ArrayList<>();
+            final int maxLength = getMaxRestoredQueryLength();
+            int length = 0;
             for (final RequestParameter param : searchParameters) {
                 for (final String value : param.getValues()) {
+                    final String encoded = URLEncoder.encode(value, Constants.CHARSET_UTF_8);
+                    // Restoring the query is a convenience; the login is not. cookie.search.
+                    // parameter.max.length bounds the COMPRESSED cookie and is therefore no bound
+                    // at all on the URL built from it -- percent-encoding a CJK query multiplies
+                    // its length by nine, so a query well inside query.max.length can produce a
+                    // Location header the container refuses to write, and the login that would
+                    // otherwise have succeeded answers 500 instead. Dropping the restore leaves
+                    // the user logged in on the search top page. The bound is configurable because
+                    // the container bound it protects against is: see tomcat.maxHttpHeaderSize.
+                    length += param.getName().length() + encoded.length() + 2;
+                    if (length > maxLength) {
+                        logger.warn("Stored search parameters exceed {} characters once encoded; " + "logging in without restoring them.",
+                                maxLength);
+                        return OptionalThing.empty();
+                    }
                     paramList.add(param.getName());
-                    paramList.add(URLEncoder.encode(value, Constants.CHARSET_UTF_8));
+                    paramList.add(encoded);
                 }
             }
             if (logger.isDebugEnabled()) {

--- a/src/main/java/org/codelibs/fess/helper/SearchHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SearchHelper.java
@@ -663,8 +663,17 @@ public class SearchHelper {
                     if (cookieName.equals(cookie.getName())) {
                         try {
                             final String encoded = cookie.getValue();
+                            // The write side refuses to store a cookie longer than this, so a
+                            // longer one did not come from this server. Applying the same bound
+                            // here keeps the two sides symmetric and rejects an oversized value
+                            // before it is decompressed.
+                            final int maxLength = fessConfig.getCookieSearchParameterMaxLengthAsInteger();
+                            if (encoded.length() > maxLength) {
+                                logger.warn("Ignoring stored search parameters: the cookie is longer than {} characters.", maxLength);
+                                return new RequestParameter[0];
+                            }
                             final byte[] compressed = Base64.getUrlDecoder().decode(encoded);
-                            final byte[] jsonBytes = gzipDecompress(compressed);
+                            final byte[] jsonBytes = gzipDecompress(compressed, getMaxDecompressedParameterLength(fessConfig));
                             final List<?> list = mapper.readValue(jsonBytes, List.class);
 
                             final List<RequestParameter> result = new ArrayList<>();
@@ -696,19 +705,47 @@ public class SearchHelper {
     }
 
     /**
-     * Decompresses GZIP-compressed data.
+     * Resolves how far the stored search parameters may be allowed to decompress.
+     *
+     * <p>{@code cookie.search.parameter.max.length} bounds the <em>encoded</em> cookie, which is
+     * gzip, so it is no bound on what that cookie expands to -- and the cookie arrives from the
+     * client. Hence a bound of its own, and a configurable one: the shipped value is far above
+     * anything the write side can produce, but a deployment that raises the encoded bound has to
+     * be able to raise this with it.</p>
+     *
+     * <p>The generated accessor answers null for a <em>blank</em> value, and this is read on the
+     * login path, so a blank one falls back to the shipped default rather than throwing.</p>
+     *
+     * @param fessConfig the configuration to read the bound from
+     * @return the maximum number of decompressed bytes to accept
+     */
+    protected int getMaxDecompressedParameterLength(final FessConfig fessConfig) {
+        final Integer value = fessConfig.getCookieSearchParameterMaxDecompressedLengthAsInteger();
+        return value != null ? value : 65536;
+    }
+
+    /**
+     * Decompresses GZIP-compressed data, refusing to expand beyond the given bound.
+     *
+     * The only caller that does not compress its own input is the stored-parameter cookie, which
+     * the client supplies. Stopping at the bound rather than reading to EOF keeps a small, highly
+     * compressible cookie from allocating without limit.
      *
      * @param compressed The GZIP-compressed data to decompress
+     * @param maxLength The maximum number of decompressed bytes to accept
      * @return Decompressed data
-     * @throws IORuntimeException if decompression fails
+     * @throws IORuntimeException if decompression fails or the data expands beyond maxLength
      */
-    protected byte[] gzipDecompress(final byte[] compressed) {
+    protected byte[] gzipDecompress(final byte[] compressed, final int maxLength) {
         try (final ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
                 final GZIPInputStream gzipIn = new GZIPInputStream(bis);
                 final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
             final byte[] buffer = new byte[1024];
             int len;
             while ((len = gzipIn.read(buffer)) > 0) {
+                if (bos.size() + len > maxLength) {
+                    throw new IORuntimeException(new IOException("Compressed data expands beyond " + maxLength + " bytes."));
+                }
                 bos.write(buffer, 0, len);
             }
             return bos.toByteArray();

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -1384,6 +1384,12 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. 1000 */
     String COOKIE_SEARCH_PARAMETER_MAX_LENGTH = "cookie.search.parameter.max.length";
 
+    /** The key of the configuration. e.g. 65536 */
+    String COOKIE_SEARCH_PARAMETER_MAX_DECOMPRESSED_LENGTH = "cookie.search.parameter.max.decompressed.length";
+
+    /** The key of the configuration. e.g. 4096 */
+    String COOKIE_SEARCH_PARAMETER_MAX_RESTORED_LENGTH = "cookie.search.parameter.max.restored.length";
+
     /** The key of the configuration. e.g. fsrp */
     String COOKIE_SEARCH_PARAMETER_NAME = "cookie.search.parameter.name";
 
@@ -7123,6 +7129,40 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     Integer getCookieSearchParameterMaxLengthAsInteger();
 
     /**
+     * Get the value for the key 'cookie.search.parameter.max.decompressed.length'. <br>
+     * The value is, e.g. 65536 <br>
+     * comment: Maximum size in bytes the stored search parameters may decompress to.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterMaxDecompressedLength();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.max.decompressed.length' as {@link Integer}. <br>
+     * The value is, e.g. 65536 <br>
+     * comment: Maximum size in bytes the stored search parameters may decompress to.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getCookieSearchParameterMaxDecompressedLengthAsInteger();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.max.restored.length'. <br>
+     * The value is, e.g. 4096 <br>
+     * comment: Maximum length of the query string built when restoring the stored search parameters after login.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     */
+    String getCookieSearchParameterMaxRestoredLength();
+
+    /**
+     * Get the value for the key 'cookie.search.parameter.max.restored.length' as {@link Integer}. <br>
+     * The value is, e.g. 4096 <br>
+     * comment: Maximum length of the query string built when restoring the stored search parameters after login.
+     * @return The value of found property. (NotNull: if not found, exception but basically no way)
+     * @throws NumberFormatException When the property is not integer.
+     */
+    Integer getCookieSearchParameterMaxRestoredLengthAsInteger();
+
+    /**
      * Get the value for the key 'cookie.search.parameter.name'. <br>
      * The value is, e.g. fsrp <br>
      * comment: Cookie name used to store encoded search parameters before SSO login.
@@ -12715,6 +12755,22 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return getAsInteger(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_LENGTH);
         }
 
+        public String getCookieSearchParameterMaxDecompressedLength() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_DECOMPRESSED_LENGTH);
+        }
+
+        public Integer getCookieSearchParameterMaxDecompressedLengthAsInteger() {
+            return getAsInteger(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_DECOMPRESSED_LENGTH);
+        }
+
+        public String getCookieSearchParameterMaxRestoredLength() {
+            return get(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_RESTORED_LENGTH);
+        }
+
+        public Integer getCookieSearchParameterMaxRestoredLengthAsInteger() {
+            return getAsInteger(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_RESTORED_LENGTH);
+        }
+
         public String getCookieSearchParameterName() {
             return get(FessConfig.COOKIE_SEARCH_PARAMETER_NAME);
         }
@@ -14714,6 +14770,8 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_KEYS, "q,num,sort");
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_required_keys, "q");
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_LENGTH, "1000");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_DECOMPRESSED_LENGTH, "65536");
+            defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_MAX_RESTORED_LENGTH, "4096");
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_NAME, "fsrp");
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_http_only, "true");
             defaultMap.put(FessConfig.COOKIE_SEARCH_PARAMETER_SECURE, "");

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1155,6 +1155,15 @@ cookie.search.parameter.keys=q,num,sort
 cookie.search.parameter.required_keys=q
 # Maximum length of the encoded search parameters stored in cookies.
 cookie.search.parameter.max.length=1000
+# Maximum size in bytes the stored search parameters may decompress to. The bound above applies to
+# the gzipped cookie, which is no bound on what it expands to, and the cookie comes from the client.
+cookie.search.parameter.max.decompressed.length=65536
+# Maximum length of the query string built when restoring the stored search parameters after login.
+# Restoring them is a convenience and the login is not, so a longer one is dropped rather than
+# written to a Location header the container would refuse. Percent-encoding multiplies a CJK query
+# by nine, so this is far smaller than the query itself may be. Raise it together with
+# tomcat.maxHttpHeaderSize in tomcat_config.properties, which bounds the response headers.
+cookie.search.parameter.max.restored.length=4096
 # Cookie name used to store encoded search parameters before SSO login.
 cookie.search.parameter.name=fsrp
 # Whether to set HttpOnly attribute to the search parameter cookie.

--- a/src/test/java/org/codelibs/fess/app/web/sso/SsoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/sso/SsoActionTest.java
@@ -18,6 +18,10 @@ package org.codelibs.fess.app.web.sso;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.codelibs.fess.entity.RequestParameter;
+import org.codelibs.fess.helper.SearchHelper;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+
 import org.apache.logging.log4j.Level;
 import org.codelibs.fess.exception.SsoMessageException;
 import org.codelibs.fess.exception.SsoProcessException;
@@ -30,6 +34,7 @@ import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.lastaflute.core.message.UserMessages;
+import org.lastaflute.web.UrlChain;
 import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.response.HtmlResponse;
 import org.lastaflute.web.validation.VaMessenger;
@@ -131,6 +136,92 @@ public class SsoActionTest extends UnitFessTestCase {
         }
     }
 
+    // ===================================================================================
+    //                                                       Restoring the stored search query
+    //                                                       =================================
+
+    /**
+     * Builds an action whose stored search parameters are exactly the given ones.
+     */
+    private TestableSsoAction actionWithStoredParameters(final RequestParameter... parameters) {
+        return actionWithStoredParameters(4096, parameters);
+    }
+
+    /** @param maxRestoredLength the value of cookie.search.parameter.max.restored.length */
+    private TestableSsoAction actionWithStoredParameters(final int maxRestoredLength, final RequestParameter... parameters) {
+        final TestableSsoAction action = new TestableSsoAction();
+        action.storeParameters(maxRestoredLength, parameters);
+        return action;
+    }
+
+    @Test
+    public void test_redirectToSearchPage_restoresAQueryThatFits() {
+        final TestableSsoAction action = actionWithStoredParameters(new RequestParameter("q", new String[] { "kerberos" }));
+
+        assertTrue(action.redirectToSearchPage().isPresent());
+        assertEquals(List.of("q", "kerberos"), action.redirectParams);
+    }
+
+    @Test
+    public void test_redirectToSearchPage_dropsAQueryTooLongToRedirectWith() {
+        // cookie.search.parameter.max.length bounds the COMPRESSED cookie, so it is no bound at
+        // all on the URL built from it: percent-encoding a CJK query multiplies its length by
+        // nine. A query the search page accepts can therefore produce a Location header the
+        // container refuses to write, and the login answers 500 instead of succeeding.
+        final StringBuilder cjk = new StringBuilder();
+        while (cjk.length() < 850) {
+            cjk.append('\u691c');
+        }
+        final TestableSsoAction action = actionWithStoredParameters(new RequestParameter("q", new String[] { cjk.toString() }));
+
+        assertFalse(action.redirectToSearchPage().isPresent(), "the login must not be lost to the query it was going to restore");
+    }
+
+    @Test
+    public void test_redirectToSearchPage_dropsTheWholeRestoreRatherThanHalfOfIt() {
+        // A partial restore would run a DIFFERENT search from the one the user asked for -- the
+        // paging and sorting parameters would be gone while q stayed. Nothing is restored.
+        final StringBuilder cjk = new StringBuilder();
+        while (cjk.length() < 850) {
+            cjk.append('\u691c');
+        }
+        final TestableSsoAction action = actionWithStoredParameters(new RequestParameter("q", new String[] { cjk.toString() }),
+                new RequestParameter("num", new String[] { "20" }));
+
+        assertFalse(action.redirectToSearchPage().isPresent());
+        assertTrue(action.redirectParams.isEmpty());
+    }
+
+    @Test
+    public void test_redirectToSearchPage_honoursTheConfiguredBound() {
+        // The bound is a configuration key because the container bound it protects against is one
+        // too (tomcat.maxHttpHeaderSize). A deployment that raised that has to be able to raise
+        // this, or the query it can now carry is still dropped.
+        final StringBuilder cjk = new StringBuilder();
+        while (cjk.length() < 850) {
+            cjk.append('\u691c');
+        }
+        final RequestParameter q = new RequestParameter("q", new String[] { cjk.toString() });
+
+        assertFalse(actionWithStoredParameters(4096, q).redirectToSearchPage().isPresent(), "the shipped bound drops it");
+        assertTrue(actionWithStoredParameters(65536, q).redirectToSearchPage().isPresent(), "a raised bound restores it");
+    }
+
+    @Test
+    public void test_redirectToSearchPage_fallsBackWhenTheBoundIsBlank() {
+        // getAsInteger answers null for a blank value, and this is read on the login path: a blank
+        // key must fall back to the shipped default, not throw.
+        final TestableSsoAction action = new TestableSsoAction();
+        action.storeParametersWithNoConfiguredBound(new RequestParameter("q", new String[] { "kerberos" }));
+
+        assertTrue(action.redirectToSearchPage().isPresent());
+    }
+
+    @Test
+    public void test_redirectToSearchPage_withNothingStored() {
+        assertFalse(actionWithStoredParameters().redirectToSearchPage().isPresent());
+    }
+
     /**
      * SsoAction with the seams that need the DI container replaced: the message stores and the
      * action path resolver are not available to a plain unit test.
@@ -138,6 +229,44 @@ public class SsoActionTest extends UnitFessTestCase {
     private static class TestableSsoAction extends SsoAction {
         final List<String> savedErrors = new CopyOnWriteArrayList<>();
         final List<String> savedInfos = new CopyOnWriteArrayList<>();
+        final List<Object> redirectParams = new CopyOnWriteArrayList<>();
+
+        @Override
+        protected HtmlResponse redirectWith(final Class<?> actionType, final UrlChain moreUrl) {
+            redirectParams.addAll(List.of(moreUrl.getParamsOnGet()));
+            return REDIRECT_TO_LOGIN;
+        }
+
+        /** searchHelper and fessConfig are protected in another package, so they are set here. */
+        void storeParameters(final int maxRestoredLength, final RequestParameter... parameters) {
+            searchHelper = new SearchHelper() {
+                @Override
+                public RequestParameter[] getSearchParameters() {
+                    return parameters;
+                }
+            };
+            fessConfig = new FessConfig.SimpleImpl() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Integer getCookieSearchParameterMaxRestoredLengthAsInteger() {
+                    return maxRestoredLength;
+                }
+            };
+        }
+
+        /** The same seams, with the bound left blank so the fallback is what answers. */
+        void storeParametersWithNoConfiguredBound(final RequestParameter... parameters) {
+            storeParameters(4096, parameters);
+            fessConfig = new FessConfig.SimpleImpl() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Integer getCookieSearchParameterMaxRestoredLengthAsInteger() {
+                    return null;
+                }
+            };
+        }
 
         @Override
         protected void saveError(final VaMessenger<FessMessages> validationMessagesLambda) {

--- a/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
@@ -57,7 +57,7 @@ public class SearchHelperTest extends UnitFessTestCase {
         String encoded = searchHelper.serializeParameters(params);
         assertNotNull(encoded);
         byte[] compressed = Base64.getUrlDecoder().decode(encoded);
-        byte[] jsonBytes = searchHelper.gzipDecompress(compressed);
+        byte[] jsonBytes = searchHelper.gzipDecompress(compressed, 65536);
         String json = new String(jsonBytes);
         assertTrue(json.contains("q"));
         assertTrue(json.contains("lang"));
@@ -85,6 +85,99 @@ public class SearchHelperTest extends UnitFessTestCase {
         assertEquals("lang", result[1].getName());
         assertEquals("en", result[1].getValues()[0]);
         assertEquals("ja", result[1].getValues()[1]);
+    }
+
+    @Test
+    public void test_getSearchParameters_rejectsCookieLongerThanTheWriteSideStores() {
+        // storeSearchParameters refuses to write a cookie longer than
+        // cookie.search.parameter.max.length, so a longer one did not come from this server.
+        // The cookie built here is perfectly VALID -- it round-trips through the same serializer
+        // the write side uses -- so only the length check can reject it. A malformed oversized
+        // value would be rejected by the base64 decoder instead and prove nothing.
+        final StringBuilder incompressible = new StringBuilder();
+        for (int i = 0; incompressible.length() < 8192; i++) {
+            incompressible.append(Long.toHexString(i * 2654435761L % 0xFFFFFFFFL));
+        }
+        final String encoded = searchHelper
+                .serializeParameters(new RequestParameter[] { new RequestParameter("q", new String[] { incompressible.toString() }) });
+        assertTrue("the cookie has to exceed the bound for this to test anything", encoded.length() > 4096);
+        getMockRequest().addCookie(new Cookie("FESS_SEARCH_PARAM", encoded));
+
+        assertEquals(0, searchHelper.getSearchParameters().length);
+    }
+
+    @Test
+    public void test_getSearchParameters_acceptsACookieInsideThatBound() {
+        // The falsification for the test above: the same shape, short enough, is still restored.
+        final String encoded =
+                searchHelper.serializeParameters(new RequestParameter[] { new RequestParameter("q", new String[] { "kerberos" }) });
+        assertTrue(encoded.length() <= 4096);
+        getMockRequest().addCookie(new Cookie("FESS_SEARCH_PARAM", encoded));
+
+        final RequestParameter[] result = searchHelper.getSearchParameters();
+        assertEquals(1, result.length);
+        assertEquals("kerberos", result[0].getValues()[0]);
+    }
+
+    @Test
+    public void test_getSearchParameters_survivesACookieThatExpandsWithoutBound() {
+        // A cookie inside the encoded bound whose gzip expands far past it. Before the bound in
+        // gzipDecompress this allocated the whole expansion; the contract asserted here is only
+        // that nothing is restored and nothing is thrown to the caller.
+        final StringBuilder value = new StringBuilder("[[\"q\",[\"");
+        for (int i = 0; i < 2_000_000; i++) {
+            value.append('A');
+        }
+        value.append("\"]]]");
+        final String encoded =
+                Base64.getUrlEncoder().withoutPadding().encodeToString(searchHelper.gzipCompress(value.toString().getBytes()));
+        assertTrue("the bomb has to fit inside the encoded bound to test anything", encoded.length() <= 4096);
+        getMockRequest().addCookie(new Cookie("FESS_SEARCH_PARAM", encoded));
+
+        assertEquals(0, searchHelper.getSearchParameters().length);
+    }
+
+    @Test
+    public void test_gzipDecompress_stopsAtTheBound() {
+        final byte[] payload = new byte[1025];
+        try {
+            searchHelper.gzipDecompress(searchHelper.gzipCompress(payload), 1024);
+            fail("expected the bound to stop the decompression");
+        } catch (final Exception e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void test_gzipDecompress_leavesAnythingInsideTheBoundAlone() {
+        // The falsification for the test above: the bound must not reject the round trip the
+        // mechanism actually performs.
+        final byte[] payload = new byte[1024];
+        assertEquals(payload.length, searchHelper.gzipDecompress(searchHelper.gzipCompress(payload), 1024).length);
+    }
+
+    @Test
+    public void test_getSearchParameters_honoursTheConfiguredDecompressedBound() {
+        // The bound is a configuration key, not a constant: an operator who narrows it must see
+        // the narrower bound applied, and the shipped default must leave the same cookie alone.
+        final String encoded =
+                searchHelper.serializeParameters(new RequestParameter[] { new RequestParameter("q", new String[] { "k".repeat(4000) }) });
+        assertTrue("the cookie has to fit the encoded bound for this to test the decompressed one", encoded.length() <= 4096);
+        getMockRequest().addCookie(new Cookie("FESS_SEARCH_PARAM", encoded));
+        ComponentUtil.setFessConfig(new MockFessConfig() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Integer getCookieSearchParameterMaxDecompressedLengthAsInteger() {
+                return 100;
+            }
+        });
+        assertEquals(0, searchHelper.getSearchParameters().length);
+
+        // Control: the shipped default restores exactly the same cookie.
+        getMockRequest().addCookie(new Cookie("FESS_SEARCH_PARAM", encoded));
+        ComponentUtil.setFessConfig(new MockFessConfig());
+        assertEquals(1, searchHelper.getSearchParameters().length);
     }
 
     // Test addRewriter method
@@ -373,7 +466,7 @@ public class SearchHelperTest extends UnitFessTestCase {
         byte[] originalBytes = testData.getBytes();
 
         byte[] compressed = searchHelper.gzipCompress(originalBytes);
-        byte[] decompressed = searchHelper.gzipDecompress(compressed);
+        byte[] decompressed = searchHelper.gzipDecompress(compressed, 65536);
 
         assertEquals(testData, new String(decompressed));
         // For small strings, gzip overhead might make compressed data larger
@@ -403,6 +496,16 @@ public class SearchHelperTest extends UnitFessTestCase {
 
         @Override
         public Integer getCookieSearchParameterMaxLengthAsInteger() {
+            return 4096;
+        }
+
+        @Override
+        public Integer getCookieSearchParameterMaxDecompressedLengthAsInteger() {
+            return 65536;
+        }
+
+        @Override
+        public Integer getCookieSearchParameterMaxRestoredLengthAsInteger() {
             return 4096;
         }
 


### PR DESCRIPTION
## The problem

`FessSearchAction#redirectToLogin` stores the search parameters in a cookie so that `SsoAction` can restore them after the user has authenticated (#2895). The write side bounds what it stores. The read side bounds nothing, and neither side bounds the URL the restore builds.

Two consequences, both of which turn a **successful** authentication into an empty `500` with `Connection: close` and nothing in the application log.

### 1. An ordinary query can be too long to redirect with

`cookie.search.parameter.max.length` (default `1000`) bounds the **compressed** cookie. That is no bound at all on the redirect URL built from it: the cookie holds gzip, the URL holds percent-encoding, and for CJK those differ by two orders of magnitude — one character becomes three UTF-8 bytes and therefore nine characters once encoded.

A query of 850 Japanese characters is inside `query.max.length` (`1000`), so the search page accepts it:

| | |
|---|---|
| query | 850 characters |
| stored cookie | **90 bytes** (inside the 1000 bound) |
| restored `Location` | **7650 characters** |
| result | `500`, empty body, nothing logged |

Tomcat's default `maxHttpHeaderSize` is 8192 bytes and applies to responses as well as requests, so the `Location` cannot be written. And because the `500` discards the `Set-Cookie` that `getSearchParameters` had already queued to clear the stored parameters, the browser presents the same cookie on the next attempt: **every login retry fails the same way** until the 60-second max age runs out. A shorter query of the same kind logs in normally, so the failure looks arbitrary from the outside.

### 2. The cookie is client-supplied and decompressed without a bound

`gzipDecompress` reads to EOF into a `ByteArrayOutputStream`. A cookie that fits comfortably in a request header expands to megabytes — 5232 bytes of cookie decompressed to 4 MB in testing, which then produced the same unwritable `Location`.

## The fix

Three bounds, each symmetric with something the write side already does:

- `getSearchParameters` ignores a cookie longer than `cookie.search.parameter.max.length`. The write side refuses to *store* one that long, so a longer one did not come from this server, and rejecting it before decompressing costs nothing.
- `gzipDecompress` stops at **`cookie.search.parameter.max.decompressed.length`** (new, default `65536`) — three orders of magnitude above anything the write side can produce.
- `redirectToSearchPage` drops the restore — whole, rather than in part — when the encoded parameters would exceed **`cookie.search.parameter.max.restored.length`** (new, default `4096`), and logs why at `warn`. Restoring the query is a convenience; the login is not. The user lands logged in on the search top page instead of not landing at all.

Dropping the restore *whole* matters: a partial restore would run a different search from the one the user asked for, with `q` kept and the paging and sorting gone.

### Why these are configuration keys and not constants

What the second bound protects against is itself configurable: `tomcat.maxHttpHeaderSize` in `tomcat_config.properties` bounds the response headers, and the SPNEGO documentation asks deployments with large Kerberos tickets to raise it to `65536`. A hard-coded `4096` would keep dropping the restore on exactly the deployments that had raised the container's limit to accommodate it. The key's comment says to raise the two together. The decompression bound is a key for the same reason and for consistency with the rest of the `cookie.search.parameter.*` family, where every other bound is already configurable.

Both are read through their generated accessor with a fallback for a blank value: `getAsInteger` answers `null` for `key=`, and both are read on the login path, where an NPE is the failure this PR exists to remove.

## Verification

`mvn test`: **7384 passed**, 0 failures.

New tests cover each bound and its negative control — an oversized-but-valid cookie, a cookie that expands past the bound, a payload at the bound, a long CJK query, an ordinary query that must still be restored, the configured value being honoured in *both* directions, and the blank-value fallback. Each was confirmed to fail with the corresponding bound removed, so none of them is vacuous.

End to end against a live SPNEGO deployment with `login.required=true`: the 850-character CJK query now logs in (`302`), the retry logs in, the 4 MB cookie is answered rather than faulted, the ordinary query is still restored to `/search/?q=...` and still runs, and raising `cookie.search.parameter.max.restored.length` through the deployed configuration visibly changes the behaviour rather than being silently capped.

## Scope

Present since 15.1.0 (#2895), so this is not a 15.8 regression — milestone 15.9.0. It is, however, reachable without any attacker: a user who pastes a paragraph into the search box on a login-required deployment cannot log in and gets no explanation.
