### PR TITLE
fix(dict): report a write to a dictionary that does not exist

### DIFF
--- a/src/main/java/org/codelibs/fess/app/service/CharMappingService.java
+++ b/src/main/java/org/codelibs/fess/app/service/CharMappingService.java
@@ -22,6 +22,7 @@ import org.codelibs.core.beans.util.BeanUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.CharMappingPager;
 import org.codelibs.fess.dict.DictionaryFile.PagingList;
+import org.codelibs.fess.dict.DictionaryException;
 import org.codelibs.fess.dict.DictionaryManager;
 import org.codelibs.fess.dict.mapping.CharMappingFile;
 import org.codelibs.fess.dict.mapping.CharMappingItem;
@@ -39,6 +40,9 @@ import jakarta.annotation.Resource;
  * </p>
  */
 public class CharMappingService {
+
+    /** Message prefix for a dictionary id that resolves to no dictionary file. */
+    protected static final String NOT_FOUND_MESSAGE = "CharMapping dictionary is not found: ";
 
     /**
      * Creates a new instance of CharMappingService.
@@ -127,15 +131,15 @@ public class CharMappingService {
      *
      * @param dictId the dictionary ID to store the character mapping item in
      * @param charMappingItem the character mapping item to store
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void store(final String dictId, final CharMappingItem charMappingItem) {
-        getCharMappingFile(dictId).ifPresent(file -> {
-            if (charMappingItem.getId() == 0) {
-                file.insert(charMappingItem);
-            } else {
-                file.update(charMappingItem);
-            }
-        });
+        final CharMappingFile file = getCharMappingFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId));
+        if (charMappingItem.getId() == 0) {
+            file.insert(charMappingItem);
+        } else {
+            file.update(charMappingItem);
+        }
     }
 
     /**
@@ -147,10 +151,9 @@ public class CharMappingService {
      *
      * @param dictId the dictionary ID to delete the character mapping item from
      * @param charMappingItem the character mapping item to delete
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void delete(final String dictId, final CharMappingItem charMappingItem) {
-        getCharMappingFile(dictId).ifPresent(file -> {
-            file.delete(charMappingItem);
-        });
+        getCharMappingFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId)).delete(charMappingItem);
     }
 }

--- a/src/main/java/org/codelibs/fess/app/service/KuromojiService.java
+++ b/src/main/java/org/codelibs/fess/app/service/KuromojiService.java
@@ -22,6 +22,7 @@ import org.codelibs.core.beans.util.BeanUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.KuromojiPager;
 import org.codelibs.fess.dict.DictionaryFile.PagingList;
+import org.codelibs.fess.dict.DictionaryException;
 import org.codelibs.fess.dict.DictionaryManager;
 import org.codelibs.fess.dict.kuromoji.KuromojiFile;
 import org.codelibs.fess.dict.kuromoji.KuromojiItem;
@@ -34,6 +35,10 @@ import jakarta.annotation.Resource;
  * Service class for Kuromoji.
  */
 public class KuromojiService {
+
+    /** Message prefix for a dictionary id that resolves to no dictionary file. */
+    protected static final String NOT_FOUND_MESSAGE = "Kuromoji dictionary is not found: ";
+
     /** The dictionary manager. */
     @Resource
     protected DictionaryManager dictionaryManager;
@@ -99,15 +104,15 @@ public class KuromojiService {
      *
      * @param dictId The dictionary ID.
      * @param kuromojiItem The Kuromoji item to store.
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void store(final String dictId, final KuromojiItem kuromojiItem) {
-        getKuromojiFile(dictId).ifPresent(file -> {
-            if (kuromojiItem.getId() == 0) {
-                file.insert(kuromojiItem);
-            } else {
-                file.update(kuromojiItem);
-            }
-        });
+        final KuromojiFile file = getKuromojiFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId));
+        if (kuromojiItem.getId() == 0) {
+            file.insert(kuromojiItem);
+        } else {
+            file.update(kuromojiItem);
+        }
     }
 
     /**
@@ -115,10 +120,9 @@ public class KuromojiService {
      *
      * @param dictId The dictionary ID.
      * @param kuromojiItem The Kuromoji item to delete.
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void delete(final String dictId, final KuromojiItem kuromojiItem) {
-        getKuromojiFile(dictId).ifPresent(file -> {
-            file.delete(kuromojiItem);
-        });
+        getKuromojiFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId)).delete(kuromojiItem);
     }
 }

--- a/src/main/java/org/codelibs/fess/app/service/ProtwordsService.java
+++ b/src/main/java/org/codelibs/fess/app/service/ProtwordsService.java
@@ -22,6 +22,7 @@ import org.codelibs.core.beans.util.BeanUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.ProtwordsPager;
 import org.codelibs.fess.dict.DictionaryFile.PagingList;
+import org.codelibs.fess.dict.DictionaryException;
 import org.codelibs.fess.dict.DictionaryManager;
 import org.codelibs.fess.dict.protwords.ProtwordsFile;
 import org.codelibs.fess.dict.protwords.ProtwordsItem;
@@ -35,6 +36,9 @@ import jakarta.annotation.Resource;
  * This service provides operations for managing protected words dictionary files and items.
  */
 public class ProtwordsService {
+
+    /** Message prefix for a dictionary id that resolves to no dictionary file. */
+    protected static final String NOT_FOUND_MESSAGE = "Protwords dictionary is not found: ";
 
     /**
      * Default constructor.
@@ -98,25 +102,24 @@ public class ProtwordsService {
      * Stores a protected words item (insert or update).
      * @param dictId the dictionary ID
      * @param protwordsItem the item to store
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void store(final String dictId, final ProtwordsItem protwordsItem) {
-        getProtwordsFile(dictId).ifPresent(file -> {
-            if (protwordsItem.getId() == 0) {
-                file.insert(protwordsItem);
-            } else {
-                file.update(protwordsItem);
-            }
-        });
+        final ProtwordsFile file = getProtwordsFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId));
+        if (protwordsItem.getId() == 0) {
+            file.insert(protwordsItem);
+        } else {
+            file.update(protwordsItem);
+        }
     }
 
     /**
      * Deletes a protected words item.
      * @param dictId the dictionary ID
      * @param protwordsItem the item to delete
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void delete(final String dictId, final ProtwordsItem protwordsItem) {
-        getProtwordsFile(dictId).ifPresent(file -> {
-            file.delete(protwordsItem);
-        });
+        getProtwordsFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId)).delete(protwordsItem);
     }
 }

--- a/src/main/java/org/codelibs/fess/app/service/StemmerOverrideService.java
+++ b/src/main/java/org/codelibs/fess/app/service/StemmerOverrideService.java
@@ -22,6 +22,7 @@ import org.codelibs.core.beans.util.BeanUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.StemmerOverridePager;
 import org.codelibs.fess.dict.DictionaryFile.PagingList;
+import org.codelibs.fess.dict.DictionaryException;
 import org.codelibs.fess.dict.DictionaryManager;
 import org.codelibs.fess.dict.stemmeroverride.StemmerOverrideFile;
 import org.codelibs.fess.dict.stemmeroverride.StemmerOverrideItem;
@@ -39,6 +40,9 @@ import jakarta.annotation.Resource;
  * specific terms, improving search accuracy for domain-specific vocabularies.
  */
 public class StemmerOverrideService {
+
+    /** Message prefix for a dictionary id that resolves to no dictionary file. */
+    protected static final String NOT_FOUND_MESSAGE = "StemmerOverride dictionary is not found: ";
 
     /** Dictionary manager for accessing dictionary files. */
     @Resource
@@ -112,15 +116,16 @@ public class StemmerOverrideService {
      *
      * @param dictId The ID of the stemmer override dictionary
      * @param stemmerOvberrideItem The stemmer override item to store
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void store(final String dictId, final StemmerOverrideItem stemmerOvberrideItem) {
-        getStemmerOverrideFile(dictId).ifPresent(file -> {
-            if (stemmerOvberrideItem.getId() == 0) {
-                file.insert(stemmerOvberrideItem);
-            } else {
-                file.update(stemmerOvberrideItem);
-            }
-        });
+        final StemmerOverrideFile file =
+                getStemmerOverrideFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId));
+        if (stemmerOvberrideItem.getId() == 0) {
+            file.insert(stemmerOvberrideItem);
+        } else {
+            file.update(stemmerOvberrideItem);
+        }
     }
 
     /**
@@ -128,10 +133,9 @@ public class StemmerOverrideService {
      *
      * @param dictId The ID of the stemmer override dictionary
      * @param stemmerOvberrideItem The stemmer override item to delete
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void delete(final String dictId, final StemmerOverrideItem stemmerOvberrideItem) {
-        getStemmerOverrideFile(dictId).ifPresent(file -> {
-            file.delete(stemmerOvberrideItem);
-        });
+        getStemmerOverrideFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId)).delete(stemmerOvberrideItem);
     }
 }

--- a/src/main/java/org/codelibs/fess/app/service/StopwordsService.java
+++ b/src/main/java/org/codelibs/fess/app/service/StopwordsService.java
@@ -22,6 +22,7 @@ import org.codelibs.core.beans.util.BeanUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.StopwordsPager;
 import org.codelibs.fess.dict.DictionaryFile.PagingList;
+import org.codelibs.fess.dict.DictionaryException;
 import org.codelibs.fess.dict.DictionaryManager;
 import org.codelibs.fess.dict.stopwords.StopwordsFile;
 import org.codelibs.fess.dict.stopwords.StopwordsItem;
@@ -36,6 +37,9 @@ import jakarta.annotation.Resource;
  * including retrieving, storing, and deleting stopwords.
  */
 public class StopwordsService {
+
+    /** Message prefix for a dictionary id that resolves to no dictionary file. */
+    protected static final String NOT_FOUND_MESSAGE = "Stopwords dictionary is not found: ";
     /** The dictionary manager for accessing dictionary files. */
     @Resource
     protected DictionaryManager dictionaryManager;
@@ -102,15 +106,15 @@ public class StopwordsService {
      *
      * @param dictId        The ID of the dictionary.
      * @param stopwordsItem The stopword item to store.
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void store(final String dictId, final StopwordsItem stopwordsItem) {
-        getStopwordsFile(dictId).ifPresent(file -> {
-            if (stopwordsItem.getId() == 0) {
-                file.insert(stopwordsItem);
-            } else {
-                file.update(stopwordsItem);
-            }
-        });
+        final StopwordsFile file = getStopwordsFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId));
+        if (stopwordsItem.getId() == 0) {
+            file.insert(stopwordsItem);
+        } else {
+            file.update(stopwordsItem);
+        }
     }
 
     /**
@@ -118,10 +122,9 @@ public class StopwordsService {
      *
      * @param dictId        The ID of the dictionary.
      * @param stopwordsItem The stopword item to delete.
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void delete(final String dictId, final StopwordsItem stopwordsItem) {
-        getStopwordsFile(dictId).ifPresent(file -> {
-            file.delete(stopwordsItem);
-        });
+        getStopwordsFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId)).delete(stopwordsItem);
     }
 }

--- a/src/main/java/org/codelibs/fess/app/service/SynonymService.java
+++ b/src/main/java/org/codelibs/fess/app/service/SynonymService.java
@@ -22,6 +22,7 @@ import org.codelibs.core.beans.util.BeanUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.pager.SynonymPager;
 import org.codelibs.fess.dict.DictionaryFile.PagingList;
+import org.codelibs.fess.dict.DictionaryException;
 import org.codelibs.fess.dict.DictionaryManager;
 import org.codelibs.fess.dict.synonym.SynonymFile;
 import org.codelibs.fess.dict.synonym.SynonymItem;
@@ -36,6 +37,9 @@ import jakarta.annotation.Resource;
  * including retrieving, storing, and deleting synonyms.
  */
 public class SynonymService {
+
+    /** Message prefix for a dictionary id that resolves to no dictionary file. */
+    protected static final String NOT_FOUND_MESSAGE = "Synonym dictionary is not found: ";
     /** The dictionary manager for accessing dictionary files. */
     @Resource
     protected DictionaryManager dictionaryManager;
@@ -101,15 +105,15 @@ public class SynonymService {
      *
      * @param dictId      The ID of the dictionary.
      * @param synonymItem The synonym item to store.
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void store(final String dictId, final SynonymItem synonymItem) {
-        getSynonymFile(dictId).ifPresent(file -> {
-            if (synonymItem.getId() == 0) {
-                file.insert(synonymItem);
-            } else {
-                file.update(synonymItem);
-            }
-        });
+        final SynonymFile file = getSynonymFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId));
+        if (synonymItem.getId() == 0) {
+            file.insert(synonymItem);
+        } else {
+            file.update(synonymItem);
+        }
     }
 
     /**
@@ -117,10 +121,9 @@ public class SynonymService {
      *
      * @param dictId      The ID of the dictionary.
      * @param synonymItem The synonym item to delete.
+     * @throws org.codelibs.fess.dict.DictionaryException if the dictionary ID resolves to no dictionary file
      */
     public void delete(final String dictId, final SynonymItem synonymItem) {
-        getSynonymFile(dictId).ifPresent(file -> {
-            file.delete(synonymItem);
-        });
+        getSynonymFile(dictId).orElseThrow(() -> new DictionaryException(NOT_FOUND_MESSAGE + dictId)).delete(synonymItem);
     }
 }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/kuromoji/ApiAdminDictKuromojiAction.java
@@ -115,7 +115,12 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateInstance(GLOBAL));
             return null;
         });
