### PR TITLE
fix(osdd): serve the description document for the running host

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/OsddHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/OsddHelper.java
@@ -15,20 +15,24 @@
  */
 package org.codelibs.fess.helper;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.nio.charset.Charset;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.fess.util.OriginUtil;
 import org.lastaflute.web.response.StreamResponse;
+import org.lastaflute.web.util.LaRequestUtil;
 import org.lastaflute.web.util.LaServletContextUtil;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Helper class for Open Search Description Document.
@@ -43,6 +47,12 @@ public class OsddHelper {
     }
 
     private static final Logger logger = LogManager.getLogger(OsddHelper.class);
+
+    /**
+     * The placeholder in the OSDD file that is replaced with the URL this Fess
+     * instance is being served from, as {@code scheme://host[:port][/contextPath]}.
+     */
+    protected static final String CONTEXT_URL_PLACEHOLDER = "${fess.context.url}";
 
     /** The OSDD file path. */
     protected String osddPath;
@@ -124,7 +134,8 @@ public class OsddHelper {
     }
 
     /**
-     * Returns the OSDD as a stream response.
+     * Returns the OSDD as a stream response, with {@link #CONTEXT_URL_PLACEHOLDER}
+     * resolved against the current request.
      *
      * @return the stream response
      */
@@ -133,11 +144,45 @@ public class OsddHelper {
             throw ComponentUtil.getResponseManager().new404("Unsupported Open Search Description Document response.");
         }
 
