### PR TITLE
build: bundle the Groovy script plugin with the distribution

### DIFF
--- a/deps.xml
+++ b/deps.xml
@@ -15,6 +15,14 @@
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://repo1.maven.org/maven2" />
+	<property name="maven.codelibs.release.repo.url" value="https://maven.codelibs.org/release" />
+
+	<!-- webapp plugins bundled with the distribution -->
+	<!-- Hand-bump this for each Fess release: fess-script-groovy is released on its own
+	     cadence, and ${project.version} would resolve to a SNAPSHOT the release repo never serves.
+	     Fess 15.10 drops the plugin: delete this property, the install.webapp.plugins target
+	     below and the install-webapp-plugins execution in pom.xml then, don't bump it. -->
+	<property name="fess.script.groovy.version" value="15.9.0" />
 
 	<target name="install.jars">
 		<mkdir dir="${target.dir}" />
@@ -54,6 +62,20 @@
 		</delete>
 	</target>
 
+	<!-- Fetches the plugins the distribution bundles into WEB-INF/plugin. Kept out of
+	     install.jars, which that directory's jars are deleted by and which runs on every
+	     mvn test through the antrun plugin-level configuration: a test run must not depend
+	     on a plugin release being published. pom.xml calls this at prepare-package. -->
+	<target name="install.webapp.plugins">
+		<mkdir dir="${target.dir}" />
+		<antcall target="install.webapp.plugin">
+			<param name="repo.url" value="${maven.codelibs.release.repo.url}" />
+			<param name="jar.groupId" value="org/codelibs/fess" />
+			<param name="jar.artifactId" value="fess-script-groovy" />
+			<param name="jar.version" value="${fess.script.groovy.version}" />
+		</antcall>
+	</target>
+
 	<target name="install.env.jar">
 		<get dest="${target.dir}">
 			<url url="${repo.url}/${jar.groupId}/${jar.artifactId}/${jar.version}/${jar.artifactId}-${file.version}.jar" />
@@ -62,5 +84,12 @@
 		<copy file="${target.dir}/${jar.artifactId}-${file.version}.jar" todir="${suggest.dir}/lib" />
 		<copy file="${target.dir}/${jar.artifactId}-${file.version}.jar" todir="${thumbnail.dir}/lib" />
 		<copy file="${target.dir}/${jar.artifactId}-${file.version}.jar" todir="${chunk.dir}/lib" />
+	</target>
+
+	<target name="install.webapp.plugin">
+		<get dest="${target.dir}">
+			<url url="${repo.url}/${jar.groupId}/${jar.artifactId}/${jar.version}/${jar.artifactId}-${jar.version}.jar" />
+		</get>
+		<copy file="${target.dir}/${jar.artifactId}-${jar.version}.jar" todir="${webinf.dir}/plugin" />
 	</target>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,27 @@
 							</target>
 						</configuration>
 					</execution>
+					<execution>
+						<!-- The plugins the distribution bundles. This is a separate execution because
+						     the fetch must not run during mvn test: the plugin release it downloads is
+						     published on its own cadence and may not exist yet. It is bound to
+						     prepare-package so it runs after install.jars, which empties WEB-INF/plugin
+						     and which the plugin-level target below runs. combine.self="override" keeps
+						     the plugin-level target out of this one. Maven merges it into every execution
+						     otherwise, and what survives that merge depends on how Xpp3Dom pairs
+						     same-named children: today this ant task wins and the plugin-level ones are
+						     dropped, but renaming or reordering the tasks below changes that silently. -->
+						<id>install-webapp-plugins</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target combine.self="override">
+								<ant antfile="${basedir}/deps.xml" target="install.webapp.plugins" />
+							</target>
+						</configuration>
+					</execution>
 				</executions>
 				<configuration>
 					<target>


### PR DESCRIPTION
Bundles the fess-script-groovy plugin with the distribution.

Groovy left core earlier in this stack. An installation upgraded from 15.8 has
scheduled jobs and crawl settings whose script type is Groovy, or is unset and
therefore means Groovy; without the plugin present they all fail with
`groovy is not found`. Shipping it pre-installed keeps those working with no
action from the administrator.

Fess 15.10 drops this step and the plugin becomes an opt-in install from the
admin Plugin page.

The fetch runs at `prepare-package`, in its own antrun execution, so `mvn test`
is unaffected. It is deliberately not tolerant of a missing artifact: a bundled
plugin that quietly failed to download would ship a distribution in which every
Groovy setting breaks.

**This pull request cannot go green yet.** fess-script-groovy 15.9.0 has not
been released to maven.codelibs.org — it will be its first release there — so
`mvn package` fails on a 404. Release the plugin first, then merge this. The
five pull requests below it in the stack are unaffected.

Top of the stack. Merge the rest first.
