### PR TITLE
fix(search): refuse a search that asks for the total not to be tracked

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
@@ -359,6 +359,9 @@ public class FessMessages extends FessLabels {
     /** The key of the message: The specified facet {0} is unsupported. */
     public static final String ERRORS_invalid_query_unsupported_facet_field = "{errors.invalid_query_unsupported_facet_field}";
 
+    /** The key of the message: The specified track_total_hits {0} is unsupported. */
+    public static final String ERRORS_invalid_query_unsupported_track_total_hits = "{errors.invalid_query_unsupported_track_total_hits}";
+
     /** The key of the message: Could not process the specified query. */
     public static final String ERRORS_invalid_query_cannot_process = "{errors.invalid_query_cannot_process}";
 
@@ -2260,6 +2263,21 @@ public class FessMessages extends FessLabels {
     public FessMessages addErrorsInvalidQueryUnsupportedFacetField(String property, String arg0) {
         assertPropertyNotNull(property);
         add(property, new UserMessage(ERRORS_invalid_query_unsupported_facet_field, arg0));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.invalid_query_unsupported_track_total_hits' with parameters.
+     * <pre>
+     * message: The specified track_total_hits {0} is unsupported.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsInvalidQueryUnsupportedTrackTotalHits(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_invalid_query_unsupported_track_total_hits, arg0));
         return this;
     }
 

--- a/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
+++ b/src/main/java/org/codelibs/fess/opensearch/client/SearchEngineClient.java
@@ -2478,15 +2478,26 @@ public class SearchEngineClient implements Client {
         /**
          * Builds the track total hits configuration.
          *
+         * <p>Turning the total off is not supported. OpenSearch answers such a request by leaving
+         * {@code hits.total} out of the response, and the record count derived from it is what the
+         * pager, the result screen and the {@code record_count} of the API are all built on: without
+         * it the response handler reads a null total and every search comes back empty. The value is
+         * refused wherever it is given, as a search parameter and in
+         * {@code query.track.total.hits} alike.</p>
+         *
          * @param fessConfig the Fess configuration
+         * @throws InvalidQueryException if the total was asked not to be tracked
          */
         protected void buildTrackTotalHits(final FessConfig fessConfig) {
             if (isScroll) {
                 return;
             }
             if (StringUtil.isNotBlank(trackTotalHits)) {
-                if (Constants.TRUE.equalsIgnoreCase(trackTotalHits) || Constants.FALSE.equalsIgnoreCase(trackTotalHits)) {
-                    searchRequestBuilder.setTrackTotalHits(Boolean.parseBoolean(trackTotalHits));
+                if (Constants.FALSE.equalsIgnoreCase(trackTotalHits)) {
+                    throw unsupportedTrackTotalHits(trackTotalHits);
+                }
+                if (Constants.TRUE.equalsIgnoreCase(trackTotalHits)) {
+                    searchRequestBuilder.setTrackTotalHits(true);
                     return;
                 }
                 try {
@@ -2497,11 +2508,27 @@ public class SearchEngineClient implements Client {
                 }
             }
             final Object trackTotalHitsValue = fessConfig.getQueryTrackTotalHitsValue();
+            if (Boolean.FALSE.equals(trackTotalHitsValue)) {
+                throw unsupportedTrackTotalHits(fessConfig.getQueryTrackTotalHits());
+            }
             if (trackTotalHitsValue instanceof Boolean) {
                 searchRequestBuilder.setTrackTotalHits((Boolean) trackTotalHitsValue);
             } else if (trackTotalHitsValue instanceof Number) {
                 searchRequestBuilder.setTrackTotalHitsUpTo(((Number) trackTotalHitsValue).intValue());
             }
+        }
+
+        /**
+         * Builds the failure for a track total hits value that would leave the response without a
+         * total.
+         *
+         * @param value the value that was given
+         * @return the exception to throw
+         */
+        protected InvalidQueryException unsupportedTrackTotalHits(final String value) {
+            return new InvalidQueryException(
+                    messages -> messages.addErrorsInvalidQueryUnsupportedTrackTotalHits(UserMessages.GLOBAL_PROPERTY_KEY, value),
+                    "Unsupported track_total_hits: " + value);
         }
 
         /**

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -771,7 +771,9 @@ query.max.length=1000
 query.timeout=10000
 # Whether to enable logging for query timeouts.
 query.timeout.logging=true
-# Maximum number of total hits to track in queries.
+# Maximum number of total hits to track in queries. Only a positive number or true is
+# supported: false leaves the response without a hit count, and a search that asks for it,
+# here or as a search parameter, is refused.
 query.track.total.hits=10000
 # Fields used for geo search queries.
 query.geo.fields=location

--- a/src/main/resources/fess_message.properties
+++ b/src/main/resources/fess_message.properties
@@ -137,6 +137,7 @@ errors.invalid_query_sort_value = The specified sort {0} is invalid.
 errors.invalid_query_unsupported_sort_field = The specified sort {0} is unsupported.
 errors.invalid_query_unsupported_sort_order = The specified sort order {0} is unsupported.
 errors.invalid_query_unsupported_facet_field = The specified facet {0} is unsupported.
+errors.invalid_query_unsupported_track_total_hits = The specified track_total_hits {0} is unsupported.
 errors.invalid_query_cannot_process=Could not process the specified query.
 errors.crud_invalid_mode = The mode is incorrect. (not {0}, but {1})
 errors.crud_failed_to_create_instance = Failed to create a new data.

--- a/src/main/resources/fess_message_de.properties
+++ b/src/main/resources/fess_message_de.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = Die angegebene Sortierung {0} ist ungültig.
 errors.invalid_query_unsupported_sort_field = Die angegebene Sortierung {0} wird nicht unterstützt.
 errors.invalid_query_unsupported_sort_order = Die angegebene Sortierreihenfolge {0} wird nicht unterstützt.
 errors.invalid_query_unsupported_facet_field = Die angegebene Facette {0} wird nicht unterstützt.
+errors.invalid_query_unsupported_track_total_hits = Der angegebene Wert {0} für track_total_hits wird nicht unterstützt.
 errors.invalid_query_cannot_process=Die angegebene Abfrage konnte nicht verarbeitet werden.
 errors.crud_invalid_mode = Der Modus ist falsch. (nicht {0}, sondern {1})
 errors.crud_failed_to_create_instance = Fehler beim Erstellen neuer Daten.

--- a/src/main/resources/fess_message_en.properties
+++ b/src/main/resources/fess_message_en.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = The specified sort {0} is invalid.
 errors.invalid_query_unsupported_sort_field = The specified sort {0} is unsupported.
 errors.invalid_query_unsupported_sort_order = The specified sort order {0} is unsupported.
 errors.invalid_query_unsupported_facet_field = The specified facet {0} is unsupported.
+errors.invalid_query_unsupported_track_total_hits = The specified track_total_hits {0} is unsupported.
 errors.invalid_query_cannot_process=Could not process the specified query.
 errors.crud_invalid_mode = The mode is incorrect. (not {0}, but {1})
 errors.crud_failed_to_create_instance = Failed to create a new data.

--- a/src/main/resources/fess_message_es.properties
+++ b/src/main/resources/fess_message_es.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = El orden de clasificación especificado {0} no
 errors.invalid_query_unsupported_sort_field = El campo de ordenación especificado {0} no es compatible.
 errors.invalid_query_unsupported_sort_order = El orden de clasificación especificado {0} no es compatible.
 errors.invalid_query_unsupported_facet_field = La faceta especificada {0} no es compatible.
+errors.invalid_query_unsupported_track_total_hits = El valor {0} de track_total_hits especificado no es compatible.
 errors.invalid_query_cannot_process=No se pudo procesar la consulta especificada.
 errors.crud_invalid_mode = Modo incorrecto. (Es {1}, no {0})
 errors.crud_failed_to_create_instance = No se pudieron crear nuevos datos.

--- a/src/main/resources/fess_message_fr.properties
+++ b/src/main/resources/fess_message_fr.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = Le tri spécifié {0} n'est pas valide.
 errors.invalid_query_unsupported_sort_field = Le tri spécifié {0} n'est pas pris en charge.
 errors.invalid_query_unsupported_sort_order = L'ordre de tri spécifié {0} n'est pas pris en charge.
 errors.invalid_query_unsupported_facet_field = La facette spécifiée {0} n'est pas prise en charge.
+errors.invalid_query_unsupported_track_total_hits = La valeur {0} de track_total_hits spécifiée n'est pas prise en charge.
 errors.invalid_query_cannot_process=Impossible de traiter la requête spécifiée.
 errors.crud_invalid_mode = Le mode est incorrect. (pas {0}, mais {1})
 errors.crud_failed_to_create_instance = Échec de la création de nouvelles données.

--- a/src/main/resources/fess_message_hi.properties
+++ b/src/main/resources/fess_message_hi.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = निर्दिष्ट सॉर्ट {0
 errors.invalid_query_unsupported_sort_field = निर्दिष्ट सॉर्ट {0} असमर्थित है।
 errors.invalid_query_unsupported_sort_order = निर्दिष्ट सॉर्ट क्रम {0} असमर्थित है।
 errors.invalid_query_unsupported_facet_field = निर्दिष्ट पहलू {0} असमर्थित है।
+errors.invalid_query_unsupported_track_total_hits = निर्दिष्ट track_total_hits {0} असमर्थित है।
 errors.invalid_query_cannot_process=निर्दिष्ट क्वेरी को संसाधित नहीं किया जा सका।
 errors.crud_invalid_mode = मोड गलत है। ({0} नहीं, बल्कि {1})
 errors.crud_failed_to_create_instance = नया डेटा बनाने में विफल।

--- a/src/main/resources/fess_message_id.properties
+++ b/src/main/resources/fess_message_id.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = Sortir yang ditentukan {0} tidak valid.
 errors.invalid_query_unsupported_sort_field = Sortir yang ditentukan {0} tidak didukung.
 errors.invalid_query_unsupported_sort_order = Urutan sortir yang ditentukan {0} tidak didukung.
 errors.invalid_query_unsupported_facet_field = Faset yang ditentukan {0} tidak didukung.
+errors.invalid_query_unsupported_track_total_hits = Nilai track_total_hits {0} yang ditentukan tidak didukung.
 errors.invalid_query_cannot_process=Tidak dapat memproses kueri yang ditentukan.
 errors.crud_invalid_mode = Mode tidak benar. (bukan {0}, tetapi {1})
 errors.crud_failed_to_create_instance = Gagal membuat data baru.

--- a/src/main/resources/fess_message_it.properties
+++ b/src/main/resources/fess_message_it.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = L'ordinamento specificato {0} non è valido.
 errors.invalid_query_unsupported_sort_field = Il campo di ordinamento specificato {0} non è supportato.
 errors.invalid_query_unsupported_sort_order = L'ordinamento specificato {0} non è supportato.
 errors.invalid_query_unsupported_facet_field = La faccetta specificata {0} non è supportata.
+errors.invalid_query_unsupported_track_total_hits = Il valore {0} di track_total_hits specificato non è supportato.
 errors.invalid_query_cannot_process=Impossibile elaborare la query specificata.
 errors.crud_invalid_mode = Modalità non valida. (È {1}, non {0})
 errors.crud_failed_to_create_instance = Impossibile creare nuovi dati.

--- a/src/main/resources/fess_message_ja.properties
+++ b/src/main/resources/fess_message_ja.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = 指定されたソート {0} が無効です�
 errors.invalid_query_unsupported_sort_field = 指定されたソート {0} はサポートされていません。
 errors.invalid_query_unsupported_sort_order = 指定されたソート順 {0} はサポートされていません。
 errors.invalid_query_unsupported_facet_field = 指定されたファセット {0} はサポートされていません。
+errors.invalid_query_unsupported_track_total_hits = 指定された track_total_hits {0} はサポートされていません。
 errors.invalid_query_cannot_process=指定されたクエリーを処理できませんでした。
 errors.crud_invalid_mode = モードが正しくありません。({0} でなく、{1} です)
 errors.crud_failed_to_create_instance = 新しいデータの作成に失敗しました。

--- a/src/main/resources/fess_message_ko.properties
+++ b/src/main/resources/fess_message_ko.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = 지정된 정렬 {0}이(가) 잘못되었습�
 errors.invalid_query_unsupported_sort_field = 지정된 정렬 {0}은(는) 지원되지 않습니다.
 errors.invalid_query_unsupported_sort_order = 지정된 정렬 순서 {0}은(는) 지원되지 않습니다.
 errors.invalid_query_unsupported_facet_field = 지정된 패싯 {0}은(는) 지원되지 않습니다.
+errors.invalid_query_unsupported_track_total_hits = 지정된 track_total_hits {0}은(는) 지원되지 않습니다.
 errors.invalid_query_cannot_process=지정된 쿼리를 처리할 수 없습니다.
 errors.crud_invalid_mode = 모드가 잘못되었습니다. ({0}이(가) 아니고 {1}입니다)
 errors.crud_failed_to_create_instance = 새 데이터를 만들지 못했습니다.

--- a/src/main/resources/fess_message_nl.properties
+++ b/src/main/resources/fess_message_nl.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = De opgegeven sorteerwaarde {0} is ongeldig.
 errors.invalid_query_unsupported_sort_field = Het opgegeven sorteerveld {0} wordt niet ondersteund.
 errors.invalid_query_unsupported_sort_order = De opgegeven sorteervolgorde {0} wordt niet ondersteund.
 errors.invalid_query_unsupported_facet_field = Het opgegeven facet {0} wordt niet ondersteund.
+errors.invalid_query_unsupported_track_total_hits = De opgegeven track_total_hits {0} wordt niet ondersteund.
 errors.invalid_query_cannot_process=Kan de opgegeven query niet verwerken.
 errors.crud_invalid_mode = Ongeldige modus. (Is {1}, niet {0})
 errors.crud_failed_to_create_instance = Kan geen nieuwe gegevens maken.

--- a/src/main/resources/fess_message_pl.properties
+++ b/src/main/resources/fess_message_pl.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = Określona wartość sortowania {0} jest niepr
 errors.invalid_query_unsupported_sort_field = Określone pole sortowania {0} nie jest obsługiwane.
 errors.invalid_query_unsupported_sort_order = Określona kolejność sortowania {0} nie jest obsługiwana.
 errors.invalid_query_unsupported_facet_field = Określony aspekt {0} nie jest obsługiwany.
+errors.invalid_query_unsupported_track_total_hits = Określona wartość {0} parametru track_total_hits nie jest obsługiwana.
 errors.invalid_query_cannot_process=Nie można przetworzyć określonego zapytania.
 errors.crud_invalid_mode = Nieprawidłowy tryb. (Jest {1}, a nie {0})
 errors.crud_failed_to_create_instance = Nie można utworzyć nowych danych.

--- a/src/main/resources/fess_message_pt_BR.properties
+++ b/src/main/resources/fess_message_pt_BR.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = A ordenação especificada {0} é inválida.
 errors.invalid_query_unsupported_sort_field = O campo de ordenação especificado {0} não é suportado.
 errors.invalid_query_unsupported_sort_order = A ordem de ordenação especificada {0} não é suportada.
 errors.invalid_query_unsupported_facet_field = A faceta especificada {0} não é suportada.
+errors.invalid_query_unsupported_track_total_hits = O valor {0} de track_total_hits especificado não é suportado.
 errors.invalid_query_cannot_process=Não foi possível processar a consulta especificada.
 errors.crud_invalid_mode = Modo inválido. (É {1}, não {0})
 errors.crud_failed_to_create_instance = Não foi possível criar novos dados.

--- a/src/main/resources/fess_message_ru.properties
+++ b/src/main/resources/fess_message_ru.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = Указанная сортировка {0} н
 errors.invalid_query_unsupported_sort_field = Указанная сортировка {0} не поддерживается.
 errors.invalid_query_unsupported_sort_order = Указанный порядок сортировки {0} не поддерживается.
 errors.invalid_query_unsupported_facet_field = Указанная фасета {0} не поддерживается.
+errors.invalid_query_unsupported_track_total_hits = Указанное значение {0} параметра track_total_hits не поддерживается.
 errors.invalid_query_cannot_process=Не удалось обработать указанный запрос.
 errors.crud_invalid_mode = Режим неверный. (не {0}, а {1})
 errors.crud_failed_to_create_instance = Не удалось создать новые данные.

--- a/src/main/resources/fess_message_tr.properties
+++ b/src/main/resources/fess_message_tr.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = Belirtilen sıralama {0} geçersiz.
 errors.invalid_query_unsupported_sort_field = Belirtilen sıralama {0} desteklenmiyor.
 errors.invalid_query_unsupported_sort_order = Belirtilen sıralama düzeni {0} desteklenmiyor.
 errors.invalid_query_unsupported_facet_field = Belirtilen facet {0} desteklenmiyor.
+errors.invalid_query_unsupported_track_total_hits = Belirtilen track_total_hits {0} desteklenmiyor.
 errors.invalid_query_cannot_process=Belirtilen sorgu işlenemedi.
 errors.crud_invalid_mode = Mod yanlış. ({0} değil, {1})
 errors.crud_failed_to_create_instance = Yeni veri oluşturulamadı.

--- a/src/main/resources/fess_message_zh_CN.properties
+++ b/src/main/resources/fess_message_zh_CN.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = 指定的排序 {0} 无效。
 errors.invalid_query_unsupported_sort_field = 指定的排序字段 {0} 不受支持。
 errors.invalid_query_unsupported_sort_order = 指定的排序顺序 {0} 不受支持。
 errors.invalid_query_unsupported_facet_field = 指定的分类筛选字段 {0} 不受支持。
+errors.invalid_query_unsupported_track_total_hits = 指定的 track_total_hits {0} 不受支持。
 errors.invalid_query_cannot_process=无法处理指定的查询。
 errors.crud_invalid_mode = 模式不正确。(是 {1}，而不是 {0})
 errors.crud_failed_to_create_instance = 无法创建新数据。

--- a/src/main/resources/fess_message_zh_TW.properties
+++ b/src/main/resources/fess_message_zh_TW.properties
@@ -133,6 +133,7 @@ errors.invalid_query_sort_value = 指定的排序 {0} 無效。
 errors.invalid_query_unsupported_sort_field = 指定的排序欄位 {0} 不支援。
 errors.invalid_query_unsupported_sort_order = 指定的排序順序 {0} 不支援。
 errors.invalid_query_unsupported_facet_field = 指定的分類篩選欄位 {0} 不支援。
+errors.invalid_query_unsupported_track_total_hits = 指定的 track_total_hits {0} 不支援。
 errors.invalid_query_cannot_process=無法處理指定的查詢。
 errors.crud_invalid_mode = 模式不正確。(是 {1}，而不是 {0})
 errors.crud_failed_to_create_instance = 無法建立新資料。

--- a/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientTrackTotalHitsTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/client/SearchEngineClientTrackTotalHitsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.opensearch.client;
+
+import org.codelibs.fess.exception.InvalidQueryException;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.opensearch.client.SearchEngineClient.SearchConditionBuilder;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.search.SearchAction;
+import org.opensearch.action.search.SearchRequestBuilder;
+
+/**
+ * Verifies that a search is never sent with the total turned off.
+ *
+ * <p>{@code track_total_hits=false} makes OpenSearch leave {@code hits.total} out of the response,
+ * and {@code SearchHits#getTotalHits()} then returns null. Every record count Fess shows - the
+ * pager, the result screen, {@code record_count} in the API - is derived from that total, and the
+ * response handler read it unconditionally, so such a search came back as zero documents with a
+ * NullPointerException in fess.log. The value is refused where it enters instead.</p>
+ */
+public class SearchEngineClientTrackTotalHitsTest extends UnitFessTestCase {
+
+    @Test
+    public void test_requestedFalse_isRefused() {
+        try {
+            build("false", ComponentUtil.getFessConfig());
+            fail("InvalidQueryException should be thrown for track_total_hits=false.");
+        } catch (final InvalidQueryException e) {
+            assertNotNull(e.getMessageCode());
+            assertTrue(e.getMessage().contains("false"));
+        }
+    }
+
+    // The parameter is compared without regard to case wherever else it is read, so the refusal
+    // cannot be sidestepped by spelling it differently.
+    @Test
+    public void test_requestedFalseInAnyCase_isRefused() {
+        try {
+            build("False", ComponentUtil.getFessConfig());
+            fail("InvalidQueryException should be thrown for track_total_hits=False.");
+        } catch (final InvalidQueryException e) {
+            assertNotNull(e.getMessageCode());
+        }
+    }
+
+    @Test
+    public void test_requestedTrue_countsEveryMatch() {
+        assertEquals(Integer.MAX_VALUE, trackTotalHitsUpTo(build("true", ComponentUtil.getFessConfig())));
+    }
+
+    @Test
+    public void test_requestedNumber_countsUpToIt() {
+        assertEquals(100, trackTotalHitsUpTo(build("100", ComponentUtil.getFessConfig())));
+    }
+
+    @Test
+    public void test_notRequested_countsUpToTheConfiguredValue() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        assertEquals(fessConfig.getQueryTrackTotalHitsValue(), trackTotalHitsUpTo(build(null, fessConfig)));
+    }
+
+    // An administrator can put the same unsupported value in the configuration file, and it is
+    // refused there too rather than quietly producing searches that answer nothing.
+    @Test
+    public void test_configuredFalse_isRefused() {
+        final FessConfig fessConfig = new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getQueryTrackTotalHits() {
+                return "false";
+            }
+
+            @Override
+            public Object getQueryTrackTotalHitsValue() {
+                return Boolean.FALSE;
+            }
+        };
+
+        try {
+            build(null, fessConfig);
+            fail("InvalidQueryException should be thrown for query.track.total.hits=false.");
+        } catch (final InvalidQueryException e) {
+            assertNotNull(e.getMessageCode());
+            assertTrue(e.getMessage().contains("false"));
+        }
+    }
+
+    private Integer trackTotalHitsUpTo(final SearchRequestBuilder searchRequestBuilder) {
+        return searchRequestBuilder.request().source().trackTotalHitsUpTo();
+    }
+
+    private SearchRequestBuilder build(final String trackTotalHits, final FessConfig fessConfig) {
+        final SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(new SearchEngineClient(), SearchAction.INSTANCE);
+        SearchConditionBuilder.builder(searchRequestBuilder).trackTotalHits(trackTotalHits).buildTrackTotalHits(fessConfig);
+        return searchRequestBuilder;
+    }
+}


### PR DESCRIPTION
track_total_hits=false is accepted both as a search parameter and as the value
of query.track.total.hits, and OpenSearch answers such a request by leaving
hits.total out of the response entirely: SearchHits holds the total as
@Nullable, writes a hasTotalHits flag on the wire, and omits the field from the
JSON. The response handler read the total unconditionally, so every search sent
that way died on a NullPointerException before a single hit was copied out, was
swallowed one frame up, and came back as an empty result set: record_count 0,
relation EQUAL_TO, no documents at all, and one warning per request in
fess.log. On a 3,229 document index the same query returned three documents
with the default setting, three with track_total_hits=100, and nothing with
track_total_hits=false.

The record count is not decoration. The pager derives allPageCount from it, the
result screen prints it, and the API reports it as record_count, so a response
that carries no total cannot serve a search, and a number invented in its place
would be a count of nothing. The value is therefore refused wherever it is
given, as an invalid query, the same way an unsupported sort field or facet
field is refused: as a search parameter, so the caller is told what was wrong
with the request instead of receiving an empty result set, and in
query.track.total.hits, so an installation configured that way fails visibly at
the first search rather than answering every one of them with nothing.

true and any positive number keep working exactly as before.

This is not a 15.9 regression; the affected code is unchanged since 15.8.

---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
