### PR TITLE
fix(log): leave a trace when a request ends as a 500

### DIFF
--- a/src/main/java/org/codelibs/fess/filter/ServerErrorLoggingFilter.java
+++ b/src/main/java/org/codelibs/fess/filter/ServerErrorLoggingFilter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.filter;
+
+import java.io.IOException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.lastaflute.web.servlet.filter.RequestLoggingFilter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Reports every request that ends as a 500 with a single WARN line.
+ *
+ * <p>{@code web.xml} switches {@code errorLogging} off on {@code lastaShowbaseFilter}, so
+ * {@link RequestLoggingFilter} writes its multi-line server-error dump at debug on the
+ * {@code org.lastaflute} logger, and it neither rethrows the exception nor lets the container
+ * see it. With the shipped log level that dump is dropped, and a 500 leaves no trace anywhere.
+ * This filter restores a minimum: what failed, where, and why, on one line.</p>
+ *
+ * <p>The exception itself is only reachable through
+ * {@link RequestLoggingFilter#setServerErrorHandlerOnThread(RequestLoggingFilter.RequestServerErrorHandler)},
+ * whose callback the logging filter invokes from {@code sendInternalServerError} — that is, on
+ * the 500 path only. Client errors ({@code RequestClientErrorException}, e.g. 404) go through a
+ * separate callback and deliberate redirects never raise at all, so neither reaches this class.
+ * The handler is per-thread, hence this wrapper: it is registered through
+ * {@code FwWebDirection#directServletFilter(filter, false)} so that it runs outside the logging
+ * filter, and installs the callback for the duration of the request.</p>
+ */
+public class ServerErrorLoggingFilter implements Filter {
+
+    private static final Logger logger = LogManager.getLogger(ServerErrorLoggingFilter.class);
+
+    /**
+     * Creates a new instance of ServerErrorLoggingFilter.
+     */
+    public ServerErrorLoggingFilter() {
+        // Default constructor
+    }
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+            throws IOException, ServletException {
+        RequestLoggingFilter.setServerErrorHandlerOnThread(this::logServerError);
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            // RequestLoggingFilter clears the handler itself for routed requests, but not on the
+            // static-resource path, so do not leave it attached to a pooled container thread.
+            RequestLoggingFilter.setServerErrorHandlerOnThread(null);
+        }
+    }
+
+    /**
+     * Writes the one line an operator needs to find out that a 500 happened.
+     *
+     * <p>The stack trace stays at debug on purpose: an operator running with the shipped level
+     * gets the method, the path, the exception class and its message, and nothing else. The
+     * query string is left out because it carries caller-supplied values.</p>
+     *
+     * @param request the request that failed
+     * @param response the response, possibly already committed
+     * @param cause the exception that became the 500
+     */
+    protected void logServerError(final HttpServletRequest request, final HttpServletResponse response, final Throwable cause) {
+        // The throwable is passed as its class name and message, never as the trailing argument,
+        // so that log4j2 does not append a stack trace to this WARN line.
+        logger.warn("Server error: {} {} [{}: {}]", request.getMethod(), request.getRequestURI(), cause.getClass().getName(),
+                cause.getMessage());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Server error: {} {}", request.getMethod(), request.getRequestURI(), cause);
+        }
+    }
+
+}

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessFwAssistantDirector.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessFwAssistantDirector.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.app.web.base.FessAdminAction;
+import org.codelibs.fess.filter.ServerErrorLoggingFilter;
 import org.codelibs.fess.mylasta.direction.sponsor.FessActionAdjustmentProvider;
 import org.codelibs.fess.mylasta.direction.sponsor.FessApiFailureHook;
 import org.codelibs.fess.mylasta.direction.sponsor.FessCookieResourceProvider;
