### PR TITLE
fix(search): filter the restored search parameters the way the stored ones are filtered

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/sso/SsoAction.java
@@ -226,6 +226,10 @@ public class SsoAction extends FessLoginAction {
             int length = 0;
             for (final RequestParameter param : searchParameters) {
                 for (final String value : param.getValues()) {
+                    // The name is encoded for the same reason the value is: both reach this point
+                    // from a client-supplied cookie, and an unencoded '&' or '=' in a name splits
+                    // into query parameters of its own once the redirect URL is assembled.
+                    final String encodedName = URLEncoder.encode(param.getName(), Constants.CHARSET_UTF_8);
                     final String encoded = URLEncoder.encode(value, Constants.CHARSET_UTF_8);
                     // Restoring the query is a convenience; the login is not. cookie.search.
                     // parameter.max.length bounds the COMPRESSED cookie and is therefore no bound
@@ -235,13 +239,13 @@ public class SsoAction extends FessLoginAction {
                     // otherwise have succeeded answers 500 instead. Dropping the restore leaves
                     // the user logged in on the search top page. The bound is configurable because
                     // the container bound it protects against is: see tomcat.maxHttpHeaderSize.
-                    length += param.getName().length() + encoded.length() + 2;
+                    length += encodedName.length() + encoded.length() + 2;
                     if (length > maxLength) {
                         logger.warn("Stored search parameters exceed {} characters once encoded; " + "logging in without restoring them.",
                                 maxLength);
                         return OptionalThing.empty();
                     }
-                    paramList.add(param.getName());
+                    paramList.add(encodedName);
                     paramList.add(encoded);
                 }
             }

--- a/src/main/java/org/codelibs/fess/helper/SearchHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SearchHelper.java
@@ -676,10 +676,21 @@ public class SearchHelper {
                             final byte[] jsonBytes = gzipDecompress(compressed, getMaxDecompressedParameterLength(fessConfig));
                             final List<?> list = mapper.readValue(jsonBytes, List.class);
 
+                            // The write side stores only the names in cookie.search.parameter.keys.
+                            // The cookie is supplied by the client, so a name outside that list did
+                            // not come from this server and there is nothing to restore it to.
+                            final Set<String> allowedKeys = getCookieSearchParameterKeySet(fessConfig);
                             final List<RequestParameter> result = new ArrayList<>();
                             for (final Object item : list) {
                                 if ((item instanceof final List<?> pair) && (pair.size() == 2 && pair.get(0) instanceof final String name
                                         && pair.get(1) instanceof final List<?> valueList)) {
+                                    if (!allowedKeys.contains(name)) {
+                                        if (logger.isDebugEnabled()) {
+                                            logger.debug("Skipping a stored search parameter outside {}: {}",
+                                                    fessConfig.getCookieSearchParameterKeys(), name);
+                                        }
+                                        continue;
+                                    }
                                     final String[] values = valueList.stream().filter(String.class::isInstance).toArray(n -> new String[n]);
                                     result.add(new RequestParameter(name, values));
                                 }
@@ -702,6 +713,21 @@ public class SearchHelper {
             }
             return new RequestParameter[0];
         }).orElse(new RequestParameter[0]);
+    }
+
+    /**
+     * Resolves {@code cookie.search.parameter.keys} into the set of names that may be restored.
+     *
+     * @param fessConfig the configuration to read the key list from
+     * @return the allowed parameter names, empty when the list is blank
+     */
+    protected Set<String> getCookieSearchParameterKeySet(final FessConfig fessConfig) {
+        final String keysStr = fessConfig.getCookieSearchParameterKeys();
+        if (StringUtil.isBlank(keysStr)) {
+            return Set.of();
+        }
+        return StreamUtil.split(keysStr, ",")
+                .get(stream -> stream.map(String::trim).filter(StringUtil::isNotEmpty).collect(Collectors.toSet()));
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/sso/SsoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/sso/SsoActionTest.java
@@ -218,6 +218,26 @@ public class SsoActionTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_redirectToSearchPage_encodesTheNameAsWellAsTheValue() {
+        // Both halves reach this point from a client-supplied cookie. Encoding only the value
+        // leaves an '&' in the name splitting into a query parameter of its own once the redirect
+        // URL is assembled.
+        final TestableSsoAction action = actionWithStoredParameters(new RequestParameter("q&injected=1&x", new String[] { "ok" }));
+
+        assertTrue(action.redirectToSearchPage().isPresent());
+        assertEquals(List.of("q%26injected%3D1%26x", "ok"), action.redirectParams);
+    }
+
+    @Test
+    public void test_redirectToSearchPage_leavesAnOrdinaryNameReadable() {
+        // The falsification: encoding must not disturb the names the mechanism actually stores.
+        final TestableSsoAction action = actionWithStoredParameters(new RequestParameter("num", new String[] { "20" }));
+
+        assertTrue(action.redirectToSearchPage().isPresent());
+        assertEquals(List.of("num", "20"), action.redirectParams);
+    }
+
+    @Test
     public void test_redirectToSearchPage_withNothingStored() {
         assertFalse(actionWithStoredParameters().redirectToSearchPage().isPresent());
     }

--- a/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/SearchHelperTest.java
@@ -180,6 +180,44 @@ public class SearchHelperTest extends UnitFessTestCase {
         assertEquals(1, searchHelper.getSearchParameters().length);
     }
 
+    @Test
+    public void test_getSearchParameters_dropsNamesTheWriteSideWouldNeverStore() {
+        // storeSearchParameters copies only the names in cookie.search.parameter.keys into the
+        // cookie. The cookie comes back from the client, so a name outside that list did not come
+        // from this server -- and the caller feeds these names into a redirect URL.
+        final String encoded = searchHelper.serializeParameters(new RequestParameter[] {
+                new RequestParameter("q", new String[] { "kerberos" }), new RequestParameter("evil", new String[] { "1" }) });
+        getMockRequest().addCookie(new Cookie("FESS_SEARCH_PARAM", encoded));
+
+        final RequestParameter[] result = searchHelper.getSearchParameters();
+        assertEquals(1, result.length);
+        assertEquals("q", result[0].getName());
+    }
+
+    @Test
+    public void test_getSearchParameters_keepsEveryNameTheWriteSideDoesStore() {
+        // The falsification: the filter must not be so tight that it drops the mechanism's own
+        // output. MockFessConfig configures the keys as "q,lang".
+        final String encoded = searchHelper.serializeParameters(new RequestParameter[] {
+                new RequestParameter("q", new String[] { "kerberos" }), new RequestParameter("lang", new String[] { "en" }) });
+        getMockRequest().addCookie(new Cookie("FESS_SEARCH_PARAM", encoded));
+
+        assertEquals(2, searchHelper.getSearchParameters().length);
+    }
+
+    @Test
+    public void test_getCookieSearchParameterKeySet_trimsAndSkipsBlanks() {
+        final FessConfig config = new MockFessConfig() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getCookieSearchParameterKeys() {
+                return " q , ,num,";
+            }
+        };
+        assertEquals(java.util.Set.of("q", "num"), searchHelper.getCookieSearchParameterKeySet(config));
+    }
+
     // Test addRewriter method
     @Test
     public void test_addRewriter() {


### PR DESCRIPTION
> Stacked on #3325. Review that one first; this diff is the second commit.

## The problem

`SearchHelper#storeSearchParameters` copies only the names listed in `cookie.search.parameter.keys` (default `q,num,sort`) into the cookie. `getSearchParameters` reads the cookie back and accepts **whatever names it carries**, and `SsoAction#redirectToSearchPage` then appends those names to the post-login redirect URL with only the *value* URL-encoded:

```java
paramList.add(param.getName());                                  // raw
paramList.add(URLEncoder.encode(value, Constants.CHARSET_UTF_8)); // encoded
```

The cookie is supplied by the client, so both halves of that asymmetry are reachable. Measured against a live deployment:

| stored name | resulting `Location` |
|---|---|
| `evil` | `/search/?q=ok&evil=1` — a name the write side never stores |
| `q&injected=1&x` | `/search/?q&injected=1&x=ok` — one name became two parameters |
| `q#frag` | `/search/?q#frag=ok` — the rest of the query string is cut off |
| `%zz` | `/search/?%zz=ok` — a malformed escape reaches the browser |

The redirect target itself is built from `SearchAction.class` and cannot be moved, so the reach is confined to the parameters of the search page the user lands on — a path traversal in the name lands in the query string, not the path. There is no privilege boundary crossed here, and setting the cookie requires cookie-write access to the victim's browser. But neither half of the asymmetry has a reason to exist.

## The fix

- `getSearchParameters` applies the same `cookie.search.parameter.keys` allow list on the way out that `storeSearchParameters` applies on the way in. A name outside the list is skipped and logged at `debug`.
- `redirectToSearchPage` encodes the name as well as the value.

Both, rather than either alone: the allow list is the policy, and the encoding is what makes the URL construction correct whatever an operator puts in the list.

## Verification

`mvn test`: **7386 passed**, 0 failures.

New tests cover a name outside the list, a name carrying the query separators, and the key-list parsing (trimming, blank entries). Each is paired with a positive control — an allow-listed name in the *same* cookie must still be restored, and an ordinary name must still appear unencoded — so the filter cannot pass by dropping everything. Both new assertions were confirmed to fail with the corresponding half of the fix removed.

End to end against a live SPNEGO deployment: a cookie carrying `q` and `evil` now restores to `/search/?q=ok` with `evil` gone; `q&injected=1&x` restores nothing and lands on the top page; and the ordinary stored query is still restored and still runs.

## Scope

Present since 15.1.0 (#2895) — not a 15.8 regression, and no privilege boundary is crossed, so milestone 15.9.0.
