### PR TITLE
feat: resolve crawl.order as a UrlQueueOrder component name

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/service/FessUrlQueueService.java
+++ b/src/main/java/org/codelibs/fess/crawler/service/FessUrlQueueService.java
@@ -76,7 +76,10 @@ public class FessUrlQueueService extends OpenSearchUrlQueueService {
             }
             logger.warn("Component {} is not a UrlQueueOrder. Falling back to the default order.", name);
         } catch (final Exception e) {
-            logger.warn("Invalid crawl order specified: {}. Falling back to the default order.", configured, e);
+            logger.warn("Invalid crawl order specified: {}. Falling back to the default order.", configured);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to resolve crawl order component: {}", name, e);
+            }
         }
         return super.getUrlQueueOrder(sessionId);
     }

--- a/src/main/java/org/codelibs/fess/crawler/service/FessUrlQueueService.java
+++ b/src/main/java/org/codelibs/fess/crawler/service/FessUrlQueueService.java
@@ -15,38 +15,30 @@
  */
 package org.codelibs.fess.crawler.service;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.fess.crawler.entity.OpenSearchUrlQueue;
+import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
 import org.codelibs.fess.crawler.service.impl.OpenSearchUrlQueueService;
 import org.codelibs.fess.crawler.util.OpenSearchCrawlerConfig;
 import org.codelibs.fess.helper.CrawlingConfigHelper;
 import org.codelibs.fess.opensearch.config.exentity.CrawlingConfig;
 import org.codelibs.fess.opensearch.config.exentity.CrawlingConfig.ConfigName;
 import org.codelibs.fess.util.ComponentUtil;
