### PR TITLE
feat(search): report a backend older than OpenSearch 3 at startup

### DIFF
--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -52,6 +52,7 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.lang.ThreadUtil;
 import org.codelibs.curl.CurlResponse;
 import org.codelibs.fesen.client.EngineInfo;
+import org.codelibs.fesen.client.EngineInfo.EngineType;
 import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.FacetInfo;
@@ -438,6 +439,8 @@ public class SearchEngineClient implements Client {
         }
 
         waitForYellowStatus(fessConfig);
+
+        warnUnlessOpenSearch3();
 
         indexConfigList.forEach(configName -> {
             final String[] values = configName.split("/");
@@ -2799,6 +2802,46 @@ public class SearchEngineClient implements Client {
      */
     public void setClusterName(final String clusterName) {
         this.clusterName = clusterName;
+    }
+
+    /**
+     * Logs an error unless the backend is OpenSearch 3.x or later.
+     *
+     * <p>Fess walks whole result sets -- document export, purge, label updates, backup, the
+     * scroll search API, suggest dictionary builds -- over a point in time ordered by a
+     * {@code _shard_doc} tiebreaker. That sort field is only implemented from OpenSearch 3.x;
+     * an earlier backend answers {@code 400 No mapping found for [_shard_doc] in order to sort
+     * on}. Worse, over HTTP a 400 on a request carrying a body does not surface as an error but
+     * hangs, because the client's socket timeout is disabled by default, so those jobs would
+     * stall rather than fail visibly.</p>
+     *
+     * <p>Startup is not aborted: search itself still works, and an operator may be mid-upgrade.
+     * The error is logged so the mismatch is noticed before a scheduled job hangs.</p>
+     */
+    protected void warnUnlessOpenSearch3() {
+        final EngineType engineType;
+        try {
+            engineType = getEngineInfo().getType();
+        } catch (final Exception e) {
+            logger.debug("Failed to detect the search engine type.", e);
+            return;
+        }
+        if (engineType == EngineType.OPENSEARCH3) {
+            return;
+        }
+        reportUnsupportedEngine(engineType);
+    }
+
+    /**
+     * Reports a backend Fess cannot walk result sets on.
+     *
+     * @param engineType the engine the backend reported
+     */
+    protected void reportUnsupportedEngine(final EngineType engineType) {
+        logger.error("The search engine reports {}, but Fess requires OpenSearch 3.x or later. Operations that walk every "
+                + "matching document (document export, purge, label update, backup, the scroll search API and "
+                + "suggest dictionary builds) sort by _shard_doc, which earlier engines do not implement; over "
+                + "HTTP they will hang rather than report an error.", engineType);
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientTest.java
@@ -15,6 +15,10 @@
  */
 package org.codelibs.fess.opensearch.client;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.codelibs.fesen.client.EngineInfo;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -47,6 +51,73 @@ public class SearchEngineClientTest extends UnitFessTestCase {
         String testValue = "test";
         assertNotNull(testValue);
         assertEquals("test", testValue);
+    }
+
+    /**
+     * A client reporting the given backend, recording whether the unsupported-engine report fired.
+     */
+    private SearchEngineClient clientReporting(final String distribution, final String number, final AtomicInteger reports) {
+        return new SearchEngineClient() {
+            @Override
+            public EngineInfo getEngineInfo() {
+                return new EngineInfo(Map.of("version", Map.of("number", number, "distribution", distribution)));
+            }
+
+            @Override
+            protected void reportUnsupportedEngine(final EngineInfo.EngineType engineType) {
+                reports.incrementAndGet();
+            }
+        };
+    }
+
+    /**
+     * OpenSearch 3.x is what Fess needs, so startup must stay quiet.
+     */
+    @Test
+    public void test_warnUnlessOpenSearch3_quietOnOpenSearch3() {
+        final AtomicInteger reports = new AtomicInteger(0);
+        clientReporting("opensearch", "3.8.0", reports).warnUnlessOpenSearch3();
+        assertEquals(0, reports.get());
+    }
+
+    /**
+     * OpenSearch 2.x cannot sort by _shard_doc, so the mismatch must be reported.
+     */
+    @Test
+    public void test_warnUnlessOpenSearch3_reportsOpenSearch2() {
+        final AtomicInteger reports = new AtomicInteger(0);
+        clientReporting("opensearch", "2.19.4", reports).warnUnlessOpenSearch3();
+        assertEquals(1, reports.get());
+    }
+
+    /**
+     * Elasticsearch has no _shard_doc sort either, so it is reported the same way.
+     */
+    @Test
+    public void test_warnUnlessOpenSearch3_reportsElasticsearch() {
+        final AtomicInteger reports = new AtomicInteger(0);
+        clientReporting("elasticsearch", "8.11.0", reports).warnUnlessOpenSearch3();
+        assertEquals(1, reports.get());
+    }
+
+    /**
+     * A client that cannot report its engine must not break startup.
+     */
+    @Test
+    public void test_warnUnlessOpenSearch3_survivesUndetectableEngine() {
+        final AtomicInteger reports = new AtomicInteger(0);
+        new SearchEngineClient() {
+            @Override
+            public EngineInfo getEngineInfo() {
+                throw new IllegalStateException("client is not HttpClient.");
+            }
+
+            @Override
+            protected void reportUnsupportedEngine(final EngineInfo.EngineType engineType) {
+                reports.incrementAndGet();
+            }
+        }.warnUnlessOpenSearch3();
+        assertEquals(0, reports.get());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Logs an error at startup when the search engine is older than OpenSearch 3.x.

Fess walks whole result sets — document export, purge, label updates, backup, the scroll
search API and suggest dictionary builds — with a sort that ends in a `_shard_doc`
tiebreaker. That sort field is only implemented from OpenSearch 3.x; an earlier backend
answers `400 No mapping found for [_shard_doc] in order to sort on`.

Over HTTP that failure is invisible. A 400 on a request carrying a body does not surface as
an error but hangs, because the client's socket timeout is disabled by default. A cluster on
OpenSearch 2.x therefore looks healthy until a scheduled job stalls with no message — this
was observed taking over two hours with no output.

## Behaviour

- The check runs once in `open()`, right after the cluster becomes reachable.
- **Startup is not aborted.** Search itself still works, and an operator may be mid-upgrade,
  so this is a signal rather than a hard stop.
- A client that cannot report its engine (for example a non-HTTP client in tests) is ignored
  rather than treated as unsupported.
- Elasticsearch backends are reported the same way, since they have no `_shard_doc` sort
  either.

## Test plan

- `mvn test -Dtest=SearchEngineClientTest` — 17 tests, all passing. Four of them pin the
  decision itself, not just the absence of an exception: OpenSearch 3.x stays quiet,
  OpenSearch 2.x and Elasticsearch each report once, and an undetectable engine reports
  nothing.
