### PR TITLE
fix(backup): serve the mapping files from the backup API

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/backup/AdminBackupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/backup/AdminBackupAction.java
@@ -479,11 +479,19 @@ public class AdminBackupAction extends FessAdminAction {
         return redirect(getClass()); // no-op
     }
 
-    private Path getDocJsonPath() {
+    /**
+     * Get the path of the document mapping file.
+     * @return The path of doc.json.
+     */
+    public static Path getDocJsonPath() {
         return ResourceUtil.getClassesPath("fess_indices", "fess", "doc.json");
     }
 
-    private Path getFessJsonPath() {
+    /**
+     * Get the path of the index mapping file.
+     * @return The path of fess.json.
+     */
+    public static Path getFessJsonPath() {
         return ResourceUtil.getClassesPath("fess_indices", "fess.json");
     }
 

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupAction.java
@@ -19,7 +19,9 @@ import static org.codelibs.core.stream.StreamUtil.stream;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.NDJSON_EXTENTION;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getBackupItems;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getClickLogNdjsonWriteCall;
+import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getDocJsonPath;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getFavoriteLogNdjsonWriteCall;
+import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getFessJsonPath;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getSearchLogNdjsonWriteCall;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getUserInfoNdjsonWriteCall;
 
@@ -30,6 +32,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -93,6 +97,12 @@ public class ApiAdminBackupAction extends FessApiAdminAction {
                     }
                 });
             }
+            if ("fess.json".equals(id)) {
+                return streamMappingFile(id, getFessJsonPath());
+            }
+            if ("doc.json".equals(id)) {
+                return streamMappingFile(id, getDocJsonPath());
+            }
             if (!id.endsWith(NDJSON_EXTENTION)) {
                 final String index;
                 final String filename;
@@ -141,6 +151,14 @@ public class ApiAdminBackupAction extends FessApiAdminAction {
 
         throwValidationErrorApi(messages -> messages.addErrorsCouldNotFindBackupIndex(GLOBAL));
         return StreamResponse.asEmptyBody(); // no-op
+    }
+
+    private StreamResponse streamMappingFile(final String id, final Path path) {
+        return asStream(id).contentTypeOctetStream().stream(out -> {
+            try (final InputStream in = Files.newInputStream(path)) {
+                out.write(in);
+            }
+        });
     }
 
     private StreamResponse writeNdjsonResponse(final String id, final Consumer<Writer> writeCall) {

--- a/src/test/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupActionTest.java
@@ -19,11 +19,16 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.codelibs.core.io.CopyUtil;
 import org.codelibs.fess.Constants;
+import org.codelibs.fess.app.web.admin.backup.AdminBackupAction;
+import org.codelibs.fess.app.web.base.FessBaseAction;
 import org.codelibs.fess.opensearch.client.SearchEngineClient;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.BooleanFunction;
@@ -72,6 +77,44 @@ public class ApiAdminBackupActionTest extends UnitFessTestCase {
     }
 
     // ===================================================================================
+    //                                                                       Mapping files
+    //                                                                       =============
+
+    /**
+     * fess.json is an index mapping shipped with the product, not an index that can be walked. The
+     * API routed it into the bulk branch, which searched for an index literally called "fess.json"
+     * and answered 200 with an empty body while the admin screen served 41,137 bytes.
+     */
+    @Test
+    public void test_get$file_fessJsonIsServedAsTheMappingFile() throws Exception {
+        final List<String> walked = registerWalkingClient();
+
+        final StreamResponse response = new ApiAdminBackupAction().get$file("fess.json");
+
+        // The bulk branch appends ".bulk" to an id that does not already carry it.
+        assertEquals("fess.json", response.getFileName());
+        final String served = served(response);
+        assertTrue(walked.isEmpty(), "a mapping file must not be looked up in the search engine: " + walked);
+        assertEquals(served(adminDownload("fess.json")), served);
+    }
+
+    /**
+     * The same holds for doc.json, which the admin screen served as 12,754 bytes while the API
+     * answered 200 with an empty body.
+     */
+    @Test
+    public void test_get$file_docJsonIsServedAsTheMappingFile() throws Exception {
+        final List<String> walked = registerWalkingClient();
+
+        final StreamResponse response = new ApiAdminBackupAction().get$file("doc.json");
+
+        assertEquals("doc.json", response.getFileName());
+        final String served = served(response);
+        assertTrue(walked.isEmpty(), "a mapping file must not be looked up in the search engine: " + walked);
+        assertEquals(served(adminDownload("doc.json")), served);
+    }
+
+    // ===================================================================================
     //                                                                            Helpers
     //                                                                            =======
 
@@ -87,13 +130,16 @@ public class ApiAdminBackupActionTest extends UnitFessTestCase {
     }
 
     /**
-     * Registers a search engine client whose walk hands out the given hits.
+     * Registers a search engine client whose walk hands out the given hits, and returns the list of
+     * indices it was asked to walk.
      */
-    private void registerWalkingClient(final SearchHit... hits) {
+    private List<String> registerWalkingClient(final SearchHit... hits) {
+        final List<String> walked = new ArrayList<>();
         ComponentUtil.register(new SearchEngineClient() {
             @Override
             public <T> long scrollSearch(final String index, final SearchCondition<SearchRequestBuilder> condition,
                     final EntityCreator<T, SearchResponse, SearchHit> creator, final BooleanFunction<T> cursor) {
+                walked.add(index);
                 long count = 0;
                 for (final SearchHit hit : hits) {
                     count++;
@@ -106,6 +152,32 @@ public class ApiAdminBackupActionTest extends UnitFessTestCase {
                 return count;
             }
         }, "searchEngineClient");
+        return walked;
+    }
+
+    /**
+     * Runs the admin screen download for the same id, which is the behaviour the API has to match.
+     */
+    private StreamResponse adminDownload(final String id) throws Exception {
+        final AdminBackupAction action = new AdminBackupAction();
+        final Field field = FessBaseAction.class.getDeclaredField("fessConfig");
+        field.setAccessible(true);
+        field.set(action, ComponentUtil.getFessConfig());
+        return (StreamResponse) action.download(id);
+    }
+
+    /**
+     * Returns what the client would actually receive: the streamed text, or the failure that
+     * reached it instead. The mapping files are read from the built webapp rather than from the
+     * unit test tree, so both paths may legitimately fail to find one here; what must never differ
+     * is which of the two happens.
+     */
+    private String served(final StreamResponse response) {
+        try {
+            return drain(response);
+        } catch (final Exception e) {
+            return e.getClass().getSimpleName() + ": " + e.getMessage();
+        }
     }
 
     /**


### PR DESCRIPTION
fess.json and doc.json are the index mappings shipped inside the webapp, not
indices that can be walked, and the admin screen has always read them off
disk. The API had no branch for them, so ApiAdminBackupAction.java:96 sent
both into the bulk branch, which searched for an index literally named
"fess.json". The walk found nothing, the writer was flushed empty and the
request still ended in 200:

    GET /api/admin/backup/file/fess.json/   200, 0 bytes (screen: 41,137)
    GET /api/admin/backup/file/doc.json/    200, 0 bytes (screen: 12,754)

The attachment was also misnamed, because that branch appends ".bulk" to an
id that does not already carry one, so the download arrived as
fess.json.bulk. A backup taken through the API was therefore missing both
mapping files, and nothing in the response said so.

The API now routes the two ids to the same files the screen reads. The two
path helpers on AdminBackupAction became static so that both paths resolve
the mapping locations through one definition instead of a copy that can
drift.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
