### PR TITLE
feat(di): evaluate Di xml expressions as ECMAScript 6

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/di/FessJavaScriptExpressionEngine.java
+++ b/src/main/java/org/codelibs/fess/mylasta/di/FessJavaScriptExpressionEngine.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.mylasta.di;
+
+import javax.script.ScriptEngine;
+
+import org.codelibs.sai.api.scripting.SaiScriptEngineFactory;
+import org.lastaflute.di.core.LaContainer;
+import org.lastaflute.di.core.expression.engine.JavaScriptExpressionEngine;
+
+/**
+ * The expression engine of Di xml, which evaluates expressions as ECMAScript 6.
+ *
+ * <p>
+ * Sai parses a script as ECMAScript 5.1 unless <code>--language=es6</code> is given, and
+ * {@link JavaScriptExpressionEngine} looks the engine up by name via
+ * <code>ScriptEngineManager</code>, which has no way to pass such an option. So this class builds
+ * the Sai engine from its factory instead, where the option can be specified.
+ * </p>
+ *
+ * @author shinsuke
+ */
+public class FessJavaScriptExpressionEngine extends JavaScriptExpressionEngine {
+
+    /** The arguments for the Sai engine. "-doe" is the default of SaiScriptEngineFactory#getScriptEngine(). */
+    protected static final String[] ENGINE_ARGS = { "-doe", "--language=es6" };
+
+    /** The factory of the Sai engine. It is thread-safe and holds no state. */
+    protected static final SaiScriptEngineFactory ENGINE_FACTORY = new SaiScriptEngineFactory();
+
+    @Override
+    protected ScriptEngine comeOnScriptEngine(final String exp, final LaContainer container) {
+        // a script engine is not thread safe, so it is prepared per execution as the super class does
+        return ENGINE_FACTORY.getScriptEngine(ENGINE_ARGS);
+    }
+}

--- a/src/main/resources/lasta_di.properties
+++ b/src/main/resources/lasta_di.properties
@@ -11,3 +11,5 @@ smart.package1 = org.codelibs.fess.app
 # script engine
 dixml.script.managed.engine.name = sai
 
+# expression engine of Di xml, which runs the script engine above as ECMAScript 6
+dixml.script.expression.engine = org.codelibs.fess.mylasta.di.FessJavaScriptExpressionEngine

--- a/src/test/java/org/codelibs/fess/mylasta/di/FessJavaScriptExpressionEngineTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/di/FessJavaScriptExpressionEngineTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.mylasta.di;
+
+import java.util.HashMap;
+
+import javax.script.ScriptEngine;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+import org.lastaflute.di.core.LastaDiProperties;
+import org.lastaflute.di.core.expression.ScriptingExpression;
+import org.lastaflute.di.core.factory.SingletonLaContainerFactory;
+
+public class FessJavaScriptExpressionEngineTest extends UnitFessTestCase {
+
+    @Test
+    public void test_registeredInLastaDiProperties() {
+        assertEquals(FessJavaScriptExpressionEngine.class, LastaDiProperties.getInstance().getDiXmlScriptExpressionEngineType());
+    }
+
+    @Test
+    public void test_comeOnScriptEngine_es6() throws Exception {
+        final ScriptEngine engine = new FessJavaScriptExpressionEngine().comeOnScriptEngine("dummy", null);
+        // destructuring, for-of, an arrow function and a template literal are all ES6 only
+        assertEquals("6", engine.eval("const [a, b, c] = [1, 2, 3]; let s = 0; for (const v of [a, b, c]) { s += v; } `${s}`"));
+        assertEquals("42", engine.eval("const f = x => x * 2; `${f(21)}`"));
+    }
+
+    @Test
+    public void test_comeOnScriptEngine_es5() throws Exception {
+        final ScriptEngine engine = new FessJavaScriptExpressionEngine().comeOnScriptEngine("dummy", null);
+        assertEquals("ok", engine.eval("var v = 'ok'; v"));
+    }
+
+    @Test
+    public void test_evaluatedAsDiXmlExpression() {
+        // the path a Di xml expression actually takes
+        final ScriptingExpression expression = new ScriptingExpression("`sum=${((x, y) => x + y)(1, 2)}`");
+        final Object evaluated = expression.evaluate(new HashMap<>(), SingletonLaContainerFactory.getContainer(), Object.class);
+        assertEquals("sum=3", evaluated);
+    }
+}


### PR DESCRIPTION
## Summary

Di xml expressions are evaluated by Sai, and Sai parses ECMAScript 5.1 unless it is given
`--language=es6`. This passes that option, so Di xml expressions can use ES6 syntax.

## How

lasta-di's `JavaScriptExpressionEngine` resolves the engine with
`ScriptEngineManager.getEngineByName("sai")` (the name comes from
`dixml.script.managed.engine.name`), and that API takes no engine arguments. But the engine is
chosen per evaluation in `comeOnScriptEngine()`, which is `protected`, and lasta-di lets an
application replace the whole `ExpressionEngine` through the `dixml.script.expression.engine`
property. So:

- `FessJavaScriptExpressionEngine` extends `JavaScriptExpressionEngine` and overrides
  `comeOnScriptEngine()` to build the engine with
  `SaiScriptEngineFactory#getScriptEngine("-doe", "--language=es6")`. `-doe` is what
  `SaiScriptEngineFactory#getScriptEngine()` passes by default, so it is kept.
- `lasta_di.properties` registers that class as `dixml.script.expression.engine`.

`dixml.script.managed.engine.name = sai` is left in place: `SingletonLaContainerFactory` still
reads it to warm the script engine up on a background thread during startup.

### Why not a system property

`-Dsai.args=--language=es6` (or `-Dsai.option.language=es6`) has the same effect, but it is per
JVM, so it would have to be added to `FESS_JAVA_OPTS` **and** to `jvm.crawler.options`,
`jvm.suggest.options`, `jvm.chunk.options` and `jvm.thumbnail.options`, and it would be missing
in any embedding that does not go through those. `lasta_di.properties` travels with the
classpath, so every process reads the same setting.

## Notes

- Requires sai 0.4.0-SNAPSHOT: codelibs/fess-parent#75. Under `--language=es6`, 0.3.0 accepts
  only let/const, block scope and default parameters, so this change would buy almost nothing
  on it. **CI here fails until #75 is merged and a new fess-parent snapshot is deployed** -
  running the tests with `-Dsai.version=0.3.0` reproduces it (2 errors,
  `ParserException: Expected an operand but found error` on the template literal).
- ES6 **syntax** only. Sai adds no ES6 built-ins: `Symbol`, `Map`, `Promise`, `Object.assign`,
  `Array.from` and `String.prototype.includes` are all still `undefined`.

## Verification

- `mvn test` - 7431 tests, 0 failures, 0 errors, 0 skipped (4 of them added here). Every
  `UnitFessTestCase` boots the Di container, so the whole suite re-evaluates all `fess_*.xml`
  expressions through the ES6 engine.
- `FessJavaScriptExpressionEngineTest`, 4 tests:
  - the engine is the one registered in `lasta_di.properties`
  - ES6 syntax evaluates: destructuring, for-of, arrow function, template literal
  - ES5 syntax still evaluates
  - a template literal and an arrow function evaluated through `ScriptingExpression`, the path
    a Di xml expression actually takes
- `mvn formatter:format license:format` - 1689 files, 0 changed.
