### PR TITLE
fix(user): apply the password policy to the admin API as well

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/user/AdminUserAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/user/AdminUserAction.java
@@ -430,14 +430,25 @@ public class AdminUserAction extends FessAdminAction {
                 messages.addErrorsInvalidConfirmPassword("confirmPassword");
             }, validationErrorLambda);
         }
-        if (StringUtil.isNotBlank(form.password)) {
-            final String validationError = ComponentUtil.getSystemHelper().validatePassword(form.password);
-            if (StringUtil.isNotBlank(validationError)) {
-                resetPassword(form);
-                throwValidationError(messages -> {
-                    addPasswordValidationError(messages, validationError);
-                }, validationErrorLambda);
-            }
+        verifyPasswordPolicy(form, messages -> throwValidationError(messages, validationErrorLambda));
+    }
+
+    /**
+     * Applies the configured password policy to the form's password, reporting the first rule it
+     * breaks. Shared with the REST API so that a password the admin screens refuse cannot be set
+     * through an API call instead.
+     *
+     * @param form the form carrying the password to check
+     * @param throwError callback to report a policy violation
+     */
+    public static void verifyPasswordPolicy(final CreateForm form, final Consumer<VaMessenger<FessMessages>> throwError) {
+        if (StringUtil.isBlank(form.password)) {
+            return;
+        }
+        final String validationError = ComponentUtil.getSystemHelper().validatePassword(form.password);
+        if (StringUtil.isNotBlank(validationError)) {
+            resetPassword(form);
+            throwError.accept(messages -> addPasswordValidationError(messages, validationError));
         }
     }
 