-        return new StreamResponse(osddFile.getName()).contentType(contentType + "; charset=" + encoding).stream(out -> {
-            try (InputStream ins = new FileInputStream(osddFile)) {
-                out.write(ins);
-            }
-        });
+        final Charset charset = Charset.forName(StringUtil.isBlank(encoding) ? Constants.UTF_8 : encoding);
+        final byte[] content =
+                FileUtil.readText(osddFile, charset.name()).replace(CONTEXT_URL_PLACEHOLDER, getContextUrl()).getBytes(charset);
+        return new StreamResponse(osddFile.getName()).contentType(contentType + "; charset=" + encoding)
+                .stream(out -> out.write(new ByteArrayInputStream(content)));
+    }
+
+    /**
+     * Returns the URL this Fess instance is being served from, as
+     * {@code scheme://host[:port][/contextPath]}. The origin is taken from the
+     * current request and canonicalized by {@link OriginUtil}, so the default port
+     * for the scheme is omitted. Returns an empty string when no request is in
+     * scope or the request carries no usable origin; the document then falls back
+     * to context-relative URLs.
+     *
+     * @return the context URL, or an empty string when it cannot be resolved
+     */
+    protected String getContextUrl() {
+        return LaRequestUtil.getOptionalRequest().map(this::buildContextUrl).orElse(StringUtil.EMPTY);
+    }
+
+    /**
+     * Builds the context URL for the given request.
+     *
+     * @param request the current request
+     * @return the context URL, or null when the request carries no usable origin
+     */
+    protected String buildContextUrl(final HttpServletRequest request) {
+        final String origin = OriginUtil.canonicalize(request.getRequestURL().toString());
+        if (origin == null) {
+            logger.warn("Could not resolve the origin of {}. Open Search Description Document uses relative URLs.",
+                    request.getRequestURL());
+            return null;
+        }
+        final String contextPath = request.getContextPath();
+        if (StringUtil.isBlank(contextPath) || "/".equals(contextPath)) {
+            return origin;
+        }
+        return origin + contextPath;
     }
 
     /**

--- a/src/main/webapp/WEB-INF/orig/open-search/osdd.xml
+++ b/src/main/webapp/WEB-INF/orig/open-search/osdd.xml
@@ -4,8 +4,8 @@
   <Description>Full Text Search for Your Documents.</Description>
   <Tags>Full Text Search</Tags>
   <Contact>fess-user@lists.sourceforge.jp</Contact>
-  <SearchForm>http://localhost:8080/fess/</SearchForm>
-  <Url type="text/html" template="http://localhost:8080/fess/search?q={searchTerms}"/>
+  <SearchForm>${fess.context.url}/</SearchForm>
+  <Url type="text/html" template="${fess.context.url}/search?q={searchTerms}"/>
   <InputEncoding>UTF-8</InputEncoding>
   <OutputEncoding>UTF-8</OutputEncoding>
 </OpenSearchDescription>

--- a/src/test/java/org/codelibs/fess/helper/OsddHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/OsddHelperTest.java
@@ -18,17 +18,60 @@ package org.codelibs.fess.helper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.core.io.InputStreamUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequest;
+import org.dbflute.utflute.mocklet.MockletServletContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.lastaflute.web.response.StreamResponse;
 import org.lastaflute.web.servlet.request.stream.WrittenStreamOut;
 
 public class OsddHelperTest extends UnitFessTestCase {
+
+    private String originalContextPath;
+
+    @Override
+    protected void tearDown(final TestInfo testInfo) throws Exception {
+        if (originalContextPath != null) {
+            // the servlet context is shared by every test case, so put it back
+            ((MockletServletContext) getMockRequest().getServletContext()).setContextPath(originalContextPath);
+            originalContextPath = null;
+        }
+        super.tearDown(testInfo);
+    }
+
+    private void prepareRequest(final String scheme, final String serverName, final int serverPort, final String contextPath) {
+        final MockletHttpServletRequest request = getMockRequest();
+        request.setScheme(scheme);
+        request.setServerName(serverName);
+        request.setServerPort(serverPort);
+        final MockletServletContext servletContext = (MockletServletContext) request.getServletContext();
+        originalContextPath = servletContext.getContextPath();
+        servletContext.setContextPath(contextPath);
+    }
+
+    private String toText(final StreamResponse streamResponse) throws IOException {
+        final AtomicReference<String> ref = new AtomicReference<>();
+        streamResponse.getStreamCall().callback(new WrittenStreamOut() {
+
+            @Override
+            public void write(final InputStream ins) throws IOException {
+                ref.set(new String(InputStreamUtil.getBytes(ins), Constants.UTF_8));
+            }
+
+            @Override
+            public OutputStream stream() {
+                return null;
+            }
+        });
+        return ref.get();
+    }
 
     @Test
     public void test_init_nofile() {
@@ -69,6 +112,7 @@ public class OsddHelperTest extends UnitFessTestCase {
                 return "none";
             }
         });
+        prepareRequest("https", "search.example.com", 8443, "/fess");
         final OsddHelper osddHelper = new OsddHelper();
         osddHelper.setOsddPath("osdd/osdd.xml");
         osddHelper.setEncoding(Constants.UTF_8);
@@ -77,30 +121,57 @@ public class OsddHelperTest extends UnitFessTestCase {
 
         final StreamResponse streamResponse = osddHelper.asStream();
         assertEquals("text/xml; charset=UTF-8", streamResponse.getContentType());
-        streamResponse.getStreamCall().callback(new WrittenStreamOut() {
+        assertEquals("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+                  <ShortName>Fess</ShortName>
+                  <Description>Full Text Search for Your Documents.</Description>
+                  <Tags>Full Text Search</Tags>
+                  <Contact>fess-user@lists.sourceforge.jp</Contact>
+                  <SearchForm>https://search.example.com:8443/fess/</SearchForm>
+                  <Url type="text/html" template="https://search.example.com:8443/fess/search?q={searchTerms}"/>
+                  <InputEncoding>UTF-8</InputEncoding>
+                  <OutputEncoding>UTF-8</OutputEncoding>
+                </OpenSearchDescription>
+                """, toText(streamResponse));
+    }
 
+    @Test
+    public void test_asStream_rootContextPath() throws IOException {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             @Override
-            public void write(final InputStream ins) throws IOException {
-                assertEquals("""
-                        <?xml version="1.0" encoding="UTF-8"?>
-                        <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-                          <ShortName>Fess</ShortName>
-                          <Description>Full Text Search for Your Documents.</Description>
-                          <Tags>Full Text Search</Tags>
-                          <Contact>fess-user@lists.sourceforge.jp</Contact>
-                          <SearchForm>http://localhost:8080/fess/</SearchForm>
-                          <Url type="text/html" template="http://localhost:8080/fess/search?q={searchTerms}"/>
-                          <InputEncoding>UTF-8</InputEncoding>
-                          <OutputEncoding>UTF-8</OutputEncoding>
-                        </OpenSearchDescription>
-                        """, new String(InputStreamUtil.getBytes(ins)));
-            }
-
-            @Override
-            public OutputStream stream() {
-                return null;
+            public String getOsddLinkEnabled() {
+                return "true";
             }
         });
+        prepareRequest("http", "search.example.com", 8081, "/");
+        final OsddHelper osddHelper = new OsddHelper();
+        osddHelper.setOsddPath("osdd/osdd.xml");
+        osddHelper.init();
+
+        final String content = toText(osddHelper.asStream());
+        assertTrue(content.contains("<SearchForm>http://search.example.com:8081/</SearchForm>"));
+        assertTrue(content.contains("template=\"http://search.example.com:8081/search?q={searchTerms}\""));
+        assertFalse(content.contains("localhost"));
+        assertFalse(content.contains(OsddHelper.CONTEXT_URL_PLACEHOLDER));
+    }
+
+    @Test
+    public void test_asStream_defaultPortOmitted() throws IOException {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            @Override
+            public String getOsddLinkEnabled() {
+                return "true";
+            }
+        });
+        prepareRequest("https", "search.example.com", 443, "/");
+        final OsddHelper osddHelper = new OsddHelper();
+        osddHelper.setOsddPath("osdd/osdd.xml");
+        osddHelper.init();
+
+        final String content = toText(osddHelper.asStream());
+        assertTrue(content.contains("<SearchForm>https://search.example.com/</SearchForm>"));
+        assertTrue(content.contains("template=\"https://search.example.com/search?q={searchTerms}\""));
     }
 
     @Test

--- a/src/test/resources/osdd/osdd.xml
+++ b/src/test/resources/osdd/osdd.xml
@@ -4,8 +4,8 @@
   <Description>Full Text Search for Your Documents.</Description>
   <Tags>Full Text Search</Tags>
   <Contact>fess-user@lists.sourceforge.jp</Contact>
-  <SearchForm>http://localhost:8080/fess/</SearchForm>
-  <Url type="text/html" template="http://localhost:8080/fess/search?q={searchTerms}"/>
+  <SearchForm>${fess.context.url}/</SearchForm>
+  <Url type="text/html" template="${fess.context.url}/search?q={searchTerms}"/>
   <InputEncoding>UTF-8</InputEncoding>
   <OutputEncoding>UTF-8</OutputEncoding>
 </OpenSearchDescription>


### PR DESCRIPTION
The OpenSearch description document at /osdd/ was streamed to the browser
byte for byte, and the shipped copy names http://localhost:8080/fess/ as both
the search form and the search template. That address is wrong on every
installation: the ZIP distribution serves at the root, so even an untouched
default install has no /fess/ context path, and any host or port other than
localhost:8080 misses as well. Adding Fess as a browser search engine
therefore either failed outright or silently sent every query somewhere else.

The document now carries a ${fess.context.url} placeholder that is resolved
per request from the scheme, host, port and context path the request arrived
on, so the document always describes the server that served it. The origin is
canonicalized the same way the API origin check canonicalizes it, which drops
the default port for the scheme, and the context path is appended only when
the application is not deployed at the root.

A file without the placeholder is still streamed unchanged, so an operator who
replaced the document with their own keeps whatever it says.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
