### PR TITLE
fix(auth): stop the logout endpoints from recording a logout nobody performed

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
@@ -98,9 +98,9 @@ public class LogoutHandler {
 
     /**
      * Writes the {@code LOGOUT} activity record, mirroring {@code LogoutAction.index()} so the
-     * v2 endpoint produces the same audit.log line as the classic flow. When no user is bound
-     * the record still carries {@code user:-}, matching the classic behaviour for an
-     * already-anonymous caller.
+     * v2 endpoint produces the same audit.log line as the classic flow. Nothing is written when
+     * no user is bound: a logout that ended no session is not an event, and a line naming nobody
+     * only dilutes the log an operator reads to find out who did what.
      *
      * <p>Audit-sink failures are logged and swallowed so the actual logout still runs and the
      * endpoint stays idempotent.</p>
@@ -109,7 +109,7 @@ public class LogoutHandler {
      */
     private void recordLogoutActivity(final FessLoginAssist assist) {
         try {
-            ComponentUtil.getActivityHelper().logout(assist.getSavedUserBean());
+            assist.getSavedUserBean().ifPresent(user -> ComponentUtil.getActivityHelper().logout(assist.getSavedUserBean()));
         } catch (final RuntimeException e) {
             logger.warn("[v2/logout] failed to write the LOGOUT audit record", e);
         }

--- a/src/main/java/org/codelibs/fess/app/web/logout/LogoutAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/logout/LogoutAction.java
@@ -59,7 +59,11 @@ public class LogoutAction extends FessSearchAction {
     @Execute
     public HtmlResponse index() {
         final OptionalThing<FessUserBean> userBean = getUserBean();
-        activityHelper.logout(userBean);
+        // Only a logout that ended a session is an event. This endpoint is anonymous, so writing
+        // the record unconditionally let any client append "action:LOGOUT user:-" to audit.log
+        // once per request, for as long as it cared to - lines that name nobody, in the log an
+        // operator reads to find out who did.
+        userBean.ifPresent(user -> activityHelper.logout(userBean));
         final String redirectUrl = userBean.map(user -> ComponentUtil.getSsoManager().logout(user)).orElse(null);
         fessLoginAssist.logout();
         userInfoHelper.deleteUserCodeFromCookie(request);

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LogoutHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LogoutHandlerTest.java
@@ -115,6 +115,21 @@ public class LogoutHandlerTest extends UnitFessTestCase {
     }
 
     @Test
+    public void logout_writesNoAuditRecordWhenNobodyWasLoggedIn() throws Exception {
+        // The endpoint is idempotent and reachable without a session, so an unconditional write
+        // let a caller append "action:LOGOUT user:-" once per request for as long as it cared to.
+        // A logout that ended no session is not an event.
+        final List<String> audit = new ArrayList<>();
+        ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
+        ComponentUtil.register(new StubLoginAssist(null), FessLoginAssist.class.getCanonicalName());
+        final CapturingResponse res = new CapturingResponse();
+        new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
+        assertEquals(200, res.status, res.body());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of(), audit,
+                "a logout that ended no session must not name one in the audit log");
+    }
+
+    @Test
     public void logout_auditFailureStillLogsOutAndReturnsOk() throws Exception {
         // A broken audit sink must not prevent the actual logout: the endpoint stays idempotent
         // and FessLoginAssist.logout() must still run.
@@ -248,7 +263,7 @@ public class LogoutHandlerTest extends UnitFessTestCase {
         int logoutCount;
 
         StubLoginAssist(final String userId) {
-            bound = new FessUserBean(new StubFessUser(userId));
+            bound = userId == null ? null : new FessUserBean(new StubFessUser(userId));
         }
 
         @Override

--- a/src/test/java/org/codelibs/fess/app/web/logout/LogoutActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/logout/LogoutActionTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.logout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codelibs.fess.entity.FessUser;
+import org.codelibs.fess.helper.ActivityHelper;
+import org.codelibs.fess.helper.UserInfoHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
+import org.codelibs.fess.sso.SsoManager;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalThing;
+import org.junit.jupiter.api.Test;
+import org.lastaflute.web.response.HtmlResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * What {@code /logout/} records.
+ *
+ * <p>The endpoint is reachable without a session -- it has to be, since a caller whose session
+ * has already expired still arrives here -- so whatever one request writes is what an unbounded
+ * loop of them writes.</p>
+ */
+public class LogoutActionTest extends UnitFessTestCase {
+
+    /** Marker returned instead of the real redirect, which needs the action path resolver. */
+    private static final HtmlResponse REDIRECT_TO_LOGIN = HtmlResponse.fromRedirectPathAsIs("/login/");
+
+    /** Records what would have reached audit.log. */
+    private static ActivityHelper recordingActivityHelper(final List<String> audit) {
+        ComponentUtil.register(new SsoManager(), "ssoManager");
+        return new ActivityHelper() {
+            @Override
+            public void logout(final OptionalThing<FessUserBean> user) {
+                audit.add("action:LOGOUT\tuser:" + user.map(FessUserBean::getUserId).orElse("-"));
+            }
+        };
+    }
+
+    @Test
+    public void test_index_recordsTheLogoutOfALoggedInUser() {
+        final List<String> audit = new ArrayList<>();
+        final TestableLogoutAction action = new TestableLogoutAction("carol", recordingActivityHelper(audit));
+
+        assertSame(REDIRECT_TO_LOGIN, action.index());
+        assertEquals(List.of("action:LOGOUT\tuser:carol"), audit);
+    }
+
+    @Test
+    public void test_index_recordsNothingWhenNobodyWasLoggedIn() {
+        // An anonymous caller used to append "action:LOGOUT user:-" per request: a line that names
+        // nobody, in the log an operator reads to find out who did what.
+        final List<String> audit = new ArrayList<>();
+        final TestableLogoutAction action = new TestableLogoutAction(null, recordingActivityHelper(audit));
+
+        assertSame(REDIRECT_TO_LOGIN, action.index());
+        assertEquals(List.of(), audit);
+    }
+
+    @Test
+    public void test_index_endsTheSessionEitherWay() {
+        // The record is the only thing conditional on a user being present; the logout itself
+        // must still run, or a half-established session would survive it.
+        final List<String> audit = new ArrayList<>();
+        final TestableLogoutAction loggedIn = new TestableLogoutAction("carol", recordingActivityHelper(audit));
+        loggedIn.index();
+        assertEquals(1, loggedIn.logoutCount);
+
+        final TestableLogoutAction anonymous = new TestableLogoutAction(null, recordingActivityHelper(audit));
+        anonymous.index();
+        assertEquals(1, anonymous.logoutCount);
+    }
+
+    /**
+     * LogoutAction with the seams a plain unit test cannot provide: the user bean, the login
+     * assist, the user-code cookie and the action path resolver.
+     */
+    private static class TestableLogoutAction extends LogoutAction {
+        private final OptionalThing<FessUserBean> userBean;
+
+        int logoutCount;
+
+        TestableLogoutAction(final String userId, final ActivityHelper helper) {
+            userBean = userId == null ? OptionalThing.empty() : OptionalThing.of(new FessUserBean(new StubFessUser(userId)));
+            activityHelper = helper;
+            fessLoginAssist = new org.codelibs.fess.app.web.base.login.FessLoginAssist() {
+                @Override
+                public void logout() {
+                    logoutCount++;
+                }
+            };
+            userInfoHelper = new UserInfoHelper() {
+                @Override
+                public void deleteUserCodeFromCookie(final HttpServletRequest request) {
+                    // no cookie store in a unit test
+                }
+            };
+        }
+
+        @Override
+        public OptionalThing<FessUserBean> getUserBean() {
+            return userBean;
+        }
+
+        @Override
+        protected HtmlResponse redirect(final Class<?> actionType) {
+            return REDIRECT_TO_LOGIN;
+        }
+    }
+
+    /** Minimal {@link FessUser} with no roles, groups or permissions. */
+    private static class StubFessUser implements FessUser {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        StubFessUser(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String[] getRoleNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getGroupNames() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getPermissions() {
+            return new String[0];
+        }
+    }
+}


### PR DESCRIPTION
> Stacked on #3326. Review that one first; this diff is the third commit.

## The problem

`LogoutAction.index()` wrote the `LOGOUT` activity record before checking whether anybody was logged in:

```java
final OptionalThing<FessUserBean> userBean = getUserBean();
activityHelper.logout(userBean);   // unconditional
```

`ActivityHelper#logout` fills in `-` for an absent user, so an anonymous request produced

```
action:LOGOUT	user:-	permissions:-	ip:...	time:...
```

The endpoint is reachable without a session — it has to be, since a caller whose session already expired still arrives here — and it is a `GET`. So a client can append one such line per request, for as long as it cares to, to the log an operator reads to find out who did what. Measured against a live deployment: **20 anonymous requests to `/logout/` produced exactly 20 of these lines.**

Each line records nothing (it names no user and no permissions) while diluting the records that do. This is the same shape of problem as #3269 and #3315, one log further in: those bounded what an anonymous request writes to `fess.log`, and this is `audit.log`.

## The fix

A logout that ended no session is not an event. Both endpoints now write the record only when a user bean is bound.

- `LogoutAction.index()` — the local logout, the user-code cookie clearing and the redirect are all unchanged, so a caller with a stale session still gets exactly the same response.
- `LogoutHandler` (`POST /api/v2/auth/logout`) — this one is currently shielded by its CSRF gate, which requires a session, so it is not reachable today. But the code behind the gate had the same shape and its javadoc named the old behaviour as intended (*"When no user is bound the record still carries `user:-`, matching the classic behaviour"*). Fixing one and leaving the other would leave the next reader with two contradictory statements of intent, so both are corrected and the javadoc now says what the code does.

## Verification

`mvn test`: **7390 passed**, 0 failures.

New tests cover the logged-in case (the record is still written, with the user still resolved — it has to be written *before* `logout()` drops the bean), the anonymous case (nothing is written), and that the logout itself still runs either way, so the guard cannot be mistaken for skipping the logout. Both new assertions were confirmed to fail with the guard removed.

End to end against a live SPNEGO deployment: a real logout still writes exactly one `LOGOUT` line and still ends the session — the session cookie stops reading the user's documents and the admin screen stops answering `200` — while an anonymous `/logout/` writes none and still answers `302`.

## Scope

Long-standing behaviour, not a 15.8 regression, and no privilege boundary is crossed — milestone 15.9.0.
