### PR TITLE
fix(search): stop reporting an unreachable engine as zero results

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessLabels.java
@@ -2886,6 +2886,9 @@ public class FessLabels extends UserMessages {
     /** The key of the message: The search processing time has exceeded the limit. The displayed results may be partial. */
     public static final String LABELS_process_time_is_exceeded = "{labels.process_time_is_exceeded}";
 
+    /** The key of the message: The search could not be completed, so no results can be shown. This does not mean that no document matched. Please try again later. */
+    public static final String LABELS_search_could_not_be_completed = "{labels.search_could_not_be_completed}";
+
     /** The key of the message: Given Name */
     public static final String LABELS_user_given_name = "{labels.user_given_name}";
 

--- a/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/RankFusionProcessor.java
@@ -482,14 +482,20 @@ public class RankFusionProcessor implements AutoCloseable {
      * former. The same flag is already set for a timeout, which is the milder version of exactly
      * this condition.
      * </p>
+     * <p>
+     * The count relation carries the same distinction. No total was ever obtained here, so the
+     * response says {@code GREATER_THAN_OR_EQUAL_TO} rather than {@code EQUAL_TO}: zero or more
+     * documents match, which is all that is actually known. Declaring the zero exact would
+     * contradict the {@code partialResults} flag set beside it.
+     * </p>
      *
      * @param params search request parameters, for the start position
      * @param pageSize the page size to report
      * @return an empty response list flagged as partial
      */
     protected QueryResponseList createDegradedResponseList(final SearchRequestParams params, final int pageSize) {
-        return createResponseList(Collections.emptyList(), 0, Relation.EQUAL_TO.toString(), 0, true, null, params.getStartPosition(),
-                pageSize, 0);
+        return createResponseList(Collections.emptyList(), 0, Relation.GREATER_THAN_OR_EQUAL_TO.toString(), 0, true, null,
+                params.getStartPosition(), pageSize, 0);
     }
 
     /**

--- a/src/main/resources/fess_label.properties
+++ b/src/main/resources/fess_label.properties
@@ -952,6 +952,7 @@ labels.backup_name=Name
 labels.backup_bulk_file=Bulk File
 labels.backup_button_upload=Upload
 labels.process_time_is_exceeded=The search processing time has exceeded the limit. The displayed results may be partial.
+labels.search_could_not_be_completed=The search could not be completed, so no results can be shown. This does not mean that no document matched. Please try again later.
 labels.user_given_name=Given Name
 labels.givenName=Given Name
 labels.user_surname=Surname

--- a/src/main/resources/fess_label_de.properties
+++ b/src/main/resources/fess_label_de.properties
@@ -952,6 +952,7 @@ labels.backup_name=Name
 labels.backup_bulk_file=Bulk-Datei
 labels.backup_button_upload=Hochladen
 labels.process_time_is_exceeded=Die Suchverarbeitungszeit hat das Limit überschritten. Die angezeigten Ergebnisse können unvollständig sein.
+labels.search_could_not_be_completed=Die Suche konnte nicht abgeschlossen werden, daher können keine Ergebnisse angezeigt werden. Das bedeutet nicht, dass kein Dokument übereingestimmt hat. Bitte versuchen Sie es später erneut.
 labels.user_given_name=Vorname
 labels.givenName=Vorname (gegebener Name)
 labels.user_surname=Nachname

--- a/src/main/resources/fess_label_en.properties
+++ b/src/main/resources/fess_label_en.properties
@@ -952,6 +952,7 @@ labels.backup_name=Name
 labels.backup_bulk_file=Bulk File
 labels.backup_button_upload=Upload
 labels.process_time_is_exceeded=The search processing time has exceeded the limit. The displayed results may be partial.
+labels.search_could_not_be_completed=The search could not be completed, so no results can be shown. This does not mean that no document matched. Please try again later.
 labels.user_given_name=Given Name
 labels.givenName=Given Name
 labels.user_surname=Surname

--- a/src/main/resources/fess_label_es.properties
+++ b/src/main/resources/fess_label_es.properties
@@ -951,6 +951,7 @@ labels.backup_name=Nombre
 labels.backup_bulk_file=Archivo masivo
 labels.backup_button_upload=Subir
 labels.process_time_is_exceeded=Se ha superado el tiempo de espera de la búsqueda. Los resultados mostrados pueden ser parciales.
+labels.search_could_not_be_completed=No se pudo completar la búsqueda, por lo que no se pueden mostrar resultados. Esto no significa que ningún documento coincidiera. Vuelva a intentarlo más tarde.
 labels.user_given_name=Nombre de pila
 labels.givenName=Nombre (dado)
 labels.user_surname=Apellido

--- a/src/main/resources/fess_label_fr.properties
+++ b/src/main/resources/fess_label_fr.properties
@@ -952,6 +952,7 @@ labels.backup_name=Nom
 labels.backup_bulk_file=Fichier en vrac
 labels.backup_button_upload=Téléverser
 labels.process_time_is_exceeded=Le temps de traitement de la recherche a dépassé la limite. Les résultats affichés peuvent être partiels.
+labels.search_could_not_be_completed=La recherche n'a pas pu être effectuée, aucun résultat ne peut donc être affiché. Cela ne signifie pas qu'aucun document ne correspond. Veuillez réessayer plus tard.
 labels.user_given_name=Prénom
 labels.givenName=Prénom (nom donné)
 labels.user_surname=Nom de famille

--- a/src/main/resources/fess_label_hi.properties
+++ b/src/main/resources/fess_label_hi.properties
@@ -952,6 +952,7 @@ labels.backup_name=नाम
 labels.backup_bulk_file=बल्क फ़ाइल
 labels.backup_button_upload=अपलोड
 labels.process_time_is_exceeded=खोज प्रसंस्करण समय सीमा पार कर गया है। प्रदर्शित परिणाम आंशिक हो सकते हैं।
+labels.search_could_not_be_completed=खोज पूरी नहीं की जा सकी, इसलिए कोई परिणाम नहीं दिखाया जा सकता। इसका अर्थ यह नहीं है कि कोई दस्तावेज़ मेल नहीं खाया। कृपया बाद में पुनः प्रयास करें।
 labels.user_given_name=दिया गया नाम
 labels.givenName=दिया गया नाम
 labels.user_surname=उपनाम

--- a/src/main/resources/fess_label_id.properties
+++ b/src/main/resources/fess_label_id.properties
@@ -952,6 +952,7 @@ labels.backup_name=Nama
 labels.backup_bulk_file=Berkas Bulk
 labels.backup_button_upload=Unggah
 labels.process_time_is_exceeded=Waktu pemrosesan pencarian telah melebihi batas. Hasil yang ditampilkan mungkin parsial.
+labels.search_could_not_be_completed=Pencarian tidak dapat diselesaikan, sehingga tidak ada hasil yang dapat ditampilkan. Ini tidak berarti bahwa tidak ada dokumen yang cocok. Silakan coba lagi nanti.
 labels.user_given_name=Nama Depan
 labels.givenName=Nama Depan
 labels.user_surname=Nama Belakang

--- a/src/main/resources/fess_label_it.properties
+++ b/src/main/resources/fess_label_it.properties
@@ -945,6 +945,7 @@ labels.backup_name=Nome
 labels.backup_bulk_file=File di massa
 labels.backup_button_upload=Carica
 labels.process_time_is_exceeded=Il tempo di attesa della ricerca è stato superato. I risultati visualizzati potrebbero essere parziali.
+labels.search_could_not_be_completed=Non è stato possibile completare la ricerca, quindi non è possibile mostrare alcun risultato. Questo non significa che nessun documento corrisponda. Riprovare più tardi.
 labels.user_given_name=Nome
 labels.givenName=Nome (dato)
 labels.user_surname=Cognome

--- a/src/main/resources/fess_label_ja.properties
+++ b/src/main/resources/fess_label_ja.properties
@@ -947,6 +947,7 @@ labels.backup_name=名前
 labels.backup_bulk_file=バルクファイル
 labels.backup_button_upload=アップロード
 labels.process_time_is_exceeded=検索待ち時間の上限を超えました。表示された結果は検索結果の一部である可能性があります。
+labels.search_could_not_be_completed=検索を完了できなかったため、結果を表示できません。一致する文書がなかったことを意味するものではありません。しばらくしてから再度お試しください。
 labels.user_given_name=名前(名)
 labels.givenName=名前(名)
 labels.user_surname=名前(姓)

--- a/src/main/resources/fess_label_ko.properties
+++ b/src/main/resources/fess_label_ko.properties
@@ -945,6 +945,7 @@ labels.backup_name=이름
 labels.backup_bulk_file=벌크 파일
 labels.backup_button_upload=업로드
 labels.process_time_is_exceeded=검색 대기 시간 상한을 초과했습니다. 표시된 결과는 검색 결과의 일부일 수 있습니다.
+labels.search_could_not_be_completed=검색을 완료할 수 없어 결과를 표시할 수 없습니다. 일치하는 문서가 없다는 의미는 아닙니다. 잠시 후 다시 시도해 주세요.
 labels.user_given_name=이름
 labels.givenName=이름 (주어진 이름)
 labels.user_surname=성

--- a/src/main/resources/fess_label_nl.properties
+++ b/src/main/resources/fess_label_nl.properties
@@ -952,6 +952,7 @@ labels.backup_name=Naam
 labels.backup_bulk_file=Bulkbestand
 labels.backup_button_upload=Uploaden
 labels.process_time_is_exceeded=De wachttijd voor zoeken is overschreden. De weergegeven resultaten zijn mogelijk gedeeltelijk.
+labels.search_could_not_be_completed=De zoekopdracht kon niet worden voltooid, dus er kunnen geen resultaten worden weergegeven. Dit betekent niet dat er geen document overeenkwam. Probeer het later opnieuw.
 labels.user_given_name=Voornaam
 labels.givenName=Voornaam (gegeven naam)
 labels.user_surname=Achternaam

--- a/src/main/resources/fess_label_pl.properties
+++ b/src/main/resources/fess_label_pl.properties
@@ -952,6 +952,7 @@ labels.backup_name=Nazwa
 labels.backup_bulk_file=Plik zbiorczy
 labels.backup_button_upload=Prześlij
 labels.process_time_is_exceeded=Przekroczono limit czasu oczekiwania na wyszukiwanie. Wyświetlone wyniki mogą być częściowe.
+labels.search_could_not_be_completed=Nie udało się ukończyć wyszukiwania, więc nie można wyświetlić żadnych wyników. Nie oznacza to, że żaden dokument nie pasował. Spróbuj ponownie później.
 labels.user_given_name=Imię (imię własne)
 labels.givenName=Imię (imię własne)
 labels.user_surname=Nazwisko

--- a/src/main/resources/fess_label_pt_BR.properties
+++ b/src/main/resources/fess_label_pt_BR.properties
@@ -951,6 +951,7 @@ labels.backup_name=Nome
 labels.backup_bulk_file=Arquivo em massa
 labels.backup_button_upload=Fazer upload
 labels.process_time_is_exceeded=O tempo de espera da pesquisa foi excedido. Os resultados exibidos podem ser parciais.
+labels.search_could_not_be_completed=Não foi possível concluir a pesquisa, portanto nenhum resultado pode ser exibido. Isso não significa que nenhum documento correspondeu. Tente novamente mais tarde.
 labels.user_given_name=Nome
 labels.givenName=Nome (dado)
 labels.user_surname=Sobrenome

--- a/src/main/resources/fess_label_ru.properties
+++ b/src/main/resources/fess_label_ru.properties
@@ -952,6 +952,7 @@ labels.backup_name=Имя
 labels.backup_bulk_file=Массовый файл
 labels.backup_button_upload=Загрузить
 labels.process_time_is_exceeded=Время обработки поиска превысило лимит. Отображаемые результаты могут быть частичными.
+labels.search_could_not_be_completed=Не удалось выполнить поиск, поэтому результаты не могут быть показаны. Это не означает, что ни один документ не совпал. Повторите попытку позже.
 labels.user_given_name=Имя
 labels.givenName=Имя (данное имя)
 labels.user_surname=Фамилия

--- a/src/main/resources/fess_label_tr.properties
+++ b/src/main/resources/fess_label_tr.properties
@@ -952,6 +952,7 @@ labels.backup_name=Ad
 labels.backup_bulk_file=Toplu Dosya
 labels.backup_button_upload=Yükle
 labels.process_time_is_exceeded=Arama işleme süresi sınırı aştı. Gösterilen sonuçlar kısmi olabilir.
+labels.search_could_not_be_completed=Arama tamamlanamadı, bu nedenle hiçbir sonuç gösterilemiyor. Bu, hiçbir belgenin eşleşmediği anlamına gelmez. Lütfen daha sonra tekrar deneyin.
 labels.user_given_name=Ad
 labels.givenName=Ad
 labels.user_surname=Soyadı

--- a/src/main/resources/fess_label_zh_CN.properties
+++ b/src/main/resources/fess_label_zh_CN.properties
@@ -945,6 +945,7 @@ labels.backup_name=名称
 labels.backup_bulk_file=批量文件
 labels.backup_button_upload=上传
 labels.process_time_is_exceeded=搜索等待时间已超出。显示的结果可能不完整。
+labels.search_could_not_be_completed=搜索未能完成，因此无法显示结果。这并不表示没有匹配的文档。请稍后重试。
 labels.user_given_name=名字
 labels.givenName=名字 (名)
 labels.user_surname=姓氏

--- a/src/main/resources/fess_label_zh_TW.properties
+++ b/src/main/resources/fess_label_zh_TW.properties
@@ -952,6 +952,7 @@ labels.backup_name=名稱
 labels.backup_bulk_file=批量檔案
 labels.backup_button_upload=上傳
 labels.process_time_is_exceeded=搜尋等待時間已超出。顯示的結果可能不完整。
+labels.search_could_not_be_completed=搜尋未能完成，因此無法顯示結果。這並不表示沒有相符的文件。請稍後再試。
 labels.user_given_name=名字
 labels.givenName=名字 (名)
 labels.user_surname=姓氏

--- a/src/main/webapp/WEB-INF/orig/view/searchNoResult.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/searchNoResult.jsp
@@ -1,5 +1,12 @@
 <%@page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8"%>
 <%-- query did not match any document --%>
+<c:if test="${partialResults}">
+	<div class="alert alert-warning">
+		<p>
+			<la:message key="labels.search_could_not_be_completed" />
+		</p>
+	</div>
+</c:if>
 <div id="result" class="row">
 	<div class="col-md-8">
 		<div class="text-center py-4">

--- a/src/main/webapp/WEB-INF/view/searchNoResult.jsp
+++ b/src/main/webapp/WEB-INF/view/searchNoResult.jsp
@@ -1,5 +1,12 @@
 <%@page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8"%>
 <%-- query did not match any document --%>
+<c:if test="${partialResults}">
+	<div class="alert alert-warning">
+		<p>
+			<la:message key="labels.search_could_not_be_completed" />
+		</p>
+	</div>
+</c:if>
 <div id="result" class="row">
 	<div class="col-md-8">
 		<div class="text-center py-4">

--- a/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorErrorHandlingTest.java
+++ b/src/test/java/org/codelibs/fess/rank/fusion/RankFusionProcessorErrorHandlingTest.java
@@ -189,6 +189,42 @@ public class RankFusionProcessorErrorHandlingTest extends UnitFessTestCase {
     }
 
     /**
+     * Test that a search which never ran does not declare its zero count exact.
+     */
+    @Test
+    public void test_degradedResponse_countIsNotExact() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            processor.setSearcher(new ExceptionThrowingSearcher(new RuntimeException("Main searcher failed")));
+            processor.init();
+
+            final QueryResponseList results =
+                    (QueryResponseList) processor.search("*", new TestSearchRequestParams(0, 10, 0), OptionalThing.empty());
+            assertEquals(0L, results.getAllRecordCount());
+            // EQUAL_TO would tell the caller that exactly zero documents match, contradicting the
+            // partialResults flag set beside it: no total was ever obtained here.
+            assertEquals("a total that was never obtained must not be reported as exact", Relation.GREATER_THAN_OR_EQUAL_TO.toString(),
+                    results.getAllRecordCountRelation());
+        }
+    }
+
+    /**
+     * Test that a search which ran and matched nothing still reports an exact zero.
+     */
+    @Test
+    public void test_genuineZeroHits_countIsExact() throws Exception {
+        try (RankFusionProcessor processor = new RankFusionProcessor()) {
+            processor.setSearcher(new TestSearcher(0));
+            processor.init();
+
+            final QueryResponseList results =
+                    (QueryResponseList) processor.search("*", new TestSearchRequestParams(0, 10, 0), OptionalThing.empty());
+            assertEquals(0L, results.getAllRecordCount());
+            assertEquals("a search that ran and matched nothing knows the count exactly", Relation.EQUAL_TO.toString(),
+                    results.getAllRecordCountRelation());
+        }
+    }
+
+    /**
      * Test handling of very slow searcher (simulates timeout scenario).
      */
     @Test