-        kuromojiService.store(body.dictId, entity);
+        try {
+            kuromojiService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to create a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
@@ -141,7 +146,12 @@ public class ApiAdminDictKuromojiAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudCouldNotFindCrudTable(GLOBAL, String.valueOf(body.id)));
             return null;
         });
-        kuromojiService.store(body.dictId, entity);
+        try {
+            kuromojiService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to update a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(false).status(ApiResult.Status.OK).result());
     }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/ApiAdminDictMappingAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/mapping/ApiAdminDictMappingAction.java
@@ -112,7 +112,12 @@ public class ApiAdminDictMappingAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateInstance(GLOBAL));
             return null;
         });
-        charMappingService.store(body.dictId, entity);
+        try {
+            charMappingService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to create a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
@@ -137,7 +142,12 @@ public class ApiAdminDictMappingAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudCouldNotFindCrudTable(GLOBAL, String.valueOf(body.id)));
             return null;
         });
-        charMappingService.store(body.dictId, entity);
+        try {
+            charMappingService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to update a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(false).status(ApiResult.Status.OK).result());
     }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/ApiAdminDictProtwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/protwords/ApiAdminDictProtwordsAction.java
@@ -112,7 +112,12 @@ public class ApiAdminDictProtwordsAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateInstance(GLOBAL));
             return null;
         });
