### PR TITLE
feat(script)!: default to JavaScript and treat an unset script type as Groovy

### DIFF
--- a/src/main/java/org/codelibs/fess/Constants.java
+++ b/src/main/java/org/codelibs/fess/Constants.java
@@ -875,8 +875,17 @@ public class Constants extends CoreLibConstants {
     /** Execution type for content chunk vector indexing operations. */
     public static final String EXECUTE_TYPE_CHUNK = "chunk";
 
-    /** Default script type (Groovy). */
-    public static final String DEFAULT_SCRIPT = "groovy";
+    /** Default script type for newly created settings. */
+    public static final String DEFAULT_SCRIPT = "javascript";
+
+    /**
+     * Script type used when a setting does not name one.
+     *
+     * <p>A setting created before 15.9 has no explicit script type, and its script is written in
+     * Groovy, so an unset type means Groovy. Groovy itself lives in the fess-script-groovy plugin
+     * from 15.9 on.</p>
+     */
+    public static final String LEGACY_SCRIPT = "groovy";
 
     // ============================================================
     // Text Fragment Constants

--- a/src/main/java/org/codelibs/fess/Constants.java
+++ b/src/main/java/org/codelibs/fess/Constants.java
@@ -558,9 +558,6 @@ public class Constants extends CoreLibConstants {
     /** Default job target value (all configurations). */
     public static final String DEFAULT_JOB_TARGET = "all";
 
-    /** Default job script type (Groovy). */
-    public static final String DEFAULT_JOB_SCRIPT_TYPE = "groovy";
-
     /** Exit code for successful operation. */
     public static final int EXIT_OK = 0;
 

--- a/src/main/java/org/codelibs/fess/app/job/ScriptExecutorJob.java
+++ b/src/main/java/org/codelibs/fess/app/job/ScriptExecutorJob.java
@@ -115,7 +115,7 @@ public class ScriptExecutorJob implements LaJob {
                 logger.info("Starting job: id={}", id);
             }
 
-            final Object ret = jobExecutor.execute(Constants.DEFAULT_SCRIPT, script);
+            final Object ret = jobExecutor.execute(scriptType, script);
             if (ret == null) {
                 if (scheduledJob.isLoggingEnabled() && logger.isInfoEnabled()) {
                     logger.info("Finished job: id={}", id);

--- a/src/main/java/org/codelibs/fess/app/web/admin/scheduler/CreateForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/scheduler/CreateForm.java
@@ -120,7 +120,7 @@ public class CreateForm {
     public void initialize() {
         target = Constants.DEFAULT_JOB_TARGET;
         cronExpression = Constants.DEFAULT_CRON_EXPRESSION;
-        scriptType = Constants.DEFAULT_JOB_SCRIPT_TYPE;
+        scriptType = ComponentUtil.getFessConfig().getJobDefaultScript();
         sortOrder = 0;
         createdBy = ComponentUtil.getSystemHelper().getUsername();
         createdTime = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();

--- a/src/main/java/org/codelibs/fess/ds/AbstractDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/AbstractDataStore.java
@@ -158,7 +158,7 @@ public abstract class AbstractDataStore implements DataStore {
     protected String getScriptType(final DataStoreParams paramMap) {
         final String value = paramMap.getAsString(SCRIPT_TYPE);
         if (StringUtil.isBlank(value)) {
-            return Constants.DEFAULT_SCRIPT;
+            return Constants.LEGACY_SCRIPT;
         }
         return value;
     }

--- a/src/main/java/org/codelibs/fess/helper/PathMappingHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PathMappingHelper.java
@@ -18,7 +18,10 @@ package org.codelibs.fess.helper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 
@@ -28,6 +31,8 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.opensearch.config.exbhv.PathMappingBhv;
 import org.codelibs.fess.opensearch.config.exentity.PathMapping;
+import org.codelibs.fess.script.ScriptEngine;
+import org.codelibs.fess.script.ScriptEngineFactory;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.util.DocumentUtil;
 import org.lastaflute.di.core.exception.ComponentNotFoundException;
@@ -52,8 +57,16 @@ public class PathMappingHelper extends AbstractConfigHelper {
     /** Function matcher for encode URL. */
     protected static final String FUNCTION_ENCODEURL_MATCHER = "function:encodeUrl";
 
-    /** Groovy matcher prefix. */
-    protected static final String GROOVY_MATCHER = "groovy:";
+    /**
+     * Replacement prefixes that name a script engine rather than a URL scheme.
+     *
+     * <p>Both are valid URI schemes, so the prefix alone cannot tell them apart. These are the
+     * script types Fess itself records in settings, so a mapping using one of them and finding no
+     * engine is a missing plugin worth reporting, while any other unregistered prefix -
+     * <code>http:</code>, <code>https:</code>, <code>file:</code>, <code>ftp:</code>,
+     * <code>smb:</code> and the rest - is an ordinary replacement and stays silent.</p>
+     */
+    protected static final Set<String> SCRIPT_ENGINE_NAMES = Set.of(Constants.DEFAULT_SCRIPT, Constants.LEGACY_SCRIPT);
 
     /** Map of path mappings by process type. */
     protected final Map<String, List<PathMapping>> pathMappingMap = new HashMap<>();
@@ -225,16 +238,67 @@ public class PathMappingHelper extends AbstractConfigHelper {
         if (FUNCTION_ENCODEURL_MATCHER.equals(replacement)) {
             return (u, m) -> DocumentUtil.encodeUrl(u);
         }
-        if (!replacement.startsWith(GROOVY_MATCHER)) {
+        final int separatorIndex = replacement.indexOf(':');
+        if (separatorIndex <= 0) {
             return (u, m) -> m.replaceAll(replacement);
         }
-        final String template = replacement.substring(GROOVY_MATCHER.length());
+        final String engineName = replacement.substring(0, separatorIndex);
+        final String template = replacement.substring(separatorIndex + 1);
+        // The engine is looked up on the first evaluation, not here: engines register during DI
+        // post-construction, after these functions are built, so a decision made now would depend
+        // on registration order. The decision is then kept, because the registered set no longer
+        // changes once startup is over.
+        final AtomicReference<BiFunction<String, Matcher, String>> resolvedRef = new AtomicReference<>();
+        return (u, m) -> {
+            BiFunction<String, Matcher, String> resolved = resolvedRef.get();
+            if (resolved == null) {
+                resolved = resolveEngineMatcher(engineName, template, replacement);
+                resolvedRef.set(resolved);
+            }
+            return resolved.apply(u, m);
+        };
+    }
+
+    /**
+     * Resolves the engine named by a replacement prefix, falling back to a plain replacement.
+     *
+     * <p>A replacement containing a colon is far more often an ordinary path mapping such as
+     * <code>file:</code> than a script, so every way of failing to reach an engine has to end in
+     * the plain replacement. Throwing here would leave {@code PathMapping#process} logging a
+     * warning and returning the raw URL, which indexes the wrong URL for a mapping that never
+     * wanted an engine in the first place.</p>
+     *
+     * @param engineName the prefix before the first colon
+     * @param template the script text after the first colon
+     * @param replacement the whole replacement, used when falling back
+     * @return the matcher function to use for every evaluation of this replacement
+     */
+    protected BiFunction<String, Matcher, String> resolveEngineMatcher(final String engineName, final String template,
+            final String replacement) {
+        ScriptEngine scriptEngine = null;
+        try {
+            final ScriptEngineFactory scriptEngineFactory = ComponentUtil.getScriptEngineFactory();
+            if (scriptEngineFactory.hasScriptEngine(engineName)) {
+                scriptEngine = scriptEngineFactory.getScriptEngine(engineName);
+            }
+        } catch (final Exception e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to load a script engine for {}.", replacement, e);
+            }
+        }
+        if (scriptEngine == null) {
+            if (SCRIPT_ENGINE_NAMES.contains(engineName.toLowerCase(Locale.ROOT))) {
+                logger.warn("No script engine is registered for {}, so \"{}\" is used as a plain replacement."
+                        + " Install the plugin providing it, such as fess-script-groovy for groovy.", engineName, replacement);
+            }
+            return (u, m) -> m.replaceAll(replacement);
+        }
+        final ScriptEngine engine = scriptEngine;
         return (u, m) -> {
             final Map<String, Object> paramMap = new HashMap<>();
             paramMap.put("url", u);
             paramMap.put("matcher", m);
-            final Object value =
-                    ComponentUtil.getScriptEngineFactory().getScriptEngine(Constants.DEFAULT_SCRIPT).evaluate(template, paramMap);
+            final Object value = engine.evaluate(template, paramMap);
             if (value == null) {
                 return u;
             }

--- a/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
+++ b/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
@@ -58,7 +58,7 @@ public class DocBoostMatcher {
     public DocBoostMatcher(final BoostDocumentRule rule) {
         matchExpression = rule.getUrlExpr();
         boostExpression = rule.getBoostExpr();
-        scriptType = ComponentUtil.getFessConfig().getCrawlerDefaultScript();
+        scriptType = Constants.LEGACY_SCRIPT;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -242,7 +242,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. 0 */
     String JOB_MAX_CRAWLER_PROCESSES = "job.max.crawler.processes";
 
-    /** The key of the configuration. e.g. groovy */
+    /** The key of the configuration. e.g. javascript */
     String JOB_DEFAULT_SCRIPT = "job.default.script";
 
     /** The key of the configuration. e.g.  */
@@ -397,9 +397,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /** The key of the configuration. e.g. 10 */
     String HTTP_FILEUPLOAD_MAX_FILE_COUNT = "http.fileupload.max.file.count";
-
-    /** The key of the configuration. e.g. groovy */
-    String CRAWLER_DEFAULT_SCRIPT = "crawler.default.script";
 
     /** The key of the configuration. e.g. 0 */
     String CRAWLER_HTTP_thread_pool_SIZE = "crawler.http.thread_pool.size";
@@ -2666,7 +2663,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /**
      * Get the value for the key 'job.default.script'. <br>
-     * The value is, e.g. groovy <br>
+     * The value is, e.g. javascript <br>
      * comment: Default script language for jobs.
      * @return The value of found property. (NotNull: if not found, exception but basically no way)
      */
@@ -3368,14 +3365,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * @throws NumberFormatException When the property is not integer.
      */
     Integer getHttpFileuploadMaxFileCountAsInteger();
-
-    /**
-     * Get the value for the key 'crawler.default.script'. <br>
-     * The value is, e.g. groovy <br>
-     * comment: Default script for the crawler (e.g., groovy).
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getCrawlerDefaultScript();
 
     /**
      * Get the value for the key 'crawler.http.thread_pool.size'. <br>
@@ -11007,10 +10996,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return getAsInteger(FessConfig.HTTP_FILEUPLOAD_MAX_FILE_COUNT);
         }
 
-        public String getCrawlerDefaultScript() {
-            return get(FessConfig.CRAWLER_DEFAULT_SCRIPT);
-        }
-
         public String getCrawlerHttpThreadPoolSize() {
             return get(FessConfig.CRAWLER_HTTP_thread_pool_SIZE);
         }
@@ -14417,7 +14402,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.JOB_TEMPLATE_SCRIPT,
                     "return container.getComponent(\"crawlJob\").logLevel(\"info\").webConfigIds([{0}] as String[]).fileConfigIds([{1}] as String[]).dataConfigIds([{2}] as String[]).jobExecutor(executor).execute();");
             defaultMap.put(FessConfig.JOB_MAX_CRAWLER_PROCESSES, "0");
-            defaultMap.put(FessConfig.JOB_DEFAULT_SCRIPT, "groovy");
+            defaultMap.put(FessConfig.JOB_DEFAULT_SCRIPT, "javascript");
             defaultMap.put(FessConfig.JOB_SYSTEM_PROPERTY_FILTER_PATTERN, "");
             defaultMap.put(FessConfig.PROCESSORS, "0");
             defaultMap.put(FessConfig.JAVA_COMMAND_PATH, "java");
@@ -14471,7 +14456,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.HTTP_FILEUPLOAD_MAX_SIZE, "262144000");
             defaultMap.put(FessConfig.HTTP_FILEUPLOAD_THRESHOLD_SIZE, "262144");
             defaultMap.put(FessConfig.HTTP_FILEUPLOAD_MAX_FILE_COUNT, "10");
-            defaultMap.put(FessConfig.CRAWLER_DEFAULT_SCRIPT, "groovy");
             defaultMap.put(FessConfig.CRAWLER_HTTP_thread_pool_SIZE, "0");
             defaultMap.put(FessConfig.CRAWLER_DATA_SERIALIZER, "kryo");
             defaultMap.put(FessConfig.CRAWLER_DOCUMENT_MAX_SITE_LENGTH, "100");

--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/CrawlingConfig.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/CrawlingConfig.java
@@ -89,7 +89,7 @@ public interface CrawlingConfig {
         if (StringUtil.isNotBlank(scriptType)) {
             return scriptType;
         }
-        return Constants.DEFAULT_SCRIPT;
+        return Constants.LEGACY_SCRIPT;
     }
 
     public enum ConfigType {

--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/ScheduledJob.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/ScheduledJob.java
@@ -36,7 +36,7 @@ public class ScheduledJob extends BsScheduledJob {
     public String getScriptType() {
         final String st = super.getScriptType();
         if (StringUtil.isBlank(st)) {
-            return "groovy";
+            return Constants.LEGACY_SCRIPT;
         }
         return st;
     }

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -235,7 +235,7 @@ job.template.script=return container.getComponent("crawlJob").logLevel("info").w
 # Maximum number of crawler processes.
 job.max.crawler.processes=0
 # Default script language for jobs.
-job.default.script=groovy
+job.default.script=javascript
 # Pattern to filter system properties for jobs.
 job.system.property.filter.pattern=
 
@@ -352,8 +352,6 @@ http.fileupload.max.file.count=10
 
 # common
 
-# Default script for the crawler (e.g., groovy).
-crawler.default.script=groovy
 # Number of threads for HTTP crawling.
 crawler.http.thread_pool.size=0
 # Serializer type for crawler data (e.g., kryo).

--- a/src/test/java/org/codelibs/fess/ds/AbstractDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/AbstractDataStoreTest.java
@@ -22,19 +22,13 @@ import java.util.concurrent.CountDownLatch;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.ds.callback.IndexUpdateCallback;
 import org.codelibs.fess.entity.DataStoreParams;
-import org.codelibs.fess.exception.JobProcessingException;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
-import org.codelibs.fess.script.AbstractScriptEngine;
 import org.codelibs.fess.script.ScriptEngineFactory;
+import org.codelibs.fess.script.javascript.JavaScriptEngine;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.lastaflute.di.core.factory.SingletonLaContainerFactory;
-
-import groovy.lang.Binding;
-import groovy.lang.GroovyClassLoader;
-import groovy.lang.GroovyShell;
 
 public class AbstractDataStoreTest extends UnitFessTestCase {
     public AbstractDataStore dataStore;
@@ -55,32 +49,10 @@ public class AbstractDataStoreTest extends UnitFessTestCase {
             }
         };
 
-        ScriptEngineFactory scriptEngineFactory = new ScriptEngineFactory();
-        ComponentUtil.register(scriptEngineFactory, "scriptEngineFactory");
-        new AbstractScriptEngine() {
-
-            @Override
-            public Object evaluate(String template, Map<String, Object> paramMap) {
-                final Map<String, Object> bindingMap = new HashMap<>(paramMap);
-                bindingMap.put("container", SingletonLaContainerFactory.getContainer());
-                final GroovyShell groovyShell = new GroovyShell(new Binding(bindingMap));
-                try {
-                    return groovyShell.evaluate(template);
-                } catch (final JobProcessingException e) {
-                    throw e;
-                } catch (final Exception e) {
-                    return null;
-                } finally {
-                    final GroovyClassLoader loader = groovyShell.getClassLoader();
-                    loader.clearCache();
-                }
-            }
-
-            @Override
-            protected String getName() {
-                return Constants.DEFAULT_SCRIPT;
-            }
-        }.register();
+        ComponentUtil.register(new ScriptEngineFactory(), "scriptEngineFactory");
+        // The real engine, not a stub: these tests are about what Constants.DEFAULT_SCRIPT
+        // evaluates a data store field script to, which only the engine behind that name answers.
+        new JavaScriptEngine().register();
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/helper/PathMappingHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/PathMappingHelperTest.java
@@ -17,13 +17,17 @@ package org.codelibs.fess.helper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.opensearch.config.exentity.PathMapping;
+import org.codelibs.fess.script.ScriptEngine;
+import org.codelibs.fess.script.ScriptEngineFactory;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -34,6 +38,7 @@ public class PathMappingHelperTest extends UnitFessTestCase {
     @Override
     protected void setUp(TestInfo testInfo) throws Exception {
         super.setUp(testInfo);
+        ComponentUtil.register(new ScriptEngineFactory(), "scriptEngineFactory");
         pathMappingHelper = new PathMappingHelper();
         pathMappingHelper.init();
     }
@@ -401,5 +406,110 @@ public class PathMappingHelperTest extends UnitFessTestCase {
 
         final String url = "file:///home/user with spaces/";
         assertEquals("http://localhost/user with spaces/", pathMappingHelper.replaceUrl(sessionId, url));
+    }
+
+    @Test
+    public void test_replaceUrl_javascriptPrefix() {
+        final ScriptEngineFactory factory = new ScriptEngineFactory();
+        factory.add("javascript", (template, paramMap) -> "js:" + paramMap.get("url"));
+        ComponentUtil.register(factory, "scriptEngineFactory");
+
+        final PathMappingHelper helper = new PathMappingHelper();
+        final PathMapping pathMapping = new PathMapping();
+        pathMapping.setRegex("^http://example.com/");
+        pathMapping.setReplacement("javascript:url");
+        final List<PathMapping> list = new ArrayList<>();
+        list.add(pathMapping);
+
+        assertEquals("js:http://example.com/a.html", helper.replaceUrl(list, "http://example.com/a.html"));
+    }
+
+    @Test
+    public void test_replaceUrl_unknownPrefixIsPlainReplacement() {
+        final ScriptEngineFactory factory = new ScriptEngineFactory();
+        ComponentUtil.register(factory, "scriptEngineFactory");
+
+        final PathMappingHelper helper = new PathMappingHelper();
+        final PathMapping pathMapping = new PathMapping();
+        pathMapping.setRegex("^http://example.com/");
+        pathMapping.setReplacement("https://example.net/");
+        final List<PathMapping> list = new ArrayList<>();
+        list.add(pathMapping);
+
+        assertEquals("https://example.net/a.html", helper.replaceUrl(list, "http://example.com/a.html"));
+    }
+
+    @Test
+    public void test_replaceUrl_groovyPrefix() {
+        final ScriptEngineFactory factory = new ScriptEngineFactory();
+        factory.add("groovy", (template, paramMap) -> "groovy:" + paramMap.get("url"));
+        ComponentUtil.register(factory, "scriptEngineFactory");
+
+        final PathMappingHelper helper = new PathMappingHelper();
+        final PathMapping pathMapping = new PathMapping();
+        pathMapping.setRegex("^http://example.com/");
+        pathMapping.setReplacement("groovy:url");
+        final List<PathMapping> list = new ArrayList<>();
+        list.add(pathMapping);
+
+        assertEquals("groovy:http://example.com/a.html", helper.replaceUrl(list, "http://example.com/a.html"));
+    }
+
+    @Test
+    public void test_replaceUrl_missingGroovyEngineIsPlainReplacement() {
+        ComponentUtil.register(new ScriptEngineFactory(), "scriptEngineFactory");
+
+        final PathMappingHelper helper = new PathMappingHelper();
+        final PathMapping pathMapping = new PathMapping();
+        pathMapping.setRegex("^http://example.com/");
+        pathMapping.setReplacement("groovy:url");
+        final List<PathMapping> list = new ArrayList<>();
+        list.add(pathMapping);
+
+        assertEquals("groovy:urla.html", helper.replaceUrl(list, "http://example.com/a.html"));
+    }
+
+    @Test
+    public void test_replaceUrl_plainReplacementWhenEngineLookupFails() {
+        ComponentUtil.register(new ScriptEngineFactory() {
+            @Override
+            public boolean hasScriptEngine(final String name) {
+                throw new IllegalStateException("no script engine registry");
+            }
+        }, "scriptEngineFactory");
+
+        final PathMappingHelper helper = new PathMappingHelper();
+        final PathMapping pathMapping = new PathMapping();
+        pathMapping.setRegex("ftp:");
+        pathMapping.setReplacement("file:");
+        final List<PathMapping> list = new ArrayList<>();
+        list.add(pathMapping);
+
+        assertEquals("file:/home/taro/test.txt", helper.replaceUrl(list, "ftp:/home/taro/test.txt"));
+    }
+
+    @Test
+    public void test_replaceUrl_engineResolvedOncePerReplacement() {
+        final AtomicInteger lookupCount = new AtomicInteger();
+        final ScriptEngineFactory factory = new ScriptEngineFactory() {
+            @Override
+            public ScriptEngine getScriptEngine(final String name) {
+                lookupCount.incrementAndGet();
+                return super.getScriptEngine(name);
+            }
+        };
+        factory.add("javascript", (template, paramMap) -> "js:" + paramMap.get("url"));
+        ComponentUtil.register(factory, "scriptEngineFactory");
+
+        final PathMappingHelper helper = new PathMappingHelper();
+        final PathMapping pathMapping = new PathMapping();
+        pathMapping.setRegex("^http://example.com/");
+        pathMapping.setReplacement("javascript:url");
+        final List<PathMapping> list = new ArrayList<>();
+        list.add(pathMapping);
+
+        assertEquals("js:http://example.com/a.html", helper.replaceUrl(list, "http://example.com/a.html"));
+        assertEquals("js:http://example.com/b.html", helper.replaceUrl(list, "http://example.com/b.html"));
+        assertEquals(1, lookupCount.get());
     }
 }

--- a/src/test/java/org/codelibs/fess/opensearch/config/exentity/ScheduledJobScriptTypeTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/config/exentity/ScheduledJobScriptTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.opensearch.config.exentity;
+
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+public class ScheduledJobScriptTypeTest extends UnitFessTestCase {
+
+    @Test
+    public void test_getScriptType_blankFallsBackToLegacy() {
+        final ScheduledJob job = new ScheduledJob();
+        assertEquals(Constants.LEGACY_SCRIPT, job.getScriptType());
+
+        job.setScriptType("");
+        assertEquals(Constants.LEGACY_SCRIPT, job.getScriptType());
+
+        job.setScriptType("  ");
+        assertEquals(Constants.LEGACY_SCRIPT, job.getScriptType());
+    }
+
+    @Test
+    public void test_getScriptType_explicitWins() {
+        final ScheduledJob job = new ScheduledJob();
+        job.setScriptType("javascript");
+        assertEquals("javascript", job.getScriptType());
+    }
+
+    @Test
+    public void test_legacyIsGroovyAndDefaultIsJavaScript() {
+        assertEquals("groovy", Constants.LEGACY_SCRIPT);
+        assertEquals("javascript", Constants.DEFAULT_SCRIPT);
+    }
+}


### PR DESCRIPTION
Makes JavaScript the default script engine and defines what an unrecorded script
type means.

Two ideas that have to stay apart:

- `Constants.DEFAULT_SCRIPT` is now `javascript` — the engine a **new** setting
  records.
- `Constants.LEGACY_SCRIPT` is new and is `groovy` — the engine a setting
  resolves to when it records **no** script type. A setting created before 15.9
  has Groovy expressions and no recorded type, so unset has to keep meaning
  Groovy. This is permanent, not a transition, and it is what lets an
  installation upgraded from 15.8 keep working untouched.

Also fixes a long-standing bug: the scheduler read the script type stored on a
job and then ignored it, passing the product default to the executor instead.
The admin screen's Execution Method field has been silently inert.

`crawler.default.script` is removed. Its only reader was the document boost path,
which from now on takes the engine from the rule itself. `job.default.script` is
honoured for the first time — it had existed in the configuration and been read
by nothing.

Path mapping replacements now name their engine: the text before the first `:`
selects it, so `javascript:` works alongside `groovy:`. An unrecognised prefix
such as `https:` still means a plain replacement, and any failure to resolve an
engine falls back to that rather than dropping the mapping.

Part of a stack. Do not merge alone.
