### PR TITLE
build(deps): build kopf from main and clean up transport-grpc jars

### DIFF
--- a/deps.xml
+++ b/deps.xml
@@ -7,10 +7,10 @@
 	<property name="thumbnail.dir" value="${basedir}/src/main/webapp/WEB-INF/env/thumbnail" />
 	<property name="chunk.dir" value="${basedir}/src/main/webapp/WEB-INF/env/chunk" />
 	<property name="site.dir" value="${basedir}/src/main/webapp/WEB-INF/site" />
-	<property name="kopf.version" value="15.8.0" />
-	<property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/tags/v${kopf.version}.zip" />
-	<!-- property name="kopf.version" value="main" / -->
-	<!-- property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/heads/${kopf.version}.zip" / -->
+	<!-- property name="kopf.version" value="15.8.0" / -->
+	<!-- property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/tags/v${kopf.version}.zip" / -->
+	<property name="kopf.version" value="main" />
+	<property name="kopf.url" value="https://github.com/codelibs/fess-kopf/archive/refs/heads/${kopf.version}.zip" />
 
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />

--- a/module.xml
+++ b/module.xml
@@ -111,7 +111,9 @@
 				<include name="reindex/httpcore5-*" />
 				<include name="reindex/slf4j-api-*" />
 				<include name="transport-grpc/failureaccess-*" />
+				<include name="transport-grpc/grpc-*" />
 				<include name="transport-grpc/guava-*" />
+				<include name="transport-grpc/perfmark-api-*" />
 			</fileset>
 		</delete>
 	</target>


### PR DESCRIPTION
## Summary
Points the fess-kopf build source at the `main` branch instead of the pinned `v15.8.0` tag, and extends the transport-grpc cleanup fileset in `module.xml` to remove a couple of jars it was previously missing.

## Changes Made
- `deps.xml`: comment out the `kopf.version`/`kopf.url` properties pinned to the `v15.8.0` release tag and enable the properties that build from the `main` branch instead
- `module.xml`: add `transport-grpc/grpc-*` and `transport-grpc/perfmark-api-*` to the `<delete>` fileset so those jars get cleaned up alongside the other transport-grpc dependencies

## Testing
- N/A (build script changes only; no automated tests apply)

## Breaking Changes
- None

## Additional Notes
- Building kopf from `main` means the packaged kopf plugin will track unreleased changes rather than the stable tag — worth reverting to the tagged release before cutting a Fess release build.