-        protwordsService.store(body.dictId, entity);
+        try {
+            protwordsService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to create a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
@@ -137,7 +142,12 @@ public class ApiAdminDictProtwordsAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudCouldNotFindCrudTable(GLOBAL, String.valueOf(body.id)));
             return null;
         });
-        protwordsService.store(body.dictId, entity);
+        try {
+            protwordsService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to update a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(false).status(ApiResult.Status.OK).result());
     }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/ApiAdminDictStemmeroverrideAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stemmeroverride/ApiAdminDictStemmeroverrideAction.java
@@ -112,7 +112,12 @@ public class ApiAdminDictStemmeroverrideAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateInstance(GLOBAL));
             return null;
         });
-        stemmerOverrideService.store(body.dictId, entity);
+        try {
+            stemmerOverrideService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to create a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
@@ -137,7 +142,12 @@ public class ApiAdminDictStemmeroverrideAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudCouldNotFindCrudTable(GLOBAL, String.valueOf(body.id)));
             return null;
         });
-        stemmerOverrideService.store(body.dictId, entity);
+        try {
+            stemmerOverrideService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to update a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(false).status(ApiResult.Status.OK).result());
     }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/ApiAdminDictStopwordsAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/stopwords/ApiAdminDictStopwordsAction.java
@@ -113,7 +113,12 @@ public class ApiAdminDictStopwordsAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateInstance(GLOBAL));
             return null;
         });
