### PR TITLE
fix: report an invalid crawl.order once per crawl, not once per queue poll

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/service/FessUrlQueueService.java
+++ b/src/main/java/org/codelibs/fess/crawler/service/FessUrlQueueService.java
@@ -16,6 +16,8 @@
 package org.codelibs.fess.crawler.service;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,6 +41,17 @@ public class FessUrlQueueService extends OpenSearchUrlQueueService {
     /** Aliases from the crawl.order values that shipped before the orders became components. */
     protected static final Map<String, String> LEGACY_ORDER_NAMES =
             Map.of("sequential", "sequentialUrlQueueOrder", "random", "randomUrlQueueOrder");
+
+    /**
+     * The crawl.order values already reported as unusable.
+     *
+     * <p>
+     * The order is resolved on every queue poll, so without this a single misconfigured
+     * crawling config fills the crawler log with the same warning. The crawler runs as its own
+     * process per crawl, so this reports each bad value once per crawl.
+     * </p>
+     */
+    protected final Set<String> reportedInvalidOrders = ConcurrentHashMap.newKeySet();
 
     /**
      * Constructs a new FessUrlQueueService with the specified crawler configuration.
@@ -74,11 +87,15 @@ public class FessUrlQueueService extends OpenSearchUrlQueueService {
             if (component instanceof UrlQueueOrder) {
                 return (UrlQueueOrder) component;
             }
-            logger.warn("Component {} is not a UrlQueueOrder. Falling back to the default order.", name);
+            if (reportedInvalidOrders.add(configured)) {
+                logger.warn("Component {} is not a UrlQueueOrder. Falling back to the default order.", name);
+            }
         } catch (final Exception e) {
-            logger.warn("Invalid crawl order specified: {}. Falling back to the default order.", configured);
-            if (logger.isDebugEnabled()) {
-                logger.debug("Failed to resolve crawl order component: {}", name, e);
+            if (reportedInvalidOrders.add(configured)) {
+                logger.warn("Invalid crawl order specified: {}. Falling back to the default order.", configured);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Failed to resolve crawl order component: {}", name, e);
+                }
             }
         }
         return super.getUrlQueueOrder(sessionId);

--- a/src/test/java/org/codelibs/fess/crawler/service/FessUrlQueueServiceTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/service/FessUrlQueueServiceTest.java
@@ -79,6 +79,17 @@ public class FessUrlQueueServiceTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_invalidNameIsReportedOnceNotPerPoll() {
+        final TestFessUrlQueueService service = new TestFessUrlQueueService("noSuchOrder");
+        for (int i = 0; i < 5; i++) {
+            assertTrue(service.getUrlQueueOrder("s1") instanceof SequentialUrlQueueOrder);
+        }
+        // getUrlQueueOrder runs once per queue poll; the warning must not.
+        assertEquals(1, service.reportedInvalidOrders.size());
+        assertTrue(service.reportedInvalidOrders.contains("noSuchOrder"));
+    }
+
+    @Test
     public void test_wrongTypeFallsBackToDefault() {
         // systemProperties is a registered component (test_app.xml) that is not a UrlQueueOrder.
         final UrlQueueOrder order = new TestFessUrlQueueService("systemProperties").getUrlQueueOrder("s1");


### PR DESCRIPTION
Follow-up from verifying #3353 against a live crawl.

`getUrlQueueOrder` runs on every queue poll, so one typo in `crawl.order` filled the crawler log with the same line. Measured on a 10-page fixture: **24 identical warnings** at the shipped polling batch size, 30 at a batch size of 1. The count tracks `poll()` calls — including the empty polls at the end of a crawl — not batches, so shrinking the batch is not what drives it.

Each unusable value is now reported once. The crawler runs as its own process per crawl, so that is once per crawl, and a second crawling config with a different bad value still gets its own line. The debug detail moved inside the same guard, so a debug-level run does not collect the exception 24 times either.

Verified on the same fixture after the change: `config.crawl.order=noSuchOrder` produces exactly one warning and the crawl completes on the default order.

## Tests

`mvn -B clean package` passes: 7431 tests, no failures. `FessUrlQueueServiceTest` gains a case asserting that repeated resolution of the same bad value records it once.
