### PR TITLE
feat(dashboard): pass the admin locale to the kopf iframe

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/dashboard/AdminDashboardAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dashboard/AdminDashboardAction.java
@@ -15,6 +15,8 @@
  */
 package org.codelibs.fess.app.web.admin.dashboard;
 
+import java.util.Locale;
+
 import org.codelibs.fess.annotation.Secured;
 import org.codelibs.fess.api.engine.SearchEngineApiManager;
 import org.codelibs.fess.app.web.base.FessAdminAction;
@@ -75,6 +77,14 @@ public class AdminDashboardAction extends FessAdminAction {
         searchEngineApiManager.saveToken();
         return asHtml(path_AdminDashboard_AdminDashboardJsp).renderWith(data -> {
             RenderDataUtil.register(data, "serverPath", searchEngineApiManager.getServerPath());
+            // kopf renders in an iframe, which is a separate document and so
+            // inherits nothing from this page. The locale has to be handed over
+            // explicitly: the plugin cannot re-derive it, because Accept-Language
+            // and the browser_lang parameter can disagree with each other.
+            // Null-checked as FessSearchAction does: the dashboard must not fail
+            // to render over a locale it could not resolve.
+            final Locale locale = requestManager.getUserLocale();
+            RenderDataUtil.register(data, "kopfLang", (locale != null ? locale : Locale.ENGLISH).toLanguageTag());
         });
     }
 

--- a/src/main/webapp/WEB-INF/view/admin/dashboard/admin_dashboard.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dashboard/admin_dashboard.jsp
@@ -16,7 +16,7 @@ ${fe:html(true)}
 
     <main class="content-wrapper position-relative">
         <iframe class="w-100 h-100 position-absolute" style="border: 0;"
-                src="<%=request.getContextPath()%>${serverPath}<%= response.encodeURL("/_plugin/kopf/") %>"
+                src="<%=request.getContextPath()%>${serverPath}<%= response.encodeURL("/_plugin/kopf/") %>?lang=${f:u(kopfLang)}"
                 title="<la:message key="labels.dashboard_plugin" />"></iframe>
     </main>
 


### PR DESCRIPTION
kopf renders in an iframe on the admin dashboard. An iframe is a separate
document and inherits nothing from the page around it, so the console could be
in Japanese while the tool inside it was in English. This hands the locale over
so it isn't.

## Why it has to be passed

`FessUserLocaleProcessProvider.getRequestedLocale()` returns empty, which
LastaFlute reads as "browser default", so the console's locale is the request's
`Accept-Language`; `findBusinessLocale()` additionally honours the
`browser_lang` parameter (`query.browser.lang.parameter.name`). There is no
stored per-user language preference in Fess.

So the authoritative value is whatever `requestManager.getUserLocale()`
resolved for this request. Letting the plugin read `navigator.language` instead
approximates it and is wrong in two cases: when the console was opened with
`?browser_lang=`, and whenever `Accept-Language` and `navigator.language`
disagree.

## Why the iframe URL

`kopf_external_settings.json` ships inside the plugin's own `_site` — `deps.xml`
extracts `_site/**` from the fess-kopf archive — so it is static per install and
cannot carry a per-request value. The iframe URL is the only channel left.

Appending a query string is inert with respect to serving:
`SearchEngineApiManager.processPluginRequest` resolves files from
`request.getServletPath()` alone and picks the Content-Type from the path's
extension. Neither consults the query string. kopf routes on the hash, so
`location.search` survives every in-app navigation.

## The change

```java
final Locale locale = requestManager.getUserLocale();
RenderDataUtil.register(data, "kopfLang", (locale != null ? locale : Locale.ENGLISH).toLanguageTag());
```

plus `?lang=${f:u(kopfLang)}` on the iframe `src`.

`getUserLocale()` is null-checked the way `FessSearchAction` (line 282) already
does — the dashboard must not fail to render over a locale it could not
resolve.

## Notes for review

- **No `deps.xml` change.** `master` already builds kopf from the fess-kopf
  `main` branch head (`kopf.version=main`, heads archive), so this takes effect
  as soon as the plugin side lands. Merge order does not matter: a kopf that
  predates it ignores the parameter and falls back to the browser's preference,
  and this change against such a kopf is a no-op.
- **CI does not compile JSPs**, so the one-line view change was checked by
  construction rather than by a build: `f` is declared in
  `/WEB-INF/view/common/common.jsp`, which `web.xml` applies to every `*.jsp`
  as an `include-prelude`, and `${f:u(...)}` is already used in around twenty
  admin views with no directive of their own. `${kopfLang}` reaches the page by
  the same `RenderDataUtil` mechanism as `${serverPath}` on the same line.
- `mvn compile`, `formatter:format` and `license:format` are clean.

## Plugin side

codelibs/fess-kopf#59 — sixteen catalogues matching the `fess_label` set, with
resolution reproducing `ResourceBundle`'s fallback so the iframe and the page
around it can never end up in different languages. Verified there against a
live OpenSearch 3.8.0 at the real mount path, inside a dashboard iframe, with
this exact `?lang=` hand-off.