-        stopwordsService.store(body.dictId, entity);
+        try {
+            stopwordsService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to create a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
@@ -138,7 +143,12 @@ public class ApiAdminDictStopwordsAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudCouldNotFindCrudTable(GLOBAL, String.valueOf(body.id)));
             return null;
         });
-        stopwordsService.store(body.dictId, entity);
+        try {
+            stopwordsService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to update a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(false).status(ApiResult.Status.OK).result());
     }

--- a/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/ApiAdminDictSynonymAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/dict/synonym/ApiAdminDictSynonymAction.java
@@ -113,7 +113,12 @@ public class ApiAdminDictSynonymAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateInstance(GLOBAL));
             return null;
         });
-        synonymService.store(body.dictId, entity);
+        try {
+            synonymService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to create a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(true).status(ApiResult.Status.OK).result());
     }
@@ -138,7 +143,12 @@ public class ApiAdminDictSynonymAction extends FessApiAdminAction {
             throwValidationErrorApi(messages -> messages.addErrorsCrudCouldNotFindCrudTable(GLOBAL, String.valueOf(body.id)));
             return null;
         });
-        synonymService.store(body.dictId, entity);
+        try {
+            synonymService.store(body.dictId, entity);
+        } catch (final Exception e) {
+            logger.warn("Failed to update a dictionary entry: dictId={}", body.dictId, e);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, buildThrowableMessage(e)));
+        }
         return asJson(
                 new ApiResult.ApiUpdateResponse().id(String.valueOf(entity.getId())).created(false).status(ApiResult.Status.OK).result());
     }