@@ -447,7 +458,7 @@ public class AdminUserAction extends FessAdminAction {
      * @param messages the FessMessages object to add the error to
      * @param errorKey the error key identifying the type of password validation error
      */
-    protected void addPasswordValidationError(final FessMessages messages, final String errorKey) {
+    protected static void addPasswordValidationError(final FessMessages messages, final String errorKey) {
         switch (errorKey) {
         case "errors.password_length" -> messages.addErrorsPasswordLength("password",
                 String.valueOf(ComponentUtil.getFessConfig().getPasswordMinLengthAsInteger()));

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/user/ApiAdminUserAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/user/ApiAdminUserAction.java
@@ -17,16 +17,19 @@ package org.codelibs.fess.app.web.api.admin.user;
 
 import static org.codelibs.fess.app.web.admin.user.AdminUserAction.getUser;
 import static org.codelibs.fess.app.web.admin.user.AdminUserAction.validateAttributes;
+import static org.codelibs.fess.app.web.admin.user.AdminUserAction.verifyPasswordPolicy;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.app.pager.UserPager;
 import org.codelibs.fess.app.service.UserService;
 import org.codelibs.fess.app.web.CrudMode;
 import org.codelibs.fess.app.web.api.ApiResult;
+import org.codelibs.fess.app.web.admin.user.CreateForm;
 import org.codelibs.fess.app.web.api.admin.FessApiAdminAction;
 import org.codelibs.fess.opensearch.user.exentity.User;
 import org.lastaflute.web.Execute;
@@ -104,6 +107,7 @@ public class ApiAdminUserAction extends FessApiAdminAction {
     @Execute
     public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
+        verifyPassword(body, true);
         body.crudMode = CrudMode.CREATE;
         final User entity = getUser(body).orElseGet(() -> {
             throwValidationErrorApi(messages -> {
@@ -132,6 +136,7 @@ public class ApiAdminUserAction extends FessApiAdminAction {
     public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         validateAttributes(body.attributes, this::throwValidationErrorApi);
+        verifyPassword(body, false);
         body.crudMode = CrudMode.EDIT;
         final User entity = getUser(body).orElseGet(() -> {
             throwValidationErrorApi(messages -> {
@@ -146,6 +151,26 @@ public class ApiAdminUserAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, buildThrowableMessage(e)));
         }
         return asJson(new ApiResult.ApiUpdateResponse().id(entity.getId()).created(false).status(ApiResult.Status.OK).result());
+    }
+
+    /**
+     * Runs the password checks the admin screens run. Without this the API could store a password
+     * the screens refuse, and the account is then usable to log in with it.
+     *
+     * <p>The confirmation field is a typing aid rather than part of the policy, so it is only
+     * compared when the caller sends one; an API client that omits it keeps working.</p>
+     *
+     * @param body the request body carrying the password
+     * @param creating true while creating a user, when a password is mandatory
+     */
+    protected void verifyPassword(final CreateForm body, final boolean creating) {
+        if (creating && StringUtil.isBlank(body.password)) {
+            throwValidationErrorApi(messages -> messages.addErrorsBlankPassword("password"));
+        }
+        if (body.confirmPassword != null && !body.confirmPassword.equals(body.password)) {
+            throwValidationErrorApi(messages -> messages.addErrorsInvalidConfirmPassword("confirmPassword"));
+        }
+        verifyPasswordPolicy(body, this::throwValidationErrorApi);
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/admin/user/AdminUserActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/user/AdminUserActionTest.java
@@ -19,7 +19,10 @@ import java.util.Map;
 
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.web.CrudMode;
+import org.codelibs.fess.helper.SystemHelper;
+import org.codelibs.fess.mylasta.action.FessMessages;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -170,5 +173,59 @@ public class AdminUserActionTest extends UnitFessTestCase {
         assertEquals(2, CrudMode.EDIT);
         assertEquals(3, CrudMode.DELETE);
         assertEquals(4, CrudMode.DETAILS);
+    }
+
+    /**
+     * The password policy is shared with the REST API, so a password the screens refuse cannot be
+     * set through an API call instead. A blacklisted password is one such case.
+     */
+    @Test
+    public void test_verifyPasswordPolicy_rejectsABlacklistedPassword() {
+        assertTrue(policyErrorOf("admin").contains("password"));
+    }
+
+    /**
+     * A password shorter than password.min.length is refused too.
+     */
+    @Test
+    public void test_verifyPasswordPolicy_rejectsATooShortPassword() {
+        assertTrue(policyErrorOf("x").contains("password"));
+    }
+
+    /**
+     * A password that satisfies the policy reports nothing, and the form keeps it.
+     */
+    @Test
+    public void test_verifyPasswordPolicy_acceptsACompliantPassword() {
+        assertEquals("", policyErrorOf("Str0ng-Passw0rd!"));
+    }
+
+    /**
+     * An edit that leaves the password empty keeps the stored one, so a blank value is not a policy
+     * violation at this point.
+     */
+    @Test
+    public void test_verifyPasswordPolicy_ignoresABlankPassword() {
+        assertEquals("", policyErrorOf(null));
+        assertEquals("", policyErrorOf(""));
+    }
+
+    /**
+     * Runs the shared policy check over one password and returns what it reported, or an empty
+     * string when it reported nothing.
+     */
+    private String policyErrorOf(final String password) {
+        ComponentUtil.register(new SystemHelper(), "systemHelper");
+        final CreateForm form = new CreateForm();
+        form.crudMode = CrudMode.CREATE;
+        form.password = password;
+        form.confirmPassword = password;
+        final StringBuilder reported = new StringBuilder();
+        AdminUserAction.verifyPasswordPolicy(form, messenger -> {
+            final FessMessages messages = new FessMessages();
+            messenger.message(messages);
+            reported.append(messages.toString());
+        });
+        return reported.toString();
     }
 }


### PR DESCRIPTION
Stacked on #3357.

## Problem

The admin screens run `verifyPassword` before storing a user, so a password that is too short, blacklisted, or does not match its confirmation is refused. `POST /api/admin/user/setting` and `PUT /api/admin/user/setting` stored the same body with none of those checks.

A one-character password, and one on the `password.invalid.admin.passwords` list, are both accepted with `response.status: 0`, and the account can then be used to log in. Setting `password.min.length` or `password.invalid.admin.passwords` therefore only constrained the screens; anyone holding an admin API token could bypass the policy.

`ApiAdminUserAction` contains no occurrence of `verifyPassword` or `validatePassword`. This is not new in 15.9 — the policy was added to the screens and the API path was not updated with it.

## Fix

The policy part of `verifyPassword` becomes a shared static, so both paths apply the same rules, and the API runs it on create and on update. A blank password on create is still rejected; on update it still means "keep the stored one".

The confirmation field is a typing aid rather than part of the policy, so the API only compares it when the caller sends one. A client that omits `confirm_password` keeps working.

## Tests

`AdminUserActionTest` gains four cases over the shared check: a blacklisted password, a too-short password, a compliant one, and a blank one on an update.
