### PR TITLE
fix(dict): check kuromoji entries on the admin API too

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/dict/kuromoji/AdminDictKuromojiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/dict/kuromoji/AdminDictKuromojiAction.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.app.web.admin.dict.kuromoji;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.function.Consumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,6 +33,7 @@ import org.codelibs.fess.app.web.admin.dict.AdminDictAction;
 import org.codelibs.fess.app.web.base.FessAdminAction;
 import org.codelibs.fess.app.web.base.FessBaseAction;
 import org.codelibs.fess.dict.kuromoji.KuromojiItem;
+import org.codelibs.fess.mylasta.action.FessMessages;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.util.RenderDataUtil;
 import org.dbflute.optional.OptionalEntity;
@@ -39,6 +41,7 @@ import org.dbflute.optional.OptionalThing;
 import org.lastaflute.web.Execute;
 import org.lastaflute.web.response.ActionResponse;
 import org.lastaflute.web.response.HtmlResponse;
+import org.lastaflute.web.validation.VaMessenger;
 import org.lastaflute.web.response.render.RenderData;
 import org.lastaflute.web.ruts.process.ActionRuntime;
 import org.lastaflute.web.validation.VaErrorHook;
@@ -504,15 +507,25 @@ public class AdminDictKuromojiAction extends FessAdminAction {
      * @param form The create form.
      */
     protected void verifyForm(final CreateForm form) {
+        verifyKuromojiEntry(form, messages -> throwValidationError(messages, this::asEditHtml));
+    }
+
+    /**
+     * Checks an entry against the rules the user dictionary itself enforces: a token may not
+     * contain a space, and the segmentation and the reading must be split into the same number of
+     * tokens. Shared with the REST API, because an entry that breaks either rule is only rejected
+     * when the search engine next loads the dictionary -- and it refuses to open the index at all
+     * at that point, which is a long way from where the entry was added.
+     *
+     * @param form the entry to check
+     * @param throwError callback to report a violation
+     */
+    public static void verifyKuromojiEntry(final CreateForm form, final Consumer<VaMessenger<FessMessages>> throwError) {
         if (form.token != null && form.token.split(" ").length > 1) {
-            throwValidationError(messages -> {
-                messages.addErrorsInvalidKuromojiToken("token", form.token);
-            }, this::asEditHtml);
+            throwError.accept(messages -> messages.addErrorsInvalidKuromojiToken("token", form.token));
         }
         if (form.segmentation != null && form.reading != null && form.segmentation.split(" ").length != form.reading.split(" ").length) {
-            throwValidationError(messages -> {
-                messages.addErrorsInvalidKuromojiSegmentation("segmentation", form.segmentation, form.reading);
-            }, this::asEditHtml);
+            throwError.accept(messages -> messages.addErrorsInvalidKuromojiSegmentation("segmentation", form.segmentation, form.reading));
         }
     }
 

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.app.web.api.admin.dict.kuromoji;
 
 import static org.codelibs.fess.app.web.admin.dict.kuromoji.AdminDictKuromojiAction.createKuromojiItem;
+import static org.codelibs.fess.app.web.admin.dict.kuromoji.AdminDictKuromojiAction.verifyKuromojiEntry;
 
 import java.io.File;
 import java.io.IOException;
@@ -105,6 +106,7 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
     public JsonResponse<ApiResult> post$setting(final String dictId, final CreateBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
+        verifyKuromojiEntry(body, this::throwValidationErrorApi);
         body.crudMode = CrudMode.CREATE;
         final KuromojiItem entity = createKuromojiItem(this, body, () -> {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateInstance(GLOBAL));
@@ -130,6 +132,7 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
     public JsonResponse<ApiResult> put$setting(final String dictId, final EditBody body) {
         body.dictId = dictId;
         validateApi(body, messages -> {});
+        verifyKuromojiEntry(body, this::throwValidationErrorApi);
         body.crudMode = CrudMode.EDIT;
         final KuromojiItem entity = createKuromojiItem(this, body, () -> {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, String.valueOf(body.id)));

--- a/src/test/java/org/codelibs/fess/app/web/admin/dict/kuromoji/AdminDictKuromojiActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/dict/kuromoji/AdminDictKuromojiActionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.admin.dict.kuromoji;
+
+import org.codelibs.fess.mylasta.action.FessMessages;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The user dictionary rules are checked before an entry is stored. An entry that breaks one of
+ * them is otherwise only rejected when the search engine next loads the dictionary, and it then
+ * refuses to open the index, which takes search down a long way from where the entry was added.
+ */
+public class AdminDictKuromojiActionTest extends UnitFessTestCase {
+
+    /**
+     * The segmentation and the reading have to be split into the same number of tokens. This is
+     * the entry shape the engine rejects with "the number of segmentations does not the match
+     * number of readings".
+     */
+    @Test
+    public void test_verifyKuromojiEntry_rejectsMismatchedSegmentationAndReading() {
+        assertTrue(errorOf("token", "one two", "ONE").contains("segmentation"));
+    }
+
+    /**
+     * A token may not contain a space.
+     */
+    @Test
+    public void test_verifyKuromojiEntry_rejectsATokenWithASpace() {
+        assertTrue(errorOf("two tokens", "two tokens", "TWO TOKENS").contains("token"));
+    }
+
+    /**
+     * A well formed entry reports nothing, whether it is one token or several.
+     */
+    @Test
+    public void test_verifyKuromojiEntry_acceptsAWellFormedEntry() {
+        assertEquals("", errorOf("token", "one two", "ONE TWO"));
+        assertEquals("", errorOf("token", "token", "TOKEN"));
+    }
+
+    /**
+     * Fields that were not filled in are left to the existing required-field validation.
+     */
+    @Test
+    public void test_verifyKuromojiEntry_ignoresMissingFields() {
+        assertEquals("", errorOf(null, null, null));
+        assertEquals("", errorOf("token", "one two", null));
+    }
+
+    /**
+     * Runs the shared rules over one entry and returns what they reported, or an empty string.
+     */
+    private String errorOf(final String token, final String segmentation, final String reading) {
+        final CreateForm form = new CreateForm();
+        form.token = token;
+        form.segmentation = segmentation;
+        form.reading = reading;
+        final StringBuilder reported = new StringBuilder();
+        AdminDictKuromojiAction.verifyKuromojiEntry(form, messenger -> {
+            final FessMessages messages = new FessMessages();
+            messenger.message(messages);
+            reported.append(messages.toString());
+        });
+        return reported.toString();
+    }
+}


### PR DESCRIPTION
Stacked on #3360.

## Problem

The admin screens run `verifyForm` before storing a kuromoji entry, so a token containing a space, or a segmentation and a reading split into different numbers of tokens, is refused. `POST` and `PUT /api/admin/dict/kuromoji/setting/{dictId}` stored the same body without either check.

The user dictionary is only parsed when the search engine loads it, which happens while the index is being reopened. An entry that breaks a rule makes that load fail:

```
Failed to verify index [...]; nested: Failed to load ...KuromojiTokenizerFactory;
nested: Illegal user dictionary entry ... -
  the number of segmentations (2) does not the match number of readings (1)
```

The open fails with it and the index is left closed, so every search answers with `index_closed_exception`. Removing the entry afterwards does not reopen the index; recovery means flushing the dictionary out again and opening the index by hand.

So one mistyped line entered through the API takes search down, at a point far from where it was entered, and the screens it was entered through cannot put it back.

## Fix

The rules move to a shared static and the API runs them on create and on update, so the entry is refused where it is entered.

## Tests

`AdminDictKuromojiActionTest` covers the mismatched segmentation and reading, a token containing a space, well-formed entries of one and of several tokens, and entries with fields left empty.
