### PR TITLE
fix(sso): name an Entra ID user by its directory object id

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/EntraIdCredential.java
@@ -32,6 +32,8 @@ import org.lastaflute.web.login.credential.LoginCredential;
 
 import com.microsoft.aad.msal4j.IAccount;
 import com.microsoft.aad.msal4j.IAuthenticationResult;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
 
 /**
  * Microsoft Entra ID credential implementation for Fess authentication.
@@ -193,12 +195,14 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                 final SystemHelper systemHelper = ComponentUtil.getSystemHelper();
                 final Set<String> permissionSet = new HashSet<>();
                 final IAccount account = authResult.account();
-                final String homeAccountId = account.homeAccountId();
+                final String objectId = getObjectId();
                 final String username = account.username();
                 if (logger.isDebugEnabled()) {
-                    logger.debug("homeAccountId={}, username={}", homeAccountId, username);
+                    logger.debug("objectId={}, username={}", objectId, username);
                 }
-                permissionSet.add(systemHelper.getSearchRoleByDirectoryUser(homeAccountId));
+                if (StringUtil.isNotBlank(objectId)) {
+                    permissionSet.add(systemHelper.getSearchRoleByDirectoryUser(objectId));
+                }
                 permissionSet.add(systemHelper.getSearchRoleByDirectoryUser(username));
                 if (ComponentUtil.getFessConfig().isEntraIdUseDomainServices() && username.indexOf('@') >= 0) {
                     final String[] values = username.split("@");
@@ -211,6 +215,36 @@ public class EntraIdCredential implements LoginCredential, FessCredential {
                 permissions = permissionSet.stream().filter(StringUtil::isNotBlank).distinct().toArray(n -> new String[n]);
             }
             return permissions;
+        }
+
+        /**
+         * Reads the {@code oid} claim -- the user's object id in this tenant -- out of the ID
+         * token.
+         *
+         * <p>Microsoft Graph names a user by that object id, so it is the value a crawler writes
+         * into the {@code role} field of a document this user owns. {@code IAccount} exposes no
+         * plain object id of its own: {@code homeAccountId()} is MSAL4J's own account key, and
+         * {@code getTenantProfiles()} is null on the account an {@code IAuthenticationResult}
+         * carries.
+         *
+         * @return The object id, or null when the ID token carries none.
+         */
+        protected String getObjectId() {
+            final String idToken = authResult.idToken();
+            if (StringUtil.isBlank(idToken)) {
+                logger.warn("No ID token for {}. The object id permission is not granted.", getName());
+                return null;
+            }
+            try {
+                final JWTClaimsSet claimsSet = JWTParser.parse(idToken).getJWTClaimsSet();
+                if (claimsSet != null) {
+                    return claimsSet.getStringClaim("oid");
+                }
+                logger.warn("The ID token of {} carries no claims. The object id permission is not granted.", getName());
+            } catch (final Exception e) {
+                logger.warn("Failed to read the oid claim of {}. The object id permission is not granted.", getName(), e);
+            }
+            return null;
         }
 
         @Override

