### PR TITLE
fix(api): keep the internal query out of the search error body

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
+++ b/src/main/java/org/codelibs/fess/api/v2/V2EnvelopeWriter.java
@@ -17,10 +17,15 @@ package org.codelibs.fess.api.v2;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.exception.InvalidAccessTokenException;
+import org.codelibs.fess.mylasta.action.FessMessages;
+import org.codelibs.fess.util.ComponentUtil;
+import org.lastaflute.web.validation.VaMessenger;
 
 import tools.jackson.databind.ObjectMapper;
 
@@ -142,6 +147,33 @@ public class V2EnvelopeWriter {
      */
     public void writeError(final HttpServletResponse res, final V2ErrorCode code, final String message) throws IOException {
         writeErrorWithDetails(res, code, message, null);
+    }
+
+    /**
+     * Writes an error envelope whose message is resolved from the application message resources.
+     *
+     * <p>An exception's own {@code getMessage()} is written for the log, not for the wire.
+     * {@code SearchEngineClient} used to put the whole {@code SearchRequestBuilder} dump there, and
+     * a handler that forwarded it handed the role filter terms, the {@code _source} allow-list, the
+     * internal field names and the per-field boosts to whoever issued the request. Handlers
+     * therefore pass the message code the exception was raised with, and only the message a user is
+     * meant to read reaches the caller.</p>
+     *
+     * @param res the HTTP response to write to
+     * @param code the v2 error code; its default HTTP status is applied to the response
+     * @param locale the caller's locale; {@code null} falls back to English
+     * @param messageCode the message code to resolve against {@code fess_message}
+     * @throws IOException if writing the envelope fails
+     */
+    public void writeUserMessageError(final HttpServletResponse res, final V2ErrorCode code, final Locale locale,
+            final VaMessenger<FessMessages> messageCode) throws IOException {
+        final FessMessages messages = new FessMessages();
+        messageCode.message(messages);
+        writeError(res, code,
+                ComponentUtil.getMessageManager()
+                        .toMessageList(locale != null ? locale : Locale.ENGLISH, messages)
+                        .stream()
+                        .collect(Collectors.joining(" ")));
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandler.java
@@ -34,6 +34,7 @@ import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.query.QueryFieldConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
+import org.lastaflute.core.message.UserMessages;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
@@ -162,11 +163,19 @@ public class ScrollSearchHandler {
             }
         } catch (final InvalidRequestParameterException e) {
             ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
-        } catch (final InvalidQueryException | ResultOffsetExceededException e) {
+        } catch (final InvalidQueryException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("invalid /api/v2/documents/all request", e);
             }
-            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeUserMessageError(response, V2ErrorCode.INVALID_REQUEST, request.getLocale(), e.getMessageCode());
+        } catch (final ResultOffsetExceededException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("invalid /api/v2/documents/all request", e);
+            }
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeUserMessageError(response, V2ErrorCode.INVALID_REQUEST, request.getLocale(),
+                            messages -> messages.addErrorsResultSizeExceeded(UserMessages.GLOBAL_PROPERTY_KEY));
         } catch (final UncheckedIOException e) {
             // Surface the underlying IOException so the servlet container can log/respond.
             throw e.getCause();

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/SearchHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/SearchHandler.java
@@ -39,6 +39,7 @@ import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.util.FacetResponse;
 import org.codelibs.fess.util.FacetResponse.Field;
 import org.dbflute.optional.OptionalThing;
+import org.lastaflute.core.message.UserMessages;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -106,11 +107,19 @@ public class SearchHandler {
             ComponentUtil.getV2EnvelopeWriter().writeSuccess(response, buildPayload(params.getQuery(), data));
         } catch (final InvalidRequestParameterException e) {
             ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
-        } catch (final InvalidQueryException | ResultOffsetExceededException e) {
+        } catch (final InvalidQueryException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("invalid /api/v2/search request", e);
             }
-            ComponentUtil.getV2EnvelopeWriter().writeError(response, V2ErrorCode.INVALID_REQUEST, e.getMessage());
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeUserMessageError(response, V2ErrorCode.INVALID_REQUEST, request.getLocale(), e.getMessageCode());
+        } catch (final ResultOffsetExceededException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("invalid /api/v2/search request", e);
+            }
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeUserMessageError(response, V2ErrorCode.INVALID_REQUEST, request.getLocale(),
+                            messages -> messages.addErrorsResultSizeExceeded(UserMessages.GLOBAL_PROPERTY_KEY));
         } catch (final Exception e) {
             ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2/search");
         }

