### PR TITLE
fix(script): name the failing job in the JavaScript engine warning

### DIFF
--- a/src/main/java/org/codelibs/fess/script/javascript/JavaScriptEngine.java
+++ b/src/main/java/org/codelibs/fess/script/javascript/JavaScriptEngine.java
@@ -163,8 +163,8 @@ public class JavaScriptEngine extends AbstractScriptEngine {
         } catch (final Exception e) {
             final String truncatedScript =
                     template.length() > maxScriptLogLength ? template.substring(0, maxScriptLogLength) + "..." : template;
-            logger.warn("Failed to evaluate JavaScript: script(length={})={}, parameterKeys={}", template.length(), truncatedScript,
-                    safeParamMap.keySet(), e);
+            logger.warn("Failed to evaluate JavaScript: job={}, script(length={})={}, parameterKeys={}", describeCurrentJob(),
+                    template.length(), truncatedScript, safeParamMap.keySet(), e);
             logScriptExecution(template, "failure:" + e.getClass().getSimpleName());
             return null;
         }
@@ -240,6 +240,25 @@ public class JavaScriptEngine extends AbstractScriptEngine {
             }
         }
         return null;
+    }
+
+    /**
+     * Describes the scheduled job the current evaluation belongs to, for the warning in
+     * {@link #evaluate(String, Map)}.
+     *
+     * <p>A failed evaluation returns null instead of propagating, so a scheduler job whose script
+     * cannot be evaluated is still recorded with a successful status. Naming the job here is what
+     * ties that job log entry back to the warning; the script text on its own does not say which
+     * job produced it.</p>
+     *
+     * @return the job name and id, or "none" when the evaluation is not part of a scheduled job
+     */
+    protected String describeCurrentJob() {
+        final ScheduledJob job = getCurrentScheduledJob();
+        if (job == null) {
+            return "none";
+        }
+        return job.getName() + "(id=" + job.getId() + ")";
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/script/javascript/JavaScriptEngineTest.java
+++ b/src/test/java/org/codelibs/fess/script/javascript/JavaScriptEngineTest.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.codelibs.fess.exception.JobProcessingException;
+import org.codelibs.fess.opensearch.config.exentity.ScheduledJob;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -184,6 +186,44 @@ public class JavaScriptEngineTest extends UnitFessTestCase {
             }
         } finally {
             executor.shutdown();
+        }
+    }
+
+    @Test
+    public void test_evaluate_failureWarnsWithTheJobName() {
+        // A swallowed failure leaves the scheduler job with a successful status, so the warning is
+        // the only record of it. Without the job name the warning cannot be matched to the job.
+        final ScheduledJob scheduledJob = new ScheduledJob();
+        scheduledJob.setId("J1");
+        scheduledJob.setName("Migrated Crawler");
+        final JavaScriptEngine engine = new JavaScriptEngine() {
+            @Override
+            protected ScheduledJob getCurrentScheduledJob() {
+                return scheduledJob;
+            }
+        };
+        engine.init();
+        final LogCapturingAppender capture = LogCapturingAppender.attach(JavaScriptEngine.class);
+        try {
+            assertNull(engine.evaluate("def x = 1; return \"${x}\";", new HashMap<>()));
+            assertTrue(capture.warnings().stream().anyMatch(m -> m.contains("job=Migrated Crawler(id=J1)")),
+                    "the warning must name the job whose script failed: " + capture.warnings());
+        } finally {
+            capture.detach();
+            engine.close();
+        }
+    }
+
+    @Test
+    public void test_evaluate_failureWarnsWithoutAJob() {
+        // Document boosts, crawler field scripts and path mappings run outside the scheduler.
+        final LogCapturingAppender capture = LogCapturingAppender.attach(JavaScriptEngine.class);
+        try {
+            assertNull(javaScriptEngine.evaluate("def x = 1; return \"${x}\";", new HashMap<>()));
+            assertTrue(capture.warnings().stream().anyMatch(m -> m.contains("job=none")),
+                    "an evaluation outside a scheduled job must say so: " + capture.warnings());
+        } finally {
+            capture.detach();
         }
     }
 


### PR DESCRIPTION
`ScriptEngine#evaluate` logs a failed evaluation and returns `null`. `ScriptExecutorJob`
reads `null` as "the script produced no result", so the run is stored with
`job_status=ok` and an empty `script_result`. The WARN line is then the only record that
the script never ran.

That line carried the script text and the parameter keys, but nothing that identifies the
scheduler job, so it could not be matched to the entry shown in `/admin/joblog/`.

This adds the job name and id to it:

```
WARN Failed to evaluate JavaScript: job=Nightly Crawler(id=OFdMc5kBx1...),
     script(length=25)=def x = 1; return "${x}";, parameterKeys=[executor]
```

The job comes from `getCurrentScheduledJob()`, which the engine already consults for the
audit log, so no new lookup is added. Evaluations that do not belong to a scheduled job —
document boosts, crawler field scripts, path mapping replacements — log `job=none`.

Nothing else changes: the failure is still swallowed and the job status is untouched.
`fess-script-groovy` gets the same change so both engines log the same shape.

### Tests

`JavaScriptEngineTest`

- `test_evaluate_failureWarnsWithTheJobName` — a failing script under a scheduled job warns with `job=<name>(id=<id>)`
- `test_evaluate_failureWarnsWithoutAJob` — the same script outside the scheduler warns with `job=none`

Both fail when the message change alone is reverted.
