### PR TITLE
test: register crawling helpers with ComponentUtil instead of the DI container

### DIFF
--- a/deps.xml
+++ b/deps.xml
@@ -16,13 +16,16 @@
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://repo1.maven.org/maven2" />
 	<property name="maven.codelibs.release.repo.url" value="https://maven.codelibs.org/release" />
+	<property name="maven.codelibs.snapshot.repo.url" value="https://maven.codelibs.org/snapshot" />
 
 	<!-- webapp plugins bundled with the distribution -->
 	<!-- Hand-bump this for each Fess release: fess-script-groovy is released on its own
 	     cadence, and ${project.version} would resolve to a SNAPSHOT the release repo never serves.
+	     15.9.0 is not going to be published for a while, so this names the snapshot; see
+	     install.webapp.plugins for what to undo once a release exists.
 	     Fess 15.10 drops the plugin: delete this property, the install.webapp.plugins target
 	     below and the install-webapp-plugins execution in pom.xml then, don't bump it. -->
-	<property name="fess.script.groovy.version" value="15.9.0" />
+	<property name="fess.script.groovy.version" value="15.9.0-SNAPSHOT" />
 
 	<target name="install.jars">
 		<mkdir dir="${target.dir}" />
@@ -68,11 +71,32 @@
 	     on a plugin release being published. pom.xml calls this at prepare-package. -->
 	<target name="install.webapp.plugins">
 		<mkdir dir="${target.dir}" />
+		<!-- A snapshot is served under a timestamped file name
+		     (fess-script-groovy-15.9.0-20260829.021938-2.jar): the plain -SNAPSHOT.jar is a 404, and
+		     maven-metadata.xml is the only place the real name is written down. Its metadata/version
+		     is still the -SNAPSHOT one and its snapshotVersions hold one entry per artifact, which
+		     xmlproperty joins with commas, so the name is rebuilt from the parts that are single
+		     valued. Once fess-script-groovy has a release, delete these three tasks and pass
+		     maven.codelibs.release.repo.url as repo.url and fess.script.groovy.version as
+		     file.version. -->
+		<get src="${maven.codelibs.snapshot.repo.url}/org/codelibs/fess/fess-script-groovy/${fess.script.groovy.version}/maven-metadata.xml"
+			dest="${target.dir}/fess-script-groovy-maven-metadata.xml" />
+		<xmlproperty file="${target.dir}/fess-script-groovy-maven-metadata.xml" prefix="script.groovy" />
+		<loadresource property="fess.script.groovy.release.version">
+			<string value="${fess.script.groovy.version}" />
+			<filterchain>
+				<tokenfilter>
+					<replacestring from="-SNAPSHOT" to="" />
+				</tokenfilter>
+			</filterchain>
+		</loadresource>
 		<antcall target="install.webapp.plugin">
-			<param name="repo.url" value="${maven.codelibs.release.repo.url}" />
+			<param name="repo.url" value="${maven.codelibs.snapshot.repo.url}" />
 			<param name="jar.groupId" value="org/codelibs/fess" />
 			<param name="jar.artifactId" value="fess-script-groovy" />
 			<param name="jar.version" value="${fess.script.groovy.version}" />
+			<param name="file.version"
+				value="${fess.script.groovy.release.version}-${script.groovy.metadata.versioning.snapshot.timestamp}-${script.groovy.metadata.versioning.snapshot.buildNumber}" />
 		</antcall>
 	</target>
 
@@ -86,10 +110,13 @@
 		<copy file="${target.dir}/${jar.artifactId}-${file.version}.jar" todir="${chunk.dir}/lib" />
 	</target>
 
+	<!-- file.version is the version in the file name on the server, which is not jar.version for a
+	     snapshot; the copy renames it back so what Fess ships is named the same on every build. -->
 	<target name="install.webapp.plugin">
 		<get dest="${target.dir}">
