### PR TITLE
feat!: drop the storage: crawl protocol

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/ProtocolHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ProtocolHelper.java
@@ -252,11 +252,11 @@ public class ProtocolHelper {
      * Used to determine if special handling is needed for file system URLs.
      *
      * @param url the URL to check
-     * @return true if the URL is a file system path (file, smb, smb1, ftp, storage, s3, gcs)
+     * @return true if the URL is a file system path (file, smb, smb1, ftp, s3, gcs)
      */
     public boolean isFileSystemPath(final String url) {
         return url.startsWith("file:") || url.startsWith("smb:") || url.startsWith("smb1:") || url.startsWith("ftp:")
-                || url.startsWith("storage:") || url.startsWith("s3:") || url.startsWith("gcs:");
+                || url.startsWith("s3:") || url.startsWith("gcs:");
     }
 
     /**
@@ -280,6 +280,6 @@ public class ProtocolHelper {
      */
     public boolean hasKnownProtocol(final String path) {
         return path.startsWith("http:") || path.startsWith("https:") || path.startsWith("smb:") || path.startsWith("smb1:")
-                || path.startsWith("ftp:") || path.startsWith("storage:") || path.startsWith("s3:") || path.startsWith("gcs:");
+                || path.startsWith("ftp:") || path.startsWith("s3:") || path.startsWith("gcs:");
     }
 }

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -3567,7 +3567,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /**
      * Get the value for the key 'crawler.file.protocols'. <br>
-     * The value is, e.g. file,smb,smb1,ftp,storage,s3,gcs <br>
+     * The value is, e.g. file,smb,smb1,ftp,s3,gcs <br>
      * comment: Supported file protocols for crawling.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */

--- a/src/main/java/org/codelibs/fess/util/GsaConfigParser.java
+++ b/src/main/java/org/codelibs/fess/util/GsaConfigParser.java
@@ -98,7 +98,7 @@ public class GsaConfigParser extends DefaultHandler {
     protected String[] webProtocols = { "http:", "https:" };
 
     /** Array of supported file protocols for URL classification. */
-    protected String[] fileProtocols = { "file:", "smb:", "smb1:", "ftp:", "storage:" };
+    protected String[] fileProtocols = { "file:", "smb:", "smb1:", "ftp:" };
 
     /** Queue to track the current XML element hierarchy during parsing. */
     protected LinkedList<String> tagQueue;

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -385,7 +385,7 @@ crawler.crawling.data.encoding=UTF-8
 # Supported web protocols for crawling.
 crawler.web.protocols=http,https
 # Supported file protocols for crawling.
-crawler.file.protocols=file,smb,smb1,ftp,storage,s3,gcs
+crawler.file.protocols=file,smb,smb1,ftp,s3,gcs
 # Pattern for environment variable keys in crawling data.
 crawler.data.env.param.key.pattern=^FESS_ENV_.*
 # Whether to ignore robots.txt during crawling.

--- a/src/test/java/org/codelibs/fess/app/web/admin/wizard/AdminWizardActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/wizard/AdminWizardActionTest.java
@@ -42,7 +42,7 @@ public class AdminWizardActionTest extends UnitFessTestCase {
 
             @Override
             public String getCrawlerFileProtocols() {
-                return "file,smb,smb1,ftp,storage,s3,gcs";
+                return "file,smb,smb1,ftp,s3,gcs";
             }
         });
         final ProtocolHelper protocolHelper = new ProtocolHelper();
