### PR TITLE
feat(boostdoc): let each document boost rule choose its script engine

### DIFF
--- a/src/main/config/es/fess_config_boost_document_rule.json
+++ b/src/main/config/es/fess_config_boost_document_rule.json
@@ -13,6 +13,9 @@
           "createdTime" : {
             "type" : "long"
           },
+          "scriptType" : {
+            "type" : "keyword"
+          },
           "sortOrder" : {
             "type" : "integer"
           },

--- a/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/CreateForm.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/boostdoc/CreateForm.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.app.web.admin.boostdoc;
 
+import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.web.CrudMode;
 import org.codelibs.fess.util.ComponentUtil;
 import org.lastaflute.web.validation.Required;
@@ -52,6 +53,10 @@ public class CreateForm {
     @Size(max = 10000)
     public String boostExpr;
 
+    /** The script type used to evaluate the expressions. */
+    @Size(max = 100)
+    public String scriptType;
+
     /** Sort order for displaying boost configurations */
     @Required
     @Min(value = 0)
@@ -73,6 +78,7 @@ public class CreateForm {
     public void initialize() {
         crudMode = CrudMode.CREATE;
         sortOrder = 0;
+        scriptType = Constants.DEFAULT_SCRIPT;
         createdBy = ComponentUtil.getSystemHelper().getUsername();
         createdTime = ComponentUtil.getSystemHelper().getCurrentTimeAsLong();
     }

--- a/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
+++ b/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.opensearch.config.exentity.BoostDocumentRule;
 import org.codelibs.fess.util.ComponentUtil;
@@ -58,7 +59,17 @@ public class DocBoostMatcher {
     public DocBoostMatcher(final BoostDocumentRule rule) {
         matchExpression = rule.getUrlExpr();
         boostExpression = rule.getBoostExpr();
-        scriptType = Constants.LEGACY_SCRIPT;
+        final String ruleScriptType = rule.getScriptType();
+        scriptType = StringUtil.isBlank(ruleScriptType) ? Constants.LEGACY_SCRIPT : ruleScriptType;
+    }
+
+    /**
+     * Gets the script engine type used to evaluate this rule's expressions.
+     *
+     * @return the script type
+     */
+    public String getScriptType() {
+        return scriptType;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
@@ -2466,6 +2466,9 @@ public class FessLabels extends UserMessages {
     /** The key of the message: Boost Expression */
     public static final String LABELS_boost_document_rule_boost_expr = "{labels.boost_document_rule_boost_expr}";
 
+    /** The key of the message: Script Type */
+    public static final String LABELS_boost_document_rule_script_type = "{labels.boost_document_rule_script_type}";
+
     /** The key of the message: Sort Order */
     public static final String LABELS_boost_document_rule_sort_order = "{labels.boost_document_rule_sort_order}";
 

--- a/src/main/java/org/codelibs/fess/opensearch/config/bsbhv/BsBoostDocumentRuleBhv.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/bsbhv/BsBoostDocumentRuleBhv.java
@@ -76,6 +76,7 @@ public abstract class BsBoostDocumentRuleBhv extends EsAbstractBehavior<BoostDoc
             result.setBoostExpr(DfTypeUtil.toString(source.get("boostExpr")));
             result.setCreatedBy(DfTypeUtil.toString(source.get("createdBy")));
             result.setCreatedTime(DfTypeUtil.toLong(source.get("createdTime")));
+            result.setScriptType(DfTypeUtil.toString(source.get("scriptType")));
             result.setSortOrder(DfTypeUtil.toInteger(source.get("sortOrder")));
             result.setUpdatedBy(DfTypeUtil.toString(source.get("updatedBy")));
             result.setUpdatedTime(DfTypeUtil.toLong(source.get("updatedTime")));

--- a/src/main/java/org/codelibs/fess/opensearch/config/bsentity/BsBoostDocumentRule.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/bsentity/BsBoostDocumentRule.java
@@ -46,6 +46,9 @@ public class BsBoostDocumentRule extends EsAbstractEntity {
     /** createdTime */
     protected Long createdTime;
 
+    /** scriptType */
+    protected String scriptType;
+
     /** sortOrder */
     protected Integer sortOrder;
 
@@ -88,6 +91,9 @@ public class BsBoostDocumentRule extends EsAbstractEntity {
         if (createdTime != null) {
             addFieldToSource(sourceMap, "createdTime", createdTime);
         }
+        if (scriptType != null) {
+            addFieldToSource(sourceMap, "scriptType", scriptType);
+        }
         if (sortOrder != null) {
             addFieldToSource(sourceMap, "sortOrder", sortOrder);
         }
@@ -116,6 +122,7 @@ public class BsBoostDocumentRule extends EsAbstractEntity {
         sb.append(dm).append(boostExpr);
         sb.append(dm).append(createdBy);
         sb.append(dm).append(createdTime);
+        sb.append(dm).append(scriptType);
         sb.append(dm).append(sortOrder);
         sb.append(dm).append(updatedBy);
         sb.append(dm).append(updatedTime);
@@ -158,6 +165,16 @@ public class BsBoostDocumentRule extends EsAbstractEntity {
     public void setCreatedTime(Long value) {
         registerModifiedProperty("createdTime");
         this.createdTime = value;
+    }
+
+    public String getScriptType() {
+        checkSpecifiedProperty("scriptType");
+        return convertEmptyToNull(scriptType);
+    }
+
+    public void setScriptType(String value) {
+        registerModifiedProperty("scriptType");
+        this.scriptType = value;
     }
 
     public Integer getSortOrder() {

--- a/src/main/java/org/codelibs/fess/opensearch/config/bsentity/dbmeta/BoostDocumentRuleDbm.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/bsentity/dbmeta/BoostDocumentRuleDbm.java
@@ -85,6 +85,8 @@ public class BoostDocumentRuleDbm extends AbstractDBMeta {
                 (et, vl) -> ((BoostDocumentRule) et).setCreatedBy(DfTypeUtil.toString(vl)), "createdBy");
         setupEpg(_epgMap, et -> ((BoostDocumentRule) et).getCreatedTime(),
                 (et, vl) -> ((BoostDocumentRule) et).setCreatedTime(DfTypeUtil.toLong(vl)), "createdTime");
+        setupEpg(_epgMap, et -> ((BoostDocumentRule) et).getScriptType(),
+                (et, vl) -> ((BoostDocumentRule) et).setScriptType(DfTypeUtil.toString(vl)), "scriptType");
         setupEpg(_epgMap, et -> ((BoostDocumentRule) et).getSortOrder(),
                 (et, vl) -> ((BoostDocumentRule) et).setSortOrder(DfTypeUtil.toInteger(vl)), "sortOrder");
         setupEpg(_epgMap, et -> ((BoostDocumentRule) et).getUpdatedBy(),
@@ -135,6 +137,8 @@ public class BoostDocumentRuleDbm extends AbstractDBMeta {
             false, "keyword", 0, 0, null, null, false, null, null, null, null, null, false);
     protected final ColumnInfo _columnCreatedTime = cci("createdTime", "createdTime", null, null, Long.class, "createdTime", null, false,
             false, false, "Long", 0, 0, null, null, false, null, null, null, null, null, false);
+    protected final ColumnInfo _columnScriptType = cci("scriptType", "scriptType", null, null, String.class, "scriptType", null, false,
+            false, false, "keyword", 0, 0, null, null, false, null, null, null, null, null, false);
     protected final ColumnInfo _columnSortOrder = cci("sortOrder", "sortOrder", null, null, Integer.class, "sortOrder", null, false, false,
             false, "Integer", 0, 0, null, null, false, null, null, null, null, null, false);
     protected final ColumnInfo _columnUpdatedBy = cci("updatedBy", "updatedBy", null, null, String.class, "updatedBy", null, false, false,
@@ -154,6 +158,10 @@ public class BoostDocumentRuleDbm extends AbstractDBMeta {
 
     public ColumnInfo columnCreatedTime() {
         return _columnCreatedTime;
+    }
+
+    public ColumnInfo columnScriptType() {
+        return _columnScriptType;
     }
 
     public ColumnInfo columnSortOrder() {
@@ -177,6 +185,7 @@ public class BoostDocumentRuleDbm extends AbstractDBMeta {
         ls.add(columnBoostExpr());
         ls.add(columnCreatedBy());
         ls.add(columnCreatedTime());
+        ls.add(columnScriptType());
         ls.add(columnSortOrder());
         ls.add(columnUpdatedBy());
         ls.add(columnUpdatedTime());

--- a/src/main/java/org/codelibs/fess/opensearch/config/cbean/bs/BsBoostDocumentRuleCB.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/cbean/bs/BsBoostDocumentRuleCB.java
@@ -188,6 +188,10 @@ public class BsBoostDocumentRuleCB extends EsAbstractConditionBean {
             doColumn("createdTime");
         }
 
+        public void columnScriptType() {
+            doColumn("scriptType");
+        }
+
         public void columnSortOrder() {
             doColumn("sortOrder");
         }

--- a/src/main/java/org/codelibs/fess/opensearch/config/cbean/ca/bs/BsBoostDocumentRuleCA.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/cbean/ca/bs/BsBoostDocumentRuleCA.java
@@ -603,6 +603,139 @@ public abstract class BsBoostDocumentRuleCA extends EsAbstractConditionAggregati
         }
     }
 
+    public void setScriptType_Terms() {
+        setScriptType_Terms(null);
+    }
+
+    public void setScriptType_Terms(ConditionOptionCall<TermsAggregationBuilder> opLambda) {
+        setScriptType_Terms("scriptType", opLambda, null);
+    }
+
+    public void setScriptType_Terms(ConditionOptionCall<TermsAggregationBuilder> opLambda, OperatorCall<BsBoostDocumentRuleCA> aggsLambda) {
+        setScriptType_Terms("scriptType", opLambda, aggsLambda);
+    }
+
+    public void setScriptType_Terms(String name, ConditionOptionCall<TermsAggregationBuilder> opLambda,
+            OperatorCall<BsBoostDocumentRuleCA> aggsLambda) {
+        TermsAggregationBuilder builder = regTermsA(name, "scriptType");
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+        if (aggsLambda != null) {
+            BoostDocumentRuleCA ca = new BoostDocumentRuleCA();
+            aggsLambda.callback(ca);
+            ca.getAggregationBuilderList().forEach(builder::subAggregation);
+        }
+    }
+
+    public void setScriptType_SignificantTerms() {
+        setScriptType_SignificantTerms(null);
+    }
+
+    public void setScriptType_SignificantTerms(ConditionOptionCall<SignificantTermsAggregationBuilder> opLambda) {
+        setScriptType_SignificantTerms("scriptType", opLambda, null);
+    }
+
+    public void setScriptType_SignificantTerms(ConditionOptionCall<SignificantTermsAggregationBuilder> opLambda,
+            OperatorCall<BsBoostDocumentRuleCA> aggsLambda) {
+        setScriptType_SignificantTerms("scriptType", opLambda, aggsLambda);
+    }
+
+    public void setScriptType_SignificantTerms(String name, ConditionOptionCall<SignificantTermsAggregationBuilder> opLambda,
+            OperatorCall<BsBoostDocumentRuleCA> aggsLambda) {
+        SignificantTermsAggregationBuilder builder = regSignificantTermsA(name, "scriptType");
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+        if (aggsLambda != null) {
+            BoostDocumentRuleCA ca = new BoostDocumentRuleCA();
+            aggsLambda.callback(ca);
+            ca.getAggregationBuilderList().forEach(builder::subAggregation);
+        }
+    }
+
+    public void setScriptType_IpRange() {
+        setScriptType_IpRange(null);
+    }
+
+    public void setScriptType_IpRange(ConditionOptionCall<IpRangeAggregationBuilder> opLambda) {
+        setScriptType_IpRange("scriptType", opLambda, null);
+    }
+
+    public void setScriptType_IpRange(ConditionOptionCall<IpRangeAggregationBuilder> opLambda,
+            OperatorCall<BsBoostDocumentRuleCA> aggsLambda) {
+        setScriptType_IpRange("scriptType", opLambda, aggsLambda);
+    }
+
+    public void setScriptType_IpRange(String name, ConditionOptionCall<IpRangeAggregationBuilder> opLambda,
+            OperatorCall<BsBoostDocumentRuleCA> aggsLambda) {
+        IpRangeAggregationBuilder builder = regIpRangeA(name, "scriptType");
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+        if (aggsLambda != null) {
+            BoostDocumentRuleCA ca = new BoostDocumentRuleCA();
+            aggsLambda.callback(ca);
+            ca.getAggregationBuilderList().forEach(builder::subAggregation);
+        }
+    }
+
+    public void setScriptType_Count() {
+        setScriptType_Count(null);
+    }
+
+    public void setScriptType_Count(ConditionOptionCall<ValueCountAggregationBuilder> opLambda) {
+        setScriptType_Count("scriptType", opLambda);
+    }
+
+    public void setScriptType_Count(String name, ConditionOptionCall<ValueCountAggregationBuilder> opLambda) {
+        ValueCountAggregationBuilder builder = regCountA(name, "scriptType");
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_Cardinality() {
+        setScriptType_Cardinality(null);
+    }
+
+    public void setScriptType_Cardinality(ConditionOptionCall<CardinalityAggregationBuilder> opLambda) {
+        setScriptType_Cardinality("scriptType", opLambda);
+    }
+
+    public void setScriptType_Cardinality(String name, ConditionOptionCall<CardinalityAggregationBuilder> opLambda) {
+        CardinalityAggregationBuilder builder = regCardinalityA(name, "scriptType");
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_Missing() {
+        setScriptType_Missing(null);
+    }
+
+    public void setScriptType_Missing(ConditionOptionCall<MissingAggregationBuilder> opLambda) {
+        setScriptType_Missing("scriptType", opLambda, null);
+    }
+
+    public void setScriptType_Missing(ConditionOptionCall<MissingAggregationBuilder> opLambda,
+            OperatorCall<BsBoostDocumentRuleCA> aggsLambda) {
+        setScriptType_Missing("scriptType", opLambda, aggsLambda);
+    }
+
+    public void setScriptType_Missing(String name, ConditionOptionCall<MissingAggregationBuilder> opLambda,
+            OperatorCall<BsBoostDocumentRuleCA> aggsLambda) {
+        MissingAggregationBuilder builder = regMissingA(name, "scriptType");
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+        if (aggsLambda != null) {
+            BoostDocumentRuleCA ca = new BoostDocumentRuleCA();
+            aggsLambda.callback(ca);
+            ca.getAggregationBuilderList().forEach(builder::subAggregation);
+        }
+    }
+
     public void setSortOrder_Avg() {
         setSortOrder_Avg(null);
     }

--- a/src/main/java/org/codelibs/fess/opensearch/config/cbean/cq/bs/BsBoostDocumentRuleCQ.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/cbean/cq/bs/BsBoostDocumentRuleCQ.java
@@ -816,6 +816,230 @@ public abstract class BsBoostDocumentRuleCQ extends EsAbstractConditionQuery {
         return this;
     }
 
+    public void setScriptType_Equal(String scriptType) {
+        setScriptType_Term(scriptType, null);
+    }
+
+    public void setScriptType_Equal(String scriptType, ConditionOptionCall<TermQueryBuilder> opLambda) {
+        setScriptType_Term(scriptType, opLambda);
+    }
+
+    public void setScriptType_Term(String scriptType) {
+        setScriptType_Term(scriptType, null);
+    }
+
+    public void setScriptType_Term(String scriptType, ConditionOptionCall<TermQueryBuilder> opLambda) {
+        TermQueryBuilder builder = regTermQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_NotEqual(String scriptType) {
+        setScriptType_NotTerm(scriptType, null);
+    }
+
+    public void setScriptType_NotTerm(String scriptType) {
+        setScriptType_NotTerm(scriptType, null);
+    }
+
+    public void setScriptType_NotEqual(String scriptType, ConditionOptionCall<BoolQueryBuilder> opLambda) {
+        setScriptType_NotTerm(scriptType, opLambda);
+    }
+
+    public void setScriptType_NotTerm(String scriptType, ConditionOptionCall<BoolQueryBuilder> opLambda) {
+        not(not -> not.setScriptType_Term(scriptType), opLambda);
+    }
+
+    public void setScriptType_Terms(Collection<String> scriptTypeList) {
+        setScriptType_Terms(scriptTypeList, null);
+    }
+
+    public void setScriptType_Terms(Collection<String> scriptTypeList, ConditionOptionCall<TermsQueryBuilder> opLambda) {
+        TermsQueryBuilder builder = regTermsQ("scriptType", scriptTypeList);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_InScope(Collection<String> scriptTypeList) {
+        setScriptType_Terms(scriptTypeList, null);
+    }
+
+    public void setScriptType_InScope(Collection<String> scriptTypeList, ConditionOptionCall<TermsQueryBuilder> opLambda) {
+        setScriptType_Terms(scriptTypeList, opLambda);
+    }
+
+    public void setScriptType_Match(String scriptType) {
+        setScriptType_Match(scriptType, null);
+    }
+
+    public void setScriptType_Match(String scriptType, ConditionOptionCall<MatchQueryBuilder> opLambda) {
+        MatchQueryBuilder builder = regMatchQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_MatchPhrase(String scriptType) {
+        setScriptType_MatchPhrase(scriptType, null);
+    }
+
+    public void setScriptType_MatchPhrase(String scriptType, ConditionOptionCall<MatchPhraseQueryBuilder> opLambda) {
+        MatchPhraseQueryBuilder builder = regMatchPhraseQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_MatchPhrasePrefix(String scriptType) {
+        setScriptType_MatchPhrasePrefix(scriptType, null);
+    }
+
+    public void setScriptType_MatchPhrasePrefix(String scriptType, ConditionOptionCall<MatchPhrasePrefixQueryBuilder> opLambda) {
+        MatchPhrasePrefixQueryBuilder builder = regMatchPhrasePrefixQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_Fuzzy(String scriptType) {
+        setScriptType_Fuzzy(scriptType, null);
+    }
+
+    public void setScriptType_Fuzzy(String scriptType, ConditionOptionCall<MatchQueryBuilder> opLambda) {
+        MatchQueryBuilder builder = regFuzzyQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_Prefix(String scriptType) {
+        setScriptType_Prefix(scriptType, null);
+    }
+
+    public void setScriptType_Prefix(String scriptType, ConditionOptionCall<PrefixQueryBuilder> opLambda) {
+        PrefixQueryBuilder builder = regPrefixQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_Wildcard(String scriptType) {
+        setScriptType_Wildcard(scriptType, null);
+    }
+
+    public void setScriptType_Wildcard(String scriptType, ConditionOptionCall<WildcardQueryBuilder> opLambda) {
+        WildcardQueryBuilder builder = regWildcardQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_Regexp(String scriptType) {
+        setScriptType_Regexp(scriptType, null);
+    }
+
+    public void setScriptType_Regexp(String scriptType, ConditionOptionCall<RegexpQueryBuilder> opLambda) {
+        RegexpQueryBuilder builder = regRegexpQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_SpanTerm(String scriptType) {
+        setScriptType_SpanTerm("scriptType", null);
+    }
+
+    public void setScriptType_SpanTerm(String scriptType, ConditionOptionCall<SpanTermQueryBuilder> opLambda) {
+        SpanTermQueryBuilder builder = regSpanTermQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_GreaterThan(String scriptType) {
+        setScriptType_GreaterThan(scriptType, null);
+    }
+
+    public void setScriptType_GreaterThan(String scriptType, ConditionOptionCall<RangeQueryBuilder> opLambda) {
+        final Object _value = scriptType;
+        RangeQueryBuilder builder = regRangeQ("scriptType", ConditionKey.CK_GREATER_THAN, _value);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_LessThan(String scriptType) {
+        setScriptType_LessThan(scriptType, null);
+    }
+
+    public void setScriptType_LessThan(String scriptType, ConditionOptionCall<RangeQueryBuilder> opLambda) {
+        final Object _value = scriptType;
+        RangeQueryBuilder builder = regRangeQ("scriptType", ConditionKey.CK_LESS_THAN, _value);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_GreaterEqual(String scriptType) {
+        setScriptType_GreaterEqual(scriptType, null);
+    }
+
+    public void setScriptType_GreaterEqual(String scriptType, ConditionOptionCall<RangeQueryBuilder> opLambda) {
+        final Object _value = scriptType;
+        RangeQueryBuilder builder = regRangeQ("scriptType", ConditionKey.CK_GREATER_EQUAL, _value);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_LessEqual(String scriptType) {
+        setScriptType_LessEqual(scriptType, null);
+    }
+
+    public void setScriptType_LessEqual(String scriptType, ConditionOptionCall<RangeQueryBuilder> opLambda) {
+        final Object _value = scriptType;
+        RangeQueryBuilder builder = regRangeQ("scriptType", ConditionKey.CK_LESS_EQUAL, _value);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public void setScriptType_Exists() {
+        setScriptType_Exists(null);
+    }
+
+    public void setScriptType_Exists(ConditionOptionCall<ExistsQueryBuilder> opLambda) {
+        ExistsQueryBuilder builder = regExistsQ("scriptType");
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    @Deprecated
+    public void setScriptType_CommonTerms(String scriptType) {
+        setScriptType_CommonTerms(scriptType, null);
+    }
+
+    @Deprecated
+    public void setScriptType_CommonTerms(String scriptType, ConditionOptionCall<CommonTermsQueryBuilder> opLambda) {
+        CommonTermsQueryBuilder builder = regCommonTermsQ("scriptType", scriptType);
+        if (opLambda != null) {
+            opLambda.callback(builder);
+        }
+    }
+
+    public BsBoostDocumentRuleCQ addOrderBy_ScriptType_Asc() {
+        regOBA("scriptType");
+        return this;
+    }
+
+    public BsBoostDocumentRuleCQ addOrderBy_ScriptType_Desc() {
+        regOBD("scriptType");
+        return this;
+    }
+
     public void setSortOrder_Equal(Integer sortOrder) {
         setSortOrder_Term(sortOrder, null);
     }

--- a/src/main/java/org/codelibs/fess/opensearch/config/exentity/BoostDocumentRule.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/exentity/BoostDocumentRule.java
@@ -42,8 +42,8 @@ public class BoostDocumentRule extends BsBoostDocumentRule {
 
     @Override
     public String toString() {
-        return "BoostDocumentRule [boostExpr=" + boostExpr + ", createdBy=" + createdBy + ", createdTime=" + createdTime + ", sortOrder="
-                + sortOrder + ", updatedBy=" + updatedBy + ", updatedTime=" + updatedTime + ", urlExpr=" + urlExpr + ", docMeta=" + docMeta
-                + "]";
+        return "BoostDocumentRule [boostExpr=" + boostExpr + ", createdBy=" + createdBy + ", createdTime=" + createdTime + ", scriptType="
+                + scriptType + ", sortOrder=" + sortOrder + ", updatedBy=" + updatedBy + ", updatedTime=" + updatedTime + ", urlExpr="
+                + urlExpr + ", docMeta=" + docMeta + "]";
     }
 }

--- a/src/main/resources/fess_indices/fess_config.boost_document_rule/boost_document_rule.json
+++ b/src/main/resources/fess_indices/fess_config.boost_document_rule/boost_document_rule.json
@@ -20,6 +20,9 @@
       },
       "updatedTime": {
         "type": "long"
+      },
+      "scriptType": {
+        "type": "keyword"
       }
     }
 }

--- a/src/main/resources/fess_label.properties
+++ b/src/main/resources/fess_label.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Document Boost
 labels.boost_document_rule_list_url_expr=Condition
 labels.boost_document_rule_url_expr=Condition
 labels.boost_document_rule_boost_expr=Boost Expression
+labels.boost_document_rule_script_type=Script Type
 labels.boost_document_rule_sort_order=Sort Order
 labels.access_token_configuration=Access Token
 labels.access_token_title_details=Access Token

--- a/src/main/resources/fess_label_de.properties
+++ b/src/main/resources/fess_label_de.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Dokument-Boost
 labels.boost_document_rule_list_url_expr=Bedingung
 labels.boost_document_rule_url_expr=Bedingung
 labels.boost_document_rule_boost_expr=Boost-Ausdruck
+labels.boost_document_rule_script_type=Skripttyp
 labels.boost_document_rule_sort_order=Sortierreihenfolge
 labels.access_token_configuration=Zugriffstoken
 labels.access_token_title_details=Zugriffstoken

--- a/src/main/resources/fess_label_en.properties
+++ b/src/main/resources/fess_label_en.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Document Boost
 labels.boost_document_rule_list_url_expr=Condition
 labels.boost_document_rule_url_expr=Condition
 labels.boost_document_rule_boost_expr=Boost Expression
+labels.boost_document_rule_script_type=Script Type
 labels.boost_document_rule_sort_order=Sort Order
 labels.access_token_configuration=Access Token
 labels.access_token_title_details=Access Token

--- a/src/main/resources/fess_label_es.properties
+++ b/src/main/resources/fess_label_es.properties
@@ -811,6 +811,7 @@ labels.boost_document_rule_title_details=Impulso de documento
 labels.boost_document_rule_list_url_expr=Condición
 labels.boost_document_rule_url_expr=Condición
 labels.boost_document_rule_boost_expr=Expresión de impulso
+labels.boost_document_rule_script_type=Tipo de Script
 labels.boost_document_rule_sort_order=Orden de clasificación
 labels.access_token_configuration=Token de acceso
 labels.access_token_title_details=Token de acceso

--- a/src/main/resources/fess_label_fr.properties
+++ b/src/main/resources/fess_label_fr.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Boost de document
 labels.boost_document_rule_list_url_expr=Condition
 labels.boost_document_rule_url_expr=Condition
 labels.boost_document_rule_boost_expr=Expression de boost
+labels.boost_document_rule_script_type=Type de Script
 labels.boost_document_rule_sort_order=Ordre de tri
 labels.access_token_configuration=Jeton d'accès
 labels.access_token_title_details=Jeton d'accès

--- a/src/main/resources/fess_label_hi.properties
+++ b/src/main/resources/fess_label_hi.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=दस्तावेज़ बूस�
 labels.boost_document_rule_list_url_expr=शर्त
 labels.boost_document_rule_url_expr=शर्त
 labels.boost_document_rule_boost_expr=बूस्ट अभिव्यक्ति
+labels.boost_document_rule_script_type=स्क्रिप्ट प्रकार
 labels.boost_document_rule_sort_order=क्रमबद्ध क्रम
 labels.access_token_configuration=एक्सेस टोकन
 labels.access_token_title_details=एक्सेस टोकन

--- a/src/main/resources/fess_label_id.properties
+++ b/src/main/resources/fess_label_id.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Boost Dokumen
 labels.boost_document_rule_list_url_expr=Kondisi
 labels.boost_document_rule_url_expr=Kondisi
 labels.boost_document_rule_boost_expr=Ekspresi Boost
+labels.boost_document_rule_script_type=Jenis Script
 labels.boost_document_rule_sort_order=Urutan Sortir
 labels.access_token_configuration=Token Akses
 labels.access_token_title_details=Token Akses

--- a/src/main/resources/fess_label_it.properties
+++ b/src/main/resources/fess_label_it.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Regola di boost documento
 labels.boost_document_rule_list_url_expr=Condizione
 labels.boost_document_rule_url_expr=Condizione
 labels.boost_document_rule_boost_expr=Espressione di boost
+labels.boost_document_rule_script_type=Tipo di Script
 labels.boost_document_rule_sort_order=Ordine di ordinamento
 labels.access_token_configuration=Token di accesso
 labels.access_token_title_details=Token di accesso

--- a/src/main/resources/fess_label_ja.properties
+++ b/src/main/resources/fess_label_ja.properties
@@ -807,6 +807,7 @@ labels.boost_document_rule_title_details=ドキュメントブースト
 labels.boost_document_rule_list_url_expr=条件
 labels.boost_document_rule_url_expr=条件
 labels.boost_document_rule_boost_expr=ブースト値式
+labels.boost_document_rule_script_type=スクリプト種別
 labels.boost_document_rule_sort_order=ソート順
 labels.access_token_configuration=アクセストークン
 labels.access_token_title_details=アクセストークン

--- a/src/main/resources/fess_label_ko.properties
+++ b/src/main/resources/fess_label_ko.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=문서 부스트
 labels.boost_document_rule_list_url_expr=조건
 labels.boost_document_rule_url_expr=조건
 labels.boost_document_rule_boost_expr=부스트 값 식
+labels.boost_document_rule_script_type=스크립트 종류
 labels.boost_document_rule_sort_order=정렬 순서
 labels.access_token_configuration=액세스 토큰
 labels.access_token_title_details=액세스 토큰

--- a/src/main/resources/fess_label_nl.properties
+++ b/src/main/resources/fess_label_nl.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Documentboostregel
 labels.boost_document_rule_list_url_expr=Conditie
 labels.boost_document_rule_url_expr=Conditie
 labels.boost_document_rule_boost_expr=Boost-expressie
+labels.boost_document_rule_script_type=Scripttype
 labels.boost_document_rule_sort_order=Sorteervolgorde
 labels.access_token_configuration=Toegangstoken
 labels.access_token_title_details=Toegangstoken

--- a/src/main/resources/fess_label_pl.properties
+++ b/src/main/resources/fess_label_pl.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Reguła wzmocnienia dokumentu
 labels.boost_document_rule_list_url_expr=Warunek
 labels.boost_document_rule_url_expr=Warunek
 labels.boost_document_rule_boost_expr=Wyrażenie wzmocnienia
+labels.boost_document_rule_script_type=Typ skryptu
 labels.boost_document_rule_sort_order=Kolejność sortowania
 labels.access_token_configuration=Token dostępu
 labels.access_token_title_details=Token dostępu

--- a/src/main/resources/fess_label_pt_BR.properties
+++ b/src/main/resources/fess_label_pt_BR.properties
@@ -811,6 +811,7 @@ labels.boost_document_rule_title_details=Regra de impulso de documento
 labels.boost_document_rule_list_url_expr=Condição
 labels.boost_document_rule_url_expr=Condição
 labels.boost_document_rule_boost_expr=Expressão de impulso
+labels.boost_document_rule_script_type=Tipo de Script
 labels.boost_document_rule_sort_order=Ordem de classificação
 labels.access_token_configuration=Token de acesso
 labels.access_token_title_details=Token de acesso

--- a/src/main/resources/fess_label_ru.properties
+++ b/src/main/resources/fess_label_ru.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Ускорение документов
 labels.boost_document_rule_list_url_expr=Условие
 labels.boost_document_rule_url_expr=Условие
 labels.boost_document_rule_boost_expr=Выражение ускорения
+labels.boost_document_rule_script_type=Тип скрипта
 labels.boost_document_rule_sort_order=Порядок сортировки
 labels.access_token_configuration=Токен доступа
 labels.access_token_title_details=Токен доступа

--- a/src/main/resources/fess_label_tr.properties
+++ b/src/main/resources/fess_label_tr.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=Belge Artırma
 labels.boost_document_rule_list_url_expr=Koşul
 labels.boost_document_rule_url_expr=Koşul
 labels.boost_document_rule_boost_expr=Artırma İfadesi
+labels.boost_document_rule_script_type=Betik Türü
 labels.boost_document_rule_sort_order=Sıralama Düzeni
 labels.access_token_configuration=Erişim Belirteci
 labels.access_token_title_details=Erişim Belirteci

--- a/src/main/resources/fess_label_zh_CN.properties
+++ b/src/main/resources/fess_label_zh_CN.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=文档提升
 labels.boost_document_rule_list_url_expr=条件
 labels.boost_document_rule_url_expr=条件
 labels.boost_document_rule_boost_expr=提升值表达式
+labels.boost_document_rule_script_type=脚本类型
 labels.boost_document_rule_sort_order=排序顺序
 labels.access_token_configuration=访问令牌
 labels.access_token_title_details=访问令牌

--- a/src/main/resources/fess_label_zh_TW.properties
+++ b/src/main/resources/fess_label_zh_TW.properties
@@ -812,6 +812,7 @@ labels.boost_document_rule_title_details=文檔提升
 labels.boost_document_rule_list_url_expr=條件
 labels.boost_document_rule_url_expr=條件
 labels.boost_document_rule_boost_expr=提升值表達式
+labels.boost_document_rule_script_type=腳本類型
 labels.boost_document_rule_sort_order=排序順序
 labels.access_token_configuration=訪問令牌
 labels.access_token_title_details=訪問令牌

--- a/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc_details.jsp
@@ -68,6 +68,10 @@ ${fe:html(true)}
                                         <td>${f:h(boostExpr)}<la:hidden property="boostExpr"/></td>
                                     </tr>
                                     <tr>
+                                        <th><la:message key="labels.boost_document_rule_script_type"/></th>
+                                        <td>${f:h(scriptType)}<la:hidden property="scriptType"/></td>
+                                    </tr>
+                                    <tr>
                                         <th><la:message
                                                 key="labels.boost_document_rule_sort_order"/></th>
                                         <td>${f:h(sortOrder)}<la:hidden property="sortOrder"/></td>

--- a/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc_edit.jsp
@@ -70,6 +70,14 @@ ${fe:html(true)}
                                     </div>
                                 </div>
                                 <div class="form-group row">
+                                    <label for="scriptType" class="col-sm-3 text-sm-right col-form-label"><la:message
+                                            key="labels.boost_document_rule_script_type"/></label>
+                                    <div class="col-sm-9">
+                                        <la:errors property="scriptType"/>
+                                        <la:text styleId="scriptType" property="scriptType" styleClass="form-control"/>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
                                     <label for="sortOrder" class="col-sm-3 text-sm-right col-form-label"><la:message
                                             key="labels.boost_document_rule_sort_order"/></label>
                                     <div class="form-inline col-sm-9">

--- a/src/test/java/org/codelibs/fess/indexer/DocBoostMatcherTest.java
+++ b/src/test/java/org/codelibs/fess/indexer/DocBoostMatcherTest.java
@@ -19,50 +19,41 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.codelibs.fess.Constants;
-import org.codelibs.fess.exception.JobProcessingException;
-import org.codelibs.fess.script.AbstractScriptEngine;
+import org.codelibs.fess.opensearch.config.exentity.BoostDocumentRule;
 import org.codelibs.fess.script.ScriptEngineFactory;
+import org.codelibs.fess.script.javascript.JavaScriptEngine;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.lastaflute.di.core.factory.SingletonLaContainerFactory;
-
-import groovy.lang.Binding;
-import groovy.lang.GroovyClassLoader;
-import groovy.lang.GroovyShell;
 
 public class DocBoostMatcherTest extends UnitFessTestCase {
+
+    /** Name of the stub engine used where no JavaScript literal can produce the value under test. */
+    private static final String FIXED_VALUE_ENGINE = "fixed-value-stub";
 
     @Override
     protected void setUp(TestInfo testInfo) throws Exception {
         super.setUp(testInfo);
-        ScriptEngineFactory scriptEngineFactory = new ScriptEngineFactory();
-        ComponentUtil.register(scriptEngineFactory, "scriptEngineFactory");
-        new AbstractScriptEngine() {
+        ComponentUtil.register(new ScriptEngineFactory(), "scriptEngineFactory");
+        // The real engine, not a stub: a matcher with no rule runs on Constants.DEFAULT_SCRIPT,
+        // and these tests are about what that engine makes of the expressions.
+        new JavaScriptEngine().register();
+    }
 
-            @Override
-            public Object evaluate(String template, Map<String, Object> paramMap) {
-                final Map<String, Object> bindingMap = new HashMap<>(paramMap);
-                bindingMap.put("container", SingletonLaContainerFactory.getContainer());
-                final GroovyShell groovyShell = new GroovyShell(new Binding(bindingMap));
-                try {
-                    return groovyShell.evaluate(template);
-                } catch (final JobProcessingException e) {
-                    throw e;
-                } catch (final Exception e) {
-                    return null;
-                } finally {
-                    final GroovyClassLoader loader = groovyShell.getClassLoader();
-                    loader.clearCache();
-                }
-            }
-
-            @Override
-            protected String getName() {
-                return Constants.DEFAULT_SCRIPT;
-            }
-        }.register();
+    /**
+     * A matcher whose engine returns the given object whatever the expression. JavaScript numbers
+     * are all Double, so the Float and Long branches of getValue have no literal to reach them.
+     *
+     * @param value the value the engine returns
+     * @return a matcher bound to the stub engine
+     */
+    private DocBoostMatcher fixedValueMatcher(final Object value) {
+        ComponentUtil.getScriptEngineFactory().add(FIXED_VALUE_ENGINE, (template, paramMap) -> value);
+        final BoostDocumentRule rule = new BoostDocumentRule();
+        rule.setBoostExpr("value");
+        rule.setScriptType(FIXED_VALUE_ENGINE);
+        return new DocBoostMatcher(rule);
     }
 
     @Test
@@ -92,7 +83,7 @@ public class DocBoostMatcherTest extends UnitFessTestCase {
     public void test_string() {
         final DocBoostMatcher docBoostMatcher = new DocBoostMatcher();
         docBoostMatcher.setBoostExpression("10");
-        docBoostMatcher.setMatchExpression("data1 != null && data1.matches(\"test\")");
+        docBoostMatcher.setMatchExpression("data1 != null && /^test$/.test(data1)");
 
         final Map<String, Object> map = new HashMap<String, Object>();
 
@@ -111,7 +102,7 @@ public class DocBoostMatcherTest extends UnitFessTestCase {
         map.put("data2", "hoge");
         assertFalse(docBoostMatcher.match(map));
 
-        docBoostMatcher.setMatchExpression("data1.matches(\".*test.*\")");
+        docBoostMatcher.setMatchExpression("/.*test.*/.test(data1)");
         map.put("data1", "aaa test bbb");
         assertTrue(docBoostMatcher.match(map));
     }
@@ -139,8 +130,7 @@ public class DocBoostMatcherTest extends UnitFessTestCase {
 
     @Test
     public void test_getValue_floatReturn() {
-        final DocBoostMatcher docBoostMatcher = new DocBoostMatcher();
-        docBoostMatcher.setBoostExpression("1.5f");
+        final DocBoostMatcher docBoostMatcher = fixedValueMatcher(Float.valueOf(1.5f));
 
         final Map<String, Object> map = new HashMap<String, Object>();
         map.put("data1", 1);
@@ -150,7 +140,7 @@ public class DocBoostMatcherTest extends UnitFessTestCase {
     @Test
     public void test_getValue_doubleReturn() {
         final DocBoostMatcher docBoostMatcher = new DocBoostMatcher();
-        docBoostMatcher.setBoostExpression("2.5d");
+        docBoostMatcher.setBoostExpression("2.5");
 
         final Map<String, Object> map = new HashMap<String, Object>();
         map.put("data1", 1);
@@ -159,8 +149,7 @@ public class DocBoostMatcherTest extends UnitFessTestCase {
 
     @Test
     public void test_getValue_longReturn() {
-        final DocBoostMatcher docBoostMatcher = new DocBoostMatcher();
-        docBoostMatcher.setBoostExpression("100L");
+        final DocBoostMatcher docBoostMatcher = fixedValueMatcher(Long.valueOf(100L));
 
         final Map<String, Object> map = new HashMap<String, Object>();
         map.put("data1", 1);
@@ -253,5 +242,24 @@ public class DocBoostMatcherTest extends UnitFessTestCase {
         final DocBoostMatcher docBoostMatcher = new DocBoostMatcher();
         docBoostMatcher.setBoostExpression("10");
         assertEquals(0.0f, docBoostMatcher.getValue(new HashMap<>()));
+    }
+
+    @Test
+    public void test_scriptTypeFromRule() {
+        final ScriptEngineFactory factory = new ScriptEngineFactory();
+        factory.add("javascript", (template, paramMap) -> "from-javascript");
+        factory.add("groovy", (template, paramMap) -> "from-groovy");
+        ComponentUtil.register(factory, "scriptEngineFactory");
+
+        final BoostDocumentRule explicit = new BoostDocumentRule();
+        explicit.setUrlExpr("url != null");
+        explicit.setBoostExpr("1");
+        explicit.setScriptType("javascript");
+        assertEquals("javascript", new DocBoostMatcher(explicit).getScriptType());
+
+        final BoostDocumentRule legacy = new BoostDocumentRule();
+        legacy.setUrlExpr("url != null");
+        legacy.setBoostExpr("1");
+        assertEquals(Constants.LEGACY_SCRIPT, new DocBoostMatcher(legacy).getScriptType());
     }
 }

--- a/src/test/java/org/codelibs/fess/opensearch/config/exentity/BoostDocumentRuleTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/config/exentity/BoostDocumentRuleTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.opensearch.config.exentity;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+public class BoostDocumentRuleTest extends UnitFessTestCase {
+
+    @Test
+    public void test_scriptType() {
+        final BoostDocumentRule rule = new BoostDocumentRule();
+        assertNull(rule.getScriptType());
+
+        rule.setScriptType("javascript");
+        assertEquals("javascript", rule.getScriptType());
+        assertTrue(rule.toString().contains("scriptType=javascript"));
+    }
+}


### PR DESCRIPTION
Gives each document boost rule its own script type.

A boost rule was the one place with no way to choose an engine — it followed a
global property, `crawler.default.script`, which the previous pull request in
this stack removes. The field is added to the `boost_document_rule` index and
its generated persistence classes, mirroring the one `scheduled_job` already
has, and then wired through the admin screen and the API.

A rule that records no script type keeps resolving to Groovy, which is what a
rule written before 15.9 expects. A rule created from now on records
`javascript`.

The search form and search body deliberately do not gain the field: the pager
has no such property and the list screen has no input for it, so a value passed
there would have been silently ignored.

Part of a stack. Do not merge alone.
