### PR TITLE
chore(release): bump version to 15.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A built-in crawler collects documents from [web sites](https://fess.codelibs.org
 
 ## Requirements
 
-- Java 21 or later, for the TAR.GZ, ZIP, RPM, and DEB packages
+- Java 21 or later, for the ZIP, RPM, and DEB packages
 - OpenSearch as the search engine backend. The Docker images bundle it; for other installations you set it up separately.
 
 See the [Installation Guide](https://fess.codelibs.org/15.8/install/index.html) for supported versions and setup details.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Fess is an enterprise search server that you can install and run on any platform with a Java runtime. It is built on [OpenSearch](https://github.com/opensearch-project/OpenSearch), but prior OpenSearch knowledge is not required: Fess is configured through a browser-based administration UI.
 
-A built-in crawler collects documents from [web sites](https://fess.codelibs.org/15.7/admin/webconfig-guide.html), [file systems](https://fess.codelibs.org/15.7/admin/fileconfig-guide.html), and [data stores](https://fess.codelibs.org/15.7/admin/dataconfig-guide.html) such as databases and CSV files. Many file formats are supported, including Microsoft Office, PDF, and ZIP archives.
+A built-in crawler collects documents from [web sites](https://fess.codelibs.org/15.8/admin/webconfig-guide.html), [file systems](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html), and [data stores](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html) such as databases and CSV files. Many file formats are supported, including Microsoft Office, PDF, and ZIP archives.
 
 [Fess Site Search](https://github.com/codelibs/fess-site-search) is a free alternative to Google Site Search that you can embed in your own website. For details, see the [FSS JS Generator documentation](https://fss-generator.codelibs.org/docs/manual).
 
@@ -27,7 +27,7 @@ A built-in crawler collects documents from [web sites](https://fess.codelibs.org
 - Java 21 or later, for the TAR.GZ, ZIP, RPM, and DEB packages
 - OpenSearch as the search engine backend. The Docker images bundle it; for other installations you set it up separately.
 
-See the [Installation Guide](https://fess.codelibs.org/15.7/install/index.html) for supported versions and setup details.
+See the [Installation Guide](https://fess.codelibs.org/15.8/install/index.html) for supported versions and setup details.
 
 ## Getting Started
 
@@ -35,15 +35,15 @@ There are two ways to try Fess: download and install it yourself, or run it with
 
 ### Download and Install/Run
 
-Fess 15.7 can be downloaded from the [Releases page](https://github.com/codelibs/fess/releases). Downloads are available in three formats: DEB, RPM, and ZIP.
+Fess 15.8 can be downloaded from the [Releases page](https://github.com/codelibs/fess/releases). Downloads are available in three formats: DEB, RPM, and ZIP.
 
 The following commands show how to use the ZIP download:
 
-    $ unzip fess-15.7.x.zip
-    $ cd fess-15.7.x
+    $ unzip fess-15.8.x.zip
+    $ cd fess-15.8.x
     $ ./bin/fess
 
-For more details, see the [Installation Guide](https://fess.codelibs.org/15.7/install/index.html).
+For more details, see the [Installation Guide](https://fess.codelibs.org/15.8/install/index.html).
 
 ### Docker
 
@@ -59,7 +59,7 @@ Docker images are published on [ghcr.io](https://github.com/orgs/codelibs/packag
 
 ![Admin UI](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-Register crawling targets on the Web, File, or Data Store configuration pages in the Admin UI, then start the crawler from the [Scheduler page](https://fess.codelibs.org/15.7/admin/scheduler-guide.html).
+Register crawling targets on the Web, File, or Data Store configuration pages in the Admin UI, then start the crawler from the [Scheduler page](https://fess.codelibs.org/15.8/admin/scheduler-guide.html).
 
 ## Migration from Another Search Provider
 
@@ -67,7 +67,7 @@ See [MIGRATION.md](MIGRATION.md).
 
 ## Data Store
 
-Fess can crawl the following [storage locations and APIs](https://fess.codelibs.org/15.7/admin/dataconfig-guide.html):
+Fess can crawl the following [storage locations and APIs](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html):
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)

--- a/dbflute.xml
+++ b/dbflute.xml
@@ -2,7 +2,7 @@
 <project name="dbflute" basedir=".">
 	<property name="mydbflute.dir" value="${basedir}/mydbflute" />
 	<property name="target.dir" value="${basedir}/target" />
-	<property name="branch.name" value="fess-15.7" />
+	<property name="branch.name" value="fess-15.8" />
 	<property name="mydbflute.url" value="https://github.com/lastaflute/lastaflute-example-waterfront/archive/${branch.name}.zip" />
 
 	<target name="mydbflute.check">

--- a/deps.xml
+++ b/deps.xml
@@ -7,7 +7,7 @@
 	<property name="thumbnail.dir" value="${basedir}/src/main/webapp/WEB-INF/env/thumbnail" />
 	<property name="chunk.dir" value="${basedir}/src/main/webapp/WEB-INF/env/chunk" />
 	<property name="site.dir" value="${basedir}/src/main/webapp/WEB-INF/site" />
-	<property name="kopf.version" value="15.7.0" />
+	<property name="kopf.version" value="15.8.0" />
 	<property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/tags/v${kopf.version}.zip" />
 	<!-- property name="kopf.version" value="main" / -->
 	<!-- property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/heads/${kopf.version}.zip" / -->

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -8,7 +8,7 @@
 Fess ist ein sehr leistungsstarker und einfach zu implementierender Enterprise-Suchserver. Sie können Fess schnell auf jeder Plattform installieren und ausführen, auf der die Java-Laufzeitumgebung (JRE) läuft. Fess wird unter der [Apache-Lizenz 2.0](LICENSE) bereitgestellt.
 
 Fess basiert auf [OpenSearch](https://github.com/opensearch-project/OpenSearch), aber es ist kein Wissen oder Erfahrung mit OpenSearch erforderlich. Fess bietet eine einfach zu bedienende Administrations-GUI zur Konfiguration des Systems über Ihren Browser.
-Fess enthält auch einen Crawler, der Dokumente auf einem [Webserver](https://fess.codelibs.org/15.6/admin/webconfig-guide.html), [Dateisystem](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html) oder [Datenspeicher](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html) (wie CSV oder Datenbank) durchsuchen kann. Viele Dateiformate werden unterstützt, einschließlich (aber nicht beschränkt auf): Microsoft Office, PDF und zip.
+Fess enthält auch einen Crawler, der Dokumente auf einem [Webserver](https://fess.codelibs.org/15.8/admin/webconfig-guide.html), [Dateisystem](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html) oder [Datenspeicher](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html) (wie CSV oder Datenbank) durchsuchen kann. Viele Dateiformate werden unterstützt, einschließlich (aber nicht beschränkt auf): Microsoft Office, PDF und zip.
 
 *[Fess Site Search](https://github.com/codelibs/fess-site-search)* ist eine kostenlose Alternative zur [Google Site Search](https://enterprise.google.com/search/products/gss.html). Weitere Details finden Sie in der [Dokumentation des FSS JS Generators](https://fss-generator.codelibs.org/docs/manual).
 
@@ -26,15 +26,15 @@ Es gibt zwei Möglichkeiten, Fess auszuprobieren. Die erste besteht darin, es se
 
 ### Herunterladen und Installieren/Ausführen
 
-Fess 15.6 ist jetzt verfügbar und kann auf der [Release-Seite](https://github.com/codelibs/fess/releases "download") heruntergeladen werden. Downloads gibt es in drei Formaten: deb, rpm, zip.
+Fess 15.8 ist jetzt verfügbar und kann auf der [Release-Seite](https://github.com/codelibs/fess/releases "download") heruntergeladen werden. Downloads gibt es in drei Formaten: deb, rpm, zip.
 
 Die folgenden Befehle zeigen, wie der Zip-Download verwendet wird:
 
-    $ unzip fess-15.6.x.zip
-    $ cd fess-15.6.x
+    $ unzip fess-15.8.x.zip
+    $ cd fess-15.8.x
     $ ./bin/fess
 
-Weitere Informationen finden Sie im [Installationshandbuch](https://fess.codelibs.org/15.6/install/index.html).
+Weitere Informationen finden Sie im [Installationshandbuch](https://fess.codelibs.org/15.8/install/index.html).
 
 ### Docker
 
@@ -50,7 +50,7 @@ Wir bieten Docker-Images auf [ghcr.io](https://github.com/orgs/codelibs/packages
 
 ![Administrationsoberfläche](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-Sie können in der Administrationsoberfläche (Web, Datei, Datenspeicher) Crawling-Ziele in den Crawler-Konfigurationsseiten registrieren und den Crawler manuell auf der [Scheduler-Seite](https://fess.codelibs.org/15.6/admin/scheduler-guide.html) starten.
+Sie können in der Administrationsoberfläche (Web, Datei, Datenspeicher) Crawling-Ziele in den Crawler-Konfigurationsseiten registrieren und den Crawler manuell auf der [Scheduler-Seite](https://fess.codelibs.org/15.8/admin/scheduler-guide.html) starten.
 
 ## Migration von einem anderen Suchanbieter
 
@@ -58,7 +58,7 @@ Bitte lesen Sie [MIGRATION.md](MIGRATION.md).
 
 ## Datenspeicher
 
-Derzeit unterstützt Fess das Crawlen der folgenden [Speicherorte und APIs](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html):
+Derzeit unterstützt Fess das Crawlen der folgenden [Speicherorte und APIs](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html):
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -8,7 +8,7 @@
 Fess es un servidor de búsqueda empresarial muy potente y fácil de desplegar. Puedes instalar y ejecutar Fess rápidamente en cualquier plataforma que sea capaz de ejecutar el entorno de ejecución de Java (Java Runtime Environment). Fess se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 
 Fess está basado en [OpenSearch](https://github.com/opensearch-project/OpenSearch), pero no se requiere conocimiento o experiencia en OpenSearch. Fess proporciona una GUI de administración fácil de usar para configurar el sistema a través de tu navegador.
-Fess también incluye un rastreador (crawler), que puede rastrear documentos en un [servidor web](https://fess.codelibs.org/15.6/admin/webconfig-guide.html), [sistema de archivos](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html), o [almacenamiento de datos](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html) (como un archivo CSV o base de datos). Se admiten muchos formatos de archivos, incluidos (pero no limitados a): Microsoft Office, PDF y zip.
+Fess también incluye un rastreador (crawler), que puede rastrear documentos en un [servidor web](https://fess.codelibs.org/15.8/admin/webconfig-guide.html), [sistema de archivos](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html), o [almacenamiento de datos](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html) (como un archivo CSV o base de datos). Se admiten muchos formatos de archivos, incluidos (pero no limitados a): Microsoft Office, PDF y zip.
 
 *[Fess Site Search](https://github.com/codelibs/fess-site-search)* es una alternativa gratuita a [Google Site Search](https://enterprise.google.com/search/products/gss.html). Para más detalles, consulta la [documentación de FSS JS Generator](https://fss-generator.codelibs.org/docs/manual).
 
@@ -26,15 +26,15 @@ Hay dos maneras de probar Fess. La primera es descargar e instalarlo tú mismo. 
 
 ### Descargar e Instalar/Ejecutar
 
-Fess 15.6 ya está disponible y se puede descargar en la [página de lanzamientos](https://github.com/codelibs/fess/releases "download"). Las descargas están disponibles en 3 formatos: deb, rpm y zip.
+Fess 15.8 ya está disponible y se puede descargar en la [página de lanzamientos](https://github.com/codelibs/fess/releases "download"). Las descargas están disponibles en 3 formatos: deb, rpm y zip.
 
 Los siguientes comandos muestran cómo usar la descarga en formato zip:
 
-    $ unzip fess-15.6.x.zip
-    $ cd fess-15.6.x
+    $ unzip fess-15.8.x.zip
+    $ cd fess-15.8.x
     $ ./bin/fess
 
-Para más detalles, consulta la [Guía de Instalación](https://fess.codelibs.org/15.6/install/index.html).
+Para más detalles, consulta la [Guía de Instalación](https://fess.codelibs.org/15.8/install/index.html).
 
 ### Docker
 
@@ -50,7 +50,7 @@ Proporcionamos imágenes de Docker en [ghcr.io](https://github.com/orgs/codelibs
 
 ![Interfaz de Administración](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-Puedes registrar los objetivos de rastreo en la interfaz de administración en las páginas de configuración del rastreador (Web, Archivo, Almacenamiento de Datos), y luego iniciar el rastreador manualmente en la [página del Programador](https://fess.codelibs.org/15.6/admin/scheduler-guide.html).
+Puedes registrar los objetivos de rastreo en la interfaz de administración en las páginas de configuración del rastreador (Web, Archivo, Almacenamiento de Datos), y luego iniciar el rastreador manualmente en la [página del Programador](https://fess.codelibs.org/15.8/admin/scheduler-guide.html).
 
 ## Migración desde otro proveedor de búsqueda
 
@@ -58,7 +58,7 @@ Consulta [MIGRATION.md](MIGRATION.md).
 
 ## Almacenamiento de Datos
 
-Actualmente, Fess admite el rastreo de las siguientes [ubicaciones de almacenamiento y APIs](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html):
+Actualmente, Fess admite el rastreo de las siguientes [ubicaciones de almacenamiento y APIs](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html):
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -8,7 +8,7 @@
 Fess est un serveur de recherche très puissant et facilement déployable pour les entreprises. Vous pouvez rapidement installer et exécuter Fess sur toute plateforme où vous pouvez exécuter l'environnement d'exécution Java. Fess est fourni sous la licence [Apache License 2.0](LICENSE).
 
 Fess est basé sur [OpenSearch](https://github.com/opensearch-project/OpenSearch), mais aucune connaissance ni expérience d'OpenSearch n'est _nécessaire_. Fess fournit une interface d'administration facile à utiliser pour configurer le système via votre navigateur.
-Fess comprend également un Crawler, capable d'explorer les documents sur un [serveur web](https://fess.codelibs.org/15.6/admin/webconfig-guide.html), un [système de fichiers](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html), ou un [Data Store](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html) (comme un fichier CSV ou une base de données). De nombreux formats de fichiers sont pris en charge, y compris (mais sans s'y limiter) : Microsoft Office, PDF, et zip.
+Fess comprend également un Crawler, capable d'explorer les documents sur un [serveur web](https://fess.codelibs.org/15.8/admin/webconfig-guide.html), un [système de fichiers](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html), ou un [Data Store](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html) (comme un fichier CSV ou une base de données). De nombreux formats de fichiers sont pris en charge, y compris (mais sans s'y limiter) : Microsoft Office, PDF, et zip.
 
 *[Fess Site Search](https://github.com/codelibs/fess-site-search)* est une alternative gratuite à [Google Site Search](https://enterprise.google.com/search/products/gss.html). Pour plus de détails, consultez la [documentation FSS JS Generator](https://fss-generator.codelibs.org/docs/manual).
 
@@ -26,15 +26,15 @@ Il existe 2 manières d'essayer Fess. La première est de le télécharger et l'
 
 ### Télécharger et Installer/Exécuter
 
-Fess 15.6 est désormais disponible et peut être téléchargé sur la [page de Releases](https://github.com/codelibs/fess/releases "download"). Les téléchargements sont disponibles en 3 formats : deb, rpm, zip.
+Fess 15.8 est désormais disponible et peut être téléchargé sur la [page de Releases](https://github.com/codelibs/fess/releases "download"). Les téléchargements sont disponibles en 3 formats : deb, rpm, zip.
 
 Les commandes suivantes montrent comment utiliser le téléchargement zip :
 
-    $ unzip fess-15.6.x.zip
-    $ cd fess-15.6.x
+    $ unzip fess-15.8.x.zip
+    $ cd fess-15.8.x
     $ ./bin/fess
 
-Pour plus de détails, consultez le [guide d'installation](https://fess.codelibs.org/15.6/install/index.html).
+Pour plus de détails, consultez le [guide d'installation](https://fess.codelibs.org/15.8/install/index.html).
 
 ### Docker
 
@@ -50,7 +50,7 @@ Nous fournissons des images Docker sur [ghcr.io](https://github.com/orgs/codelib
 
 ![Admin UI](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-Vous pouvez enregistrer des cibles à explorer dans l'interface d'administration sur les pages de configuration des crawlers (Web, Fichiers, Data Store), puis démarrer manuellement le Crawler sur la [page du Planificateur](https://fess.codelibs.org/15.6/admin/scheduler-guide.html).
+Vous pouvez enregistrer des cibles à explorer dans l'interface d'administration sur les pages de configuration des crawlers (Web, Fichiers, Data Store), puis démarrer manuellement le Crawler sur la [page du Planificateur](https://fess.codelibs.org/15.8/admin/scheduler-guide.html).
 
 ## Migration depuis un autre fournisseur de recherche
 
@@ -58,7 +58,7 @@ Veuillez consulter [MIGRATION.md](MIGRATION.md).
 
 ## Data Store
 
-Actuellement, Fess prend en charge le parcours des [emplacements de stockage et API](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html) suivants :
+Actuellement, Fess prend en charge le parcours des [emplacements de stockage et API](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html) suivants :
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -7,7 +7,7 @@
 
 Fessは非常に強力で、簡単に導入できるエンタープライズ検索サーバーです。FessはJavaランタイム環境が動作する任意のプラットフォーム上で簡単にインストールして実行できます。Fessは[Apache License 2.0](LICENSE)の下で提供されています。
 
-Fessは[OpenSearch](https://github.com/opensearch-project/OpenSearch)をベースにしていますが、OpenSearchに関する知識や経験は**不要**です。Fessは、ブラウザを介してシステムを簡単に設定できる管理者向けのGUIを提供しています。Fessにはクローラも含まれており、[Webサーバー](https://fess.codelibs.org/15.6/admin/webconfig-guide.html)、[ファイルシステム](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html)、または[データストア](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html)（CSVやデータベースなど）のドキュメントをクロールできます。Microsoft Office、PDF、zipなど、多くのファイル形式に対応しています。
+Fessは[OpenSearch](https://github.com/opensearch-project/OpenSearch)をベースにしていますが、OpenSearchに関する知識や経験は**不要**です。Fessは、ブラウザを介してシステムを簡単に設定できる管理者向けのGUIを提供しています。Fessにはクローラも含まれており、[Webサーバー](https://fess.codelibs.org/15.8/admin/webconfig-guide.html)、[ファイルシステム](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html)、または[データストア](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html)（CSVやデータベースなど）のドキュメントをクロールできます。Microsoft Office、PDF、zipなど、多くのファイル形式に対応しています。
 
 *[Fess Site Search](https://github.com/codelibs/fess-site-search)*は、[Google Site Search](https://enterprise.google.com/search/products/gss.html)の無料代替です。詳細については、[FSS JS Generatorのドキュメント](https://fss-generator.codelibs.org/docs/manual)を参照してください。
 
@@ -25,15 +25,15 @@ Fessを試す方法は2つあります。1つは自分でダウンロードし�
 
 ### ダウンロードおよびインストール/実行
 
-Fess 15.6が利用可能で、[リリースページ](https://github.com/codelibs/fess/releases "download")からダウンロードできます。ダウンロードには、deb、rpm、zipの3つの形式があります。
+Fess 15.8が利用可能で、[リリースページ](https://github.com/codelibs/fess/releases "download")からダウンロードできます。ダウンロードには、deb、rpm、zipの3つの形式があります。
 
 以下のコマンドは、zipファイルを使用する例です：
 
-    $ unzip fess-15.6.x.zip
-    $ cd fess-15.6.x
+    $ unzip fess-15.8.x.zip
+    $ cd fess-15.8.x
     $ ./bin/fess
 
-詳細については、[インストールガイド](https://fess.codelibs.org/15.6/install/index.html)を参照してください。
+詳細については、[インストールガイド](https://fess.codelibs.org/15.8/install/index.html)を参照してください。
 
 ### Docker
 
@@ -49,7 +49,7 @@ Fess 15.6が利用可能で、[リリースページ](https://github.com/codelib
 
 ![Admin UI](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-管理者UIでは、（Web、ファイル、データストア）クローラの設定ページでクロール対象を登録し、[スケジューラページ](https://fess.codelibs.org/15.6/admin/scheduler-guide.html)から手動でクローラを開始できます。
+管理者UIでは、（Web、ファイル、データストア）クローラの設定ページでクロール対象を登録し、[スケジューラページ](https://fess.codelibs.org/15.8/admin/scheduler-guide.html)から手動でクローラを開始できます。
 
 ## 他の検索プロバイダーからの移行
 
@@ -57,7 +57,7 @@ Fess 15.6が利用可能で、[リリースページ](https://github.com/codelib
 
 ## データストア
 
-現在、Fessは以下の[ストレージロケーションとAPI](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html)のクロールをサポートしています：
+現在、Fessは以下の[ストレージロケーションとAPI](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html)のクロールをサポートしています：
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -7,7 +7,7 @@
 
 Fess는 매우 강력하고 쉽게 배포 가능한 엔터프라이즈 검색 서버입니다. 자바 런타임 환경(Java Runtime Environment)을 실행할 수 있는 모든 플랫폼에서 Fess를 빠르게 설치하고 실행할 수 있습니다. Fess는 [Apache License 2.0](LICENSE)에 따라 제공됩니다.
 
-Fess는 [OpenSearch](https://github.com/opensearch-project/OpenSearch)를 기반으로 하지만, OpenSearch에 대한 지식이나 경험은 필요하지 않습니다. Fess는 브라우저를 통해 시스템을 구성할 수 있는 사용하기 쉬운 관리 GUI를 제공합니다. 또한 Fess는 [웹 서버](https://fess.codelibs.org/15.6/admin/webconfig-guide.html), [파일 시스템](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html), 또는 [데이터 저장소](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html)에서 문서를 크롤링할 수 있는 크롤러도 포함하고 있습니다(CSV 또는 데이터베이스와 같은). Microsoft Office, PDF, zip을 포함한 다양한 파일 형식을 지원합니다.
+Fess는 [OpenSearch](https://github.com/opensearch-project/OpenSearch)를 기반으로 하지만, OpenSearch에 대한 지식이나 경험은 필요하지 않습니다. Fess는 브라우저를 통해 시스템을 구성할 수 있는 사용하기 쉬운 관리 GUI를 제공합니다. 또한 Fess는 [웹 서버](https://fess.codelibs.org/15.8/admin/webconfig-guide.html), [파일 시스템](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html), 또는 [데이터 저장소](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html)에서 문서를 크롤링할 수 있는 크롤러도 포함하고 있습니다(CSV 또는 데이터베이스와 같은). Microsoft Office, PDF, zip을 포함한 다양한 파일 형식을 지원합니다.
 
 *[Fess 사이트 검색](https://github.com/codelibs/fess-site-search)*은 [Google 사이트 검색](https://enterprise.google.com/search/products/gss.html)의 무료 대안입니다. 자세한 내용은 [FSS JS 생성기 문서](https://fss-generator.codelibs.org/docs/manual)를 참조하십시오.
 
@@ -25,15 +25,15 @@ Fess를 사용해보는 방법은 두 가지가 있습니다. 첫 번째는 직�
 
 ### 다운로드 및 설치/실행
 
-Fess 15.6이 현재 사용 가능하며, [릴리스 페이지](https://github.com/codelibs/fess/releases "download")에서 다운로드할 수 있습니다. 다운로드는 deb, rpm, zip의 세 가지 형식으로 제공됩니다.
+Fess 15.8이 현재 사용 가능하며, [릴리스 페이지](https://github.com/codelibs/fess/releases "download")에서 다운로드할 수 있습니다. 다운로드는 deb, rpm, zip의 세 가지 형식으로 제공됩니다.
 
 다음 명령은 zip 다운로드 사용 방법을 보여줍니다:
 
-    $ unzip fess-15.6.x.zip
-    $ cd fess-15.6.x
+    $ unzip fess-15.8.x.zip
+    $ cd fess-15.8.x
     $ ./bin/fess
 
-자세한 내용은 [설치 가이드](https://fess.codelibs.org/15.6/install/index.html)를 참조하십시오.
+자세한 내용은 [설치 가이드](https://fess.codelibs.org/15.8/install/index.html)를 참조하십시오.
 
 ### Docker
 
@@ -49,7 +49,7 @@ Fess 15.6이 현재 사용 가능하며, [릴리스 페이지](https://github.co
 
 ![관리자 UI](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-관리자 UI에서는 (웹, 파일, 데이터 저장소) 크롤러 구성 페이지에서 크롤링 대상을 등록한 다음, [스케줄러 페이지](https://fess.codelibs.org/15.6/admin/scheduler-guide.html)에서 크롤러를 수동으로 시작할 수 있습니다.
+관리자 UI에서는 (웹, 파일, 데이터 저장소) 크롤러 구성 페이지에서 크롤링 대상을 등록한 다음, [스케줄러 페이지](https://fess.codelibs.org/15.8/admin/scheduler-guide.html)에서 크롤러를 수동으로 시작할 수 있습니다.
 
 ## 다른 검색 제공자에서의 마이그레이션
 
@@ -57,7 +57,7 @@ Fess 15.6이 현재 사용 가능하며, [릴리스 페이지](https://github.co
 
 ## 데이터 저장소
 
-현재 Fess는 다음 [저장소 위치 및 API](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html)를 크롤링할 수 있습니다:
+현재 Fess는 다음 [저장소 위치 및 API](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html)를 크롤링할 수 있습니다:
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -8,7 +8,7 @@
 Fess é um servidor de busca empresarial muito poderoso e fácil de implantar. Você pode instalar e executar o Fess rapidamente em qualquer plataforma que suporte o Java Runtime Environment. O Fess é fornecido sob a [Licença Apache 2.0](LICENSE).
 
 O Fess é baseado no [OpenSearch](https://github.com/opensearch-project/OpenSearch), mas não é necessário ter conhecimento ou experiência com OpenSearch. O Fess fornece uma interface de administração fácil de usar, que permite configurar o sistema através do seu navegador.
-O Fess também inclui um rastreador (Crawler), que pode rastrear documentos em um [servidor web](https://fess.codelibs.org/15.6/admin/webconfig-guide.html), [sistema de arquivos](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html) ou [Data Store](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html) (como CSV ou banco de dados). Muitos formatos de arquivos são suportados, incluindo (mas não limitado a): Microsoft Office, PDF e zip.
+O Fess também inclui um rastreador (Crawler), que pode rastrear documentos em um [servidor web](https://fess.codelibs.org/15.8/admin/webconfig-guide.html), [sistema de arquivos](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html) ou [Data Store](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html) (como CSV ou banco de dados). Muitos formatos de arquivos são suportados, incluindo (mas não limitado a): Microsoft Office, PDF e zip.
 
 *[Fess Site Search](https://github.com/codelibs/fess-site-search)* é uma alternativa gratuita ao [Google Site Search](https://enterprise.google.com/search/products/gss.html). Para mais detalhes, veja a [documentação do FSS JS Generator](https://fss-generator.codelibs.org/docs/manual).
 
@@ -26,15 +26,15 @@ Existem duas maneiras de testar o Fess. A primeira é baixar e instalar você me
 
 ### Baixar e Instalar/Executar
 
-O Fess 15.6 já está disponível e pode ser baixado na [página de lançamentos](https://github.com/codelibs/fess/releases "download"). As opções de download incluem: deb, rpm, zip.
+O Fess 15.8 já está disponível e pode ser baixado na [página de lançamentos](https://github.com/codelibs/fess/releases "download"). As opções de download incluem: deb, rpm, zip.
 
 Os comandos a seguir mostram como usar o download em formato zip:
 
-    $ unzip fess-15.6.x.zip
-    $ cd fess-15.6.x
+    $ unzip fess-15.8.x.zip
+    $ cd fess-15.8.x
     $ ./bin/fess
 
-Para mais detalhes, veja o [Guia de Instalação](https://fess.codelibs.org/15.6/install/index.html).
+Para mais detalhes, veja o [Guia de Instalação](https://fess.codelibs.org/15.8/install/index.html).
 
 ### Docker
 
@@ -50,7 +50,7 @@ Nós fornecemos imagens Docker em [ghcr.io](https://github.com/orgs/codelibs/pac
 
 ![Interface de Administração](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-Você pode registrar alvos de rastreamento na interface de administração nas páginas de configuração do rastreador (Web, Arquivo, Data Store), e iniciar manualmente o rastreador na [página do Agendador](https://fess.codelibs.org/15.6/admin/scheduler-guide.html).
+Você pode registrar alvos de rastreamento na interface de administração nas páginas de configuração do rastreador (Web, Arquivo, Data Store), e iniciar manualmente o rastreador na [página do Agendador](https://fess.codelibs.org/15.8/admin/scheduler-guide.html).
 
 ## Migração de Outro Provedor de Busca
 
@@ -58,7 +58,7 @@ Consulte [MIGRATION.md](MIGRATION.md).
 
 ## Data Store
 
-Atualmente, o Fess suporta o rastreamento dos seguintes [locais de armazenamento e APIs](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html):
+Atualmente, o Fess suporta o rastreamento dos seguintes [locais de armazenamento e APIs](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html):
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -7,7 +7,7 @@
 
 Fess 是一个功能强大且易于部署的企业搜索服务器。您可以在任何可以运行 Java 运行时环境的平台上快速安装和运行 Fess。Fess 根据 [Apache 许可证 2.0](LICENSE) 提供。
 
-Fess 基于 [OpenSearch](https://github.com/opensearch-project/OpenSearch)，但不需要 OpenSearch 的知识或经验。Fess 提供了一个易于使用的管理 GUI，您可以通过浏览器配置系统。Fess 还包含一个爬虫，能够抓取 [Web 服务器](https://fess.codelibs.org/15.6/admin/webconfig-guide.html)、[文件系统](https://fess.codelibs.org/15.6/admin/fileconfig-guide.html)或[数据存储](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html)（如 CSV 或数据库）中的文档。Fess 支持多种文件格式，包括但不限于：Microsoft Office、PDF 和 zip。
+Fess 基于 [OpenSearch](https://github.com/opensearch-project/OpenSearch)，但不需要 OpenSearch 的知识或经验。Fess 提供了一个易于使用的管理 GUI，您可以通过浏览器配置系统。Fess 还包含一个爬虫，能够抓取 [Web 服务器](https://fess.codelibs.org/15.8/admin/webconfig-guide.html)、[文件系统](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html)或[数据存储](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html)（如 CSV 或数据库）中的文档。Fess 支持多种文件格式，包括但不限于：Microsoft Office、PDF 和 zip。
 
 *[Fess 网站搜索](https://github.com/codelibs/fess-site-search)* 是 [Google 网站搜索](https://enterprise.google.com/search/products/gss.html)的免费替代品。更多详情请参阅 [FSS JS 生成器文档](https://fss-generator.codelibs.org/docs/manual)。
 
@@ -25,15 +25,15 @@ Fess 基于 [OpenSearch](https://github.com/opensearch-project/OpenSearch)，但
 
 ### 下载并安装/运行
 
-Fess 15.6 现已发布，可在 [发布页面](https://github.com/codelibs/fess/releases "download") 下载。提供三种下载形式：deb、rpm、zip。
+Fess 15.8 现已发布，可在 [发布页面](https://github.com/codelibs/fess/releases "download") 下载。提供三种下载形式：deb、rpm、zip。
 
 以下命令展示了如何使用 zip 下载：
 
-    $ unzip fess-15.6.x.zip
-    $ cd fess-15.6.x
+    $ unzip fess-15.8.x.zip
+    $ cd fess-15.8.x
     $ ./bin/fess
 
-更多详情请参阅 [安装指南](https://fess.codelibs.org/15.6/install/index.html)。
+更多详情请参阅 [安装指南](https://fess.codelibs.org/15.8/install/index.html)。
 
 ### Docker
 
@@ -49,7 +49,7 @@ Fess 15.6 现已发布，可在 [发布页面](https://github.com/codelibs/fess/
 
 ![Admin UI](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-您可以在管理 UI 的 (Web、文件、数据存储) 爬虫配置页面中注册爬取目标，然后在 [调度器页面](https://fess.codelibs.org/15.6/admin/scheduler-guide.html)手动启动爬虫。
+您可以在管理 UI 的 (Web、文件、数据存储) 爬虫配置页面中注册爬取目标，然后在 [调度器页面](https://fess.codelibs.org/15.8/admin/scheduler-guide.html)手动启动爬虫。
 
 ## 从其他搜索提供商迁移
 
@@ -57,7 +57,7 @@ Fess 15.6 现已发布，可在 [发布页面](https://github.com/codelibs/fess/
 
 ## 数据存储
 
-当前，Fess 支持抓取以下[存储位置和 API](https://fess.codelibs.org/15.6/admin/dataconfig-guide.html)：
+当前，Fess 支持抓取以下[存储位置和 API](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html)：
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.8.0-SNAPSHOT</version>
+		<version>15.8.0</version>
 		<relativePath />
 	</parent>
 	<properties>

--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -57,7 +57,7 @@ info:
   version: 15.8.0
 externalDocs:
   description: API Documentation
-  url: https://fess.codelibs.org/15.7/api/
+  url: https://fess.codelibs.org/15.8/api/
 servers:
   - url: http://localhost:8080/api/v2
 tags:

--- a/src/main/java/org/codelibs/fess/helper/SystemHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SystemHelper.java
@@ -174,7 +174,7 @@ public class SystemHelper {
             logger.debug("Initializing {}", this.getClass().getSimpleName());
         }
         final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        cal.set(2027, 12 - 1, 1); // EOL Date
+        cal.set(2028, 2 - 1, 1); // EOL Date
         eolTime = cal.getTimeInMillis();
         if (isEoled()) {
             logger.error("Your system is out of support. See https://fess.codelibs.org/eol.html");

--- a/src/main/webapp/WEB-INF/orig/view/chat/chat.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/chat/chat.jsp
@@ -188,7 +188,22 @@ ${fe:html(true)}
 						rate_limit: '${fe:escapeJs(fe:message("labels.chat_error_rate_limit", ""))}',
 						auth_error: '${fe:escapeJs(fe:message("labels.chat_error_auth", ""))}',
 						service_unavailable: '${fe:escapeJs(fe:message("labels.chat_error_service_unavailable", ""))}',
+						timeout: '${fe:escapeJs(fe:message("labels.chat_error_timeout", ""))}',
+						context_length_exceeded: '${fe:escapeJs(fe:message("labels.chat_error_context_length_exceeded", ""))}',
+						model_not_found: '${fe:escapeJs(fe:message("labels.chat_error_model_not_found", ""))}',
+						invalid_response: '${fe:escapeJs(fe:message("labels.chat_error_invalid_response", ""))}',
+						connection_error: '${fe:escapeJs(fe:message("labels.chat_error_connection", ""))}',
 						unknown: '${fe:escapeJs(fe:message("labels.chat_error", ""))}'
+					},
+					retrying: '${fe:escapeJs(fe:message("labels.chat_retrying", ""))}',
+					waitingQueue: '${fe:escapeJs(fe:message("labels.chat_waiting_queue", ""))}',
+					hitCount: '${fe:escapeJs(fe:message("labels.chat_hit_count", ""))}',
+					fallback: {
+						no_results: '${fe:escapeJs(fe:message("labels.chat_fallback_no_results", ""))}',
+						no_relevant_results: '${fe:escapeJs(fe:message("labels.chat_fallback_no_relevant_results", ""))}'
+					},
+					warning: {
+						reasoning_token_exhausted: '${fe:escapeJs(fe:message("labels.chat_warning_token_exhausted", ""))}'
 					}
 				}
 			});

--- a/src/main/webapp/WEB-INF/orig/view/error/redirect.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/error/redirect.jsp
@@ -1,4 +1,4 @@
-<% 
+<%
 Integer statusCode = (Integer)request.getAttribute("jakarta.servlet.error.status_code");
 String servletName = (String)request.getAttribute("jakarta.servlet.error.servlet_name");
 String requestUri = (String)request.getAttribute("jakarta.servlet.error.request_uri");
@@ -21,9 +21,23 @@ if("systemError".equals(type)) {
 } else if("busy".equals(type)) {
 	redirectPage.append("/error/busy/");
 	response.sendRedirect(redirectPage.toString());
-} else if(!"badAuth".equals(type)) {
+} else if("badAuth".equals(type)) {
+	// This branch is reached only from the 401 error-page mapping, so the status the
+	// container is rendering this page for is always 401.
+	if(org.codelibs.fess.util.WebApiUtil.isApiRequestUri(requestUri, ((jakarta.servlet.http.HttpServletRequest)request).getContextPath())) {
+		// An API client needs the status, not a page: issuing no redirect leaves the 401
+		// the container already set intact, and the body below is returned as-is.
+%>Bad Authentication.<%
+	} else {
+		// A browser gets the themed error page instead of the plain-text output above.
+		// message_key lets a static theme surface a localised error detail; the JSP-mode
+		// action simply ignores the unknown parameter.
+		redirectPage.append("/error/systemerror/?message_key=errors.bad_authentication");
+		response.sendRedirect(redirectPage.toString());
+	}
+} else {
 	redirectPage.append("/error/notfound/?url=");
 	redirectPage.append(java.net.URLEncoder.encode(requestUri , "UTF-8"));
 	response.sendRedirect(redirectPage.toString());
 }
- %>Bad Authentication.
+ %>


### PR DESCRIPTION
## Summary
Prepares the 15.8.0 release: moves off the `15.8.0-SNAPSHOT` parent, points the
build scripts at the matching `fess-15.8` / `fess-kopf` v15.8.0 artifacts, and
updates the release-time values that are not derived from the project version
(EOL date, documentation links, and the `orig/view` JSP copies).

## Changes Made

### Version / build
- `pom.xml`: parent version `15.8.0-SNAPSHOT` → `15.8.0`
- `dbflute.xml`: `branch.name` `fess-15.7` → `fess-15.8` (mydbflute source branch)
- `deps.xml`: `kopf.version` `15.7.0` → `15.8.0` (fess-kopf release artifact)

### EOL
- `SystemHelper`: EOL date `2027-12-01` → `2028-02-01`

### Documentation
- `README.md`: documentation links and download instructions `15.7` → `15.8`,
  and drop the TAR.GZ package from the requirements list — Fess publishes DEB,
  RPM and ZIP only, which is what the same file already says two sections
  further down
- `docs/{de,es,fr,ja,ko,pt-BR,zh-CN}/README.md`: same links, which had been left
  behind at `15.6`
- `src/main/config/openapi/v2/openapi-user.yaml`: `externalDocs.url` `15.7` →
  `15.8` (`info.version` was already `15.8.0`)

The `online.help.*` links need no change — `SystemHelper` substitutes
`{version}` from `project.properties` at runtime.

### orig/view JSPs
`AdminDesignAction.editAsUseDefault` reads `WEB-INF/orig/view/<file>`, so a copy
that was not updated alongside its `WEB-INF/view` counterpart silently hands the
administrator an older page. Two had drifted and are now byte-identical again:

- `chat/chat.jsp` — #3130 added the retry / waiting-queue / hit-count / fallback
  / warning message wiring to the view copy only. This file is one of the 18
  registered in `fess.xml`, so the editor does serve it.
- `error/redirect.jsp` — #3188 restructured the `badAuth` branch in the view copy
  only. Not registered in the design editor, but the pair is meant to stay
  identical.

## Testing
- `mvn formatter:format && mvn license:format` — no files changed
- `mvn test -Dtest=SystemHelperTest` — 83 tests, 0 failures
- `mvn test -Dtest=AdminDesignActionTest` — 23 tests, 0 failures
- `diff -r WEB-INF/orig/view WEB-INF/view` — no differing file remains
- Verified the upstream artifacts this PR references exist: `fess-parent:15.8.0`
  on Maven Central, `fess-kopf` tag `v15.8.0`, `lastaflute-example-waterfront`
  branch `fess-15.8`
- Verified every rewritten documentation URL returns HTTP 200

## Breaking Changes
- None

## Additional Notes
- No functional Java changes.
- The EOL date follows the published policy on <https://fess.codelibs.org/eol.html>
  (~18 months after release; +2 months per minor, matching 15.6 → 2027-10-01 and
  15.7 → 2027-12-01).
- Follow-up outside this repository: the maintenance table on the EOL page does
  not list 15.8.x yet.
