### PR TITLE
fix(search): validate before the login gate on the advance screen

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/search/SearchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/search/SearchAction.java
@@ -103,13 +103,14 @@ public class SearchAction extends FessSearchAction {
      */
     @Execute
     public HtmlResponse advance(final SearchForm form) {
-        if (isLoginRequired()) {
-            return redirectToLogin();
-        }
         validate(form, messages -> {}, () -> asHtml(virtualHost(path_IndexJsp)).renderWith(data -> {
             buildInitParams();
             RenderDataUtil.register(data, "notification", fessConfig.getNotificationSearchTop());
         }));
+        if (isLoginRequired()) {
+            return redirectToLogin();
+        }
+
         if (!form.hasConditionQuery()) {
             if (StringUtil.isNotBlank(form.q)) {
                 form.as.put("q", new String[] { form.q });

--- a/src/test/java/org/codelibs/fess/app/web/search/SearchActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/search/SearchActionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.search;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codelibs.fess.app.web.base.SearchForm;
+import org.codelibs.fess.mylasta.action.FessMessages;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+import org.lastaflute.web.response.HtmlResponse;
+import org.lastaflute.web.validation.VaErrorHook;
+import org.lastaflute.web.validation.VaMore;
+import org.lastaflute.web.validation.ValidationSuccess;
+
+/**
+ * SearchForm carries validator annotations, so the framework insists that every execute method
+ * taking one calls validate() on every path out of the method. A path that returns before the
+ * call is reported as a wiring mistake once the method has already returned, which turns the
+ * response into a system error.
+ */
+public class SearchActionTest extends UnitFessTestCase {
+
+    /**
+     * The advance search screen validates before it consults the login gate, so the path that
+     * sends an anonymous visitor to login has already called validate() by then.
+     */
+    @Test
+    public void test_advance_validatesBeforeRedirectingToLogin() {
+        final List<String> calls = new ArrayList<>();
+        final SearchAction action = new SearchAction() {
+            @Override
+            public ValidationSuccess validate(final Object form, final VaMore<FessMessages> moreValidationLambda,
+                    final VaErrorHook validationErrorLambda) {
+                calls.add("validate");
+                return new ValidationSuccess(new FessMessages());
+            }
+
+            @Override
+            protected boolean isLoginRequired() {
+                return true;
+            }
+
+            @Override
+            protected HtmlResponse redirectToLogin() {
+                calls.add("redirectToLogin");
+                return null;
+            }
+        };
+
+        assertNull(action.advance(new SearchForm()));
+        assertEquals("validate redirectToLogin", String.join(" ", calls));
+    }
+}


### PR DESCRIPTION
LastaFlute treats an execute method that takes a form carrying validator
annotations but never calls validate() as a wiring mistake, and it reports that
only after the method body has already run. The advance search screen consulted
the login gate first and returned from it, so with login.required set the gated
path never reached validate() and the framework turned the redirect into a
system error.

The advanced search link sits in the header of every page and on the top page,
so on such a site a visitor who was not signed in and clicked it landed on the
error page rather than on the login screen. The screens that serve a document,
a cache entry or a thumbnail already validate first and then consult the gate,
and the search results screen does too.

The advance screen now follows the same order, so an anonymous visitor is sent
to login the way every other search-side screen sends them.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