--- a/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/EntraIdUserPermissionTest.java
@@ -40,14 +40,26 @@ import org.junit.jupiter.api.Test;
 import com.microsoft.aad.msal4j.IAccount;
 import com.microsoft.aad.msal4j.IAuthenticationResult;
 import com.microsoft.aad.msal4j.ITenantProfile;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 
 public class EntraIdUserPermissionTest extends UnitFessTestCase {
+
+    /** The user's object id in the tenant, as the ID token's {@code oid} claim carries it. */
+    private static final String OBJECT_ID = "3f7a1c9e-0b52-4d18-9a6c-2e5b8d41f0aa";
+
+    /** An ID token carrying {@link #OBJECT_ID}, in the shape MSAL4J hands back. */
+    private static final String ID_TOKEN = new PlainJWT(new JWTClaimsSet.Builder().claim("oid", OBJECT_ID).build()).serialize();
 
     private static IAuthenticationResult authResult() {
         return authResult(new Date(Long.MAX_VALUE), "access-token");
     }
 
     private static IAuthenticationResult authResult(final Date expiresOn, final String accessToken) {
+        return authResult(expiresOn, accessToken, ID_TOKEN);
+    }
+
+    private static IAuthenticationResult authResult(final Date expiresOn, final String accessToken, final String idToken) {
         final IAccount account = new IAccount() {
             private static final long serialVersionUID = 1L;
 
@@ -81,7 +93,7 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
 
             @Override
             public String idToken() {
-                return "id-token";
+                return idToken;
             }
 
             @Override
@@ -115,13 +127,17 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
      * Builds an EntraIdUser without letting its constructor talk to Microsoft Graph.
      */
     private EntraIdUser newUser() {
+        return newUser(authResult());
+    }
+
+    private EntraIdUser newUser(final IAuthenticationResult authResult) {
         ComponentUtil.register(new EntraIdAuthenticator() {
             @Override
             public void scheduleUpdateMemberOf(final EntraIdUser user) {
                 // the test drives setGroups/setRoles itself
             }
         }, EntraIdAuthenticator.class.getCanonicalName());
-        return new EntraIdUser(authResult());
+        return new EntraIdUser(authResult);
     }
 
     @Test
@@ -159,7 +175,40 @@ public class EntraIdUserPermissionTest extends UnitFessTestCase {
         // The account username is taro@contoso.onmicrosoft.com, so nothing is truncated here; the
         // assertion that matters is that the value arrives whole and prefixed.
         assertTrue(permissions.toString(), permissions.contains("1taro@contoso.onmicrosoft.com"));
-        assertTrue(permissions.toString(), permissions.contains("1home-account-id"));
+        assertTrue(permissions.toString(), permissions.contains("1" + OBJECT_ID));
+    }
+
+    @Test
+    public void test_getPermissions_namesTheUserByTheObjectIdInTheIdToken() {
+        // Microsoft Graph names a user by the object id, so that is the value a crawler writes
+        // into the role field of a document the user owns. homeAccountId() is MSAL4J's own
+        // account key -- "<object id>.<tenant id>" -- and a permission built from it matches no
+        // such role, so the user never saw a document granted to them by object id.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdUser user = newUser();
+        user.setGroups(new String[0]);
+        user.setRoles(new String[0]);
+
+        final List<String> permissions = Arrays.asList(user.getPermissions());
+
+        assertTrue(permissions.toString(), permissions.contains("1" + OBJECT_ID));
+        assertFalse(permissions.toString(), permissions.contains("1home-account-id"));
+    }
+
+    @Test
+    public void test_getPermissions_grantsNoObjectIdPermissionWhenTheIdTokenCarriesNone() {
+        // A missing or unreadable oid claim must drop the permission, not encode a literal "null"
+        // -- which is not blank, so the trailing filter would keep it, and a document whose role
+        // field held it would be readable by every such session.
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final EntraIdUser user = newUser(authResult(new Date(Long.MAX_VALUE), "access-token", "not-a-jwt"));
+        user.setGroups(new String[0]);
+        user.setRoles(new String[0]);
+
+        final List<String> permissions = Arrays.asList(user.getPermissions());
+
+        assertFalse(permissions.toString(), permissions.stream().anyMatch(p -> p.contains("null")));
+        assertTrue(permissions.toString(), permissions.contains("1taro@contoso.onmicrosoft.com"));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`EntraIdCredential` built the logged-in user's own search permission from `IAccount#homeAccountId()`. MSAL4J composes that value as `<object id>.<tenant id>` for its own account cache, so the permission became `1<object id>.<tenant id>`.

Microsoft Graph names a user by the object id alone, so that is the value a crawler writes into the `role` field of a document the user owns — `fess-ds-microsoft365` does this for OneNote notebooks and OneDrive items. The two shapes never matched, so a document granted to a user by object id was never returned to that user.

Group permissions use the plain group id on both sides and were unaffected, so this only showed up where a document is granted to a user directly.

The value changed shape in the ADAL4J to MSAL4J migration (#2914); ADAL4J's `getUserInfo().getUniqueId()` was the plain object id.

## Change

Read the object id from the `oid` claim of the ID token. `IAccount` exposes no plain object id of its own: `getTenantProfiles()` is null on the account an `IAuthenticationResult` carries, and the `uid` half of `homeAccountId` is the object id in the user's home tenant, which for a guest is not the id Graph reports.

A missing or unreadable claim drops that permission rather than encoding a literal `"null"`, which the trailing blank filter would keep. The user-principal-name permission is unchanged.

## Tests

`EntraIdUserPermissionTest` — 13 tests, green. Two new cases, both failing without the change:

- `test_getPermissions_namesTheUserByTheObjectIdInTheIdToken`
- `test_getPermissions_grantsNoObjectIdPermissionWhenTheIdTokenCarriesNone`

`EntraIdAuthenticator`'s unit tests and `OpenIdConnectCredentialTest` also run green (157 tests in total).