### PR DESCRIPTION
When the searcher throws, or when the query reaches no searcher at all, the
response is built by createDegradedResponseList. That response already carries
partialResults, which exists exactly so a caller can tell "no document matches"
from "the search could not be run", but it also hardcoded the count relation to
EQUAL_TO, which says the opposite: exactly zero documents match. With the
search engine stopped, /api/v2/search answered HTTP 200 in a few milliseconds
with status 0, record_count 0, record_count_relation EQUAL_TO and an empty data
array, for a query that returns 52 documents when the engine is up. The
relation is now GREATER_THAN_OR_EQUAL_TO: no total was ever obtained, so zero
or more is all that is known. A search that really ran and matched nothing
still reports EQUAL_TO, so the two remain distinguishable.

The response status is left at 0 and the HTTP status at 200. Callers treat a
non-zero status as a hard failure and some retry on it, so changing it would
turn a degraded answer into an outage for clients that could otherwise carry
on; partialResults plus an honest relation is the signal, and /api/v2/health
already answers 500 for monitoring.

The browser had the worse version of this. search.jsp picks the results screen
or the no-result screen on the record count alone, and only the results screen
rendered the partial-results warning, so the banner was suppressed in precisely
the case that needed it: the engine is down, the count is 0, and the visitor is
told that nothing matched the query. searchNoResult.jsp now renders the same
warning block when partialResults is set.

The wording had to be its own message. The existing one says the search
processing time has exceeded the limit, which is true of a timeout that still
returned rows but not of a backend that answered nothing, so
labels.search_could_not_be_completed is added alongside it and used by the
no-result screen: the search could not be completed, no results can be shown,
and this does not mean that no document matched. It is translated in all 17
label bundles.

Neither defect is a 15.9 regression; RankFusionProcessor.java is byte identical
to the 15.8 branch.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
