### PR TITLE
fix(error): stop the redirect loop on the system error page

### DIFF
--- a/src/main/webapp/WEB-INF/view/error/redirect.jsp
+++ b/src/main/webapp/WEB-INF/view/error/redirect.jsp
@@ -3,14 +3,31 @@ Integer statusCode = (Integer)request.getAttribute("jakarta.servlet.error.status
 String servletName = (String)request.getAttribute("jakarta.servlet.error.servlet_name");
 String requestUri = (String)request.getAttribute("jakarta.servlet.error.request_uri");
 String type = request.getParameter("type");
+String contextPath = ((jakarta.servlet.http.HttpServletRequest)request).getContextPath();
 StringBuilder redirectPage = new StringBuilder();
-redirectPage.append(((jakarta.servlet.http.HttpServletRequest)request).getContextPath());
+redirectPage.append(contextPath);
 if("systemError".equals(type)) {
-	if(requestUri != null && !requestUri.endsWith("systemError")) {
+	// The system error page is itself an action, so it can fail for the same reason the
+	// original request did. Redirecting to it again would loop until the browser gives up,
+	// which is why the request that is already on that page falls through to the container.
+	String errorPath = requestUri != null ? requestUri : "";
+	if(!contextPath.isEmpty() && errorPath.startsWith(contextPath)) {
+		errorPath = errorPath.substring(contextPath.length());
+	}
+	while(errorPath.endsWith("/")) {
+		errorPath = errorPath.substring(0, errorPath.length() - 1);
+	}
+	if(requestUri != null && !errorPath.toLowerCase(java.util.Locale.ROOT).endsWith("/error/systemerror")) {
 		redirectPage.append("/error/systemerror/");
 		response.sendRedirect(redirectPage.toString());
 	} else {
-		response.sendError(statusCode);
+		// The system error page itself failed, so there is no page left to send to. Answering
+		// from here ends the request; going to that page again is what loops. The status is the
+		// one the container is rendering this page for, read from a request attribute it is not
+		// obliged to set, hence the fallback. The cause belongs in the log, not in the response.
+		response.setStatus(statusCode != null ? statusCode.intValue() : jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		response.setContentType("text/plain; charset=UTF-8");
+%>System Error.<%
 	}
 } else if("logOut".equals(type)) {
 	redirectPage.append("/login/?type=logout&code=" + statusCode);
@@ -24,7 +41,7 @@ if("systemError".equals(type)) {
 } else if("badAuth".equals(type)) {
 	// This branch is reached only from the 401 error-page mapping, so the status the
 	// container is rendering this page for is always 401.
-	if(org.codelibs.fess.util.WebApiUtil.isApiRequestUri(requestUri, ((jakarta.servlet.http.HttpServletRequest)request).getContextPath())) {
+	if(org.codelibs.fess.util.WebApiUtil.isApiRequestUri(requestUri, contextPath)) {
 		// An API client needs the status, not a page: issuing no redirect leaves the 401
 		// the container already set intact, and the body below is returned as-is.
 %>Bad Authentication.<%


### PR DESCRIPTION
## Problem

Once any action on the search side fails, every rendered route ends in `ERR_TOO_MANY_REDIRECTS`: the browser is sent to `/error/systemerror/`, and that page redirects to itself without end.

`web.xml` maps a 500 to `WEB-INF/view/error/redirect.jsp`, which redirects to `/error/systemerror/`. `ErrorSystemerrorAction` extends `FessSearchAction`, so it fails for the same reason the original request did, and the guard meant to break the cycle reads:

    if(requestUri != null && !requestUri.endsWith("systemError")) {

The real request URI is `/error/systemerror/` - lower case, with a trailing slash - so it never ends with `systemError`. The guard has never fired.

## Change

Compare against the actual path instead: strip the context path and any trailing slash, lower-case it, and check for `/error/systemerror`. When the system error page is itself what failed, answer from the error page rather than sending the browser to that page again.

## Verification

Reproduced on a running instance whose `fess_config.properties` was missing a key this version reads, which is the state an upgrade leaves behind when the file is not merged.

Before:

    GET /login/             -> 302  Location: /error/systemerror/
    GET /error/systemerror/ -> 302  Location: /error/systemerror/   (repeats)

After:

    GET /login/             -> 302  Location: /error/systemerror/
    GET /error/systemerror/ -> 500  text/plain  "System Error."

The JSP was compiled with Jasper's `JspC` using `-compile`. Note for anyone repeating this: `JspC` exits 0 even when compilation fails, so the signal is whether a `.class` is produced, not the exit code.

This stops the loop only. The 500 behind it is addressed in #3338.

Refs #3333