@@ -173,6 +174,9 @@ public class FessFwAssistantDirector extends CachedFwAssistantDirector {
         direction.directAdjustment(createActionAdjustmentProvider());
         direction.directMessage(createMessageNameList(), "fess_label");
         direction.directApiCall(createApiFailureHook());
+        // outside the logging filter (inside=false) so that the per-thread server error handler
+        // is installed before RequestLoggingFilter swallows the exception behind errorLogging=false
+        direction.directServletFilter(createServerErrorLoggingFilter(), false);
         direction.directMultipart(FessMultipartRequestHandler::new);
         direction.directHtmlRendering(new JspHtmlRenderingProvider() {
             @Override
@@ -208,5 +212,9 @@ public class FessFwAssistantDirector extends CachedFwAssistantDirector {
 
     protected FessApiFailureHook createApiFailureHook() {
         return new FessApiFailureHook();
+    }
+
+    protected ServerErrorLoggingFilter createServerErrorLoggingFilter() {
+        return new ServerErrorLoggingFilter();
     }
 }

--- a/src/test/java/org/codelibs/fess/filter/ServerErrorLoggingFilterTest.java
+++ b/src/test/java/org/codelibs/fess/filter/ServerErrorLoggingFilterTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.filter;
+
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.codelibs.fess.unit.LogCapturingAppender;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.lastaflute.core.direction.FwAssistantDirector;
+import org.lastaflute.web.servlet.filter.RequestLoggingFilter;
+import org.lastaflute.web.servlet.filter.hook.FilterHook;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Asserts that a request ending as a 500 leaves exactly one WARN line behind.
+ *
+ * <p>The exception is delivered the way {@link RequestLoggingFilter} delivers it in production:
+ * through {@code processServerErrorCallback}, which is what {@code sendInternalServerError} calls
+ * on the 500 path and only there.</p>
+ */
+public class ServerErrorLoggingFilterTest extends UnitFessTestCase {
+
+    @Override
+    protected String prepareMockServletPath() {
+        return "/search/advance";
+    }
+
+    /** Calls the protected callback dispatch of the real logging filter. */
+    private static class ExposedLoggingFilter extends RequestLoggingFilter {
+        void fireServerError(final HttpServletRequest request, final HttpServletResponse response, final Throwable cause) {
+            processServerErrorCallback(request, response, cause);
+        }
+    }
+
+    @Test
+    public void test_serverError_logsOneWarnLineWithPathAndException() throws Exception {
+        final LogCapturingAppender appender = LogCapturingAppender.attach(ServerErrorLoggingFilter.class);
+        try {
+            final HttpServletRequest request = getMockRequest();
+            final HttpServletResponse response = getMockResponse();
+            getMockRequest().setMethod("GET");
+            final ExposedLoggingFilter loggingFilter = new ExposedLoggingFilter();
+            final IllegalStateException cause = new IllegalStateException("lonely validator annotation");
+
+            new ServerErrorLoggingFilter().doFilter(request, response,
+                    (req, res) -> loggingFilter.fireServerError(request, response, cause));
+
+            final List<String> warnings = appender.warnings();
+            assertEquals("expected exactly one WARN line, got " + warnings, 1, warnings.size());
+            final String line = warnings.get(0);
+            assertTrue(line + " must name the request path", line.contains(request.getRequestURI()));
+            assertTrue(line + " must name the request method", line.contains("GET"));
+            assertTrue(line + " must name the exception class", line.contains(IllegalStateException.class.getName()));
+            assertTrue(line + " must carry the exception message", line.contains("lonely validator annotation"));
+            // The stack trace belongs to debug: a WARN carrying the throwable would print it.
+            assertNull(appender.eventsAt(Level.WARN).get(0).getThrown(), "WARN line must not carry a stack trace");
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_noServerError_logsNothing() throws Exception {
+        final LogCapturingAppender appender = LogCapturingAppender.attach(ServerErrorLoggingFilter.class);
+        try {
+            new ServerErrorLoggingFilter().doFilter(getMockRequest(), getMockResponse(), (req, res) -> {
+                // an ordinary request: a 4xx or a redirect never reaches the server error callback
+            });
+            assertEquals("a request that did not fail must log nothing, got " + appender.events(), 0, appender.events().size());
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_registeredOutsideTheLoggingFilter() throws Exception {
+        final List<FilterHook> hooks =
+                ComponentUtil.getComponent(FwAssistantDirector.class).assistWebDirection().assistOutsideFilterHookList();
+        assertEquals("expected one outside filter hook, got " + hooks, 1, hooks.size());
+        final LogCapturingAppender appender = LogCapturingAppender.attach(ServerErrorLoggingFilter.class);
+        try {
+            final ExposedLoggingFilter loggingFilter = new ExposedLoggingFilter();
+            hooks.get(0)
+                    .hook(getMockRequest(), getMockResponse(),
+                            (req, res) -> loggingFilter.fireServerError(req, res, new IllegalStateException("registered hook")));
+            assertEquals("the registered hook must produce the WARN line, got " + appender.events(), 1, appender.warnings().size());
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    public void test_handlerDetachedAfterRequest() throws Exception {
+        final HttpServletRequest request = getMockRequest();
+        final HttpServletResponse response = getMockResponse();
+        final ExposedLoggingFilter loggingFilter = new ExposedLoggingFilter();
+        new ServerErrorLoggingFilter().doFilter(request, response, (req, res) -> {
+            // nothing failed during the request
+        });
+        final LogCapturingAppender appender = LogCapturingAppender.attach(ServerErrorLoggingFilter.class);
+        try {
+            loggingFilter.fireServerError(request, response, new IllegalStateException("after the request"));
+            assertEquals("the handler must not outlive the request, got " + appender.events(), 0, appender.events().size());
+        } finally {
+            appender.detach();
+        }
+    }
+}


### PR DESCRIPTION
web.xml sets errorLogging to false on lastaShowbaseFilter, so LastaFlute's
RequestLoggingFilter writes its server error dump at debug rather than at error,
and its actuallyFilter catches the exception, sends 500 itself and does not
rethrow, so the container never sees it either. That debug line goes to the
org.lastaflute logger, and bin/fess.in.sh ships FESS_LOG_LEVEL=warn, so the
appender drops it as well.

Under the shipped configuration an operator therefore had no way to find out that
any 500 had happened. With login.required=true, GET /search/advance and
GET /chat/clear both answer with the system error page, and neither fess.log nor
server_0.log holds a line about it. A user reports that an error page appeared
and the server side is silent.

errorLogging stays off, because turning it on brings back the multi-line
stack-trace dump that was presumably switched off deliberately. Instead Fess now
emits one WARN line of its own for an exception that becomes a 500, carrying the
method, the request path, the exception class and its message; the stack trace
stays behind debug, and the query string is left out because it holds
caller-supplied values.

The seam is RequestLoggingFilter's per-thread server error handler rather than a
servlet filter of our own around lastaShowbaseFilter: the logging filter swallows
the exception, so a wrapping filter would see a status code and never the
exception class or message the line has to carry, while that handler is invoked
from sendInternalServerError and from nowhere else. Client errors are dispatched
through a separate callback and the redirects Fess raises deliberately never
throw, so neither reaches the new line. The handler is per-thread, so
ServerErrorLoggingFilter installs it for the duration of the request and clears
it afterwards; FwWebDirection.directServletFilter with inside=false places it
outside the logging filter without another web.xml entry.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
