### PR TITLE
fix(log): bound the Tomcat JUL log with a FileHandler size limit

### DIFF
--- a/src/main/assemblies/files/logging.properties
+++ b/src/main/assemblies/files/logging.properties
@@ -7,6 +7,8 @@ java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.FileHandler.level=INFO
 java.util.logging.FileHandler.pattern=${fess.log.path}/server_%g.log
 java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
+# Without a limit the handler never rotates on size: cap each file and keep 10 (~100MB).
+java.util.logging.FileHandler.limit=10485760
 java.util.logging.FileHandler.count=10
 
 # Suppress warning logs


### PR DESCRIPTION
## Problem

`logs/server_0.log` grows without bound for the lifetime of the Fess JVM.

`bin/logging.properties` configures the Tomcat JUL handler with `count=10` but never sets
`limit`. In `java.util.logging.FileHandler`:

- `configure()` defaults `limit` to `0`.
- `publish0()` rotates only under `if (limit > 0 && ...)`, so with `limit=0` the handler
  never rotates on size and `count` never comes into play while the JVM runs.
- `count=10` still takes effect at startup, because `append` defaults to `false` and
  `openFiles()` then calls `rotate()` once per boot. So the 10 files are 10 *boots*, not a
  size ceiling.

A long-running instance therefore keeps one ever-growing `server_0.log`. Any JUL-routed
warning that repeats (for example a `TimeoutManager` failure while the search engine is
unreachable) writes a stack trace per occurrence straight into that single file.

This affects only the main Fess process. The crawler, suggest, chunk and thumbnail child
JVMs pass `-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager`
(`jvm.*.options` in `fess_config.properties`), so their JUL output goes to log4j2, which
already has rollover and `Delete` configured.

## Fix

Set `java.util.logging.FileHandler.limit=10485760` (10MB). Together with the existing
`count=10` this caps the Tomcat log at roughly 100MB.

10MB rather than the 100MB used by the log4j2 appenders because these files are not
compressed on rollover, so the ceiling is a real 100MB on disk.

## Verification

Loaded the shipped `logging.properties` through `LogManager.readConfiguration()` with the
same `${fess.log.path}` substitution `FessBoot` performs, then wrote ~30MB of records:

| | files produced | largest file |
|---|---|---|
| before | 1 | 30.7MB (unbounded) |
| after | 4 | 10.0MB |

Writing past `10 x limit` confirmed the set stays capped at `count` files, with the oldest
discarded.
