### PR TITLE
feat!: migrate to Jackson 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1562,36 +1562,58 @@
 			<version>2.33</version>
 		</dependency>
 
-		<!-- json -->
+		<!-- json: Jackson 3 (tools.jackson.*) is what Fess code compiles against -->
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
+			<groupId>tools.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 			<version>${jackson.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>tools.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>tools.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<!-- Annotations are shared by both lines and keep the com.fasterxml groupId -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 			<version>${jackson.annotations.version}</version>
 		</dependency>
+		<!-- Jackson 2 (com.fasterxml.jackson.*) still ships alongside Jackson 3. OpenSearch
+		     declares jackson-core and the three dataformats at ${jackson2.version}, but with a
+		     blanket exclusion, so it supplies no databind/annotations. These direct declarations
+		     are therefore the only pinned source of Jackson 2 for the plugin repositories that
+		     still compile against it; dropping them silently falls back to the 2.18.3 that
+		     google-cloud-storage drags in, rather than failing the build. -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>${jackson2.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
+			<version>${jackson2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-cbor</artifactId>
-			<version>${jackson.version}</version>
+			<version>${jackson2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-smile</artifactId>
-			<version>${jackson.version}</version>
+			<version>${jackson2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>${jackson.version}</version>
+			<version>${jackson2.version}</version>
 		</dependency>
 
 		<!-- template -->

--- a/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.exception.InvalidAccessTokenException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.HttpServletResponse;
 

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ChatStreamHandler.java
@@ -44,8 +44,8 @@ import org.codelibs.fess.llm.LlmException;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -691,7 +691,7 @@ public class ChatStreamHandler {
             writer.write("event: " + event + "\n");
             writer.write("data: " + MAPPER.writeValueAsString(data) + "\n\n");
             writer.flush();
-        } catch (final JsonProcessingException e) {
+        } catch (final JacksonException e) {
             logger.warn("[RAG] failed to serialize SSE data. event={}", event, e);
         }
     }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandler.java
@@ -35,7 +35,8 @@ import org.codelibs.fess.query.QueryFieldConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -147,8 +148,11 @@ public class ScrollSearchHandler {
                     writer.write(MAPPER.writeValueAsString(line));
                     writer.write('\n');
                     wroteAnyLine[0] = true;
-                } catch (final IOException e) {
-                    throw new UncheckedIOException(e);
+                } catch (final JacksonException e) {
+                    // Jackson 3 throws unchecked JacksonException instead of Jackson 2's
+                    // JsonProcessingException (an IOException), so wrap to keep feeding the
+                    // UncheckedIOException handler below unchanged.
+                    throw new UncheckedIOException(new IOException(e));
                 }
                 return true;
             }, OptionalThing.empty());

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/V2JsonBody.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/V2JsonBody.java
@@ -23,11 +23,11 @@ import java.util.Map;
 
 import org.codelibs.fess.Constants;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadConstraints;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -139,7 +139,7 @@ public class V2JsonBody {
         final byte[] jsonBytes = offset == 0 ? buf : java.util.Arrays.copyOfRange(buf, offset, buf.length);
         try {
             return mapper.readValue(new String(jsonBytes, StandardCharsets.UTF_8), TYPE);
-        } catch (final JsonProcessingException e) {
+        } catch (final JacksonException e) {
             throw new MalformedJsonException(e.getMessage());
         }
     }

--- a/src/main/java/org/codelibs/fess/app/web/admin/backup/AdminBackupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/backup/AdminBackupAction.java
@@ -81,8 +81,8 @@ import org.lastaflute.web.response.StreamResponse;
 import org.lastaflute.web.ruts.process.ActionRuntime;
 import org.xml.sax.InputSource;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import jakarta.annotation.Resource;
 

--- a/src/main/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClient.java
+++ b/src/main/java/org/codelibs/fess/embedding/opensearch/OpenSearchEmbeddingClient.java
@@ -47,8 +47,9 @@ import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.util.CredentialUrlUtil;
 import org.codelibs.fess.util.SystemUtil;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Embedding client implementation for OpenSearch ML Commons.
@@ -447,7 +448,7 @@ public class OpenSearchEmbeddingClient extends AbstractEmbeddingClient {
         final JsonNode jsonNode;
         try {
             jsonNode = objectMapper.readTree(responseBody);
-        } catch (final IOException e) {
+        } catch (final JacksonException e) {
             throw new EmbeddingException("Failed to parse OpenSearch ML predict response", e);
         }
         final JsonNode resultsNode = jsonNode.path("inference_results");

--- a/src/main/java/org/codelibs/fess/helper/CoordinatorHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/CoordinatorHelper.java
@@ -31,8 +31,8 @@ import org.codelibs.curl.CurlResponse;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;

--- a/src/main/java/org/codelibs/fess/helper/PluginHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PluginHelper.java
@@ -58,8 +58,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;

--- a/src/main/java/org/codelibs/fess/helper/SearchHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SearchHelper.java
@@ -76,7 +76,7 @@ import org.opensearch.common.document.DocumentField;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/org/codelibs/fess/helper/SearchLogHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/SearchLogHelper.java
@@ -58,8 +58,8 @@ import org.lastaflute.web.util.LaRequestUtil;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.script.Script;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import com.google.common.base.CaseFormat;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -664,7 +664,7 @@ public class SearchLogHelper {
         try {
             final Map<String, Object> source = toSource(event);
             searchLogLogger.info(objectMapper.writeValueAsString(source));
-        } catch (final JsonProcessingException e) {
+        } catch (final JacksonException e) {
             logger.warn("Failed to write {}", event, e);
         }
     }

--- a/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
+++ b/src/main/java/org/codelibs/fess/llm/AbstractLlmClient.java
@@ -49,8 +49,8 @@ import org.codelibs.fess.util.ComponentUtil;
 import org.lastaflute.web.LastaWebKey;
 import org.lastaflute.web.util.LaRequestUtil;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.HttpSession;
 

--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -179,8 +179,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
 
 import jakarta.annotation.PostConstruct;

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandlerTest.java
@@ -101,7 +101,7 @@ public class ScrollSearchHandlerTest extends UnitFessTestCase {
         errBody.put("code", "internal_error");
         errBody.put("message", "stream error");
         errLine.put("error", errBody);
-        new com.fasterxml.jackson.databind.ObjectMapper().writeValue(res.getWriter(), errLine);
+        new tools.jackson.databind.ObjectMapper().writeValue(res.getWriter(), errLine);
         res.getWriter().write('\n');
         final String body = res.body();
         // The terminator line must be valid NDJSON and contain the expected keys.

--- a/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientIndexSettingTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientIndexSettingTest.java
@@ -26,8 +26,8 @@ import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Covers {@code readIndexSetting}'s document-index guard -- document settings rewrite rules

--- a/src/test/java/org/codelibs/fess/script/javascript/ShippedScriptCompilationTest.java
+++ b/src/test/java/org/codelibs/fess/script/javascript/ShippedScriptCompilationTest.java
@@ -29,8 +29,8 @@ import javax.script.ScriptException;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class ShippedScriptCompilationTest extends UnitFessTestCase {
 

--- a/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
+++ b/src/test/java/org/codelibs/fess/theme/BundledBootstrapThemeTest.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Regression coverage for the bundled {@code bootstrap} static theme.

--- a/src/test/java/org/codelibs/fess/theme/LabelMessageThemeParityTest.java
+++ b/src/test/java/org/codelibs/fess/theme/LabelMessageThemeParityTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Verifies cross-locale key parity for the bundled bootstrap theme i18n bundles.


### PR DESCRIPTION
## Summary

Migrates Fess to the Jackson 3 line (`tools.jackson.*`), and keeps the Jackson 2 line explicitly pinned for the code that still depends on it.

Jackson 3.2.1 was already on the distribution's classpath: `opensearch-x-content:3.8.0` declares `tools.jackson.core:jackson-core` and the three `tools.jackson.dataformat` artifacts at 3.2.1. This PR makes Fess' own code use it.

**The WAR gains exactly one jar.**

```
  jackson-annotations-2.22.jar          jackson-dataformat-smile-2.22.1.jar
  jackson-core-2.22.1.jar               jackson-dataformat-smile-3.2.1.jar
  jackson-core-3.2.1.jar                jackson-dataformat-yaml-2.22.1.jar
  jackson-databind-2.22.1.jar           jackson-dataformat-yaml-3.2.1.jar
+ jackson-databind-3.2.1.jar            jackson-dataformat-xml-2.18.3.jar
  jackson-dataformat-cbor-2.22.1.jar    jackson-datatype-jsr310-2.18.3.jar
  jackson-dataformat-cbor-3.2.1.jar
```

## Dependency changes

`jackson-core`, `jackson-databind` and `jackson-dataformat-yaml` move to the `tools.jackson` groupIds at `${jackson.version}`. The Jackson 2 core, databind and three dataformats stay, now pinned at `${jackson2.version}`.

Those Jackson 2 declarations are load-bearing and deliberately kept. OpenSearch declares its four jackson dependencies with a blanket `*:*` exclusion, so it supplies no `jackson-databind` and no `jackson-annotations`. Those reach the plugin repositories only through this POM. Removing them would not fail any build -- Maven would silently fall back to the 2.18.3 that `google-cloud-storage` drags in.

`jackson-annotations` is unchanged and shared by both lines.

## Source changes (17 files)

Beyond the package rename, Jackson 3 moved or removed several APIs:

- `JsonFactory` moved to `tools.jackson.core.json`
- `JsonProcessingException` is gone. `JacksonException` replaces it and is **unchecked**, which left two `catch (IOException)` blocks unreachable:
  - `ScrollSearchHandler` wraps `JacksonException` into `UncheckedIOException` so the existing `catch (UncheckedIOException)` handler keeps its behaviour unchanged
  - `OpenSearchEmbeddingClient` catches `JacksonException` directly and still raises `EmbeddingException`

## Behaviour change

Jackson 3 enables `FAIL_ON_TRAILING_TOKENS` by default. A `/api/v2` request body carrying trailing content after the JSON value -- for example `{"q":"a"} garbage` -- was previously parsed and the trailing content ignored; it is now rejected as malformed and answered with 400. Verified against both versions directly.

Map key order is **not** affected: `ORDER_MAP_ENTRIES_BY_KEYS` still defaults to `false` in Jackson 3, so v2 and NDJSON responses keep insertion order. Every bind site in this repository targets `Map`, `List` or `TypeReference<Map<...>>`, so the POJO-oriented default flips (`SORT_PROPERTIES_ALPHABETICALLY`, `FAIL_ON_UNKNOWN_PROPERTIES`, `USE_GETTERS_AS_SETTERS`, ...) have no effect here.

## Verification

- `mvn test`: **7427 tests, 0 failures, 0 errors**
- WAR contents inspected against a pre-change build (diff above)
- The plugin repositories that still compile against Jackson 2 were checked to still resolve `jackson-databind` at 2.22.1, unchanged

## Merge order

Requires codelibs/fess-parent (`jackson.version` -> 3.2.1, new `jackson2.version`) to merge first.
