### PR TITLE
chore(ci): run pull request checks on any base branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,9 +9,6 @@ on:
     - master
     - "*.x"
   pull_request:
-    branches:
-    - master
-    - "*.x"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/theme-js.yml
+++ b/.github/workflows/theme-js.yml
@@ -10,9 +10,6 @@ on:
     - master
     - "*.x"
   pull_request:
-    branches:
-    - master
-    - "*.x"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
A pull request whose base is another feature branch matched none of the branches
listed under `pull_request`, so it got no checks at all and a stack of pull
requests could not be verified until its bottom had merged.

Removes that filter from both workflows. The `push` trigger keeps its branch
list; dropping that one too would build every branch push twice.

This is the bottom of a six-pull-request stack implementing the JavaScript
script engine for 15.9. It is independent of the rest and can merge on its own.
