### PR TITLE
fix(backup): fail the download when the backup index cannot be read

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/backup/AdminBackupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/backup/AdminBackupAction.java
@@ -457,6 +457,7 @@ public class AdminBackupAction extends FessAdminAction {
                     index = "basic_" + fessConfig.getIndexConfigIndex();
                 }
                 final String alias = index;
+                assertBackupIndexReadable(alias);
                 return asStream(filename).contentTypeOctetStream().stream(out -> {
                     try (final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out.stream(), Constants.CHARSET_UTF_8))) {
                         SearchEngineUtil.scroll(alias, hit -> {
@@ -471,12 +472,39 @@ public class AdminBackupAction extends FessAdminAction {
                             return true;
                         });
                         writer.flush();
+                    } catch (final RuntimeException e) {
+                        // The response is committed by now, so the client keeps the truncated file.
+                        // Leaving a trace is all that is left to do.
+                        logger.warn("Failed to write the backup of {}.", alias, e);
+                        throw e;
                     }
                 });
             }
         }
         throwValidationError(messages -> messages.addErrorsCouldNotFindBackupIndex(GLOBAL), this::asListHtml);
         return redirect(getClass()); // no-op
+    }
+
+    /**
+     * Walks one page of the backup target so that an unreadable index fails the request itself.
+     *
+     * <p>A closed index is routine: reindexing from the maintenance screen closes one, so does a
+     * rolling restart, and a malformed Kuromoji entry leaves one behind. Closing a single member of
+     * an alias makes the point in time fail, and the walk that discovers that runs inside the
+     * stream callback, after the framework has committed 200 and the Content-Disposition header.
+     * The browser then saves a named attachment holding nothing, and neither the client nor the log
+     * says anything went wrong. Probing here costs one page and moves the failure to a point where
+     * the request can still carry it.</p>
+     *
+     * @param index The index or alias to be written as a bulk file.
+     */
+    public static void assertBackupIndexReadable(final String index) {
+        try {
+            SearchEngineUtil.scroll(index, hit -> false);
+        } catch (final RuntimeException e) {
+            logger.warn("Failed to read the backup index {}.", index, e);
+            throw e;
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupAction.java
@@ -17,6 +17,7 @@ package org.codelibs.fess.app.web.api.admin.backup;
 
 import static org.codelibs.core.stream.StreamUtil.stream;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.NDJSON_EXTENTION;
+import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.assertBackupIndexReadable;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getBackupItems;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getClickLogNdjsonWriteCall;
 import static org.codelibs.fess.app.web.admin.backup.AdminBackupAction.getDocJsonPath;
@@ -39,6 +40,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.web.api.ApiResult;
@@ -56,6 +59,8 @@ import org.lastaflute.web.response.StreamResponse;
  *
  */
 public class ApiAdminBackupAction extends FessApiAdminAction {
+
+    private static final Logger logger = LogManager.getLogger(ApiAdminBackupAction.class);
 
     /**
      * Default constructor.
@@ -113,6 +118,7 @@ public class ApiAdminBackupAction extends FessApiAdminAction {
                     index = id;
                     filename = id + ".bulk";
                 }
+                assertBackupIndexReadable(index);
                 return asStream(filename).contentTypeOctetStream().stream(out -> {
                     try (final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out.stream(), Constants.CHARSET_UTF_8))) {
                         SearchEngineUtil.scroll(index, hit -> {
@@ -130,6 +136,11 @@ public class ApiAdminBackupAction extends FessApiAdminAction {
                             return true;
                         });
                         writer.flush();
+                    } catch (final RuntimeException e) {
+                        // The response is committed by now, so the client keeps the truncated file.
+                        // Leaving a trace is all that is left to do.
+                        logger.warn("Failed to write the backup of {}.", index, e);
+                        throw e;
                     }
                 });
             }

--- a/src/test/java/org/codelibs/fess/app/web/admin/backup/AdminBackupActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/backup/AdminBackupActionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.admin.backup;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.codelibs.fess.app.web.base.FessBaseAction;
+import org.codelibs.fess.opensearch.client.SearchEngineClient;
+import org.codelibs.fess.opensearch.client.SearchEngineClientException;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.BooleanFunction;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.search.SearchRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchHit;
+
+public class AdminBackupActionTest extends UnitFessTestCase {
+
+    /**
+     * Closing a single member of the alias, which reindexing and rolling restarts both do, makes
+     * the point in time fail. That failure used to happen inside the stream callback, once the
+     * framework had already committed 200 and the Content-Disposition header, so the browser saved
+     * a named attachment of 0 bytes where the same request had served 93,858 bytes a moment
+     * earlier, and fess.log gained no line at all. The download must instead fail while the
+     * response can still say so.
+     */
+    @Test
+    public void test_download_failsBeforeTheResponseIsCommitted() throws Exception {
+        registerFailingClient("[fess_config] Failed to open a point in time.");
+
+        final SearchEngineClientException e =
+                Assertions.assertThrows(SearchEngineClientException.class, () -> newAction().download("fess_config.bulk"));
+        assertTrue(e.getMessage().contains("fess_config"), "the failure must name the index: " + e.getMessage());
+    }
+
+    /**
+     * Whatever else happens, the failure has to be diagnosable: the log must carry the index that
+     * could not be read and the cause underneath it.
+     */
+    @Test
+    public void test_download_logsTheIndexAndTheCause() throws Exception {
+        registerFailingClient("[fess_config] Failed to open a point in time.");
+        final CapturingAppender appender = new CapturingAppender();
+        final org.apache.logging.log4j.core.Logger logger =
+                (org.apache.logging.log4j.core.Logger) LogManager.getLogger(AdminBackupAction.class);
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            Assertions.assertThrows(SearchEngineClientException.class, () -> newAction().download("fess_config.bulk"));
+        } finally {
+            logger.removeAppender(appender);
+            appender.stop();
+        }
+
+        final List<LogEvent> warnings = appender.warnings();
+        assertEquals(1, warnings.size(), "exactly one warning must be reported: " + warnings);
+        final LogEvent event = warnings.get(0);
+        Assertions.assertEquals(org.apache.logging.log4j.Level.WARN, event.getLevel(),
+                "a backup that cannot be read does not stop the system, so it is a warning, not an error");
+        assertTrue(event.getMessage().getFormattedMessage().contains("fess_config"),
+                "the log line must name the index: " + event.getMessage().getFormattedMessage());
+        assertNotNull(event.getThrown(), "the log line must carry the cause");
+        assertEquals(SearchEngineClientException.class, event.getThrown().getClass());
+    }
+
+    // ===================================================================================
+    //                                                                            Helpers
+    //                                                                            =======
+
+    private AdminBackupAction newAction() throws Exception {
+        final AdminBackupAction action = new AdminBackupAction();
+        final Field field = FessBaseAction.class.getDeclaredField("fessConfig");
+        field.setAccessible(true);
+        field.set(action, ComponentUtil.getFessConfig());
+        return action;
+    }
+
+    /**
+     * Registers a search engine client that cannot walk anything, the way a closed member index
+     * makes the real one behave.
+     */
+    private void registerFailingClient(final String message) {
+        ComponentUtil.register(new SearchEngineClient() {
+            @Override
+            public <T> long scrollSearch(final String index, final SearchCondition<SearchRequestBuilder> condition,
+                    final EntityCreator<T, SearchResponse, SearchHit> creator, final BooleanFunction<T> cursor) {
+                throw new SearchEngineClientException(message);
+            }
+        }, "searchEngineClient");
+    }
+
+    private static class CapturingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = new ArrayList<>();
+
+        CapturingAppender() {
+            super("capturing", (Filter) null, (Layout<? extends Serializable>) null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        List<LogEvent> warnings() {
+            final List<LogEvent> list = new ArrayList<>();
+            for (final LogEvent event : events) {
+                if (event.getLevel().isMoreSpecificThan(org.apache.logging.log4j.Level.WARN)) {
+                    list.add(event);
+                }
+            }
+            return list;
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/api/admin/backup/ApiAdminBackupActionTest.java
@@ -30,9 +30,11 @@ import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.web.admin.backup.AdminBackupAction;
 import org.codelibs.fess.app.web.base.FessBaseAction;
 import org.codelibs.fess.opensearch.client.SearchEngineClient;
+import org.codelibs.fess.opensearch.client.SearchEngineClientException;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.BooleanFunction;
 import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.lastaflute.web.response.StreamResponse;
 import org.lastaflute.web.servlet.request.stream.WrittenStreamOut;
@@ -112,6 +114,31 @@ public class ApiAdminBackupActionTest extends UnitFessTestCase {
         final String served = served(response);
         assertTrue(walked.isEmpty(), "a mapping file must not be looked up in the search engine: " + walked);
         assertEquals(served(adminDownload("doc.json")), served);
+    }
+
+    // ===================================================================================
+    //                                                                  Unreadable index
+    //                                                                  ================
+
+    /**
+     * The API streams the same way the admin screen does, so it loses the same way: an index that
+     * cannot be walked - one closed member of the alias is enough - only shows up once the response
+     * is committed, and the caller receives 200 and an empty file. The request has to fail before
+     * that instead.
+     */
+    @Test
+    public void test_get$file_failsBeforeTheResponseIsCommitted() {
+        ComponentUtil.register(new SearchEngineClient() {
+            @Override
+            public <T> long scrollSearch(final String index, final SearchCondition<SearchRequestBuilder> condition,
+                    final EntityCreator<T, SearchResponse, SearchHit> creator, final BooleanFunction<T> cursor) {
+                throw new SearchEngineClientException("[" + index + "] Failed to open a point in time.");
+            }
+        }, "searchEngineClient");
+
+        final SearchEngineClientException e =
+                Assertions.assertThrows(SearchEngineClientException.class, () -> new ApiAdminBackupAction().get$file("fess_config.bulk"));
+        assertTrue(e.getMessage().contains("fess_config"), "the failure must name the index: " + e.getMessage());
     }
 
     // ===================================================================================


### PR DESCRIPTION
Downloading fess_config.bulk while one member of the alias was closed answered
200 with an empty body: 93,858 bytes before, 0 bytes with fess_config.bad_word
closed, and 93,858 bytes again once it was reopened. The response still carried
Content-Disposition, so the browser saved a named attachment holding nothing,
and fess.log gained no line at all. A closed index is routine, since reindexing
from the maintenance screen closes one, so does a rolling restart, and a
malformed Kuromoji entry leaves one behind, so a backup could be empty at
exactly the moment it was needed and look like a success.

AdminBackupAction.java:460-475 builds the stream response and lets the framework
commit it before SearchEngineUtil.scroll ever runs, so the
SearchEngineClientException that SearchEngineClient.java:1770 raises when the
point in time cannot be opened is thrown inside the stream callback. By then the
status line and the headers are already sent, the callback has written nothing,
and the exception reaches neither the caller nor the log.

The download now walks one page of the target before the response is built.
Whether an index exists and whether it can be read are different questions, and
only the walk answers the second: an alias one of whose members is closed still
exists and still resolves. Reusing the same walk therefore costs one page, keeps
the check from drifting away from what the download actually does, and moves the
failure to a point where the request can still carry it. A failure that arrives
later, from a member closed between the check and the walk or from a node lost
mid stream, cannot be taken back, so it is logged with the index and the cause
instead, which at least turns a silent loss into a diagnosable one.

The API download streams through the same code and lost data the same way, so it
gets the same treatment.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