--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -1864,14 +1864,20 @@ public class SearchEngineClient implements Client {
                 }
                 searchResponse = searchRequestBuilder.execute().actionGet(ComponentUtil.getFessConfig().getIndexSearchTimeout());
             } catch (final SearchPhaseExecutionException e) {
+                // The builder dump goes to the log, never into the exception message: callers
+                // report that message to the client, and the dump carries the role filter terms,
+                // the _source allow-list, internal field names and the per-field boosts.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Invalid query {}", searchRequestBuilder, e);
+                }
                 throw new InvalidQueryException(messages -> messages.addErrorsInvalidQueryParseError(UserMessages.GLOBAL_PROPERTY_KEY),
-                        "Invalid query: " + searchRequestBuilder, e);
+                        "Invalid query.", e);
             } catch (final OpenSearchException e) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Cannot process {}", searchRequestBuilder, e);
                 }
                 throw new InvalidQueryException(messages -> messages.addErrorsInvalidQueryCannotProcess(UserMessages.GLOBAL_PROPERTY_KEY),
-                        "Failed query: " + searchRequestBuilder, e);
+                        "Failed to process the query.", e);
             }
         }
         final long execTime = systemHelper.getCurrentTimeAsLong() - startTime;
@@ -1925,8 +1931,13 @@ public class SearchEngineClient implements Client {
                     return true;
                 });
             } catch (final SearchPhaseExecutionException e) {
+                // Same contract as search(): the dump is for the log, the exception message is
+                // what the scroll API hands back to the caller.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Invalid query {}", searchRequestBuilder, e);
+                }
                 throw new InvalidQueryException(messages -> messages.addErrorsInvalidQueryParseError(UserMessages.GLOBAL_PROPERTY_KEY),
-                        "Invalid query: " + searchRequestBuilder, e);
+                        "Invalid query.", e);
             }
         }
 

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/ScrollSearchHandlerTest.java
@@ -21,9 +21,11 @@ import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.codelibs.fess.entity.SearchRequestParams;
+import org.codelibs.fess.exception.InvalidQueryException;
 import org.codelibs.fess.helper.SearchHelper;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -33,6 +35,7 @@ import org.codelibs.fess.util.BooleanFunction;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
+import org.lastaflute.core.message.UserMessages;
 
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
@@ -229,6 +232,56 @@ public class ScrollSearchHandlerTest extends UnitFessTestCase {
     }
 
     /** Minimal HttpServletResponse stub. */
