### PR TITLE
chore(deps): take the commonmark version from fess-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1660,12 +1660,12 @@
 		<dependency>
 			<groupId>org.commonmark</groupId>
 			<artifactId>commonmark</artifactId>
-			<version>0.24.0</version>
+			<version>${commonmark.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.commonmark</groupId>
 			<artifactId>commonmark-ext-gfm-tables</artifactId>
-			<version>0.24.0</version>
+			<version>${commonmark.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.owasp-java-html-sanitizer</groupId>


### PR DESCRIPTION
Stacked on #3362.

## Problem

The two commonmark artifacts were pinned to `0.24.0` here, so the `commonmark.version` property `fess-parent` declares had no effect on them. `fess-crawler` pulls `commonmark-ext-yaml-front-matter`, which resolved to `0.30.0`, and the distribution then shipped:

```
commonmark-0.24.0.jar
commonmark-ext-gfm-tables-0.24.0.jar
commonmark-ext-yaml-front-matter-0.30.0.jar
```

commonmark extensions are built against a particular core, so an extension newer than the core it extends is only safe by accident.

## Fix

Both artifacts follow the property, and all three now resolve to the same version.

## Tests

`MarkdownRendererTest` passes on 0.30.0, 36 tests.