--- a/src/test/java/org/codelibs/fess/app/service/DictionaryServiceTest.java
+++ b/src/test/java/org/codelibs/fess/app/service/DictionaryServiceTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.service;
+
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.codelibs.fess.dict.DictionaryException;
+import org.codelibs.fess.dict.kuromoji.KuromojiFile;
+import org.codelibs.fess.dict.kuromoji.KuromojiItem;
+import org.codelibs.fess.dict.mapping.CharMappingItem;
+import org.codelibs.fess.dict.protwords.ProtwordsItem;
+import org.codelibs.fess.dict.stemmeroverride.StemmerOverrideItem;
+import org.codelibs.fess.dict.stopwords.StopwordsItem;
+import org.codelibs.fess.dict.synonym.SynonymItem;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.dbflute.optional.OptionalEntity;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for what the six dictionary services do with a dictionary ID that resolves to no
+ * dictionary file. They all shared one shape, so they are covered together rather than one
+ * near-identical test class each.
+ */
+public class DictionaryServiceTest extends UnitFessTestCase {
+
+    private static final String UNKNOWN_DICT_ID = "0";
+
+    /**
+     * Writing to a dictionary ID that resolves to nothing used to do nothing at all and report
+     * nothing, so the caller was told the entry had been stored when it had not been.
+     */
+    @Test
+    public void test_store_reportsAnUnknownDictionaryId() {
+        final KuromojiService kuromojiService = new KuromojiService() {
+            @Override
+            public OptionalEntity<KuromojiFile> getKuromojiFile(final String dictId) {
+                return OptionalEntity.empty();
+            }
+        };
+        assertReported(() -> kuromojiService.store(UNKNOWN_DICT_ID, new KuromojiItem(0, "t", "s", "r", "p")));
+
+        final SynonymService synonymService = new SynonymService() {
+            @Override
+            public OptionalEntity<org.codelibs.fess.dict.synonym.SynonymFile> getSynonymFile(final String dictId) {
+                return OptionalEntity.empty();
+            }
+        };
+        assertReported(() -> synonymService.store(UNKNOWN_DICT_ID, new SynonymItem(0, new String[] { "a" }, new String[] { "b" })));
+
+        final StopwordsService stopwordsService = new StopwordsService() {
+            @Override
+            public OptionalEntity<org.codelibs.fess.dict.stopwords.StopwordsFile> getStopwordsFile(final String dictId) {
+                return OptionalEntity.empty();
+            }
+        };
+        assertReported(() -> stopwordsService.store(UNKNOWN_DICT_ID, new StopwordsItem(0, "a")));
+
+        final ProtwordsService protwordsService = new ProtwordsService() {
+            @Override
+            public OptionalEntity<org.codelibs.fess.dict.protwords.ProtwordsFile> getProtwordsFile(final String dictId) {
+                return OptionalEntity.empty();
+            }
+        };
+        assertReported(() -> protwordsService.store(UNKNOWN_DICT_ID, new ProtwordsItem(0, "a")));
+
+        final StemmerOverrideService stemmerOverrideService = new StemmerOverrideService() {
+            @Override
+            public OptionalEntity<org.codelibs.fess.dict.stemmeroverride.StemmerOverrideFile> getStemmerOverrideFile(final String dictId) {
+                return OptionalEntity.empty();
+            }
+        };
+        assertReported(() -> stemmerOverrideService.store(UNKNOWN_DICT_ID, new StemmerOverrideItem(0, "a", "b")));
+
+        final CharMappingService charMappingService = new CharMappingService() {
+            @Override
+            public OptionalEntity<org.codelibs.fess.dict.mapping.CharMappingFile> getCharMappingFile(final String dictId) {
+                return OptionalEntity.empty();
+            }
+        };
+        assertReported(() -> charMappingService.store(UNKNOWN_DICT_ID, new CharMappingItem(0, new String[] { "a" }, "b")));
+    }
+
+    /**
+     * Deleting through the same services has the same shape, so it is refused the same way.
+     */
+    @Test
+    public void test_delete_reportsAnUnknownDictionaryId() {
+        final KuromojiService kuromojiService = new KuromojiService() {
+            @Override
+            public OptionalEntity<KuromojiFile> getKuromojiFile(final String dictId) {
+                return OptionalEntity.empty();
+            }
+        };
+        assertReported(() -> kuromojiService.delete(UNKNOWN_DICT_ID, new KuromojiItem(1, "t", "s", "r", "p")));
+
+        final CharMappingService charMappingService = new CharMappingService() {
+            @Override
+            public OptionalEntity<org.codelibs.fess.dict.mapping.CharMappingFile> getCharMappingFile(final String dictId) {
+                return OptionalEntity.empty();
+            }
+        };
+        assertReported(() -> charMappingService.delete(UNKNOWN_DICT_ID, new CharMappingItem(1, new String[] { "a" }, "b")));
+    }
+
+    /**
+     * A dictionary ID that does resolve still stores the entry, so the check refuses only the case
+     * that was silently discarded.
+     */
+    @Test
+    public void test_store_writesToAKnownDictionaryId() {
+        final AtomicReference<KuromojiItem> inserted = new AtomicReference<>();
+        final KuromojiFile file = new KuromojiFile("1", "/dev/null", new Date()) {
+            @Override
+            public void insert(final KuromojiItem item) {
+                inserted.set(item);
+            }
+        };
+        final KuromojiService kuromojiService = new KuromojiService() {
+            @Override
+            public OptionalEntity<KuromojiFile> getKuromojiFile(final String dictId) {
+                return OptionalEntity.of(file);
+            }
+        };
+
+        final KuromojiItem item = new KuromojiItem(0, "t", "s", "r", "p");
+        kuromojiService.store("1", item);
+
+        assertSame(item, inserted.get());
+    }
+
+    /**
+     * Asserts that the given write reports that it stored nothing.
+     *
+     * @param write the service call under test
+     */
+    private void assertReported(final Runnable write) {
+        Assertions.assertThrows(DictionaryException.class, write::run);
+    }
+}


### PR DESCRIPTION
The six dictionary services resolved the dictionary ID with ifPresent, so an ID
that matched no dictionary file simply skipped the body of the method. Nothing
was written, nothing was raised, and the REST API went on to answer created
with status 0 and an id of 0. Every one of the six behaved this way: kuromoji,
synonym, stopwords, protwords, stemmer override and character mapping alike.

For a client this is the worst kind of failure. Loading a dictionary through
the API against a slightly wrong ID - a stale one, or the ID of a dictionary on
another host - reports every entry as accepted while storing none of them, and
the only clue is the returned id, which is the same 0 that a genuine insert of
the first entry would produce. Restoring a dictionary this way looks like it
worked and leaves the dictionary empty.

The services now resolve the dictionary file explicitly and raise a
DictionaryException when there is none, so no caller can be told a write
succeeded when it did not. That covers the screens as well, which already
translate a failure from store into an error on the edit page instead of a
success redirect. The dictionary API actions turn it into an ordinary bad
request, the way the rest of the admin API reports a value it cannot use, so a
mistyped dictionary ID gets a 400 rather than a server error. Delete takes the
same route, for the same reason.

This is not new in 15.9; the affected code is unchanged since 15.8.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