@@ -99,12 +99,6 @@ public class AdminWizardActionTest extends UnitFessTestCase {
     public void test_convertCrawlingPath_ftp_protocol() {
         assertEquals("ftp://ftp.example.com/path", wizardAction.convertCrawlingPath("ftp://ftp.example.com/path"));
         assertEquals("ftp://192.168.1.1/files", wizardAction.convertCrawlingPath("ftp://192.168.1.1/files"));
-    }
-
-    @Test
-    public void test_convertCrawlingPath_storage_protocol() {
-        assertEquals("storage://container/path", wizardAction.convertCrawlingPath("storage://container/path"));
-        assertEquals("storage://bucket/folder/file.txt", wizardAction.convertCrawlingPath("storage://bucket/folder/file.txt"));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/app/web/go/GoActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/go/GoActionTest.java
@@ -48,7 +48,7 @@ public class GoActionTest extends UnitFessTestCase {
 
             @Override
             public String getCrawlerFileProtocols() {
-                return "file,smb,smb1,ftp,storage,s3,gcs";
+                return "file,smb,smb1,ftp,s3,gcs";
             }
         });
         final ProtocolHelper protocolHelper = new ProtocolHelper();
@@ -243,13 +243,6 @@ public class GoActionTest extends UnitFessTestCase {
         assertTrue(goAction.isFileSystemPath("ftp://ftp.example.com/path/file.txt"));
         assertTrue(goAction.isFileSystemPath("ftp://user:pass@ftp.example.com/file.txt"));
         assertTrue(goAction.isFileSystemPath("ftp://192.168.1.1/file.txt"));
-    }
-
-    @Test
-    public void test_isFileSystemPath_storage_protocol() {
-        assertTrue(goAction.isFileSystemPath("storage://container/path/file.txt"));
-        assertTrue(goAction.isFileSystemPath("storage://bucket/folder/document.pdf"));
-        assertTrue(goAction.isFileSystemPath("storage://my-storage/"));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/crawler/transformer/FessFileTransformerTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/transformer/FessFileTransformerTest.java
@@ -46,7 +46,7 @@ public class FessFileTransformerTest extends UnitFessTestCase {
 
             @Override
             public String getCrawlerFileProtocols() {
-                return "file,smb,smb1,ftp,storage,s3,gcs";
+                return "file,smb,smb1,ftp,s3,gcs";
             }
 
             @Override
@@ -161,10 +161,6 @@ public class FessFileTransformerTest extends UnitFessTestCase {
         assertEquals(exp, transformer.getFileName(url, Constants.UTF_8));
 
         url = "file://example.com/test%E3%81%82.txt";
-        exp = "testあ.txt";
-        assertEquals(exp, transformer.getFileName(url, Constants.UTF_8));
-
-        url = "storage://example.com/test%E3%81%82.txt";
         exp = "testあ.txt";
         assertEquals(exp, transformer.getFileName(url, Constants.UTF_8));
 

--- a/src/test/java/org/codelibs/fess/helper/ProtocolHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ProtocolHelperTest.java
@@ -672,7 +672,7 @@ public class ProtocolHelperTest extends UnitFessTestCase {
 
             @Override
             public String getCrawlerFileProtocols() {
-                return "file,smb,ftp,storage,s3,gcs";
+                return "file,smb,ftp,s3,gcs";
             }
         });
 
@@ -710,7 +710,7 @@ public class ProtocolHelperTest extends UnitFessTestCase {
 
             @Override
             public String getCrawlerFileProtocols() {
-                return "file,smb,ftp,storage,s3,gcs";
+                return "file,smb,ftp,s3,gcs";
             }
         });
 
@@ -738,21 +738,20 @@ public class ProtocolHelperTest extends UnitFessTestCase {
 
             @Override
             public String getCrawlerFileProtocols() {
-                return "file,smb,smb1,ftp,storage,s3,gcs";
+                return "file,smb,smb1,ftp,s3,gcs";
             }
         });
 
         final ProtocolHelper protocolHelper = new ProtocolHelper();
         protocolHelper.init();
 
-        assertEquals(7, protocolHelper.getFileProtocols().length);
+        assertEquals(6, protocolHelper.getFileProtocols().length);
 
         // All file protocols should be valid
         assertTrue(protocolHelper.isValidFileProtocol("file:///path/to/file"));
         assertTrue(protocolHelper.isValidFileProtocol("smb://server/share"));
         assertTrue(protocolHelper.isValidFileProtocol("smb1://server/share"));
         assertTrue(protocolHelper.isValidFileProtocol("ftp://ftp.example.com/file"));
-        assertTrue(protocolHelper.isValidFileProtocol("storage://container/blob"));
         assertTrue(protocolHelper.isValidFileProtocol("s3://bucket/key"));
         assertTrue(protocolHelper.isValidFileProtocol("gcs://bucket/object"));
 
@@ -834,7 +833,6 @@ public class ProtocolHelperTest extends UnitFessTestCase {
         assertTrue(protocolHelper.isFileSystemPath("smb://server/share"));
         assertTrue(protocolHelper.isFileSystemPath("smb1://server/share"));
         assertTrue(protocolHelper.isFileSystemPath("ftp://ftp.example.com/file"));
-        assertTrue(protocolHelper.isFileSystemPath("storage://container/blob"));
         assertTrue(protocolHelper.isFileSystemPath("s3://bucket/path"));
         assertTrue(protocolHelper.isFileSystemPath("gcs://bucket/path"));
     }
@@ -891,7 +889,6 @@ public class ProtocolHelperTest extends UnitFessTestCase {
         assertTrue(protocolHelper.hasKnownProtocol("smb://server/share"));
         assertTrue(protocolHelper.hasKnownProtocol("smb1://server/share"));
         assertTrue(protocolHelper.hasKnownProtocol("ftp://ftp.example.com/file"));
-        assertTrue(protocolHelper.hasKnownProtocol("storage://container/blob"));
         assertTrue(protocolHelper.hasKnownProtocol("s3://bucket/path"));
         assertTrue(protocolHelper.hasKnownProtocol("gcs://bucket/path"));
     }


### PR DESCRIPTION
## Summary

Removes the `storage:` crawl protocol from the Fess side. The MinIO-based client behind it is deleted in codelibs/fess-crawler#190 in favor of `s3:`, which reaches the same S3-compatible servers through its `endpoint` parameter.

**This is a breaking change**: `storage://` paths are no longer recognized.

## Changes

| File | Change |
| --- | --- |
| `fess_config.properties` | `crawler.file.protocols` default is now `file,smb,smb1,ftp,s3,gcs` |
| `ProtocolHelper.java` | `isFileSystemPath` and `hasKnownProtocol` no longer match `storage:` |
| `GsaConfigParser.java` | `storage:` removed from `fileProtocols` |
| `FessConfig.java` | generated javadoc echo of the property value kept in sync |

Protocol handlers are discovered by scanning `org.codelibs.fess.net.protocol`, so removing the package in fess-crawler is enough — there is no registration list to update here.

## Migration

Existing file crawl configurations using `storage://bucket/path` must be changed to `s3://bucket/path`. The `endpoint`, `accessKey` and `secretKey` parameters carry over unchanged. Deployments that override `crawler.file.protocols` locally should drop the `storage` entry.

## Test updates

Four test classes pinned the old behavior and were updated:

- `GoActionTest` — removed `test_isFileSystemPath_storage_protocol`; the existing `_s3_protocol` test already covers the object-storage case
- `AdminWizardActionTest` — removed `test_convertCrawlingPath_storage_protocol`, likewise
- `FessFileTransformerTest` — removed the `storage://` URL-decoding case, already covered by the `file://` case
- `ProtocolHelperTest` — dropped the three `assertTrue` storage assertions and corrected the file-protocol count from 7 to 6

The two `assertFalse` storage assertions in `ProtocolHelperTest` were deliberately kept: they now document that `storage://` is treated as an unrecognized scheme.

## Verification

`ProtocolHelperTest`, `GoActionTest`, `AdminWizardActionTest` and `FessFileTransformerTest`: **86 tests, 0 failures**, run against a locally built `fess-crawler` with the client removed.

`mvn formatter:format license:format` applied with no further changes.

The full test suite was not run for this change.

## Companion PRs

- codelibs/fess-crawler#190 — removes the client, the dependency and the DI registration
- `fess-parent` — drops the now-unused `minio.version` property
- `fess-docs` — drops the `storage://` row from the 15.9 file config API reference
