### PR TITLE
fix(search): keep search_after total when a point in time spans indices

### DIFF
--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -175,6 +175,7 @@ import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
@@ -1747,7 +1748,13 @@ public class SearchEngineClient implements Client {
      */
     protected void pitSearch(final String index, final String keepAlive, final String searchTimeout, final SearchRequestBuilder builder,
             final BooleanFunction<SearchResponse> pageHandler) {
+        // _shard_doc alone is not a total order once the point in time spans more than one index:
+        // the value restarts per index, so the same number appears in several of them. search_after
+        // asks for values strictly greater than the last one on the page, so a page that ends on a
+        // repeated value drops every document another index still holds at or below it. Ordering by
+        // the index name as well makes the pair unique again.
         builder.addSort(SortBuilders.shardDocSort());
+        builder.addSort(SortBuilders.fieldSort("_index").order(SortOrder.ASC));
 
         final SearchRequest request = builder.request();
         final TimeValue keepAliveValue = TimeValue.parseTimeValue(keepAlive, "keepAlive");
@@ -1761,6 +1768,12 @@ public class SearchEngineClient implements Client {
             request.routing((String) null);
         }
         final String pitId = client.execute(CreatePitAction.INSTANCE, createPitRequest).actionGet(searchTimeout).getId();
+        if (pitId == null) {
+            // A closed or otherwise unavailable index answers with no identifier rather than an
+            // error, and the builder below would then fail with a bare NullPointerException that
+            // says nothing about the index.
+            throw new SearchEngineClientException("[" + index + "] Failed to open a point in time.");
+        }
         try {
             builder.setPointInTime(new PointInTimeBuilder(pitId).setKeepAlive(keepAliveValue));
             Object[] searchAfter = null;

--- a/src/main/java/org/codelibs/fess/opensearch/config/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/config/allcommon/EsAbstractBehavior.java
@@ -68,6 +68,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.transport.client.Client;
 
 /**
@@ -264,7 +265,11 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         }
         esCb.request().build(builder);
         final SearchRequestBuilder searchBuilder = esCb.build(builder);
+        // _shard_doc restarts per index, so it is only a total order while the point in time covers
+        // a single one. Ordering by the index name as well keeps search_after from skipping
+        // documents if it ever covers more.
         searchBuilder.addSort(SortBuilders.shardDocSort());
+        searchBuilder.addSort(SortBuilders.fieldSort("_index").order(SortOrder.ASC));
 
         // A point in time carries the indices, routing and preference itself, and a search that
         // repeats any of them is rejected with a 400 ("[indices]/[routing]/[preference] cannot be

--- a/src/main/java/org/codelibs/fess/opensearch/log/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/log/allcommon/EsAbstractBehavior.java
@@ -68,6 +68,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.transport.client.Client;
 
 /**
@@ -264,7 +265,11 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         }
         esCb.request().build(builder);
         final SearchRequestBuilder searchBuilder = esCb.build(builder);
+        // _shard_doc restarts per index, so it is only a total order while the point in time covers
+        // a single one. Ordering by the index name as well keeps search_after from skipping
+        // documents if it ever covers more.
         searchBuilder.addSort(SortBuilders.shardDocSort());
+        searchBuilder.addSort(SortBuilders.fieldSort("_index").order(SortOrder.ASC));
 
         // A point in time carries the indices, routing and preference itself, and a search that
         // repeats any of them is rejected with a 400 ("[indices]/[routing]/[preference] cannot be

--- a/src/main/java/org/codelibs/fess/opensearch/user/allcommon/EsAbstractBehavior.java
+++ b/src/main/java/org/codelibs/fess/opensearch/user/allcommon/EsAbstractBehavior.java
@@ -68,6 +68,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.transport.client.Client;
 
 /**
@@ -264,7 +265,11 @@ public abstract class EsAbstractBehavior<ENTITY extends Entity, CB extends Condi
         }
         esCb.request().build(builder);
         final SearchRequestBuilder searchBuilder = esCb.build(builder);
+        // _shard_doc restarts per index, so it is only a total order while the point in time covers
+        // a single one. Ordering by the index name as well keeps search_after from skipping
+        // documents if it ever covers more.
         searchBuilder.addSort(SortBuilders.shardDocSort());
+        searchBuilder.addSort(SortBuilders.fieldSort("_index").order(SortOrder.ASC));
 
         // A point in time carries the indices, routing and preference itself, and a search that
         // repeats any of them is rejected with a 400 ("[indices]/[routing]/[preference] cannot be

--- a/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientTest.java
@@ -25,13 +25,28 @@ import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.BooleanFunction;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.search.CreatePitAction;
+import org.opensearch.action.search.CreatePitResponse;
+import org.opensearch.action.search.DeletePitRequest;
+import org.opensearch.action.search.DeletePitResponse;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequestBuilder;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortOrder;
 
 public class SearchEngineClientTest extends UnitFessTestCase {
 
@@ -128,6 +143,90 @@ public class SearchEngineClientTest extends UnitFessTestCase {
             }
         }.warnUnlessOpenSearch3();
         assertEquals(0, reports.get());
+    }
+
+    /**
+     * A point in time opened on an alias covers every index behind it, and _shard_doc restarts per
+     * index -- the same value shows up in several of them. search_after asks for values strictly
+     * greater than the last one on the page, so without a second key a page ending on a repeated
+     * value silently drops whatever another index still holds at or below it. The index name is
+     * therefore sorted on as well.
+     */
+    @Test
+    public void test_pitSearch_ordersByIndexAfterShardDoc() throws Exception {
+        final List<SearchRequest> searches = new ArrayList<>();
+        final SearchEngineClient client = pitStub(searches, "pit-1");
+
+        client.pitSearch("fess_config", "1m", "10s", new SearchRequestBuilder(client, SearchAction.INSTANCE), response -> true);
+
+        assertEquals(1, searches.size());
+        final List<SortBuilder<?>> sorts = searches.get(0).source().sorts();
+        assertNotNull(sorts);
+        assertTrue(sorts.size() >= 2);
+        assertEquals("_shard_doc", sorts.get(sorts.size() - 2).getWriteableName());
+        final SortBuilder<?> last = sorts.get(sorts.size() - 1);
+        assertTrue(last instanceof FieldSortBuilder);
+        assertEquals("_index", ((FieldSortBuilder) last).getFieldName());
+        assertEquals(SortOrder.ASC, ((FieldSortBuilder) last).order());
+    }
+
+    /**
+     * A closed or otherwise unavailable index answers the create request with no identifier instead
+     * of an error. Building the point in time from that null used to fail with a bare
+     * NullPointerException, which said nothing about which index was at fault.
+     */
+    @Test
+    public void test_pitSearch_reportsAMissingPitId() throws Exception {
+        final List<SearchRequest> searches = new ArrayList<>();
+        final SearchEngineClient client = pitStub(searches, null);
+
+        try {
+            client.pitSearch("fess_config", "1m", "10s", new SearchRequestBuilder(client, SearchAction.INSTANCE), response -> true);
+            fail("a missing point in time must be reported");
+        } catch (final SearchEngineClientException e) {
+            assertTrue(e.getMessage().contains("fess_config"));
+        }
+        assertTrue(searches.isEmpty());
+    }
+
+    /**
+     * A client whose create-point-in-time answers with the given identifier and whose searches
+     * always come back empty, so a walk ends after one page.
+     */
+    private SearchEngineClient pitStub(final List<SearchRequest> searches, final String pitId) {
+        return new SearchEngineClient() {
+            {
+                // pitSearch talks to the delegate; point it back at this instance so the overrides
+                // below are the ones that answer.
+                this.client = this;
+            }
+
+            @Override
+            public void deletePits(final DeletePitRequest request, final ActionListener<DeletePitResponse> listener) {
+                listener.onResponse(new DeletePitResponse(List.of()));
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse> ActionFuture<Response> execute(
+                    final ActionType<Response> action, final Request request) {
+                final PlainActionFuture<Response> future = PlainActionFuture.newFuture();
+                if (CreatePitAction.INSTANCE.equals(action)) {
+                    future.onResponse(
+                            (Response) new CreatePitResponse(pitId, System.currentTimeMillis(), 1, 1, 0, 0, new ShardSearchFailure[0]));
+                } else if (SearchAction.INSTANCE.equals(action)) {
+                    searches.add((SearchRequest) request);
+                    try {
+                        future.onResponse((Response) responseWithIds());
+                    } catch (final Exception e) {
+                        throw new IllegalStateException(e);
+                    }
+                } else {
+                    future.onResponse(null);
+                }
+                return future;
+            }
+        };
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/opensearch/config/allcommon/EsAbstractBehaviorPitTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/config/allcommon/EsAbstractBehaviorPitTest.java
@@ -43,6 +43,9 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.search.SearchHits;
@@ -228,7 +231,8 @@ public class EsAbstractBehaviorPitTest extends UnitFessTestCase {
 
     /**
      * The sort ends with the _shard_doc tiebreaker, without which search_after has no total order
-     * to walk and can repeat or skip documents.
+     * to walk and can repeat or skip documents. _shard_doc restarts per index, so the index name
+     * follows it to keep the pair unique if the point in time ever covers more than one.
      */
     @Test
     public void test_pitSearch_appendsShardDocTiebreaker() throws Exception {
@@ -239,9 +243,13 @@ public class EsAbstractBehaviorPitTest extends UnitFessTestCase {
 
         final SearchRequest search = searchRequests().get(0);
         assertNotNull(search.source().sorts());
-        assertFalse(search.source().sorts().isEmpty());
-        final String last = search.source().sorts().get(search.source().sorts().size() - 1).getWriteableName();
-        assertEquals("_shard_doc", last);
+        final List<SortBuilder<?>> sorts = search.source().sorts();
+        assertTrue(sorts.size() >= 2);
+        assertEquals("_shard_doc", sorts.get(sorts.size() - 2).getWriteableName());
+        final SortBuilder<?> last = sorts.get(sorts.size() - 1);
+        assertTrue(last instanceof FieldSortBuilder);
+        assertEquals("_index", ((FieldSortBuilder) last).getFieldName());
+        assertEquals(SortOrder.ASC, ((FieldSortBuilder) last).order());
     }
 
     /**


### PR DESCRIPTION
Found while checking 15.9 against a live cluster before the release.

## Problem

`/admin/backup/` and `GET /api/admin/backup/file/{id}` lose documents. The request succeeds, `response.status` is `0`, and nothing is logged, so the export simply contains fewer documents than the index holds. Restoring from it drops whatever it left behind.

Exporting the configuration alias, which covers 25 indices, returned **202 of 211** documents at the shipped page size.

## Cause

#3340 replaced the scroll API with a point in time plus `search_after`, sorted on `_shard_doc` alone. `_shard_doc` restarts per index, so a point in time opened on an alias or a pattern hands the same value out more than once. Walking `fess_config.*` gives 80 distinct values for 211 documents — 79 of them repeated, with `0` appearing in seven different indices.

`search_after` asks for values strictly greater than the last one on the page, so a page that ends on a repeated value skips every document another index still holds at or below it. The loss depends on where the page boundaries land:

| page size | walked | missing |
|---|---|---|
| 10 | 202 | 9 (4.3%) |
| 25 | 200 | 11 (5.2%) |
| 50 | 208 | 3 (1.4%) |
| 100 | 210 | 1 (0.5%) |
| 500 (one page) | 211 | 0 |

A smaller page lands on more boundaries, so it loses more.

## Scope

Only walks that cover more than one index are affected. A single-index walk has no repeats, so `GET /api/v2/documents/all`, document purge, the label updater and the chunk vector job return everything; that was confirmed separately. The exposed paths are the ones that walk an alias: the backup exports, the configuration index rebuild under `/admin/maintenance/`, and `IndexExportJob`.

## Fix

Sort by the index name after `_shard_doc`. The pair is unique again, and the same walk then returns all 211 documents at every page size tried. The `EsAbstractBehavior` walkers take one index apiece and were never exposed to this, but they sort the same way now so that pointing one at an alias stays correct.

Opening a point in time on an index that cannot serve it answers with no identifier rather than an error, and `PointInTimeBuilder` then failed with a bare `NullPointerException` naming neither the index nor the cause. That is now a `SearchEngineClientException` carrying the index name.

## Tests

`SearchEngineClientTest` gains two cases: one asserting the sort ends with `_shard_doc` then `_index` ascending, one asserting a missing identifier is reported rather than thrown as an NPE. `EsAbstractBehaviorPitTest`'s tiebreaker case now covers both keys. Both new cases fail without the change.
