### PR TITLE
fix(user): refuse a role or group the caller named instead of identified

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/user/AdminUserAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/user/AdminUserAction.java
@@ -19,6 +19,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
@@ -271,6 +272,7 @@ public class AdminUserAction extends FessAdminAction {
         verifyCrudMode(form.crudMode, CrudMode.CREATE, this::asListHtml);
         validate(form, messages -> {}, this::asEditHtml);
         validateAttributes(form.attributes, v -> throwValidationError(v, this::asEditHtml));
+        verifyRolesAndGroups(form, roleService, groupService, v -> throwValidationError(v, this::asEditHtml));
         verifyPassword(form, this::asEditHtml);
         verifyToken(this::asEditHtml);
         getUser(form).ifPresent(entity -> {
@@ -301,6 +303,7 @@ public class AdminUserAction extends FessAdminAction {
         verifyCrudMode(form.crudMode, CrudMode.EDIT, this::asListHtml);
         validate(form, messages -> {}, this::asEditHtml);
         validateAttributes(form.attributes, v -> throwValidationError(v, this::asEditHtml));
+        verifyRolesAndGroups(form, roleService, groupService, v -> throwValidationError(v, this::asEditHtml));
         verifyPassword(form, this::asEditHtml);
         verifyToken(this::asEditHtml);
         getUser(form).ifPresent(entity -> {
@@ -479,6 +482,44 @@ public class AdminUserAction extends FessAdminAction {
     public static void resetPassword(final CreateForm form) {
         form.password = null;
         form.confirmPassword = null;
+    }
+
+    /**
+     * Rejects a role or group the caller identified by anything other than its id. A user stores
+     * roles and groups by id, and {@link User#getRoleNames()} reads them back by Base64-decoding
+     * them, so a value that is not an id - a role name, which an API caller has every reason to
+     * think is what is wanted - is written without complaint and cannot be read back afterwards.
+     * Shared with the REST API so that both paths refuse the same values.
+     *
+     * @param form the form carrying the role and group ids
+     * @param roleService the service used to resolve a role id
+     * @param groupService the service used to resolve a group id
+     * @param throwError callback to report an id that does not resolve
+     */
+    public static void verifyRolesAndGroups(final CreateForm form, final RoleService roleService, final GroupService groupService,
+            final Consumer<VaMessenger<FessMessages>> throwError) {
+        verifyIds(form.roles, "roles", id -> roleService.getRole(id).isPresent(), throwError);
+        verifyIds(form.groups, "groups", id -> groupService.getGroup(id).isPresent(), throwError);
+    }
+
+    /**
+     * Reports the first id in the given array that does not resolve.
+     *
+     * @param ids the ids to check, which may be null
+     * @param property the form property the ids came from
+     * @param resolvable tells whether one id resolves to a stored entity
+     * @param throwError callback to report an id that does not resolve
+     */
+    protected static void verifyIds(final String[] ids, final String property, final Predicate<String> resolvable,
+            final Consumer<VaMessenger<FessMessages>> throwError) {
+        if (ids == null) {
+            return;
+        }
+        for (final String id : ids) {
+            if (StringUtil.isBlank(id) || !resolvable.test(id)) {
+                throwError.accept(messages -> messages.addErrorsInvalidRoleOrGroupId(property, id));
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/user/ApiAdminUserAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/user/ApiAdminUserAction.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.app.web.api.admin.user;
 import static org.codelibs.fess.app.web.admin.user.AdminUserAction.getUser;
 import static org.codelibs.fess.app.web.admin.user.AdminUserAction.validateAttributes;
 import static org.codelibs.fess.app.web.admin.user.AdminUserAction.verifyPasswordPolicy;
+import static org.codelibs.fess.app.web.admin.user.AdminUserAction.verifyRolesAndGroups;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,6 +27,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.app.pager.UserPager;
+import org.codelibs.fess.app.service.GroupService;
+import org.codelibs.fess.app.service.RoleService;
 import org.codelibs.fess.app.service.UserService;
 import org.codelibs.fess.app.web.CrudMode;
 import org.codelibs.fess.app.web.api.ApiResult;
@@ -61,6 +64,14 @@ public class ApiAdminUserAction extends FessApiAdminAction {
     /** The user service for managing user settings. */
     @Resource
     private UserService userService;
+
+    /** The role service, used to check that a role id the caller sent exists. */
+    @Resource
+    private RoleService roleService;
+
+    /** The group service, used to check that a group id the caller sent exists. */
+    @Resource
+    private GroupService groupService;
 
     /**
      * Retrieves user settings with pagination.
@@ -107,6 +118,7 @@ public class ApiAdminUserAction extends FessApiAdminAction {
     @Execute
     public JsonResponse<ApiResult> post$setting(final CreateBody body) {
         validateApi(body, messages -> {});
+        verifyRolesAndGroups(body, roleService, groupService, this::throwValidationErrorApi);
         verifyPassword(body, true);
         body.crudMode = CrudMode.CREATE;
         final User entity = getUser(body).orElseGet(() -> {
@@ -136,6 +148,7 @@ public class ApiAdminUserAction extends FessApiAdminAction {
     public JsonResponse<ApiResult> put$setting(final EditBody body) {
         validateApi(body, messages -> {});
         validateAttributes(body.attributes, this::throwValidationErrorApi);
+        verifyRolesAndGroups(body, roleService, groupService, this::throwValidationErrorApi);
         verifyPassword(body, false);
         body.crudMode = CrudMode.EDIT;
         final User entity = getUser(body).orElseGet(() -> {

--- a/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
+++ b/src/main/java/org/codelibs/fess/mylasta/action/FessMessages.java
@@ -308,6 +308,9 @@ public class FessMessages extends FessLabels {
     /** The key of the message: {1} is invalid for {0}. */
     public static final String ERRORS_invalid_str_is_included = "{errors.invalid_str_is_included}";
 
+    /** The key of the message: {0} is not a registered role or group id. Use the id from the role or group list, not the name. */
+    public static final String ERRORS_invalid_role_or_group_id = "{errors.invalid_role_or_group_id}";
+
     /** The key of the message: Password is required. */
     public static final String ERRORS_blank_password = "{errors.blank_password}";
 
@@ -2020,6 +2023,21 @@ public class FessMessages extends FessLabels {
     public FessMessages addErrorsInvalidStrIsIncluded(String property, String arg0, String arg1) {
         assertPropertyNotNull(property);
         add(property, new UserMessage(ERRORS_invalid_str_is_included, arg0, arg1));
+        return this;
+    }
+
+    /**
+     * Add the created action message for the key 'errors.invalid_role_or_group_id' with parameters.
+     * <pre>
+     * message: {0} is not a registered role or group id. Use the id from the role or group list, not the name.
+     * </pre>
+     * @param property The property name for the message. (NotNull)
+     * @param arg0 The parameter arg0 for message. (NotNull)
+     * @return this. (NotNull)
+     */
+    public FessMessages addErrorsInvalidRoleOrGroupId(String property, String arg0) {
+        assertPropertyNotNull(property);
+        add(property, new UserMessage(ERRORS_invalid_role_or_group_id, arg0));
         return this;
     }
 

--- a/src/main/java/org/codelibs/fess/opensearch/user/exentity/User.java
+++ b/src/main/java/org/codelibs/fess/opensearch/user/exentity/User.java
@@ -23,7 +23,10 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.mylasta.direction.FessConfig;
@@ -34,6 +37,8 @@ import org.codelibs.fess.util.ComponentUtil;
  * @author FreeGen
  */
 public class User extends BsUser implements FessUser {
+
+    private static final Logger logger = LogManager.getLogger(User.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -59,16 +64,31 @@ public class User extends BsUser implements FessUser {
 
     @Override
     public String[] getRoleNames() {
-        return stream(getRoles()).get(stream -> stream.map(this::decode).toArray(n -> new String[n]));
+        return stream(getRoles()).get(stream -> stream.map(this::decode).filter(Objects::nonNull).toArray(n -> new String[n]));
     }
 
     @Override
     public String[] getGroupNames() {
-        return stream(getGroups()).get(stream -> stream.map(this::decode).toArray(n -> new String[n]));
+        return stream(getGroups()).get(stream -> stream.map(this::decode).filter(Objects::nonNull).toArray(n -> new String[n]));
     }
 
+    /**
+     * Decodes a stored role or group id back to its name. A value that is not an id was written by
+     * a caller that sent a name instead, and decoding it throws. Skipping it keeps the rest of the
+     * account readable, so it can still be listed and repaired, rather than failing every read of
+     * this user and therefore every login.
+     *
+     * @param value the stored role or group id
+     * @return the decoded name, or null when the value is not a valid id
+     */
     private String decode(final String value) {
-        return new String(Base64.getDecoder().decode(value), Constants.CHARSET_UTF_8);
+        try {
+            return new String(Base64.getDecoder().decode(value), Constants.CHARSET_UTF_8);
+        } catch (final IllegalArgumentException e) {
+            logger.warn("Skipped an unreadable role or group id on user {}: {} is not a Base64-encoded name. "
+                    + "Reassign the roles and groups of this user to repair it.", name, value);
+            return null;
+        }
     }
 
     @Override
@@ -97,8 +117,12 @@ public class User extends BsUser implements FessUser {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final List<String> list = new ArrayList<>();
         list.add(fessConfig.getRoleSearchUserPrefix() + getName());
-        stream(getRoles()).of(stream -> stream.forEach(s -> list.add(fessConfig.getRoleSearchRolePrefix() + decode(s))));
-        stream(getGroups()).of(stream -> stream.forEach(s -> list.add(fessConfig.getRoleSearchGroupPrefix() + decode(s))));
+        stream(getRoles()).of(stream -> stream.map(this::decode)
+                .filter(Objects::nonNull)
+                .forEach(s -> list.add(fessConfig.getRoleSearchRolePrefix() + s)));
+        stream(getGroups()).of(stream -> stream.map(this::decode)
+                .filter(Objects::nonNull)
+                .forEach(s -> list.add(fessConfig.getRoleSearchGroupPrefix() + s)));
         return list.toArray(new String[list.size()]);
     }
 

--- a/src/main/resources/fess_message.properties
+++ b/src/main/resources/fess_message.properties
@@ -120,6 +120,7 @@ errors.failed_to_upload_mapping_file = Failed to upload a mapping file.
 errors.invalid_kuromoji_token={0} is invalid as a token.
 errors.invalid_kuromoji_segmentation=The number of segmentation for {0} and {1} is different.
 errors.invalid_str_is_included = {1} is invalid for {0}.
+errors.invalid_role_or_group_id = {0} is not a registered role or group id. Use the id from the role or group list, not the name.
 errors.blank_password = Password is required.
 errors.password_length = Password must be at least {0} characters long.
 errors.password_no_uppercase = Password must contain at least one uppercase letter.

--- a/src/main/resources/fess_message_de.properties
+++ b/src/main/resources/fess_message_de.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Fehler beim Hochladen einer Mapping-Datei
 errors.invalid_kuromoji_token={0} ist als Token ungültig.
 errors.invalid_kuromoji_segmentation=Die Anzahl der Segmentierungen für {0} und {1} ist unterschiedlich.
 errors.invalid_str_is_included = {1} ist für {0} ungültig.
+errors.invalid_role_or_group_id = {0} ist keine registrierte Rollen- oder Gruppen-ID. Verwenden Sie die ID aus der Rollen- oder Gruppenliste, nicht den Namen.
 errors.blank_password = Passwort ist erforderlich.
 errors.password_length = Das Passwort muss mindestens {0} Zeichen lang sein.
 errors.password_no_uppercase = Das Passwort muss mindestens einen Großbuchstaben enthalten.

--- a/src/main/resources/fess_message_en.properties
+++ b/src/main/resources/fess_message_en.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Failed to upload a mapping file.
 errors.invalid_kuromoji_token={0} is invalid as a token.
 errors.invalid_kuromoji_segmentation=The number of segmentation for {0} and {1} is different.
 errors.invalid_str_is_included = {1} is invalid for {0}.
+errors.invalid_role_or_group_id = {0} is not a registered role or group id. Use the id from the role or group list, not the name.
 errors.blank_password = Password is required.
 errors.password_length = Password must be at least {0} characters long.
 errors.password_no_uppercase = Password must contain at least one uppercase letter.

--- a/src/main/resources/fess_message_es.properties
+++ b/src/main/resources/fess_message_es.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = No se pudo cargar el archivo de mapeo.
 errors.invalid_kuromoji_token={0} no es un token válido.
 errors.invalid_kuromoji_segmentation=El número de divisiones de {0} no coincide con el número de divisiones de {1}.
 errors.invalid_str_is_included = {1} no es válido en {0}.
+errors.invalid_role_or_group_id = {0} no es un id de rol o grupo registrado. Utilice el id de la lista de roles o grupos, no el nombre.
 errors.blank_password = Se requiere contraseña.
 errors.password_length = La contraseña debe tener al menos {0} caracteres.
 errors.password_no_uppercase = La contraseña debe contener al menos una letra mayúscula.

--- a/src/main/resources/fess_message_fr.properties
+++ b/src/main/resources/fess_message_fr.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Échec du téléversement d'un fichier de
 errors.invalid_kuromoji_token={0} n'est pas valide en tant que jeton.
 errors.invalid_kuromoji_segmentation=Le nombre de segmentations pour {0} et {1} est différent.
 errors.invalid_str_is_included = {1} n'est pas valide pour {0}.
+errors.invalid_role_or_group_id = {0} n'est pas un id de rôle ou de groupe enregistré. Utilisez l'id de la liste des rôles ou des groupes, et non le nom.
 errors.blank_password = Le mot de passe est requis.
 errors.password_length = Le mot de passe doit contenir au moins {0} caractères.
 errors.password_no_uppercase = Le mot de passe doit contenir au moins une lettre majuscule.

--- a/src/main/resources/fess_message_hi.properties
+++ b/src/main/resources/fess_message_hi.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = mapping फ़ाइल अपलोड �
 errors.invalid_kuromoji_token={0} एक token के रूप में अमान्य है।
 errors.invalid_kuromoji_segmentation={0} और {1} के लिए segmentation की संख्या भिन्न है।
 errors.invalid_str_is_included = {1} {0} के लिए अमान्य है।
+errors.invalid_role_or_group_id = {0} एक पंजीकृत भूमिका या समूह आईडी नहीं है। नाम के बजाय भूमिका या समूह सूची की आईडी का उपयोग करें।
 errors.blank_password = पासवर्ड आवश्यक है।
 errors.password_length = पासवर्ड कम से कम {0} वर्णों का होना चाहिए।
 errors.password_no_uppercase = पासवर्ड में कम से कम एक बड़ा अक्षर होना चाहिए।

--- a/src/main/resources/fess_message_id.properties
+++ b/src/main/resources/fess_message_id.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Gagal mengunggah berkas mapping.
 errors.invalid_kuromoji_token={0} tidak valid sebagai token.
 errors.invalid_kuromoji_segmentation=Jumlah segmentasi untuk {0} dan {1} berbeda.
 errors.invalid_str_is_included = {1} tidak valid untuk {0}.
+errors.invalid_role_or_group_id = {0} bukan id peran atau grup yang terdaftar. Gunakan id dari daftar peran atau grup, bukan namanya.
 errors.blank_password = Kata sandi wajib diisi.
 errors.password_length = Kata sandi harus minimal {0} karakter.
 errors.password_no_uppercase = Kata sandi harus mengandung setidaknya satu huruf besar.

--- a/src/main/resources/fess_message_it.properties
+++ b/src/main/resources/fess_message_it.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Impossibile caricare il file di mappatura
 errors.invalid_kuromoji_token={0} non è un token valido.
 errors.invalid_kuromoji_segmentation=Il numero di segmentazioni di {0} non corrisponde al numero di segmentazioni di {1}.
 errors.invalid_str_is_included = {0} non è valido in {1}.
+errors.invalid_role_or_group_id = {0} non è un id di ruolo o gruppo registrato. Utilizzare l'id dell'elenco dei ruoli o dei gruppi, non il nome.
 errors.blank_password = La password è obbligatoria.
 errors.password_length = La password deve contenere almeno {0} caratteri.
 errors.password_no_uppercase = La password deve contenere almeno una lettera maiuscola.

--- a/src/main/resources/fess_message_ja.properties
+++ b/src/main/resources/fess_message_ja.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = マッピングファイルのアップ�
 errors.invalid_kuromoji_token={0} はトークンとして正しくありません。
 errors.invalid_kuromoji_segmentation={0} の分割数と {1}の分割数が一致しません。
 errors.invalid_str_is_included = {0}では{1}は無効です。
+errors.invalid_role_or_group_id = {0}は登録されたロールまたはグループのIDではありません。名前ではなく、ロールまたはグループ一覧のIDを指定してください。
 errors.blank_password = パスワードが必要になります。
 errors.password_length = パスワードは{0}文字以上である必要があります。
 errors.password_no_uppercase = パスワードには少なくとも1つの大文字を含める必要があります。

--- a/src/main/resources/fess_message_ko.properties
+++ b/src/main/resources/fess_message_ko.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = 매핑 파일을 업로드하지 못했�
 errors.invalid_kuromoji_token={0}은(는) 토큰으로 유효하지 않습니다.
 errors.invalid_kuromoji_segmentation={0}과(와) {1}의 분할 수가 다릅니다.
 errors.invalid_str_is_included = {0}에서 {1}은(는) 유효하지 않습니다.
+errors.invalid_role_or_group_id = {0}은(는) 등록된 롤 또는 그룹 ID가 아닙니다. 이름이 아니라 롤 또는 그룹 목록의 ID를 사용하세요.
 errors.blank_password = 비밀번호가 필요합니다.
 errors.password_length = 비밀번호는 최소 {0}자 이상이어야 합니다.
 errors.password_no_uppercase = 비밀번호에 대문자가 하나 이상 포함되어야 합니다.

--- a/src/main/resources/fess_message_nl.properties
+++ b/src/main/resources/fess_message_nl.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Kan mappingbestand niet uploaden.
 errors.invalid_kuromoji_token={0} is geen geldig token.
 errors.invalid_kuromoji_segmentation=Het aantal segmentaties van {0} komt niet overeen met het aantal segmentaties van {1}.
 errors.invalid_str_is_included = {1} is ongeldig in {0}.
+errors.invalid_role_or_group_id = {0} is geen geregistreerde rol- of groeps-id. Gebruik de id uit de rollen- of groepenlijst, niet de naam.
 errors.blank_password = Wachtwoord is vereist.
 errors.password_length = Het wachtwoord moet minimaal {0} tekens bevatten.
 errors.password_no_uppercase = Het wachtwoord moet minimaal één hoofdletter bevatten.

--- a/src/main/resources/fess_message_pl.properties
+++ b/src/main/resources/fess_message_pl.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Nie można przesłać pliku mapowania.
 errors.invalid_kuromoji_token={0} nie jest prawidłowym tokenem.
 errors.invalid_kuromoji_segmentation=Liczba segmentacji {0} nie pasuje do liczby segmentacji {1}.
 errors.invalid_str_is_included = {1} jest nieprawidłowe w {0}.
+errors.invalid_role_or_group_id = {0} nie jest zarejestrowanym identyfikatorem roli ani grupy. Użyj identyfikatora z listy ról lub grup, a nie nazwy.
 errors.blank_password = Hasło jest wymagane.
 errors.password_length = Hasło musi mieć co najmniej {0} znaków.
 errors.password_no_uppercase = Hasło musi zawierać co najmniej jedną wielką literę.

--- a/src/main/resources/fess_message_pt_BR.properties
+++ b/src/main/resources/fess_message_pt_BR.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Não foi possível carregar o arquivo de 
 errors.invalid_kuromoji_token={0} não é um token válido.
 errors.invalid_kuromoji_segmentation=O número de divisões de {0} não corresponde ao número de divisões de {1}.
 errors.invalid_str_is_included = {1} é inválido em {0}.
+errors.invalid_role_or_group_id = {0} não é um id de função ou grupo registrado. Use o id da lista de funções ou grupos, não o nome.
 errors.blank_password = A senha é obrigatória.
 errors.password_length = A senha deve ter pelo menos {0} caracteres.
 errors.password_no_uppercase = A senha deve conter pelo menos uma letra maiúscula.

--- a/src/main/resources/fess_message_ru.properties
+++ b/src/main/resources/fess_message_ru.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Не удалось загрузить ф
 errors.invalid_kuromoji_token={0} недействителен как токен.
 errors.invalid_kuromoji_segmentation=Количество сегментаций для {0} и {1} отличается.
 errors.invalid_str_is_included = {1} недействителен для {0}.
+errors.invalid_role_or_group_id = {0} не является зарегистрированным идентификатором роли или группы. Используйте идентификатор из списка ролей или групп, а не имя.
 errors.blank_password = Требуется пароль.
 errors.password_length = Пароль должен содержать не менее {0} символов.
 errors.password_no_uppercase = Пароль должен содержать хотя бы одну заглавную букву.

--- a/src/main/resources/fess_message_tr.properties
+++ b/src/main/resources/fess_message_tr.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = Eşleme dosyası yüklenemedi.
 errors.invalid_kuromoji_token={0} bir belirteç olarak geçersiz.
 errors.invalid_kuromoji_segmentation={0} ve {1} için segmentasyon sayısı farklı.
 errors.invalid_str_is_included = {1}, {0} için geçersiz.
+errors.invalid_role_or_group_id = {0} kayıtlı bir rol veya grup kimliği değil. Ad yerine rol veya grup listesindeki kimliği kullanın.
 errors.blank_password = Şifre gereklidir.
 errors.password_length = Şifre en az {0} karakter uzunluğunda olmalıdır.
 errors.password_no_uppercase = Şifre en az bir büyük harf içermelidir.

--- a/src/main/resources/fess_message_zh_CN.properties
+++ b/src/main/resources/fess_message_zh_CN.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = 上传映射文件失败。
 errors.invalid_kuromoji_token={0} 不是有效的令牌。
 errors.invalid_kuromoji_segmentation={0} 的分割数与 {1} 的分割数不匹配。
 errors.invalid_str_is_included = {0} 中包含无效的 {1}。
+errors.invalid_role_or_group_id = {0} 不是已注册的角色或组 ID。请使用角色或组列表中的 ID，而不是名称。
 errors.blank_password = 密码是必需的。
 errors.password_length = 密码长度必须至少为 {0} 个字符。
 errors.password_no_uppercase = 密码必须包含至少一个大写字母。

--- a/src/main/resources/fess_message_zh_TW.properties
+++ b/src/main/resources/fess_message_zh_TW.properties
@@ -116,6 +116,7 @@ errors.failed_to_upload_mapping_file = 上傳映射檔案失敗。
 errors.invalid_kuromoji_token={0} 不是有效的令牌。
 errors.invalid_kuromoji_segmentation={0} 的分割數與 {1} 的分割數不匹配。
 errors.invalid_str_is_included = {0} 中包含無效的 {1}。
+errors.invalid_role_or_group_id = {0} 不是已註冊的角色或群組 ID。請使用角色或群組列表中的 ID，而不是名稱。
 errors.blank_password = 密碼是必需的。
 errors.password_length = 密碼長度必須至少為 {0} 個字元。
 errors.password_no_uppercase = 密碼必須包含至少一個大寫字母。

--- a/src/test/java/org/codelibs/fess/app/web/admin/user/AdminUserActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/user/AdminUserActionTest.java
@@ -18,11 +18,16 @@ package org.codelibs.fess.app.web.admin.user;
 import java.util.Map;
 
 import org.codelibs.fess.Constants;
+import org.codelibs.fess.app.service.GroupService;
+import org.codelibs.fess.app.service.RoleService;
 import org.codelibs.fess.app.web.CrudMode;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.mylasta.action.FessMessages;
+import org.codelibs.fess.opensearch.user.exentity.Group;
+import org.codelibs.fess.opensearch.user.exentity.Role;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.optional.OptionalEntity;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -208,6 +213,85 @@ public class AdminUserActionTest extends UnitFessTestCase {
     public void test_verifyPasswordPolicy_ignoresABlankPassword() {
         assertEquals("", policyErrorOf(null));
         assertEquals("", policyErrorOf(""));
+    }
+
+    /**
+     * Roles are stored by id, and a user entity Base64-decodes those ids to read them back. A role
+     * name is a natural thing for an API caller to send and is not an id, so it has to be refused
+     * here; storing it leaves an account that can no longer log in.
+     */
+    @Test
+    public void test_verifyRolesAndGroups_rejectsARoleName() {
+        final String reported = roleAndGroupErrorOf(new String[] { "guest" }, null);
+        assertTrue(reported.contains("roles"));
+        assertTrue(reported.contains("errors.invalid_role_or_group_id"));
+    }
+
+    /**
+     * Groups have the same shape and the same failure, so they are checked the same way.
+     */
+    @Test
+    public void test_verifyRolesAndGroups_rejectsAGroupName() {
+        final String reported = roleAndGroupErrorOf(null, new String[] { "sales" });
+        assertTrue(reported.contains("groups"));
+        assertTrue(reported.contains("errors.invalid_role_or_group_id"));
+    }
+
+    /**
+     * An id that is valid Base64 but names no stored role is refused too: it would give the account
+     * a permission for a role that does not exist.
+     */
+    @Test
+    public void test_verifyRolesAndGroups_rejectsAnUnknownId() {
+        assertTrue(roleAndGroupErrorOf(new String[] { "bm9ib2R5" }, null).contains("errors.invalid_role_or_group_id"));
+    }
+
+    /**
+     * The ids the screens offer resolve, so nothing is reported for them.
+     */
+    @Test
+    public void test_verifyRolesAndGroups_acceptsStoredIds() {
+        assertEquals("", roleAndGroupErrorOf(new String[] { "Z3Vlc3Q=" }, new String[] { "c2FsZXM=" }));
+    }
+
+    /**
+     * A user with no roles and no groups is allowed, as it always was.
+     */
+    @Test
+    public void test_verifyRolesAndGroups_acceptsNothingAssigned() {
+        assertEquals("", roleAndGroupErrorOf(null, null));
+    }
+
+    /**
+     * Runs the shared role and group check over one set of ids and returns what it reported, or an
+     * empty string when it reported nothing. Only "Z3Vlc3Q=" resolves as a role and only "c2FsZXM="
+     * as a group.
+     */
+    private String roleAndGroupErrorOf(final String[] roles, final String[] groups) {
+        final CreateForm form = new CreateForm();
+        form.crudMode = CrudMode.CREATE;
+        form.name = "tester";
+        form.roles = roles;
+        form.groups = groups;
+        final RoleService roleService = new RoleService() {
+            @Override
+            public OptionalEntity<Role> getRole(final String id) {
+                return "Z3Vlc3Q=".equals(id) ? OptionalEntity.of(new Role()) : OptionalEntity.empty();
+            }
+        };
+        final GroupService groupService = new GroupService() {
+            @Override
+            public OptionalEntity<Group> getGroup(final String id) {
+                return "c2FsZXM=".equals(id) ? OptionalEntity.of(new Group()) : OptionalEntity.empty();
+            }
+        };
+        final StringBuilder reported = new StringBuilder();
+        AdminUserAction.verifyRolesAndGroups(form, roleService, groupService, messenger -> {
+            final FessMessages messages = new FessMessages();
+            messenger.message(messages);
+            reported.append(messages.toString());
+        });
+        return reported.toString();
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/opensearch/user/exentity/UserTest.java
+++ b/src/test/java/org/codelibs/fess/opensearch/user/exentity/UserTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.opensearch.user.exentity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link User}, covering how stored role and group ids are read back.
+ */
+public class UserTest extends UnitFessTestCase {
+
+    /**
+     * Role and group ids are Base64-encoded names, and they decode back to those names.
+     */
+    @Test
+    public void test_getRoleNames_decodesStoredIds() {
+        final User user = new User();
+        user.setName("tester");
+        user.setRoles(new String[] { "Z3Vlc3Q=", "YWRtaW4=" });
+        user.setGroups(new String[] { "c2FsZXM=" });
+
+        assertEquals(List.of("guest", "admin"), Arrays.asList(user.getRoleNames()));
+        assertEquals(List.of("sales"), Arrays.asList(user.getGroupNames()));
+    }
+
+    /**
+     * A role stored as a name rather than an id cannot be decoded. Reading it back skips it instead
+     * of throwing, so the account can still be listed and repaired; without this every read of the
+     * user fails and the account can no longer log in.
+     */
+    @Test
+    public void test_getRoleNames_skipsAnIdThatIsNotBase64() {
+        final User user = new User();
+        user.setName("tester");
+        user.setRoles(new String[] { "guest", "YWRtaW4=" });
+        user.setGroups(new String[] { "sales" });
+
+        assertEquals(List.of("admin"), Arrays.asList(user.getRoleNames()));
+        assertEquals(List.of(), Arrays.asList(user.getGroupNames()));
+    }
+
+    /**
+     * The permission list is what a login builds the search roles from, so it has to survive the
+     * same broken value.
+     */
+    @Test
+    public void test_getPermissions_skipsAnIdThatIsNotBase64() {
+        final User user = new User();
+        user.setName("tester");
+        user.setRoles(new String[] { "guest", "YWRtaW4=" });
+        user.setGroups(new String[] { "sales" });
+
+        assertEquals(List.of("1tester", "Radmin"), Arrays.asList(user.getPermissions()));
+    }
+}


### PR DESCRIPTION
A user stores its roles and groups by id, and those ids are the Base64-encoded
names shown in the role and group lists. Nothing checked what was stored, so a
caller who sent a role name - the obvious thing to send, and the only thing a
person knows by heart - had it accepted and the account created successfully.

Reading that user back then fails, because the name is not valid Base64, and it
fails on every path that needs the roles: the account can no longer log in, and
the only trace is a stack trace in fess.log that names neither the user nor the
value that broke it. The account is unusable and there is nothing to go on.

Both the screens and the REST API now resolve every role and group id before
storing a user and refuse one that does not exist, so the mistake is reported
at the point it is made instead of becoming a broken account. The user entity
also skips an id it cannot decode, with a warning naming the user, so an
account already damaged this way can still be listed and repaired rather than
failing every read.

This is not new in 15.9; the affected code is unchanged since 15.8.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
