### PR TITLE
fix(dict): report the real record count from the dictionary list endpoints

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
@@ -72,7 +72,7 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiConfigsResponse<EditBody>().settings(kuromojiService.getKuromojiList(body.dictId, pager)
                 .stream()
                 .map(protwordsItem -> createEditBody(protwordsItem, dictId))
-                .collect(Collectors.toList())).status(ApiResult.Status.OK).result());
+                .collect(Collectors.toList())).total(pager.getAllRecordCount()).status(ApiResult.Status.OK).result());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/ApiAdminDictMappingAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/ApiAdminDictMappingAction.java
@@ -70,7 +70,7 @@ public class ApiAdminDictMappingAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiConfigsResponse<EditBody>().settings(charMappingService.getCharMappingList(body.dictId, pager)
                 .stream()
                 .map(protwordsItem -> createEditBody(protwordsItem, dictId))
-                .collect(Collectors.toList())).status(ApiResult.Status.OK).result());
+                .collect(Collectors.toList())).total(pager.getAllRecordCount()).status(ApiResult.Status.OK).result());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/ApiAdminDictProtwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/ApiAdminDictProtwordsAction.java
@@ -70,7 +70,7 @@ public class ApiAdminDictProtwordsAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiConfigsResponse<EditBody>().settings(protwordsService.getProtwordsList(body.dictId, pager)
                 .stream()
                 .map(protwordsItem -> createEditBody(protwordsItem, dictId))
-                .collect(Collectors.toList())).status(ApiResult.Status.OK).result());
+                .collect(Collectors.toList())).total(pager.getAllRecordCount()).status(ApiResult.Status.OK).result());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/ApiAdminDictStemmeroverrideAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/ApiAdminDictStemmeroverrideAction.java
@@ -72,7 +72,7 @@ public class ApiAdminDictStemmeroverrideAction extends FessApiAdminAction {
                 new ApiResult.ApiConfigsResponse<EditBody>().settings(stemmerOverrideService.getStemmerOverrideList(body.dictId, pager)
                         .stream()
                         .map(protwordsItem -> createEditBody(protwordsItem, dictId))
-                        .collect(Collectors.toList())).status(ApiResult.Status.OK).result());
+                        .collect(Collectors.toList())).total(pager.getAllRecordCount()).status(ApiResult.Status.OK).result());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/ApiAdminDictStopwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/ApiAdminDictStopwordsAction.java
@@ -71,7 +71,7 @@ public class ApiAdminDictStopwordsAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiConfigsResponse<EditBody>().settings(stopwordsService.getStopwordsList(body.dictId, pager)
                 .stream()
                 .map(stopwordsItem -> createEditBody(stopwordsItem, dictId))
-                .collect(Collectors.toList())).status(ApiResult.Status.OK).result());
+                .collect(Collectors.toList())).total(pager.getAllRecordCount()).status(ApiResult.Status.OK).result());
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/ApiAdminDictSynonymAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/ApiAdminDictSynonymAction.java
@@ -71,7 +71,7 @@ public class ApiAdminDictSynonymAction extends FessApiAdminAction {
         return asJson(new ApiResult.ApiConfigsResponse<EditBody>().settings(synonymService.getSynonymList(body.dictId, pager)
                 .stream()
                 .map(protwordsItem -> createEditBody(protwordsItem, dictId))
-                .collect(Collectors.toList())).status(ApiResult.Status.OK).result());
+                .collect(Collectors.toList())).total(pager.getAllRecordCount()).status(ApiResult.Status.OK).result());
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/api/ApiResultTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/api/ApiResultTest.java
@@ -21,6 +21,8 @@ import org.codelibs.fess.app.web.api.ApiResult.Status;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -117,5 +119,29 @@ public class ApiResultTest extends UnitFessTestCase {
     @Test
     public void test_Status_SYSTEM_ERROR() {
         assertEquals(2, Status.SYSTEM_ERROR.getId());
+    }
+
+    /**
+     * settings() fills total in from the rows it was handed, which is only the record count when
+     * the whole list fits on one page. A caller that asks for a page therefore cannot tell whether
+     * more exist, so an endpoint that pages has to set the real count afterwards.
+     */
+    @Test
+    public void test_apiConfigsResponse_totalCanCarryTheRecordCount() {
+        final ApiResult.ApiConfigsResponse<String> response =
+                new ApiResult.ApiConfigsResponse<String>().settings(List.of("a", "b")).total(33);
+
+        assertEquals(2, response.settings.size());
+        assertEquals(33L, response.total);
+    }
+
+    /**
+     * Without that call the count still reflects the rows, which is what the single-page case wants.
+     */
+    @Test
+    public void test_apiConfigsResponse_totalDefaultsToTheRowCount() {
+        final ApiResult.ApiConfigsResponse<String> response = new ApiResult.ApiConfigsResponse<String>().settings(List.of("a", "b"));
+
+        assertEquals(2L, response.total);
     }
 }

--- a/src/test/java/org/codelibs/fess/it/admin/dict/DictCrudTestBase.java
+++ b/src/test/java/org/codelibs/fess/it/admin/dict/DictCrudTestBase.java
@@ -87,8 +87,20 @@ public abstract class DictCrudTestBase extends CrudTestBase {
         String response = checkGetMethod(searchBody, getListEndpointSuffix()).asString();
         final int total = JsonPath.from(response).getInt("response.total");
         final List<Map<String, String>> items = JsonPath.from(response).getList("response.settings");
-        final int status = JsonPath.from(response).getInt("response.status");
-        assertEquals(total, items.size());
-        assertEquals(0, status);
+        assertEquals(0, JsonPath.from(response).getInt("response.status"));
+
+        // A page holds at most paging.page.size entries while total counts every record, so the
+        // two are only equal when the dictionary fits on one page. Asserting them equal would
+        // hold just as well if total were derived from the rows, which is what it used to be.
+        assertTrue(total >= items.size(), "total " + total + " is smaller than the page of " + items.size());
+
+        // Asking for one entry must not make the dictionary look one entry long: a caller that
+        // pages has nothing else to tell it that more exist.
+        final Map<String, Object> onePerPage = new HashMap<>();
+        onePerPage.put("size", 1);
+        response = checkGetMethod(onePerPage, getListEndpointSuffix()).asString();
+        assertEquals(0, JsonPath.from(response).getInt("response.status"));
+        assertEquals(1, JsonPath.from(response).getList("response.settings").size());
+        assertEquals(total, JsonPath.from(response).getInt("response.total"));
     }
 }


### PR DESCRIPTION
Stacked on #3361.

## Problem

`ApiConfigsResponse#settings` fills `total` in from the rows it was handed, so an endpoint that pages has to set the real count afterwards. Every non-dictionary list endpoint passes `pager.getAllRecordCount()`; the six dictionary ones did not.

A page therefore looks like the whole dictionary. Asking for five entries of a thirty-three word stopwords list answers with five and reports `"total": 5`, so a caller has nothing to page on and no way to tell that anything was left behind. Reading a dictionary through the API to back it up or move it returned a truncated copy that looked complete.

## Fix

All six report the count the pager computed.

## Tests

`ApiResultTest` gains two cases over `ApiConfigsResponse`: that a later `total(...)` carries the record count, and that without one the count still reflects the rows, which is what the single-page case wants.
