### PR TITLE
fix(config): fall back to the shipped defaults for a missing property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,25 @@
 						<version>1.10.11</version>
 					</dependency>
 				</dependencies>
+				<executions>
+					<execution>
+						<!-- The installed fess_config.properties is a configuration file the packages
+						     must not replace on upgrade, so it can lack keys this build knows about.
+						     This copy answers those keys. The name differs on purpose: the packaging
+						     excludes for fess_config.properties must not match it. -->
+						<id>copy-default-config</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<copy file="${basedir}/src/main/resources/fess_config.properties"
+									tofile="${project.build.outputDirectory}/fess_config_default.properties" />
+							</target>
+						</configuration>
+					</execution>
+				</executions>
 				<configuration>
 					<target>
 						<ant antfile="${basedir}/dbflute.xml" target="download.dbflute" />

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfigImpl.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfigImpl.java
@@ -15,8 +15,16 @@
  */
 package org.codelibs.fess.mylasta.direction;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.Constants;
 import org.dbflute.helper.jprop.ObjectiveProperties;
 import org.lastaflute.core.direction.PropertyFilter;
@@ -28,11 +36,48 @@ public class FessConfigImpl extends FessConfig.SimpleImpl {
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger logger = LogManager.getLogger(FessConfigImpl.class);
+
+    /**
+     * The configuration defaults this build ships. The installed fess_config.properties keeps
+     * whatever the installation put there - the packages treat it as a configuration file and do
+     * not replace it on upgrade - so it can lack keys a newer version reads. These are the answer
+     * for those keys. The name differs from fess_config.properties on purpose, so that this copy
+     * survives the packaging rules that hold the installed file back.
+     */
+    protected static final String DEFAULT_CONFIG_PATH = "fess_config_default.properties";
+
     private static class KeyNotFoundException extends Exception {
         private static final long serialVersionUID = 1L;
 
         private KeyNotFoundException(final String key) {
             super(key);
+        }
+    }
+
+    /** Reads {@link #DEFAULT_CONFIG_PATH} once, on the first configuration property that needs it. */
+    private static final class DefaultConfigHolder {
+
+        private static final Properties DEFAULT_CONFIG = loadDefaultConfig();
+
+        private static Properties loadDefaultConfig() {
+            final Properties props = new Properties();
+            try (InputStream in = FessConfigImpl.class.getClassLoader().getResourceAsStream(DEFAULT_CONFIG_PATH)) {
+                if (in == null) {
+                    logger.warn("{} is not on the classpath. A configuration property missing from"
+                            + " fess_config.properties will fail instead of falling back to its default.", DEFAULT_CONFIG_PATH);
+                    return props;
+                }
+                try (Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+                    props.load(reader);
+                }
+            } catch (final IOException e) {
+                logger.warn("Failed to read {}.", DEFAULT_CONFIG_PATH, e);
+            }
+            return props;
+        }
+
+        private DefaultConfigHolder() {
         }
     }
 
@@ -53,10 +98,20 @@ public class FessConfigImpl extends FessConfig.SimpleImpl {
                 try {
                     return cache.get(propertyKey, () -> {
                         final String value = System.getProperty(Constants.FESS_CONFIG_PREFIX + propertyKey, super.get(propertyKey));
-                        if (value == null) {
+                        if (value != null) {
+                            return value;
+                        }
+                        final String defaultValue = DefaultConfigHolder.DEFAULT_CONFIG.getProperty(propertyKey);
+                        if (defaultValue == null) {
                             throw new KeyNotFoundException(propertyKey);
                         }
-                        return value;
+                        // Reached when the installed fess_config.properties predates this build, which
+                        // is what an upgrade leaves behind whenever the file was not merged. The loading
+                        // cache does not run this again, so the warning appears once per key. The value
+                        // stays out of the log because a default can be a credential.
+                        logger.warn("{} is not in fess_config.properties, so the default this version ships is used."
+                                + " Merge the fess_config.properties of this version into the installed one.", propertyKey);
+                        return defaultValue;
                     });
                 } catch (final ExecutionException e) {
                     if (e.getCause() instanceof KeyNotFoundException) {

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessConfigImplTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessConfigImplTest.java
@@ -15,9 +15,16 @@
  */
 package org.codelibs.fess.mylasta.direction;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.helper.jprop.ObjectiveProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.lastaflute.core.direction.exception.ConfigPropertyNotFoundException;
@@ -376,6 +383,70 @@ public class FessConfigImplTest extends UnitFessTestCase {
             assertEquals(dottedValue, value);
         } finally {
             System.clearProperty(Constants.FESS_CONFIG_PREFIX + dottedKey);
+        }
+    }
+
+    // ===================================================================================
+    //                                                              Bundled Default Config
+    //                                                              ======================
+    /** Stands in for the fess_config.properties an upgraded installation kept from its previous version. */
+    private static final String PARTIAL_CONFIG_PATH = "test_fess_config_partial.properties";
+
+    /** A key the partial file above does not carry, as a key added by a newer version would not be. */
+    private static final String KEY_ONLY_IN_BUNDLED_DEFAULT = "authentication.admin.users.ignore.case";
+
+    private ObjectiveProperties loadPartialProperties() {
+        final ObjectiveProperties prop = fessConfig.newObjectiveProperties(PARTIAL_CONFIG_PATH, (key, value) -> value);
+        prop.encodeAsUTF8();
+        prop.load();
+        return prop;
+    }
+
+    private Properties loadShippedConfig() throws Exception {
+        final Properties props = new Properties();
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream("fess_config.properties");
+                Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+            props.load(reader);
+        }
+        return props;
+    }
+
+    // A key the deployed file does carry keeps its value; the bundled defaults never override it.
+    @Test
+    public void test_bundledDefault_deployedValueWins() {
+        assertEquals("Test Domain Title", loadPartialProperties().get("domain.title"));
+    }
+
+    // A key the deployed file is missing resolves to the value this build ships, which is what
+    // keeps an installation running when fess_config.properties was not merged during an upgrade.
+    @Test
+    public void test_bundledDefault_fallsBackForMissingKey() throws Exception {
+        final String shippedValue = loadShippedConfig().getProperty(KEY_ONLY_IN_BUNDLED_DEFAULT);
+        assertNotNull("The key this test reads no longer exists in fess_config.properties", shippedValue);
+        assertEquals(shippedValue.trim(), loadPartialProperties().get(KEY_ONLY_IN_BUNDLED_DEFAULT));
+    }
+
+    // The system property channel stays ahead of the bundled defaults, so an administrator can
+    // still pin a value for a key the deployed file has not caught up with.
+    @Test
+    public void test_bundledDefault_systemPropertyWins() {
+        System.setProperty(Constants.FESS_CONFIG_PREFIX + KEY_ONLY_IN_BUNDLED_DEFAULT, "true");
+        try {
+            assertEquals("true", loadPartialProperties().get(KEY_ONLY_IN_BUNDLED_DEFAULT));
+        } finally {
+            System.clearProperty(Constants.FESS_CONFIG_PREFIX + KEY_ONLY_IN_BUNDLED_DEFAULT);
+        }
+    }
+
+    // A key no channel knows still fails, so a genuine typo does not read as a configured value.
+    @Test
+    public void test_bundledDefault_unknownKeyStillThrows() {
+        final ObjectiveProperties prop = loadPartialProperties();
+        try {
+            prop.get("nonexistent.property.for.bundled.default.test");
+            fail("Should throw ConfigPropertyNotFoundException");
+        } catch (final ConfigPropertyNotFoundException e) {
+            // expected
         }
     }
 }

--- a/src/test/resources/test_fess_config_partial.properties
+++ b/src/test/resources/test_fess_config_partial.properties
@@ -1,0 +1,4 @@
+# A deliberately partial copy of fess_config.properties, standing in for the file an
+# upgraded installation keeps from its previous version. Only keys the tests read the
+# user-supplied value of belong here; every other key must resolve to a bundled default.
+domain.title = Test Domain Title


### PR DESCRIPTION
## Problem

`fess_config.properties` is installed as a configuration file the packages must not replace - `<configuration>noreplace</configuration>` for rpm, and the deb dataset excludes it from the app directory and installs it under the conf directory. An upgrade therefore keeps the file the previous version left behind. Every key a newer version added is then absent, and reading one throws `ConfigPropertyNotFoundException`.

This is not a rare corner. `FessSearchAction#setupHtmlData` reads `authentication.admin.users.ignore.case`, added in 15.8, through `FessConfig#isAdminUser(String)` on every rendered page. `RootAction`, `SearchAction`, `FessLoginAction` and `ErrorSystemerrorAction` all extend `FessSearchAction`, so the entire web tier answers 500 - the error page included. 12 keys were added between 15.7.0 and 15.8.0, so several paths reach this.

Nothing reaches the log either. `RequestLoggingFilter`, the LastaFlute component that reports an uncaught request exception, is not in the filter chain, and Tomcat's own report goes to `logs/server_%g.log` rather than `fess.log`. Confirmed on a running instance: no `ConfigPropertyNotFound` in `fess.log`, in `server_*.log`, or on stdout.

## Change

Ship this build's `fess_config.properties` a second time, as `fess_config_default.properties`, and consult it when a key resolves nowhere else. Resolution becomes:

1. `-Dfess.config.<key>`
2. `fess_config.properties`, plus the `fess_env.properties` it extends
3. the defaults this build ships (new)
4. otherwise `ConfigPropertyNotFoundException`, as before

Step 3 logs a warning naming the key. It appears once per key, because the loading cache does not run the loader again. The value stays out of the warning, since a default can be a credential.

A few notes on the shape of this:

- The copy is made at build time into `target/classes`; nothing is added to `src/main/resources`, so freegen still sees exactly one configuration source.
- The name deliberately differs from `fess_config.properties`, because the packaging excludes that hold the installed file back are `**/fess_config.properties`.
- `FessConfigImpl` is not a freegen output - `FessConfig` and `FessEnv` are - so this survives regeneration.
- LastaFlute's `extendsProperties` was not used for the fallback layer. `checkImplicitOverride()` is enabled, so any key an installed file shares with the parent without a `# @Override` comment would fail the entire load.

## Verification

- Four tests added to `FessConfigImplTest`: the installed value wins, a missing key falls back, `-Dfess.config.*` still wins over both, and a key no channel knows still throws. Red before the change, green after.
- Full suite: 7427 tests, 0 failures.
- Running instance with `authentication.admin.users.ignore.case` removed from `fess_config.properties`: `/login/` answered 500 before and 200 after, with exactly one line in `fess.log`:

      WARN  authentication.admin.users.ignore.case is not in fess_config.properties, so the default
            this version ships is used. Merge the fess_config.properties of this version into the
            installed one.

- `mvn package` produces `WEB-INF/classes/fess_config_default.properties` alongside `WEB-INF/classes/fess_config.properties` in the war.

The redirect loop that made this look like a routing problem is fixed separately in #3337.

Fixes #3333