-import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
-import org.opensearch.index.query.functionscore.RandomScoreFunctionBuilder;
-import org.opensearch.search.sort.SortBuilders;
-import org.opensearch.search.sort.SortOrder;
 
 /**
- * Fess-specific URL queue service that extends OpenSearch URL queue functionality.
- * This service provides customized URL fetching strategies including sequential and random ordering
- * based on crawling configuration parameters.
+ * Fess-specific URL queue service that selects the fetch order named by the
+ * {@code crawl.order} crawling config parameter.
  */
 public class FessUrlQueueService extends OpenSearchUrlQueueService {
 
     private static final Logger logger = LogManager.getLogger(FessUrlQueueService.class);
 
-    /** Configuration value for sequential URL processing order */
-    protected static final String ORDER_SEQUENTIAL = "sequential";
-
-    /** Configuration value for random URL processing order */
-    protected static final String ORDER_RANDOM = "random";
+    /** Aliases from the crawl.order values that shipped before the orders became components. */
+    protected static final Map<String, String> LEGACY_ORDER_NAMES =
+            Map.of("sequential", "sequentialUrlQueueOrder", "random", "randomUrlQueueOrder");
 
     /**
      * Constructs a new FessUrlQueueService with the specified crawler configuration.
@@ -58,28 +50,34 @@ public class FessUrlQueueService extends OpenSearchUrlQueueService {
     }
 
     /**
-     * Fetches URL queue list for the specified session with configurable ordering strategy.
-     * Supports sequential (default) and random ordering based on crawling configuration.
+     * Returns the configured {@code crawl.order} value for the session.
      *
      * @param sessionId the crawling session identifier
-     * @return list of URL queue entries for processing
+     * @return the configured value, or {@literal null} when it is not set
      */
-    @Override
-    protected List<OpenSearchUrlQueue> fetchUrlQueueList(final String sessionId) {
+    protected String getConfiguredCrawlOrder(final String sessionId) {
         final CrawlingConfigHelper crawlingConfigHelper = ComponentUtil.getCrawlingConfigHelper();
         final CrawlingConfig crawlingConfig = crawlingConfigHelper.get(sessionId);
         final Map<String, String> configParams = crawlingConfig.getConfigParameterMap(ConfigName.CONFIG);
-        final String crawlOrder = configParams.getOrDefault(CrawlingConfig.Param.Config.CRAWL_ORDER, ORDER_SEQUENTIAL);
-        if (ORDER_RANDOM.equals(crawlOrder)) {
-            return getList(OpenSearchUrlQueue.class, sessionId,
-                    QueryBuilders.functionScoreQuery(QueryBuilders.matchAllQuery(),
-                            new FunctionScoreQueryBuilder.FilterFunctionBuilder[] { new FunctionScoreQueryBuilder.FilterFunctionBuilder(
-                                    new RandomScoreFunctionBuilder().seed(sessionId.hashCode())) }),
-                    0, pollingFetchSize, SortBuilders.scoreSort().order(SortOrder.DESC));
+        return configParams.get(CrawlingConfig.Param.Config.CRAWL_ORDER);
+    }
+
+    @Override
+    protected UrlQueueOrder getUrlQueueOrder(final String sessionId) {
+        final String configured = getConfiguredCrawlOrder(sessionId);
+        if (StringUtil.isBlank(configured)) {
+            return super.getUrlQueueOrder(sessionId);
         }
-        if (!ORDER_SEQUENTIAL.equals(crawlOrder)) {
-            logger.warn("Invalid crawl order specified: {}. Falling back to sequential.", crawlOrder);
+        final String name = LEGACY_ORDER_NAMES.getOrDefault(configured, configured);
+        try {
+            final Object component = ComponentUtil.getComponent(name);
+            if (component instanceof UrlQueueOrder) {
+                return (UrlQueueOrder) component;
+            }
+            logger.warn("Component {} is not a UrlQueueOrder. Falling back to the default order.", name);
+        } catch (final Exception e) {
+            logger.warn("Invalid crawl order specified: {}. Falling back to the default order.", configured, e);
         }
-        return super.fetchUrlQueueList(sessionId);
+        return super.getUrlQueueOrder(sessionId);
     }
 }

--- a/src/test/java/org/codelibs/fess/crawler/service/FessUrlQueueServiceTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/service/FessUrlQueueServiceTest.java
@@ -15,51 +15,68 @@
  */
 package org.codelibs.fess.crawler.service;
 
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.codelibs.fess.crawler.order.impl.DepthFirstUrlQueueOrder;
+import org.codelibs.fess.crawler.order.impl.RandomUrlQueueOrder;
+import org.codelibs.fess.crawler.order.impl.SequentialUrlQueueOrder;
+import org.codelibs.fess.crawler.util.OpenSearchCrawlerConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 public class FessUrlQueueServiceTest extends UnitFessTestCase {
 
-    @Override
-    protected void setUp(TestInfo testInfo) throws Exception {
-        super.setUp(testInfo);
+    /** Resolves the order for a fixed crawl.order value without touching a crawling config. */
+    private static class TestFessUrlQueueService extends FessUrlQueueService {
+        private final String crawlOrder;
+
+        TestFessUrlQueueService(final String crawlOrder) {
+            // OpenSearchUrlQueueService's constructor reads getQueueIndex(), so a real config
+            // is required; its default (".crawler.queue") is never queried by these tests.
+            super(new OpenSearchCrawlerConfig());
+            this.crawlOrder = crawlOrder;
+        }
+
+        @Override
+        protected String getConfiguredCrawlOrder(final String sessionId) {
+            return crawlOrder;
+        }
     }
 
-    @Override
-    protected void tearDown(TestInfo testInfo) throws Exception {
-        super.tearDown(testInfo);
-    }
-
-    // Basic test to verify test framework is working
     @Test
-    public void test_basicAssertion() {
-        assertTrue(true);
-        assertFalse(false);
-        assertNotNull("test");
-        assertEquals(1, 1);
+    public void test_resolvesComponentName() {
+        final UrlQueueOrder order = new TestFessUrlQueueService("depthFirstUrlQueueOrder").getUrlQueueOrder("s1");
+        assertTrue(order instanceof DepthFirstUrlQueueOrder);
     }
 
-    // Test placeholder for future implementation
     @Test
-    public void test_placeholder() {
-        // This test verifies the test class can be instantiated and run
-        String testValue = "test";
-        assertNotNull(testValue);
-        assertEquals("test", testValue);
+    public void test_resolvesLegacySequential() {
+        final UrlQueueOrder order = new TestFessUrlQueueService("sequential").getUrlQueueOrder("s1");
+        assertTrue(order instanceof SequentialUrlQueueOrder);
     }
 
-    // Additional test for coverage
     @Test
-    public void test_additionalCoverage() {
-        int a = 5;
-        int b = 10;
-        int sum = a + b;
-        assertEquals(15, sum);
+    public void test_resolvesLegacyRandom() {
+        final UrlQueueOrder order = new TestFessUrlQueueService("random").getUrlQueueOrder("s1");
+        assertTrue(order instanceof RandomUrlQueueOrder);
+    }
 
-        String str = "Hello";
-        assertTrue(str.startsWith("H"));
-        assertTrue(str.endsWith("o"));
-        assertEquals(5, str.length());
+    @Test
+    public void test_blankFallsBackToDefault() {
+        final UrlQueueOrder order = new TestFessUrlQueueService("").getUrlQueueOrder("s1");
+        assertTrue(order instanceof SequentialUrlQueueOrder);
+        assertEquals(2, order.buildSorts("s1").length);
+    }
+
+    @Test
+    public void test_unknownNameFallsBackToDefault() {
+        final UrlQueueOrder order = new TestFessUrlQueueService("noSuchOrder").getUrlQueueOrder("s1");
+        assertTrue(order instanceof SequentialUrlQueueOrder);
+    }
+
+    @Test
+    public void test_wrongTypeFallsBackToDefault() {
+        // systemProperties is a registered component (test_app.xml) that is not a UrlQueueOrder.
+        final UrlQueueOrder order = new TestFessUrlQueueService("systemProperties").getUrlQueueOrder("s1");
+        assertTrue(order instanceof SequentialUrlQueueOrder);
     }
 }

--- a/src/test/java/org/codelibs/fess/crawler/service/FessUrlQueueServiceTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/service/FessUrlQueueServiceTest.java
@@ -21,6 +21,7 @@ import org.codelibs.fess.crawler.order.impl.RandomUrlQueueOrder;
 import org.codelibs.fess.crawler.order.impl.SequentialUrlQueueOrder;
 import org.codelibs.fess.crawler.util.OpenSearchCrawlerConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 
 public class FessUrlQueueServiceTest extends UnitFessTestCase {
@@ -51,7 +52,11 @@ public class FessUrlQueueServiceTest extends UnitFessTestCase {
     @Test
     public void test_resolvesLegacySequential() {
         final UrlQueueOrder order = new TestFessUrlQueueService("sequential").getUrlQueueOrder("s1");
-        assertTrue(order instanceof SequentialUrlQueueOrder);
+        // Assert identity against the container instance so the alias is actually exercised:
+        // the fallback path (LEGACY_ORDER_NAMES not containing "sequential") also returns a
+        // SequentialUrlQueueOrder, but a different instance, so only an identity check catches
+        // the alias being removed.
+        assertSame(ComponentUtil.getComponent("sequentialUrlQueueOrder"), order);
     }
 
     @Test

--- a/src/test/resources/test_app.xml
+++ b/src/test/resources/test_app.xml
@@ -8,6 +8,20 @@
 	<!-- Register systemProperties for test environment -->
 	<component name="systemProperties" class="org.codelibs.fess.unit.TestSystemProperties" />
 
+	<!-- UrlQueueOrder components, registered directly (not crawler_opensearch.xml, which pulls in
+	     fesenClient and the crawler stack that needs a running OpenSearch) for
+	     FessUrlQueueServiceTest's crawl.order resolution tests. -->
+	<component name="sequentialUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.SequentialUrlQueueOrder" />
+	<component name="randomUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.RandomUrlQueueOrder" />
+	<component name="depthFirstUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.DepthFirstUrlQueueOrder" />
+	<component name="newestFirstUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.NewestFirstUrlQueueOrder" />
+	<component name="weightFirstUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.WeightFirstUrlQueueOrder" />
+
 	<!-- Stateless helper used by v2 chat API handlers/tests (its getUserId DI path is exercised
 	     only in production; handler tests override the handler getUserId seam). -->
 	<component name="chatApiHelper" class="org.codelibs.fess.helper.ChatApiHelper" />


### PR DESCRIPTION
`crawl.order` was an if/else over two hard-coded values, so adding a fetch order meant patching Fess. fess-crawler now ships the orders as DI components behind a `UrlQueueOrder` extension point, and this makes `crawl.order` name one of them.

`FessUrlQueueService` no longer overrides `fetchUrlQueueList` and no longer builds the random query itself — that logic moved to `randomUrlQueueOrder` upstream, unchanged, including its `sessionId.hashCode()` seed. All that remains here is resolving the component:

```java
@Override
protected UrlQueueOrder getUrlQueueOrder(final String sessionId) {
    final String configured = getConfiguredCrawlOrder(sessionId);
    if (StringUtil.isBlank(configured)) {
        return super.getUrlQueueOrder(sessionId);
    }
    final String name = LEGACY_ORDER_NAMES.getOrDefault(configured, configured);
    ...
}
```

## Backward compatibility

`config.crawl.order=sequential` and `config.crawl.order=random` keep working through `LEGACY_ORDER_NAMES`, which maps them onto `sequentialUrlQueueOrder` and `randomUrlQueueOrder`. An unset value short-circuits before any container lookup and returns the default order, so the common case does not touch the container at all. An unresolvable name, or a name that resolves to something that is not a `UrlQueueOrder`, logs a warning and falls back to the default rather than failing the crawl.

The available names are `sequentialUrlQueueOrder` (the default), `randomUrlQueueOrder`, `depthFirstUrlQueueOrder`, `newestFirstUrlQueueOrder` and `weightFirstUrlQueueOrder`. A plugin can add its own through `fess_crawler++.xml`.

Note that weights are uniform unless a custom `UrlQueueWeigher` is installed, so `weightFirstUrlQueueOrder` has no practical effect out of the box.

## Tests

The test class that stood here asserted `true == true` in three methods. It now covers name resolution, both legacy aliases, the unset case, and both fallback paths. The five order components are registered in `test_app.xml` so the resolution tests exercise a real container lookup — including `crawler_opensearch.xml` instead would pull in the whole crawler stack and require a running OpenSearch.

Requires the corresponding fess-crawler change; CI here will not pass until that is released.