-			<url url="${repo.url}/${jar.groupId}/${jar.artifactId}/${jar.version}/${jar.artifactId}-${jar.version}.jar" />
+			<url url="${repo.url}/${jar.groupId}/${jar.artifactId}/${jar.version}/${jar.artifactId}-${file.version}.jar" />
 		</get>
-		<copy file="${target.dir}/${jar.artifactId}-${jar.version}.jar" todir="${webinf.dir}/plugin" />
+		<copy file="${target.dir}/${jar.artifactId}-${file.version}.jar"
+			tofile="${webinf.dir}/plugin/${jar.artifactId}-${jar.version}.jar" />
 	</target>
 </project>

--- a/src/test/java/org/codelibs/fess/crawler/transformer/FessXpathTransformerTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/transformer/FessXpathTransformerTest.java
@@ -67,7 +67,6 @@ import org.codelibs.fess.util.MemoryUtil;
 import org.codelibs.nekohtml.parsers.DOMParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.lastaflute.di.core.factory.SingletonLaContainerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
@@ -133,28 +132,38 @@ public class FessXpathTransformerTest extends UnitFessTestCase {
         FieldUtil.set(field, obj, value);
     }
 
-    /** Guards the one-time container registration in {@link #registerCrawlingHelpers()}; the
-     *  LastaDi container is a JVM-wide singleton that is not reset between test methods, and
-     *  registering the same component name into it twice throws TooManyRegistrationComponentException. */
-    private static boolean crawlingHelpersRegistered = false;
-
     /**
      * Registers the helpers needed to run a full {@link FessXpathTransformer#transform(ResponseData)}
      * call (mirrors the original setup in {@link #test_transform()}), and returns a fresh session id
      * to use with {@link ResponseData#setSessionId(String)} so {@code getCrawlingConfig(responseData)}
      * resolves a freshly-stored {@link WebConfig}. Safe to call from multiple test methods.
+     *
+     * <p>The helpers are registered with {@link ComponentUtil}, not with the LastaDi container.
+     * {@link ComponentUtil#getComponent(String)} asks the container first and only falls back to
+     * what {@code ComponentUtil.register} holds, and the container is a JVM-wide singleton that is
+     * never reset between test classes: a component registered there shadows, for the rest of the
+     * JVM, every {@code ComponentUtil.register} another test class makes under the same name -
+     * silently, because the shadowed call neither fails nor logs. Registering {@code systemHelper}
+     * that way left {@code SamlAuthenticatorTest} holding the real clock instead of the fake one it
+     * installs, so its two tests that move the clock failed whenever this class happened to run
+     * before them in the same surefire fork. What {@code ComponentUtil} holds is cleared by
+     * {@code UnitFessTestCase#tearDown}, so nothing outlives a test method and the registration is
+     * simply repeated per method.</p>
+     *
+     * <p>The instances are bare, as they were before: {@code LaContainerImpl.register(Class, name)}
+     * builds a {@code ComponentDefImpl} with no init-method definition, so none of these helpers
+     * ever had its {@code @PostConstruct init()} run here either. {@link SystemHelper#init()} in
+     * particular reads {@code WEB-INF/project.properties}, which a unit test has no copy of, and
+     * would fail if it were called.</p>
      */
     private String registerCrawlingHelpers() {
-        if (!crawlingHelpersRegistered) {
-            SingletonLaContainerFactory.getContainer().register(CrawlingInfoHelper.class, "crawlingInfoHelper");
-            SingletonLaContainerFactory.getContainer().register(PathMappingHelper.class, "pathMappingHelper");
-            SingletonLaContainerFactory.getContainer().register(CrawlingConfigHelper.class, "crawlingConfigHelper");
-            SingletonLaContainerFactory.getContainer().register(SystemHelper.class, "systemHelper");
-            SingletonLaContainerFactory.getContainer().register(FileTypeHelper.class, "fileTypeHelper");
-            SingletonLaContainerFactory.getContainer().register(DocumentHelper.class, "documentHelper");
-            SingletonLaContainerFactory.getContainer().register(LabelTypeHelper.class, "labelTypeHelper");
-            crawlingHelpersRegistered = true;
-        }
+        ComponentUtil.register(new CrawlingInfoHelper(), "crawlingInfoHelper");
+        ComponentUtil.register(new PathMappingHelper(), "pathMappingHelper");
+        ComponentUtil.register(new CrawlingConfigHelper(), "crawlingConfigHelper");
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        ComponentUtil.register(new FileTypeHelper(), "fileTypeHelper");
+        ComponentUtil.register(new DocumentHelper(), "documentHelper");
+        ComponentUtil.register(new LabelTypeHelper(), "labelTypeHelper");
 
         final WebConfig webConfig = new WebConfig();
         // A real crawl always stores a WebConfig with a DB-assigned id; give it one here too, since


### PR DESCRIPTION
Two changes:

1. **`test:`** the fix this PR was opened for - a container leak that made `SamlAuthenticatorTest` fail intermittently.
2. **`build:`** point the bundled Groovy plugin at `15.9.0-SNAPSHOT`, so the build stops failing on a release that is not published yet.

---

# 1. Container leak behind the intermittent SamlAuthenticatorTest failures

## Problem

`SamlAuthenticatorTest` fails intermittently in CI, always the same two tests and always with the same message:

```
SamlAuthenticatorTest.test_getLoginCredential_expiredRequestIdCannotBeAnswered
SamlAuthenticatorTest.test_getLoginCredential_prunedRequestIdsStillNameTheTtl
  Authentication Failure: invalid_response - Reason: The Assertion must include a Conditions element
  ==> expected: <true> but was: <false>
```

It is not flaky. It is a deterministic cross-class leak that only shows up in some run orders.

## Root cause

`FessXpathTransformerTest#registerCrawlingHelpers()` registered seven helpers, `SystemHelper` among them, into the LastaDi container:

```java
SingletonLaContainerFactory.getContainer().register(SystemHelper.class, "systemHelper");
```

The container is a JVM-wide singleton and is never reset between test classes. `ComponentUtil.getComponent(name)` asks the container first and only falls back to what `ComponentUtil.register(instance, name)` holds:

```java
try { return SingletonLaContainer.getComponent(componentName); }
catch (ComponentNotFoundException | AutoBindingFailureException e) {
    if (componentMap.containsKey(componentName)) { return componentMap.get(componentName); }
    throw e;
}
```

So once `systemHelper` exists in the container, every later `ComponentUtil.register(mock, "systemHelper")` in that JVM is ignored - with no exception and no log line.

`SamlAuthenticatorTest#createAuthenticatorWithControlledClock()` relies on exactly that fallback to install a fake clock. With the container entry present it gets the real `SystemHelper`, so `clock.addAndGet(3601_000)` moves nothing, `SamlAuthenticator#removeExpiredRequestIds` computes `(now - stored) / 1000 == 0`, the pending AuthnRequest ID is not pruned, and the intentionally minimal test response reaches java-saml, which rejects it for the missing `Conditions` element. Only the two tests that need the clock to move are affected; the other 73 tolerate any consistent clock.

CI runs with `-DforkCount=1C -DreuseForks=true`, so classes are handed to forks on a first-come basis and whether these two classes land in the same fork in that order varies per run. Locally (`forkCount=1`, filesystem order) they do not, which is why it never reproduced there.

Instrumented confirmation - same test, two run orders:

```
contaminated: helper=org.codelibs.fess.helper.SystemHelper now=1787971864341 stored=1787971864340
clean:        helper=SamlAuthenticatorTest$1              now=1000000       stored=1000000
```

## Fix

Register the helpers with `ComponentUtil` rather than with the container. What `ComponentUtil` holds is cleared by `UnitFessTestCase#tearDown`, so nothing outlives a test method and the static one-time guard is no longer needed.

The instances stay bare on purpose: `LaContainerImpl.register(Class, name)` builds a plain `ComponentDefImpl` with no init-method definition, so none of these helpers ever had its `@PostConstruct init()` run here either. (`SystemHelper#init()` reads `WEB-INF/project.properties`, which a unit test has no copy of, and fails if it is called.)

## Verification

| Check | Result |
| --- | --- |
| `FessXpathTransformerTest` | 65/65 |
| `FessXpathTransformerTest,SamlAuthenticatorTest` in one JVM, alphabetical order (the order that failed) | 140/140 |
| `mvn test` | 7427/7427 |
| `mvn test -Dparallel=classes -DthreadCount=4 -DforkCount=1C -DreuseForks=true` | 7427/7427 |

Before this change the second row failed reproducibly, 100% of the time:

```bash
mvn test -Dtest='FessXpathTransformerTest,SamlAuthenticatorTest' \
  -Dsurefire.runOrder=alphabetical -DforkCount=1   # 2 failures
mvn test -Dtest='FessXpathTransformerTest,SamlAuthenticatorTest' \
  -Dsurefire.runOrder=reversealphabetical -DforkCount=1   # green
```

### Note

`-Dparallel=classes -DthreadCount=4` in `.github/workflows/maven.yml` is a no-op: the surefire JUnit Platform provider (3.5.6) does not read `parallel` or `threadCount`, and there is no `junit-platform.properties`. Test classes never run concurrently; this was purely an ordering problem. Left as is here.

---

# 2. Bundled Groovy plugin: take the snapshot

`fess-script-groovy` 15.9.0 is not going to be released for a while, so the `prepare-package` fetch added in #3348 fails the build:

```
[get] Error opening connection java.io.FileNotFoundException:
      https://maven.codelibs.org/release/org/codelibs/fess/fess-script-groovy/15.9.0/fess-script-groovy-15.9.0.jar
[ERROR] Failed to execute goal maven-antrun-plugin:3.2.0:run (install-webapp-plugins) on project fess
```

Point it at `15.9.0-SNAPSHOT` in the snapshot repository. Repointing the URL is not enough on its own, because a snapshot is served under a timestamped file name:

```
404  .../15.9.0-SNAPSHOT/fess-script-groovy-15.9.0-SNAPSHOT.jar
200  .../15.9.0-SNAPSHOT/fess-script-groovy-15.9.0-20260829.021938-2.jar
200  .../15.9.0-SNAPSHOT/maven-metadata.xml
```

So `install.webapp.plugins` reads `maven-metadata.xml` and hands `install.webapp.plugin` a `file.version` - the same split `install.env.jar` already makes between the version in the URL and the version in the file name - and the copy renames the jar back, so what Fess ships stays `fess-script-groovy-15.9.0-SNAPSHOT.jar` on every build (which `PluginHelper#getArtifactFromFileName` parses as name `fess-script-groovy`, version `15.9.0-SNAPSHOT`).

The name is rebuilt from `versioning/snapshot/timestamp` and `buildNumber` rather than read from `snapshotVersions`: `metadata/version` is still the `-SNAPSHOT` one, and `snapshotVersions` carries one entry per artifact (jar, pom, sources, javadoc), which `xmlproperty` joins with commas.

`pom.xml` is untouched; the execution stays where #3348 put it. When `fess-script-groovy` has a release, the three added tasks come out and `repo.url` / `file.version` go back to the release property and `fess.script.groovy.version`.

## Verification

The CI sequence, run locally end to end:

```bash
mvn -B antrun:run --file pom.xml
mvn -B package --file pom.xml -Dparallel=classes -DthreadCount=4 -DforkCount=1C -DreuseForks=true
```

`BUILD SUCCESS`, `Tests run: 7427, Failures: 0, Errors: 0`, and the plugin lands where it should:

```
target/fess.war                            WEB-INF/plugin/fess-script-groovy-15.9.0-SNAPSHOT.jar
target/releases/fess-15.9.0-SNAPSHOT.zip   fess-15.9.0-SNAPSHOT/app/WEB-INF/plugin/fess-script-groovy-15.9.0-SNAPSHOT.jar
```