+    /**
+     * The scroll endpoint forwarded the exception message the same way {@code /search} did, so the
+     * {@code SearchRequestBuilder} dump reached the caller here too. Only the message the exception
+     * was raised with may go on the wire.
+     */
+    @Test
+    public void test_scroll_invalidQuery_reportsUserMessageNotTheQueryBuilder() throws Exception {
+        final FessConfig originalConfig = ComponentUtil.getFessConfig();
+        final String builderDump = "{\"from\":0,\"size\":100,\"query\":{\"bool\":{\"filter\":"
+                + "[{\"terms\":{\"role\":[\"Rfilter-term\"]}}]}},\"_source\":{\"includes\":[\"content\"]}}";
+        try {
+            ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public boolean isApiSearchScroll() {
+                    return true;
+                }
+            });
+            ComponentUtil.register(new SearchHelper() {
+                @Override
+                public long scrollSearch(final SearchRequestParams params, final BooleanFunction<Map<String, Object>> cursor,
+                        final OptionalThing<FessUserBean> userBean) {
+                    throw new InvalidQueryException(messages -> messages.addErrorsInvalidQueryParseError(UserMessages.GLOBAL_PROPERTY_KEY),
+                            "Invalid query: " + builderDump);
+                }
+            }, "searchHelper");
+            ComponentUtil.register(new QueryFieldConfig() {
+                @Override
+                public boolean isApiResponseField(final String field) {
+                    return true;
+                }
+            }, "queryFieldConfig");
+
+            final CapturingResponse res = new CapturingResponse();
+            final Map<String, String[]> params = new HashMap<>();
+            params.put("q", new String[] { "*" });
+            new ScrollSearchHandler().handle(new StubRequest("/api/v2/documents/all", params), res);
+
+            final String body = res.body();
+            assertEquals(body, 400, res.status);
+            assertFalse(body.contains("Invalid query:"), body);
+            assertFalse(body.contains("Rfilter-term"), body);
+            assertFalse(body.contains("_source"), body);
+            assertTrue(body.contains(ComponentUtil.getMessageManager().getMessage(Locale.ROOT, "errors.invalid_query_parse_error")), body);
+        } finally {
+            ComponentUtil.setFessConfig(originalConfig);
+        }
+    }
+
     private static class CapturingResponse implements HttpServletResponse {
         final StringWriter sw = new StringWriter();
         final PrintWriter writer = new PrintWriter(sw);

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/SearchHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/SearchHandlerTest.java
@@ -23,13 +23,22 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.codelibs.fess.entity.GeoInfo;
+import org.codelibs.fess.entity.SearchRenderData;
 import org.codelibs.fess.exception.InvalidQueryException;
+import org.codelibs.fess.exception.ResultOffsetExceededException;
+import org.codelibs.fess.helper.SearchHelper;
+import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.util.FacetResponse;
+import org.codelibs.fess.entity.SearchRequestParams;
+import org.dbflute.optional.OptionalThing;
 import org.junit.jupiter.api.Test;
+import org.lastaflute.core.message.UserMessages;
 
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
@@ -300,6 +309,66 @@ public class SearchHandlerTest extends UnitFessTestCase {
         public Map<String, Long> getValueCountMap() {
             return overrideValueCountMap.isEmpty() ? super.getValueCountMap() : overrideValueCountMap;
         }
+    }
+
+    /**
+     * A rejected query must not hand the caller the request the engine was given.
+     *
+     * <p>{@code SearchEngineClient} put the whole {@code SearchRequestBuilder} into the exception
+     * message, and the handler forwarded that message as {@code error.message}: an anonymous caller
+     * read back the role filter terms, the {@code _source} allow-list, the internal field names and
+     * the per-field boosts from one request. The caller now sees only the message the exception was
+     * raised with.</p>
+     */
+    @Test
+    public void test_search_invalidQuery_reportsUserMessageNotTheQueryBuilder() throws Exception {
+        final String builderDump = "{\"from\":10001,\"size\":10,\"timeout\":\"10000ms\",\"query\":{\"bool\":{\"must\":"
+                + "[{\"function_score\":{\"query\":{\"bool\":{\"filter\":[{\"terms\":{\"role\":[\"Rfilter-term\"]}}]}}}}]}},"
+                + "\"_source\":{\"includes\":[\"content\",\"title\"]}}";
+        ComponentUtil.register(new SearchHelper() {
+            @Override
+            public void search(final SearchRequestParams searchRequestParams, final SearchRenderData data,
+                    final OptionalThing<FessUserBean> userBean) {
+                throw new InvalidQueryException(messages -> messages.addErrorsInvalidQueryCannotProcess(UserMessages.GLOBAL_PROPERTY_KEY),
+                        "Failed query: " + builderDump);
+            }
+        }, "searchHelper");
+
+        final CapturingResponse res = new CapturingResponse();
+        final Map<String, String[]> params = new HashMap<>();
+        params.put("q", new String[] { "*" });
+        new SearchHandler().handle(new StubRequest("/api/v2/search", params), res);
+
+        final String body = res.body();
+        assertEquals(body, 400, res.status);
+        assertFalse(body.contains("Failed query"), body);
+        assertFalse(body.contains("function_score"), body);
+        assertFalse(body.contains("Rfilter-term"), body);
+        assertFalse(body.contains("_source"), body);
+        assertTrue(body.contains(ComponentUtil.getMessageManager().getMessage(Locale.ROOT, "errors.invalid_query_cannot_process")), body);
+    }
+
+    /**
+     * The offset ceiling has its own message; it used to arrive as the exception's own text.
+     */
+    @Test
+    public void test_search_resultOffsetExceeded_reportsUserMessage() throws Exception {
+        ComponentUtil.register(new SearchHelper() {
+            @Override
+            public void search(final SearchRequestParams searchRequestParams, final SearchRenderData data,
+                    final OptionalThing<FessUserBean> userBean) {
+                throw new ResultOffsetExceededException("The number of result size is exceeded.");
+            }
+        }, "searchHelper");
+
+        final CapturingResponse res = new CapturingResponse();
+        final Map<String, String[]> params = new HashMap<>();
+        params.put("q", new String[] { "*" });
+        new SearchHandler().handle(new StubRequest("/api/v2/search", params), res);
+
+        final String body = res.body();
+        assertEquals(body, 400, res.status);
+        assertTrue(body.contains(ComponentUtil.getMessageManager().getMessage(Locale.ROOT, "errors.result_size_exceeded")), body);
     }
 
     /** Minimal HttpServletResponse stub — local copy of SearchApiV2ManagerTest.CapturingResponse. */


### PR DESCRIPTION
SearchEngineClient built the InvalidQueryException message by appending the
SearchRequestBuilder, at line 1867 for a parse failure and at line 1873 for a
query the engine refused, and the v2 search handler forwarded that message
straight into error.message. An unauthenticated GET /api/v2/search asking for an
offset past the result window therefore answered with a message of 1616
characters holding the whole request the engine had been given: the terms the
permission filter matches on, the _source allow-list, the internal field names
and the per-field boosts. One request was enough to read all of it. The scroll
endpoint had the same shape through the third such throw at line 1928. This is
not a 15.9 regression; the released 15.8.0 distribution answers the same request
with a byte-identical body.

The dump itself is worth keeping, so it moves to the debug log beside the
"Cannot process" line already there, and the exception message becomes a short
constant. The exceptions already carry the message code for the text a user is
meant to read, and the handlers now resolve that code against fess_message for
the caller's locale through a new entry point on V2EnvelopeWriter instead of
reading getMessage().

Both halves are changed deliberately. The throw site keeps the dump out of every
consumer that logs or forwards the message, not only the two handlers, while the
handler stops the API from echoing an exception's own text at all, so a throw
site added later cannot put something internal back on the wire.

The offset ceiling was caught alongside the query errors and reported its
exception text as well; it is now split out and answers with
errors.result_size_exceeded, which is the message that describes it.
query.max.search.result.offset still defaults to 100000, so an offset between
the engine's result window and that ceiling is still reported as a query that
could not be processed; whether that default should follow the result window is
a separate question and is left alone here.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
