### PR TITLE
refactor(search): replace the scroll API with a point in time and search_after

### DIFF
--- a/dbflute.xml
+++ b/dbflute.xml
@@ -2,7 +2,7 @@
 <project name="dbflute" basedir=".">
 	<property name="mydbflute.dir" value="${basedir}/mydbflute" />
 	<property name="target.dir" value="${basedir}/target" />
-	<property name="branch.name" value="fess-15.8" />
+	<property name="branch.name" value="fess-15.9" />
 	<property name="mydbflute.url" value="https://github.com/lastaflute/lastaflute-example-waterfront/archive/${branch.name}.zip" />
 
 	<target name="mydbflute.check">

--- a/dbflute_fess/dfprop/littleAdjustmentMap.dfprop
+++ b/dbflute_fess/dfprop/littleAdjustmentMap.dfprop
@@ -204,5 +204,9 @@ map:{
     #    ; versionNoFieldName = VERSION_NO
     #}
     # - - - - - - - - - -/
+
+    # The generated classes use jakarta.annotation instead of javax.annotation.
+    # Without this the freegen task emits javax.annotation.Resource, which does not compile.
+    ; isMigrateOldJavaxToJakarta = true
 }
 # ----------------/

--- a/src/main/java/org/codelibs/fess/helper/ChunkVectorHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ChunkVectorHelper.java
@@ -413,13 +413,8 @@ public class ChunkVectorHelper {
      * to bound the memory a single run holds; with it disabled a very large corpus materializes its
      * entire pending-ID set at once, so the chunk indexer JVM heap ({@code jvm.chunk.options}) may need
      * raising. The remaining pending documents stay pending and are picked up by the next (idempotent)
-     * scheduled run. The cap is enforced by throwing a private
-     * {@link ScrollLimitReachedException} from the scroll cursor rather than by returning
-     * {@code false} from it: {@code SearchEngineClient#scrollSearch} only stops iterating the
-     * <em>current</em> page when the cursor returns {@code false} and then keeps fetching further
-     * pages, so a bare {@code false} would drain the whole (potentially millions-of-pages) scroll
-     * instead of stopping it -- the throw exits the scroll immediately, with its {@code finally}
-     * still releasing the scroll context.</p>
+     * scheduled run. The cap is enforced by returning {@code false} from the cursor, which ends
+     * the walk immediately; the point in time is released either way.</p>
      *
      * @param embeddingActive whether embedding is active for this run (widens the pending query to
      *            include {@code "chunked"} upgrade documents)
@@ -433,28 +428,25 @@ public class ChunkVectorHelper {
         final int maxDocuments = getJobMaxDocumentsPerRun();
         final boolean unlimited = isUnlimitedMaxDocuments(maxDocuments);
         final List<String> idList = new ArrayList<>();
-        try {
-            searchEngineClient.scrollSearch(fessConfig.getIndexDocumentUpdateIndex(), requestBuilder -> {
-                requestBuilder.setQuery(buildPendingQuery(embeddingActive))
-                        .setSize(SCROLL_SIZE)
-                        .setFetchSource(new String[] { fessConfig.getIndexFieldId() }, null);
-                return true;
-            }, source -> {
-                final Object idObj = source.get(fessConfig.getIndexFieldId());
-                if (idObj != null) {
-                    idList.add(idObj.toString());
-                }
-                if (!unlimited && idList.size() >= maxDocuments) {
-                    throw new ScrollLimitReachedException();
-                }
-                return true;
-            });
-        } catch (final ScrollLimitReachedException e) {
-            if (logger.isInfoEnabled()) {
-                logger.info("[ChunkVector] Reached the per-run document cap ({}); the remaining pending documents will be "
-                        + "processed on the next scheduled run.", maxDocuments);
+        searchEngineClient.scrollSearch(fessConfig.getIndexDocumentUpdateIndex(), requestBuilder -> {
+            requestBuilder.setQuery(buildPendingQuery(embeddingActive))
+                    .setSize(SCROLL_SIZE)
+                    .setFetchSource(new String[] { fessConfig.getIndexFieldId() }, null);
+            return true;
+        }, source -> {
+            final Object idObj = source.get(fessConfig.getIndexFieldId());
+            if (idObj != null) {
+                idList.add(idObj.toString());
             }
-        }
+            if (!unlimited && idList.size() >= maxDocuments) {
+                if (logger.isInfoEnabled()) {
+                    logger.info("[ChunkVector] Reached the per-run document cap ({}); the remaining pending documents will be "
+                            + "processed on the next scheduled run.", maxDocuments);
+                }
+                return false;
+            }
+            return true;
+        });
         return idList;
     }
 
@@ -502,20 +494,6 @@ public class ChunkVectorHelper {
      */
     protected boolean isRetryFailedEnabled() {
         return Boolean.parseBoolean(ComponentUtil.getFessConfig().getSystemProperty(JOB_RETRY_FAILED_PROPERTY, "false"));
-    }
-
-    /**
-     * Internal control-flow signal thrown from {@link #scrollPendingIds(boolean)}'s scroll cursor
-     * once {@link #getJobMaxDocumentsPerRun()} document IDs have been collected, to stop the scroll
-     * early without materializing the whole corpus. Never escapes {@link #scrollPendingIds(boolean)};
-     * stack trace and suppression are disabled since it carries no diagnostic value.
-     */
-    private static final class ScrollLimitReachedException extends RuntimeException {
-        private static final long serialVersionUID = 1L;
-
-        ScrollLimitReachedException() {
-            super(null, null, false, false);
-        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -123,6 +123,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.ClearScrollRequest;
 import org.opensearch.action.search.ClearScrollRequestBuilder;
 import org.opensearch.action.search.ClearScrollResponse;
+import org.opensearch.action.search.CreatePitAction;
 import org.opensearch.action.search.CreatePitRequest;
 import org.opensearch.action.search.CreatePitResponse;
 import org.opensearch.action.search.DeletePitRequest;
@@ -170,8 +171,10 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
@@ -224,19 +227,19 @@ public class SearchEngineClient implements Client {
     /** Map of configuration types to their respective configuration files */
     protected Map<String, List<String>> configListMap = new HashMap<>();
 
-    /** Scroll timeout for search operations */
+    /** Keep-alive of the point in time that search operations page over */
     protected String scrollForSearch = "1m";
 
     /** Batch size for delete operations */
     protected int sizeForDelete = 100;
 
-    /** Scroll timeout for delete operations */
+    /** Keep-alive of the point in time that delete operations page over */
     protected String scrollForDelete = "1m";
 
     /** Batch size for update operations */
     protected int sizeForUpdate = 100;
 
-    /** Scroll timeout for update operations */
+    /** Keep-alive of the point in time that update operations page over */
     protected String scrollForUpdate = "1m";
 
     /** Maximum retry attempts for configuration synchronization status checks */
@@ -1669,48 +1672,26 @@ public class SearchEngineClient implements Client {
             final BiFunction<UpdateRequestBuilder, SearchHit, UpdateRequestBuilder> builder) {
 
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        SearchResponse response = option.apply(client.prepareSearch(index)
-                .setScroll(scrollForUpdate)
-                .setSize(sizeForUpdate)
-                .setPreference(Constants.SEARCH_PREFERENCE_LOCAL)).execute().actionGet(fessConfig.getIndexScrollSearchTimeout());
+        final SearchRequestBuilder searchRequestBuilder =
+                option.apply(client.prepareSearch().setSize(sizeForUpdate).setPreference(Constants.SEARCH_PREFERENCE_LOCAL));
 
-        int count = 0;
-        String scrollId = response.getScrollId();
-        try {
-            while (scrollId != null) {
-                final SearchHits searchHits = response.getHits();
-                final SearchHit[] hits = searchHits.getHits();
-                if (hits.length == 0) {
-                    break;
+        final long[] count = { 0 };
+        pitSearch(index, scrollForUpdate, fessConfig.getIndexScrollSearchTimeout(), searchRequestBuilder, response -> {
+            final BulkRequestBuilder bulkRequest = client.prepareBulk();
+            for (final SearchHit hit : response.getHits().getHits()) {
+                final UpdateRequestBuilder requestBuilder = builder.apply(client.prepareUpdate().setIndex(index).setId(hit.getId()), hit);
+                if (requestBuilder != null) {
+                    bulkRequest.add(requestBuilder);
                 }
-
-                final BulkRequestBuilder bulkRequest = client.prepareBulk();
-                for (final SearchHit hit : hits) {
-                    final UpdateRequestBuilder requestBuilder =
-                            builder.apply(client.prepareUpdate().setIndex(index).setId(hit.getId()), hit);
-                    if (requestBuilder != null) {
-                        bulkRequest.add(requestBuilder);
-                    }
-                    count++;
-                }
-                final BulkResponse bulkResponse = bulkRequest.execute().actionGet(fessConfig.getIndexBulkTimeout());
-                if (bulkResponse.hasFailures()) {
-                    throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
-                }
-
-                response = client.prepareSearchScroll(scrollId)
-                        .setScroll(scrollForUpdate)
-                        .execute()
-                        .actionGet(fessConfig.getIndexBulkTimeout());
-                if (!scrollId.equals(response.getScrollId())) {
-                    deleteScrollContext(scrollId);
-                }
-                scrollId = response.getScrollId();
+                count[0]++;
             }
-        } finally {
-            deleteScrollContext(scrollId);
-        }
-        return count;
+            final BulkResponse bulkResponse = bulkRequest.execute().actionGet(fessConfig.getIndexBulkTimeout());
+            if (bulkResponse.hasFailures()) {
+                throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
+            }
+            return true;
+        });
+        return count[0];
     }
 
     /**
@@ -1723,60 +1704,94 @@ public class SearchEngineClient implements Client {
     public long deleteByQuery(final String index, final QueryBuilder queryBuilder) {
 
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
-        SearchResponse response = client.prepareSearch(index)
-                .setScroll(scrollForDelete)
+        final SearchRequestBuilder searchRequestBuilder = client.prepareSearch()
                 .setSize(sizeForDelete)
                 .setFetchSource(new String[] { fessConfig.getIndexFieldId() }, null)
                 .setQuery(queryBuilder)
-                .setPreference(Constants.SEARCH_PREFERENCE_LOCAL)
-                .execute()
-                .actionGet(fessConfig.getIndexScrollSearchTimeout());
+                .setPreference(Constants.SEARCH_PREFERENCE_LOCAL);
 
-        int count = 0;
-        String scrollId = response.getScrollId();
-        try {
-            while (scrollId != null) {
-                final SearchHits searchHits = response.getHits();
-                final SearchHit[] hits = searchHits.getHits();
-                if (hits.length == 0) {
-                    break;
-                }
-
-                final BulkRequestBuilder bulkRequest = client.prepareBulk();
-                for (final SearchHit hit : hits) {
-                    bulkRequest.add(client.prepareDelete().setIndex(index).setId(hit.getId()));
-                    count++;
-                }
-                final BulkResponse bulkResponse = bulkRequest.execute().actionGet(fessConfig.getIndexBulkTimeout());
-                if (bulkResponse.hasFailures()) {
-                    throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
-                }
-
-                response = client.prepareSearchScroll(scrollId)
-                        .setScroll(scrollForDelete)
-                        .execute()
-                        .actionGet(fessConfig.getIndexBulkTimeout());
-                if (!scrollId.equals(response.getScrollId())) {
-                    deleteScrollContext(scrollId);
-                }
-                scrollId = response.getScrollId();
+        final long[] count = { 0 };
+        pitSearch(index, scrollForDelete, fessConfig.getIndexScrollSearchTimeout(), searchRequestBuilder, response -> {
+            final BulkRequestBuilder bulkRequest = client.prepareBulk();
+            for (final SearchHit hit : response.getHits().getHits()) {
+                bulkRequest.add(client.prepareDelete().setIndex(index).setId(hit.getId()));
+                count[0]++;
             }
-        } finally {
-            deleteScrollContext(scrollId);
-        }
-        return count;
+            final BulkResponse bulkResponse = bulkRequest.execute().actionGet(fessConfig.getIndexBulkTimeout());
+            if (bulkResponse.hasFailures()) {
+                throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
+            }
+            return true;
+        });
+        return count[0];
     }
 
     /**
-     * Deletes a scroll context to free resources.
+     * Pages over every document the given search matches, using a point in time and
+     * {@code search_after}.
      *
-     * @param scrollId the scroll ID to delete
+     * <p>A {@code _shard_doc} tiebreaker is appended to whatever sort the caller set, which makes
+     * the order total so that {@code search_after} can walk it without skipping or repeating a
+     * document. That sort field requires an OpenSearch 3.x server; 2.x does not implement it.</p>
+     *
+     * <p>A point in time carries the indices, routing and preference itself, and a search that
+     * repeats any of them is rejected with a 400. Over HTTP such a 400 on a request with a body
+     * does not surface as an error, it hangs. So the search is issued without an index and the
+     * routing and preference are moved onto the create request.</p>
+     *
+     * @param index the index the point in time is opened on
+     * @param keepAlive how long the point in time stays alive; every page extends it
+     * @param searchTimeout how long to wait for each page
+     * @param builder the search to page over, already configured by the caller
+     * @param pageHandler called once per page; returning false ends the walk
      */
-    protected void deleteScrollContext(final String scrollId) {
-        if (scrollId != null) {
-            client.prepareClearScroll()
-                    .addScrollId(scrollId)
-                    .execute(wrap(res -> {}, e -> logger.warn("Failed to clear the scroll context.", e)));
+    protected void pitSearch(final String index, final String keepAlive, final String searchTimeout, final SearchRequestBuilder builder,
+            final BooleanFunction<SearchResponse> pageHandler) {
+        builder.addSort(SortBuilders.shardDocSort());
+
+        final SearchRequest request = builder.request();
+        final TimeValue keepAliveValue = TimeValue.parseTimeValue(keepAlive, "keepAlive");
+        final CreatePitRequest createPitRequest = new CreatePitRequest(keepAliveValue, true, index);
+        if (request.preference() != null) {
+            createPitRequest.setPreference(request.preference());
+            request.preference(null);
+        }
+        if (request.routing() != null) {
+            createPitRequest.setRouting(request.routing());
+            request.routing((String) null);
+        }
+        final String pitId = client.execute(CreatePitAction.INSTANCE, createPitRequest).actionGet(searchTimeout).getId();
+        try {
+            builder.setPointInTime(new PointInTimeBuilder(pitId).setKeepAlive(keepAliveValue));
+            Object[] searchAfter = null;
+            while (true) {
+                if (searchAfter != null) {
+                    builder.searchAfter(searchAfter);
+                }
+                final SearchResponse response = builder.execute().actionGet(searchTimeout);
+                final SearchHit[] hits = response.getHits().getHits();
+                if (hits.length == 0) {
+                    break;
+                }
+                if (!pageHandler.apply(response)) {
+                    break;
+                }
+                searchAfter = hits[hits.length - 1].getSortValues();
+            }
+        } finally {
+            deletePitContext(pitId);
+        }
+    }
+
+    /**
+     * Releases a point in time. Failures are logged rather than propagated, so that releasing in a
+     * finally block cannot mask an exception that is already unwinding.
+     *
+     * @param pitId the point in time to release
+     */
+    protected void deletePitContext(final String pitId) {
+        if (pitId != null) {
+            client.deletePits(new DeletePitRequest(pitId), wrap(res -> {}, e -> logger.warn("Failed to delete the point in time.", e)));
         }
     }
 
@@ -1878,52 +1893,31 @@ public class SearchEngineClient implements Client {
      */
     public <T> long scrollSearch(final String index, final SearchCondition<SearchRequestBuilder> condition,
             final EntityCreator<T, SearchResponse, SearchHit> creator, final BooleanFunction<T> cursor) {
-        long count = 0;
+        final long[] count = { 0 };
 
-        final SearchRequestBuilder searchRequestBuilder = client.prepareSearch(index).setScroll(scrollForSearch);
+        final SearchRequestBuilder searchRequestBuilder = client.prepareSearch();
         if (condition.build(searchRequestBuilder)) {
             final FessConfig fessConfig = ComponentUtil.getFessConfig();
-
-            String scrollId = null;
             try {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Query DSL: {}", searchRequestBuilder);
                 }
-                SearchResponse response = searchRequestBuilder.execute().actionGet(ComponentUtil.getFessConfig().getIndexSearchTimeout());
-
-                scrollId = response.getScrollId();
-                while (scrollId != null) {
-                    final SearchHits searchHits = response.getHits();
-                    final SearchHit[] hits = searchHits.getHits();
-                    if (hits.length == 0) {
-                        break;
-                    }
-
-                    for (final SearchHit hit : hits) {
-                        count++;
+                pitSearch(index, scrollForSearch, fessConfig.getIndexSearchTimeout(), searchRequestBuilder, response -> {
+                    for (final SearchHit hit : response.getHits().getHits()) {
+                        count[0]++;
                         if (!cursor.apply(creator.build(response, hit))) {
-                            break;
+                            return false;
                         }
                     }
-
-                    response = client.prepareSearchScroll(scrollId)
-                            .setScroll(scrollForDelete)
-                            .execute()
-                            .actionGet(fessConfig.getIndexBulkTimeout());
-                    if (!scrollId.equals(response.getScrollId())) {
-                        deleteScrollContext(scrollId);
-                    }
-                    scrollId = response.getScrollId();
-                }
+                    return true;
+                });
             } catch (final SearchPhaseExecutionException e) {
                 throw new InvalidQueryException(messages -> messages.addErrorsInvalidQueryParseError(UserMessages.GLOBAL_PROPERTY_KEY),
                         "Invalid query: " + searchRequestBuilder, e);
-            } finally {
-                deleteScrollContext(scrollId);
             }
         }
 
-        return count;
+        return count[0];
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/opensearch/config/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/allcommon/EsAbstractBehavior.java
@@ -25,8 +25,13 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.function.Function;
 
+import jakarta.annotation.Resource;
+
+import org.codelibs.fess.opensearch.config.allcommon.EsAbstractEntity;
 import org.codelibs.fess.opensearch.config.allcommon.EsAbstractEntity.DocMeta;
 import org.codelibs.fess.opensearch.config.allcommon.EsAbstractEntity.RequestOptionCall;
+import org.codelibs.fess.opensearch.config.allcommon.EsAbstractConditionBean;
+import org.codelibs.fess.opensearch.config.allcommon.EsPagingResultBean;
 import org.dbflute.Entity;
 import org.dbflute.bhv.AbstractBehaviorWritable;
 import org.dbflute.bhv.readable.EntityRowHandler;
@@ -48,16 +53,22 @@ import org.opensearch.action.delete.DeleteRequestBuilder;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.CreatePitAction;
+import org.opensearch.action.search.CreatePitRequest;
+import org.opensearch.action.search.DeletePitAction;
+import org.opensearch.action.search.DeletePitRequest;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateRequestBuilder;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.PointInTimeBuilder;
+import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.transport.client.Client;
-
-import jakarta.annotation.Resource;
 
 /**
  * @param <ENTITY> The type of entity.
@@ -69,6 +80,8 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     @Resource
     private Client client;
 
+    // The two "scroll" values below are the keep-alive of the point in time that query delete and
+    // cursor select page over. The names are kept for compatibility with existing DI settings.
     protected int sizeForDelete = 100;
     protected String scrollForDelete = "1m";
     protected int sizeForCursor = 100;
@@ -227,16 +240,56 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     }
 
     protected void delegateBulkRequest(final ConditionBean cb, Function<SearchHits, Boolean> handler) {
-        final SearchRequestBuilder builder = client.prepareSearch(asEsIndex()).setScroll(scrollForCursor).setSize(sizeForCursor);
-        final EsAbstractConditionBean esCb = (EsAbstractConditionBean) cb;
+        pitSearch((EsAbstractConditionBean) cb, sizeForCursor, scrollForCursor, handler);
+    }
+
+    /**
+     * Walks every hit matching the condition bean, one page at a time, over a point in time.
+     *
+     * <p>The pages are ordered by the condition bean's own sort followed by a {@code _shard_doc}
+     * tiebreaker, which makes the order total so that {@code search_after} can walk it without
+     * skipping or repeating a document. The point in time is released in every case, and the walk
+     * stops as soon as the handler returns {@code false}.</p>
+     *
+     * @param esCb the condition bean selecting the documents.
+     * @param pageSize the number of hits fetched per page.
+     * @param keepAlive how long the point in time stays alive, extended by every page.
+     * @param handler called once per page; returning false ends the walk.
+     */
+    protected void pitSearch(final EsAbstractConditionBean esCb, final int pageSize, final String keepAlive,
+            final Function<SearchHits, Boolean> handler) {
+        final SearchRequestBuilder builder = client.prepareSearch().setSize(pageSize);
         if (esCb.getPreference() != null) {
             builder.setPreference(esCb.getPreference());
         }
         esCb.request().build(builder);
-        SearchResponse response = esCb.build(builder).execute().actionGet(scrollSearchTimeout);
-        String scrollId = response.getScrollId();
+        final SearchRequestBuilder searchBuilder = esCb.build(builder);
+        searchBuilder.addSort(SortBuilders.shardDocSort());
+
+        // A point in time carries the indices, routing and preference itself, and a search that
+        // repeats any of them is rejected with a 400 ("[indices]/[routing]/[preference] cannot be
+        // used with point in time"). Over HTTP such a 400 on a request with a body does not surface
+        // as an error, it hangs. So move them onto the point in time and strip them off the search.
+        final SearchRequest searchRequest = searchBuilder.request();
+        final TimeValue keepAliveValue = TimeValue.parseTimeValue(keepAlive, "keepAlive");
+        final CreatePitRequest createPitRequest = new CreatePitRequest(keepAliveValue, true, asEsIndex());
+        if (searchRequest.preference() != null) {
+            createPitRequest.setPreference(searchRequest.preference());
+            searchRequest.preference(null);
+        }
+        if (searchRequest.routing() != null) {
+            createPitRequest.setRouting(searchRequest.routing());
+            searchRequest.routing((String) null);
+        }
+        final String pitId = client.execute(CreatePitAction.INSTANCE, createPitRequest).actionGet(scrollSearchTimeout).getId();
         try {
-            while (scrollId != null) {
+            searchBuilder.setPointInTime(new PointInTimeBuilder(pitId).setKeepAlive(keepAliveValue));
+            Object[] searchAfter = null;
+            while (true) {
+                if (searchAfter != null) {
+                    searchBuilder.searchAfter(searchAfter);
+                }
+                final SearchResponse response = searchBuilder.execute().actionGet(scrollSearchTimeout);
                 final SearchHits searchHits = getSearchHits(response);
                 final SearchHit[] hits = searchHits.getHits();
                 if (hits.length == 0) {
@@ -247,20 +300,16 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
                     break;
                 }
 
-                response = client.prepareSearchScroll(scrollId).setScroll(scrollForDelete).execute().actionGet(scrollSearchTimeout);
-                if (!scrollId.equals(response.getScrollId())) {
-                    deleteScrollContext(scrollId);
-                }
-                scrollId = response.getScrollId();
+                searchAfter = hits[hits.length - 1].getSortValues();
             }
         } finally {
-            deleteScrollContext(scrollId);
+            deletePitContext(pitId);
         }
     }
 
-    protected void deleteScrollContext(final String scrollId) {
-        if (scrollId != null) {
-            client.prepareClearScroll().addScrollId(scrollId).execute(ActionListener.wrap(() -> {}));
+    protected void deletePitContext(final String pitId) {
+        if (pitId != null) {
+            client.deletePits(new DeletePitRequest(pitId), ActionListener.wrap(() -> {}));
         }
     }
 
@@ -364,42 +413,21 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
 
     @Override
     protected int delegateQueryDelete(final ConditionBean cb, final DeleteOption<? extends ConditionBean> option) {
-        final SearchRequestBuilder builder = client.prepareSearch(asEsIndex()).setScroll(scrollForDelete).setSize(sizeForDelete);
-        final EsAbstractConditionBean esCb = (EsAbstractConditionBean) cb;
-        if (esCb.getPreference() != null) {
-            esCb.setPreference(esCb.getPreference());
-        }
-        esCb.request().build(builder);
-        SearchResponse response = esCb.build(builder).execute().actionGet(scrollSearchTimeout);
-        String scrollId = response.getScrollId();
-        int count = 0;
-        try {
-            while (scrollId != null) {
-                final SearchHits searchHits = getSearchHits(response);
-                final SearchHit[] hits = searchHits.getHits();
-                if (hits.length == 0) {
-                    break;
-                }
-
-                final BulkRequestBuilder bulkRequest = client.prepareBulk();
-                for (final SearchHit hit : hits) {
-                    bulkRequest.add(client.prepareDelete().setIndex(asEsIndex()).setId(hit.getId()));
-                }
-                count += hits.length;
-                final BulkResponse bulkResponse = bulkRequest.execute().actionGet(bulkTimeout);
-                if (bulkResponse.hasFailures()) {
-                    throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
-                }
-
-                response = client.prepareSearchScroll(scrollId).setScroll(scrollForDelete).execute().actionGet(scrollSearchTimeout);
-                if (!scrollId.equals(response.getScrollId())) {
-                    deleteScrollContext(scrollId);
-                }
+        final int[] count = new int[1];
+        pitSearch((EsAbstractConditionBean) cb, sizeForDelete, scrollForDelete, searchHits -> {
+            final SearchHit[] hits = searchHits.getHits();
+            final BulkRequestBuilder bulkRequest = client.prepareBulk();
+            for (final SearchHit hit : hits) {
+                bulkRequest.add(client.prepareDelete().setIndex(asEsIndex()).setId(hit.getId()));
             }
-        } finally {
-            deleteScrollContext(scrollId);
-        }
-        return count;
+            count[0] += hits.length;
+            final BulkResponse bulkResponse = bulkRequest.execute().actionGet(bulkTimeout);
+            if (bulkResponse.hasFailures()) {
+                throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
+            }
+            return true;
+        });
+        return count[0];
     }
 
     protected int[] delegateBatchInsert(final List<? extends Entity> entityList, final InsertOption<? extends ConditionBean> option) {

--- a/src/main/java/org/codelibs/fess/opensearch/log/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/log/allcommon/EsAbstractBehavior.java
@@ -25,8 +25,13 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.function.Function;
 
+import jakarta.annotation.Resource;
+
+import org.codelibs.fess.opensearch.log.allcommon.EsAbstractEntity;
 import org.codelibs.fess.opensearch.log.allcommon.EsAbstractEntity.DocMeta;
 import org.codelibs.fess.opensearch.log.allcommon.EsAbstractEntity.RequestOptionCall;
+import org.codelibs.fess.opensearch.log.allcommon.EsAbstractConditionBean;
+import org.codelibs.fess.opensearch.log.allcommon.EsPagingResultBean;
 import org.dbflute.Entity;
 import org.dbflute.bhv.AbstractBehaviorWritable;
 import org.dbflute.bhv.readable.EntityRowHandler;
@@ -48,16 +53,22 @@ import org.opensearch.action.delete.DeleteRequestBuilder;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.CreatePitAction;
+import org.opensearch.action.search.CreatePitRequest;
+import org.opensearch.action.search.DeletePitAction;
+import org.opensearch.action.search.DeletePitRequest;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateRequestBuilder;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.PointInTimeBuilder;
+import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.transport.client.Client;
-
-import jakarta.annotation.Resource;
 
 /**
  * @param <ENTITY> The type of entity.
@@ -69,6 +80,8 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     @Resource
     private Client client;
 
+    // The two "scroll" values below are the keep-alive of the point in time that query delete and
+    // cursor select page over. The names are kept for compatibility with existing DI settings.
     protected int sizeForDelete = 100;
     protected String scrollForDelete = "1m";
     protected int sizeForCursor = 100;
@@ -227,16 +240,56 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     }
 
     protected void delegateBulkRequest(final ConditionBean cb, Function<SearchHits, Boolean> handler) {
-        final SearchRequestBuilder builder = client.prepareSearch(asEsIndex()).setScroll(scrollForCursor).setSize(sizeForCursor);
-        final EsAbstractConditionBean esCb = (EsAbstractConditionBean) cb;
+        pitSearch((EsAbstractConditionBean) cb, sizeForCursor, scrollForCursor, handler);
+    }
+
+    /**
+     * Walks every hit matching the condition bean, one page at a time, over a point in time.
+     *
+     * <p>The pages are ordered by the condition bean's own sort followed by a {@code _shard_doc}
+     * tiebreaker, which makes the order total so that {@code search_after} can walk it without
+     * skipping or repeating a document. The point in time is released in every case, and the walk
+     * stops as soon as the handler returns {@code false}.</p>
+     *
+     * @param esCb the condition bean selecting the documents.
+     * @param pageSize the number of hits fetched per page.
+     * @param keepAlive how long the point in time stays alive, extended by every page.
+     * @param handler called once per page; returning false ends the walk.
+     */
+    protected void pitSearch(final EsAbstractConditionBean esCb, final int pageSize, final String keepAlive,
+            final Function<SearchHits, Boolean> handler) {
+        final SearchRequestBuilder builder = client.prepareSearch().setSize(pageSize);
         if (esCb.getPreference() != null) {
             builder.setPreference(esCb.getPreference());
         }
         esCb.request().build(builder);
-        SearchResponse response = esCb.build(builder).execute().actionGet(scrollSearchTimeout);
-        String scrollId = response.getScrollId();
+        final SearchRequestBuilder searchBuilder = esCb.build(builder);
+        searchBuilder.addSort(SortBuilders.shardDocSort());
+
+        // A point in time carries the indices, routing and preference itself, and a search that
+        // repeats any of them is rejected with a 400 ("[indices]/[routing]/[preference] cannot be
+        // used with point in time"). Over HTTP such a 400 on a request with a body does not surface
+        // as an error, it hangs. So move them onto the point in time and strip them off the search.
+        final SearchRequest searchRequest = searchBuilder.request();
+        final TimeValue keepAliveValue = TimeValue.parseTimeValue(keepAlive, "keepAlive");
+        final CreatePitRequest createPitRequest = new CreatePitRequest(keepAliveValue, true, asEsIndex());
+        if (searchRequest.preference() != null) {
+            createPitRequest.setPreference(searchRequest.preference());
+            searchRequest.preference(null);
+        }
+        if (searchRequest.routing() != null) {
+            createPitRequest.setRouting(searchRequest.routing());
+            searchRequest.routing((String) null);
+        }
+        final String pitId = client.execute(CreatePitAction.INSTANCE, createPitRequest).actionGet(scrollSearchTimeout).getId();
         try {
-            while (scrollId != null) {
+            searchBuilder.setPointInTime(new PointInTimeBuilder(pitId).setKeepAlive(keepAliveValue));
+            Object[] searchAfter = null;
+            while (true) {
+                if (searchAfter != null) {
+                    searchBuilder.searchAfter(searchAfter);
+                }
+                final SearchResponse response = searchBuilder.execute().actionGet(scrollSearchTimeout);
                 final SearchHits searchHits = getSearchHits(response);
                 final SearchHit[] hits = searchHits.getHits();
                 if (hits.length == 0) {
@@ -247,20 +300,16 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
                     break;
                 }
 
-                response = client.prepareSearchScroll(scrollId).setScroll(scrollForDelete).execute().actionGet(scrollSearchTimeout);
-                if (!scrollId.equals(response.getScrollId())) {
-                    deleteScrollContext(scrollId);
-                }
-                scrollId = response.getScrollId();
+                searchAfter = hits[hits.length - 1].getSortValues();
             }
         } finally {
-            deleteScrollContext(scrollId);
+            deletePitContext(pitId);
         }
     }
 
-    protected void deleteScrollContext(final String scrollId) {
-        if (scrollId != null) {
-            client.prepareClearScroll().addScrollId(scrollId).execute(ActionListener.wrap(() -> {}));
+    protected void deletePitContext(final String pitId) {
+        if (pitId != null) {
+            client.deletePits(new DeletePitRequest(pitId), ActionListener.wrap(() -> {}));
         }
     }
 
@@ -364,42 +413,21 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
 
     @Override
     protected int delegateQueryDelete(final ConditionBean cb, final DeleteOption<? extends ConditionBean> option) {
-        final SearchRequestBuilder builder = client.prepareSearch(asEsIndex()).setScroll(scrollForDelete).setSize(sizeForDelete);
-        final EsAbstractConditionBean esCb = (EsAbstractConditionBean) cb;
-        if (esCb.getPreference() != null) {
-            esCb.setPreference(esCb.getPreference());
-        }
-        esCb.request().build(builder);
-        SearchResponse response = esCb.build(builder).execute().actionGet(scrollSearchTimeout);
-        String scrollId = response.getScrollId();
-        int count = 0;
-        try {
-            while (scrollId != null) {
-                final SearchHits searchHits = getSearchHits(response);
-                final SearchHit[] hits = searchHits.getHits();
-                if (hits.length == 0) {
-                    break;
-                }
-
-                final BulkRequestBuilder bulkRequest = client.prepareBulk();
-                for (final SearchHit hit : hits) {
-                    bulkRequest.add(client.prepareDelete().setIndex(asEsIndex()).setId(hit.getId()));
-                }
-                count += hits.length;
-                final BulkResponse bulkResponse = bulkRequest.execute().actionGet(bulkTimeout);
-                if (bulkResponse.hasFailures()) {
-                    throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
-                }
-
-                response = client.prepareSearchScroll(scrollId).setScroll(scrollForDelete).execute().actionGet(scrollSearchTimeout);
-                if (!scrollId.equals(response.getScrollId())) {
-                    deleteScrollContext(scrollId);
-                }
+        final int[] count = new int[1];
+        pitSearch((EsAbstractConditionBean) cb, sizeForDelete, scrollForDelete, searchHits -> {
+            final SearchHit[] hits = searchHits.getHits();
+            final BulkRequestBuilder bulkRequest = client.prepareBulk();
+            for (final SearchHit hit : hits) {
+                bulkRequest.add(client.prepareDelete().setIndex(asEsIndex()).setId(hit.getId()));
             }
-        } finally {
-            deleteScrollContext(scrollId);
-        }
-        return count;
+            count[0] += hits.length;
+            final BulkResponse bulkResponse = bulkRequest.execute().actionGet(bulkTimeout);
+            if (bulkResponse.hasFailures()) {
+                throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
+            }
+            return true;
+        });
+        return count[0];
     }
 
     protected int[] delegateBatchInsert(final List<? extends Entity> entityList, final InsertOption<? extends ConditionBean> option) {

--- a/src/main/java/org/codelibs/fess/opensearch/user/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/user/allcommon/EsAbstractBehavior.java
@@ -25,8 +25,13 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.function.Function;
 
+import jakarta.annotation.Resource;
+
+import org.codelibs.fess.opensearch.user.allcommon.EsAbstractEntity;
 import org.codelibs.fess.opensearch.user.allcommon.EsAbstractEntity.DocMeta;
 import org.codelibs.fess.opensearch.user.allcommon.EsAbstractEntity.RequestOptionCall;
+import org.codelibs.fess.opensearch.user.allcommon.EsAbstractConditionBean;
+import org.codelibs.fess.opensearch.user.allcommon.EsPagingResultBean;
 import org.dbflute.Entity;
 import org.dbflute.bhv.AbstractBehaviorWritable;
 import org.dbflute.bhv.readable.EntityRowHandler;
@@ -48,16 +53,22 @@ import org.opensearch.action.delete.DeleteRequestBuilder;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.CreatePitAction;
+import org.opensearch.action.search.CreatePitRequest;
+import org.opensearch.action.search.DeletePitAction;
+import org.opensearch.action.search.DeletePitRequest;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateRequestBuilder;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.PointInTimeBuilder;
+import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.transport.client.Client;
-
-import jakarta.annotation.Resource;
 
 /**
  * @param <ENTITY> The type of entity.
@@ -69,6 +80,8 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     @Resource
     private Client client;
 
+    // The two "scroll" values below are the keep-alive of the point in time that query delete and
+    // cursor select page over. The names are kept for compatibility with existing DI settings.
     protected int sizeForDelete = 100;
     protected String scrollForDelete = "1m";
     protected int sizeForCursor = 100;
@@ -227,16 +240,56 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
     }
 
     protected void delegateBulkRequest(final ConditionBean cb, Function<SearchHits, Boolean> handler) {
-        final SearchRequestBuilder builder = client.prepareSearch(asEsIndex()).setScroll(scrollForCursor).setSize(sizeForCursor);
-        final EsAbstractConditionBean esCb = (EsAbstractConditionBean) cb;
+        pitSearch((EsAbstractConditionBean) cb, sizeForCursor, scrollForCursor, handler);
+    }
+
+    /**
+     * Walks every hit matching the condition bean, one page at a time, over a point in time.
+     *
+     * <p>The pages are ordered by the condition bean's own sort followed by a {@code _shard_doc}
+     * tiebreaker, which makes the order total so that {@code search_after} can walk it without
+     * skipping or repeating a document. The point in time is released in every case, and the walk
+     * stops as soon as the handler returns {@code false}.</p>
+     *
+     * @param esCb the condition bean selecting the documents.
+     * @param pageSize the number of hits fetched per page.
+     * @param keepAlive how long the point in time stays alive, extended by every page.
+     * @param handler called once per page; returning false ends the walk.
+     */
+    protected void pitSearch(final EsAbstractConditionBean esCb, final int pageSize, final String keepAlive,
+            final Function<SearchHits, Boolean> handler) {
+        final SearchRequestBuilder builder = client.prepareSearch().setSize(pageSize);
         if (esCb.getPreference() != null) {
             builder.setPreference(esCb.getPreference());
         }
         esCb.request().build(builder);
-        SearchResponse response = esCb.build(builder).execute().actionGet(scrollSearchTimeout);
-        String scrollId = response.getScrollId();
+        final SearchRequestBuilder searchBuilder = esCb.build(builder);
+        searchBuilder.addSort(SortBuilders.shardDocSort());
+
+        // A point in time carries the indices, routing and preference itself, and a search that
+        // repeats any of them is rejected with a 400 ("[indices]/[routing]/[preference] cannot be
+        // used with point in time"). Over HTTP such a 400 on a request with a body does not surface
+        // as an error, it hangs. So move them onto the point in time and strip them off the search.
+        final SearchRequest searchRequest = searchBuilder.request();
+        final TimeValue keepAliveValue = TimeValue.parseTimeValue(keepAlive, "keepAlive");
+        final CreatePitRequest createPitRequest = new CreatePitRequest(keepAliveValue, true, asEsIndex());
+        if (searchRequest.preference() != null) {
+            createPitRequest.setPreference(searchRequest.preference());
+            searchRequest.preference(null);
+        }
+        if (searchRequest.routing() != null) {
+            createPitRequest.setRouting(searchRequest.routing());
+            searchRequest.routing((String) null);
+        }
+        final String pitId = client.execute(CreatePitAction.INSTANCE, createPitRequest).actionGet(scrollSearchTimeout).getId();
         try {
-            while (scrollId != null) {
+            searchBuilder.setPointInTime(new PointInTimeBuilder(pitId).setKeepAlive(keepAliveValue));
+            Object[] searchAfter = null;
+            while (true) {
+                if (searchAfter != null) {
+                    searchBuilder.searchAfter(searchAfter);
+                }
+                final SearchResponse response = searchBuilder.execute().actionGet(scrollSearchTimeout);
                 final SearchHits searchHits = getSearchHits(response);
                 final SearchHit[] hits = searchHits.getHits();
                 if (hits.length == 0) {
@@ -247,20 +300,16 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
                     break;
                 }
 
-                response = client.prepareSearchScroll(scrollId).setScroll(scrollForDelete).execute().actionGet(scrollSearchTimeout);
-                if (!scrollId.equals(response.getScrollId())) {
-                    deleteScrollContext(scrollId);
-                }
-                scrollId = response.getScrollId();
+                searchAfter = hits[hits.length - 1].getSortValues();
             }
         } finally {
-            deleteScrollContext(scrollId);
+            deletePitContext(pitId);
         }
     }
 
-    protected void deleteScrollContext(final String scrollId) {
-        if (scrollId != null) {
-            client.prepareClearScroll().addScrollId(scrollId).execute(ActionListener.wrap(() -> {}));
+    protected void deletePitContext(final String pitId) {
+        if (pitId != null) {
+            client.deletePits(new DeletePitRequest(pitId), ActionListener.wrap(() -> {}));
         }
     }
 
@@ -364,42 +413,21 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
 
     @Override
     protected int delegateQueryDelete(final ConditionBean cb, final DeleteOption<? extends ConditionBean> option) {
-        final SearchRequestBuilder builder = client.prepareSearch(asEsIndex()).setScroll(scrollForDelete).setSize(sizeForDelete);
-        final EsAbstractConditionBean esCb = (EsAbstractConditionBean) cb;
-        if (esCb.getPreference() != null) {
-            esCb.setPreference(esCb.getPreference());
-        }
-        esCb.request().build(builder);
-        SearchResponse response = esCb.build(builder).execute().actionGet(scrollSearchTimeout);
-        String scrollId = response.getScrollId();
-        int count = 0;
-        try {
-            while (scrollId != null) {
-                final SearchHits searchHits = getSearchHits(response);
-                final SearchHit[] hits = searchHits.getHits();
-                if (hits.length == 0) {
-                    break;
-                }
-
-                final BulkRequestBuilder bulkRequest = client.prepareBulk();
-                for (final SearchHit hit : hits) {
-                    bulkRequest.add(client.prepareDelete().setIndex(asEsIndex()).setId(hit.getId()));
-                }
-                count += hits.length;
-                final BulkResponse bulkResponse = bulkRequest.execute().actionGet(bulkTimeout);
-                if (bulkResponse.hasFailures()) {
-                    throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
-                }
-
-                response = client.prepareSearchScroll(scrollId).setScroll(scrollForDelete).execute().actionGet(scrollSearchTimeout);
-                if (!scrollId.equals(response.getScrollId())) {
-                    deleteScrollContext(scrollId);
-                }
+        final int[] count = new int[1];
+        pitSearch((EsAbstractConditionBean) cb, sizeForDelete, scrollForDelete, searchHits -> {
+            final SearchHit[] hits = searchHits.getHits();
+            final BulkRequestBuilder bulkRequest = client.prepareBulk();
+            for (final SearchHit hit : hits) {
+                bulkRequest.add(client.prepareDelete().setIndex(asEsIndex()).setId(hit.getId()));
             }
-        } finally {
-            deleteScrollContext(scrollId);
-        }
-        return count;
+            count[0] += hits.length;
+            final BulkResponse bulkResponse = bulkRequest.execute().actionGet(bulkTimeout);
+            if (bulkResponse.hasFailures()) {
+                throw new IllegalBehaviorStateException(bulkResponse.buildFailureMessage());
+            }
+            return true;
+        });
+        return count[0];
     }
 
     protected int[] delegateBatchInsert(final List<? extends Entity> entityList, final InsertOption<? extends ConditionBean> option) {

--- a/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientTest.java
@@ -15,13 +15,23 @@
  */
 package org.codelibs.fess.opensearch.client;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.codelibs.fesen.client.EngineInfo;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.BooleanFunction;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.opensearch.action.search.SearchAction;
+import org.opensearch.action.search.SearchRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 
 public class SearchEngineClientTest extends UnitFessTestCase {
 
@@ -118,6 +128,120 @@ public class SearchEngineClientTest extends UnitFessTestCase {
             }
         }.warnUnlessOpenSearch3();
         assertEquals(0, reports.get());
+    }
+
+    /**
+     * Builds a SearchResponse holding one hit per given id, as if it came back over HTTP. Each hit
+     * carries a sort value so that the pager can derive its next search_after.
+     */
+    private SearchResponse responseWithIds(final String... ids) throws Exception {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},");
+        buf.append("\"hits\":{\"total\":{\"value\":").append(ids.length).append(",\"relation\":\"eq\"},\"max_score\":null,\"hits\":[");
+        for (int i = 0; i < ids.length; i++) {
+            if (i > 0) {
+                buf.append(',');
+            }
+            buf.append("{\"_index\":\"test\",\"_id\":\"").append(ids[i]).append("\",\"_score\":null,");
+            buf.append("\"_source\":{\"doc_id\":\"").append(ids[i]).append("\"},\"sort\":[").append(i + 1).append("]}");
+        }
+        buf.append("]}}");
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
+                DeprecationHandler.IGNORE_DEPRECATIONS, buf.toString())) {
+            return SearchResponse.fromXContent(parser);
+        }
+    }
+
+    /**
+     * A cursor returning false must end the whole walk, not just the current page. Before this was
+     * fixed the pager kept fetching further pages after the cursor had asked to stop.
+     */
+    @Test
+    public void test_scrollSearch_cursorReturningFalseStopsTheWalk() throws Exception {
+        final AtomicInteger pagesOffered = new AtomicInteger(0);
+        final SearchResponse page1 = responseWithIds("1", "2");
+        final SearchResponse page2 = responseWithIds("3", "4");
+        final SearchEngineClient client = new SearchEngineClient() {
+            {
+                // scrollSearch builds its request through the delegate; point it back at this
+                // instance so the overridden prepareSearch below is the one that answers.
+                this.client = this;
+            }
+
+            @Override
+            public SearchRequestBuilder prepareSearch(final String... indices) {
+                // The pager is stubbed out below, so the builder is never executed.
+                return new SearchRequestBuilder(null, SearchAction.INSTANCE);
+            }
+
+            @Override
+            protected void pitSearch(final String index, final String keepAlive, final String searchTimeout,
+                    final SearchRequestBuilder builder, final BooleanFunction<SearchResponse> pageHandler) {
+                for (final SearchResponse page : new SearchResponse[] { page1, page2 }) {
+                    pagesOffered.incrementAndGet();
+                    if (!pageHandler.apply(page)) {
+                        return;
+                    }
+                }
+            }
+        };
+
+        final List<String> seen = new ArrayList<>();
+        final long count = client.scrollSearch("test", requestBuilder -> true, (response, hit) -> hit.getSourceAsMap(),
+                (final Map<String, Object> source) -> {
+                    seen.add((String) source.get("doc_id"));
+                    return false;
+                });
+
+        assertEquals(1, pagesOffered.get());
+        assertEquals(1, seen.size());
+        assertEquals("1", seen.get(0));
+        assertEquals(1L, count);
+    }
+
+    /**
+     * A cursor that keeps returning true must be offered every page.
+     */
+    @Test
+    public void test_scrollSearch_cursorReturningTrueWalksEveryPage() throws Exception {
+        final AtomicInteger pagesOffered = new AtomicInteger(0);
+        final SearchResponse page1 = responseWithIds("1", "2");
+        final SearchResponse page2 = responseWithIds("3", "4");
+        final SearchEngineClient client = new SearchEngineClient() {
+            {
+                // scrollSearch builds its request through the delegate; point it back at this
+                // instance so the overridden prepareSearch below is the one that answers.
+                this.client = this;
+            }
+
+            @Override
+            public SearchRequestBuilder prepareSearch(final String... indices) {
+                // The pager is stubbed out below, so the builder is never executed.
+                return new SearchRequestBuilder(null, SearchAction.INSTANCE);
+            }
+
+            @Override
+            protected void pitSearch(final String index, final String keepAlive, final String searchTimeout,
+                    final SearchRequestBuilder builder, final BooleanFunction<SearchResponse> pageHandler) {
+                for (final SearchResponse page : new SearchResponse[] { page1, page2 }) {
+                    pagesOffered.incrementAndGet();
+                    if (!pageHandler.apply(page)) {
+                        return;
+                    }
+                }
+            }
+        };
+
+        final List<String> seen = new ArrayList<>();
+        final long count = client.scrollSearch("test", requestBuilder -> true, (response, hit) -> hit.getSourceAsMap(),
+                (final Map<String, Object> source) -> {
+                    seen.add((String) source.get("doc_id"));
+                    return true;
+                });
+
+        assertEquals(2, pagesOffered.get());
+        assertEquals(List.of("1", "2", "3", "4"), seen);
+        assertEquals(4L, count);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Replaces the scroll API with a point in time and `search_after` everywhere Fess walks a
whole result set.

The scroll API keeps a search context alive on the server for the length of the walk, and
OpenSearch steers callers towards a point in time with `search_after` instead. This moves
`SearchEngineClient` and the generated esflute behaviors over.

## Changes

**`SearchEngineClient`** gains a single `pitSearch` pager that opens the point in time,
appends a `_shard_doc` tiebreaker so the sort is a total order, extends the keep-alive on
every page and releases the point in time in every case. `scrollSearch` (both overloads),
`updateByQuery` and `deleteByQuery` are moved onto it.

A point in time carries the indices, routing and preference itself, and a search that
repeats any of them is rejected with a 400 — which over HTTP hangs rather than fails, since
the socket timeout is disabled by default. So the search is issued without an index and the
routing and preference move onto the create request. A side effect is that the local search
preference of update and delete by query now takes effect; it could not have done so on the
search itself.

**The walk now stops when a cursor returns `false`.** Previously that only broke out of the
current page and the next page was fetched anyway, so a caller asking to stop still drained
the whole result set. Every existing cursor returns `true` unconditionally, so nothing else
changes behaviour — except `ChunkVectorHelper`, which threw a private
`ScrollLimitReachedException` from its cursor purely to work around this. That exception and
its catch are gone.

**Timeouts:** every page of update and delete by query now waits for
`index.scroll.search.timeout`. Previously only the first search used it and the scroll
continuations waited on `index.bulk.timeout`, which was a search waiting on a bulk timeout.

**esflute:** the three generated `EsAbstractBehavior` classes are regenerated from the
updated template, which pages cursor selects and query delete the same way. `dbflute.xml`
points at the `fess-15.9` engine branch to pick it up.

`littleAdjustmentMap.dfprop` gains `isMigrateOldJavaxToJakarta`. Without it the freegen task
emits `javax.annotation.Resource`, which does not compile against this tree; the checked-in
classes already used `jakarta.annotation`, so the setting was missing rather than newly
needed. Only the three `EsAbstractBehavior` classes are taken from the regeneration — a full
freegen run also rewrites 214 unrelated files, including `FessConfig`, because the
checked-in output has drifted from what the current templates produce.

## Compatibility

- **Requires an OpenSearch 3.x server.** `_shard_doc` is not implemented on 2.x, which
  answers 400 `No mapping found for [_shard_doc] in order to sort on`.
- Depends on codelibs/fesen-httpclient#40, without which a point-in-time search over HTTP
  hangs, and on codelibs/fess-parent#76, which picks that up.
- No public signature, config key or public setter changes. `SearchHelper#scrollSearch`,
  `SearchEngineUtil#scroll`, `GET /api/v2/documents/all` and `api.search.scroll` are all
  untouched, so the v1 and classic API plugins need no change.
- The `Client` interface still declares `searchScroll`, `prepareSearchScroll` and
  `clearScroll`, so those delegating methods remain; what is gone is every walk that used
  them.

## Test plan

- `mvn test` — 7433 tests, all passing
- `mvn clean javadoc:jar` — passes
- Two new tests in `SearchEngineClientTest` pin the stop semantics. They were checked against
  the old behaviour: restoring it makes the stopping test fail with `expected: <1> but was:
  <2>`, so they are not vacuous.
