### PR TITLE
fix(ui): give the search screens a name, a heading and a skip link

### DIFF
--- a/src/main/resources/fess_label.properties
+++ b/src/main/resources/fess_label.properties
@@ -1281,3 +1281,7 @@ labels.searchlist_content_chunk_managed=This content is managed by the content c
 labels.searchlist_content_chunk_summary=content ({0} chunks / {1} chars total)
 labels.searchlist_content_chunk_item=Chunk {0} ({1} chars)
 labels.searchlist_content_too_large=The content is {0} characters long and too large to display.
+
+labels.skip_to_main_content=Skip to main content
+labels.search_query_label=Search query
+labels.search_result_heading=Search Results

--- a/src/main/resources/fess_label_de.properties
+++ b/src/main/resources/fess_label_de.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=Dieser Inhalt wird von der Content-Chunk
 labels.searchlist_content_chunk_item=Chunk {0} ({1} Zeichen)
 labels.searchlist_content_chunk_summary=content ({0} Chunks / insgesamt {1} Zeichen)
 labels.searchlist_content_too_large=Der Inhalt ist {0} Zeichen lang und zu groß, um angezeigt zu werden.
+
+labels.skip_to_main_content=Zum Hauptinhalt springen
+labels.search_query_label=Suchanfrage
+labels.search_result_heading=Suchergebnisse

--- a/src/main/resources/fess_label_en.properties
+++ b/src/main/resources/fess_label_en.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=This content is managed by the content c
 labels.searchlist_content_chunk_summary=content ({0} chunks / {1} chars total)
 labels.searchlist_content_chunk_item=Chunk {0} ({1} chars)
 labels.searchlist_content_too_large=The content is {0} characters long and too large to display.
+
+labels.skip_to_main_content=Skip to main content
+labels.search_query_label=Search query
+labels.search_result_heading=Search Results

--- a/src/main/resources/fess_label_es.properties
+++ b/src/main/resources/fess_label_es.properties
@@ -1281,3 +1281,7 @@ labels.searchlist_content_chunk_managed=Este contenido está gestionado por la c
 labels.searchlist_content_chunk_item=Fragmento {0} ({1} caracteres)
 labels.searchlist_content_chunk_summary=content ({0} fragmentos / {1} caracteres en total)
 labels.searchlist_content_too_large=El contenido tiene {0} caracteres y es demasiado grande para mostrarse.
+
+labels.skip_to_main_content=Ir al contenido principal
+labels.search_query_label=Consulta de búsqueda
+labels.search_result_heading=Resultados de búsqueda

--- a/src/main/resources/fess_label_fr.properties
+++ b/src/main/resources/fess_label_fr.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=Ce contenu est géré par le pipeline de
 labels.searchlist_content_chunk_item=Fragment {0} ({1} caractères)
 labels.searchlist_content_chunk_summary=content ({0} fragments / {1} caractères au total)
 labels.searchlist_content_too_large=Le contenu comporte {0} caractères et est trop volumineux pour être affiché.
+
+labels.skip_to_main_content=Aller au contenu principal
+labels.search_query_label=Requête de recherche
+labels.search_result_heading=Résultats de recherche

--- a/src/main/resources/fess_label_hi.properties
+++ b/src/main/resources/fess_label_hi.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=यह सामग्री कंट�
 labels.searchlist_content_chunk_item=चंक {0} ({1} वर्ण)
 labels.searchlist_content_chunk_summary=content ({0} चंक / कुल {1} वर्ण)
 labels.searchlist_content_too_large=सामग्री {0} वर्णों की है और प्रदर्शित करने के लिए बहुत बड़ी है।
+
+labels.skip_to_main_content=मुख्य सामग्री पर जाएं
+labels.search_query_label=खोज क्वेरी
+labels.search_result_heading=खोज परिणाम

--- a/src/main/resources/fess_label_id.properties
+++ b/src/main/resources/fess_label_id.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=Konten ini dikelola oleh pipeline chunk 
 labels.searchlist_content_chunk_item=Chunk {0} ({1} karakter)
 labels.searchlist_content_chunk_summary=content ({0} chunk / {1} karakter total)
 labels.searchlist_content_too_large=Konten memiliki panjang {0} karakter dan terlalu besar untuk ditampilkan.
+
+labels.skip_to_main_content=Lewati ke konten utama
+labels.search_query_label=Kueri pencarian
+labels.search_result_heading=Hasil pencarian

--- a/src/main/resources/fess_label_it.properties
+++ b/src/main/resources/fess_label_it.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=Questo contenuto è gestito dalla pipeli
 labels.searchlist_content_chunk_item=Chunk {0} ({1} caratteri)
 labels.searchlist_content_chunk_summary=content ({0} chunk / {1} caratteri totali)
 labels.searchlist_content_too_large=Il contenuto è lungo {0} caratteri ed è troppo grande per essere visualizzato.
+
+labels.skip_to_main_content=Vai al contenuto principale
+labels.search_query_label=Query di ricerca
+labels.search_result_heading=Risultati della ricerca

--- a/src/main/resources/fess_label_ja.properties
+++ b/src/main/resources/fess_label_ja.properties
@@ -1281,3 +1281,7 @@ labels.searchlist_content_chunk_managed=\u3053\u306e\u30b3\u30f3\u30c6\u30f3\u30
 labels.searchlist_content_chunk_summary=content\uff08{0} \u30c1\u30e3\u30f3\u30af / \u8a08 {1} \u6587\u5b57\uff09
 labels.searchlist_content_chunk_item=\u30c1\u30e3\u30f3\u30af {0}\uff08{1} \u6587\u5b57\uff09
 labels.searchlist_content_too_large=content \u306f {0} \u6587\u5b57\u306e\u305f\u3081\u8868\u793a\u3067\u304d\u307e\u305b\u3093\u3002
+
+labels.skip_to_main_content=メインコンテンツへスキップ
+labels.search_query_label=検索キーワード
+labels.search_result_heading=検索結果

--- a/src/main/resources/fess_label_ko.properties
+++ b/src/main/resources/fess_label_ko.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=이 콘텐츠는 콘텐츠 청크 파이
 labels.searchlist_content_chunk_item=청크 {0} ({1}자)
 labels.searchlist_content_chunk_summary=content ({0}개 청크 / 총 {1}자)
 labels.searchlist_content_too_large=콘텐츠 길이가 {0}자로 너무 커서 표시할 수 없습니다.
+
+labels.skip_to_main_content=본문으로 건너뛰기
+labels.search_query_label=검색어
+labels.search_result_heading=검색 결과

--- a/src/main/resources/fess_label_nl.properties
+++ b/src/main/resources/fess_label_nl.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=Deze inhoud wordt beheerd door de conten
 labels.searchlist_content_chunk_item=Chunk {0} ({1} tekens)
 labels.searchlist_content_chunk_summary=content ({0} chunks / {1} tekens totaal)
 labels.searchlist_content_too_large=De inhoud is {0} tekens lang en te groot om weer te geven.
+
+labels.skip_to_main_content=Ga naar hoofdinhoud
+labels.search_query_label=Zoekopdracht
+labels.search_result_heading=Zoekresultaten

--- a/src/main/resources/fess_label_pl.properties
+++ b/src/main/resources/fess_label_pl.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=Ta treść jest zarządzana przez potok 
 labels.searchlist_content_chunk_item=Fragment {0} ({1} znaków)
 labels.searchlist_content_chunk_summary=content ({0} fragmentów / łącznie {1} znaków)
 labels.searchlist_content_too_large=Treść ma długość {0} znaków i jest zbyt duża, aby ją wyświetlić.
+
+labels.skip_to_main_content=Przejdź do głównej treści
+labels.search_query_label=Zapytanie wyszukiwania
+labels.search_result_heading=Wyniki wyszukiwania

--- a/src/main/resources/fess_label_pt_BR.properties
+++ b/src/main/resources/fess_label_pt_BR.properties
@@ -1281,3 +1281,7 @@ labels.searchlist_content_chunk_managed=Este conteúdo é gerenciado pelo pipeli
 labels.searchlist_content_chunk_item=Fragmento {0} ({1} caracteres)
 labels.searchlist_content_chunk_summary=content ({0} fragmentos / {1} caracteres no total)
 labels.searchlist_content_too_large=O conteúdo tem {0} caracteres e é grande demais para ser exibido.
+
+labels.skip_to_main_content=Ir para o conteúdo principal
+labels.search_query_label=Consulta de pesquisa
+labels.search_result_heading=Resultados da pesquisa

--- a/src/main/resources/fess_label_ru.properties
+++ b/src/main/resources/fess_label_ru.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=Этот контент управляе
 labels.searchlist_content_chunk_item=Фрагмент {0} ({1} символов)
 labels.searchlist_content_chunk_summary=content ({0} фрагментов / всего {1} символов)
 labels.searchlist_content_too_large=Длина содержимого — {0} символов, оно слишком велико для отображения.
+
+labels.skip_to_main_content=Перейти к основному содержанию
+labels.search_query_label=Поисковый запрос
+labels.search_result_heading=Результаты поиска

--- a/src/main/resources/fess_label_tr.properties
+++ b/src/main/resources/fess_label_tr.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=Bu içerik, içerik parçası (chunk) ar
 labels.searchlist_content_chunk_item=Parça {0} ({1} karakter)
 labels.searchlist_content_chunk_summary=content ({0} parça / toplam {1} karakter)
 labels.searchlist_content_too_large=İçerik {0} karakter uzunluğunda ve görüntülenemeyecek kadar büyük.
+
+labels.skip_to_main_content=Ana içeriğe atla
+labels.search_query_label=Arama sorgusu
+labels.search_result_heading=Arama sonuçları

--- a/src/main/resources/fess_label_zh_CN.properties
+++ b/src/main/resources/fess_label_zh_CN.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=此内容由内容分块管道管理，�
 labels.searchlist_content_chunk_item=分块 {0}（{1} 个字符）
 labels.searchlist_content_chunk_summary=content（{0} 个分块 / 共 {1} 个字符）
 labels.searchlist_content_too_large=内容长度为 {0} 个字符，过大无法显示。
+
+labels.skip_to_main_content=跳转到主内容
+labels.search_query_label=搜索查询
+labels.search_result_heading=搜索结果

--- a/src/main/resources/fess_label_zh_TW.properties
+++ b/src/main/resources/fess_label_zh_TW.properties
@@ -1282,3 +1282,7 @@ labels.searchlist_content_chunk_managed=此內容由內容分塊管線管理，�
 labels.searchlist_content_chunk_item=分塊 {0}（{1} 個字元）
 labels.searchlist_content_chunk_summary=content（{0} 個分塊 / 共 {1} 個字元）
 labels.searchlist_content_too_large=內容長度為 {0} 個字元，過大無法顯示。
+
+labels.skip_to_main_content=跳至主要內容
+labels.search_query_label=搜尋查詢
+labels.search_result_heading=搜尋結果

--- a/src/main/webapp/WEB-INF/orig/view/advance.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/advance.jsp
@@ -18,6 +18,9 @@ ${fe:html(true)}
 	<la:form styleClass="form-stacked" action="/search/" method="get" styleId="searchForm">
 		${fe:facetForm()}${fe:geoForm()}
 		<header>
+			<a href="#mainContent"
+				class="visually-hidden-focusable position-absolute top-0 start-0 m-2"><la:message
+					key="labels.skip_to_main_content" /></a>
 			<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
 				<div class="container">
 					<la:link styleClass="navbar-brand d-inline-flex" href="/">
@@ -88,7 +91,7 @@ ${fe:html(true)}
 			</nav>
 		</header>
 
-		<main id="content" class="container">
+		<main id="mainContent" class="container">
 			<h2>
 				<la:message key="labels.advance_search_title" />
 			</h2>

--- a/src/main/webapp/WEB-INF/orig/view/chat/chat.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/chat/chat.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
 </head>
 <body>
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="row">
 			<div class="col-12 col-lg-10 offset-lg-1">
 				<div class="card shadow-sm">

--- a/src/main/webapp/WEB-INF/orig/view/error/badRequest.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/error/badRequest.jsp
@@ -15,7 +15,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.request_error_title" />

--- a/src/main/webapp/WEB-INF/orig/view/error/busy.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/error/busy.jsp
@@ -14,7 +14,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.busy_title" />

--- a/src/main/webapp/WEB-INF/orig/view/error/error.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/error/error.jsp
@@ -14,7 +14,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.error_title" />

--- a/src/main/webapp/WEB-INF/orig/view/error/notFound.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/error/notFound.jsp
@@ -14,7 +14,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.page_not_found_title" />

--- a/src/main/webapp/WEB-INF/orig/view/error/system.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/error/system.jsp
@@ -15,7 +15,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.system_error_title" />

--- a/src/main/webapp/WEB-INF/orig/view/header.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/header.jsp
@@ -3,6 +3,9 @@
 	role="search">
 	${fe:facetForm()}${fe:geoForm()}
 	<header>
+		<a href="#mainContent"
+			class="visually-hidden-focusable position-absolute top-0 start-0 m-2"><la:message
+				key="labels.skip_to_main_content" /></a>
 		<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark d-print-none">
 			<div id="content" class="container">
 				<la:link styleClass="navbar-brand d-inline-flex" href="/">
@@ -15,6 +18,8 @@
 					class="d-flex col-md-6 col-sm-8 col-7 me-auto p-0"
 					role="search">
 					<div class="input-group">
+						<label for="query" class="visually-hidden"><la:message
+								key="labels.search_query_label" /></label>
 						<la:text property="q" maxlength="1000" styleId="query"
 							styleClass="form-control" autocomplete="off" />
 						<button type="submit" name="search" id="searchButton"

--- a/src/main/webapp/WEB-INF/orig/view/help.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/help.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
 </head>
 <body>
 	<jsp:include page="header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="row">
 			<div class="col">
 

--- a/src/main/webapp/WEB-INF/orig/view/index.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/index.jsp
@@ -20,6 +20,9 @@ ${fe:html(true)}
 	<la:form action="/search" method="get" styleId="searchForm">
 		${fe:facetForm()}${fe:geoForm()}
 		<header>
+			<a href="#mainContent"
+				class="visually-hidden-focusable position-absolute top-0 start-0 m-2"><la:message
+					key="labels.skip_to_main_content" /></a>
 			<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
 				<div id="content" class="container">
 					<div class="navbar-brand"></div>
@@ -112,7 +115,7 @@ ${fe:html(true)}
 				</div>
 			</div>
 		</div>
-		<main class="container">
+		<main id="mainContent" class="container">
 			<div class="row">
 				<div class="col text-center searchFormBox">
 					<h1 class="mainLogo">
@@ -132,6 +135,8 @@ ${fe:html(true)}
 						<legend><la:message key="labels.search" /></legend>
 						<div class="clearfix">
 							<div class="mx-auto col-10 col-sm-8 col-md-8 col-lg-6">
+								<label for="contentQuery" class="visually-hidden"><la:message
+										key="labels.search_query_label" /></label>
 								<la:text styleClass="query form-control"
 									property="q" size="50" maxlength="1000" styleId="contentQuery"
 									autocomplete="off" />

--- a/src/main/webapp/WEB-INF/orig/view/search.jsp
+++ b/src/main/webapp/WEB-INF/orig/view/search.jsp
@@ -20,7 +20,10 @@ ${fe:html(true)}
 </head>
 <body class="search">
 	<jsp:include page="header.jsp" />
-	<main id="content" class="container">
+	<main id="mainContent" class="container">
+		<h1 class="visually-hidden">
+			<la:message key="labels.search_result_heading" />
+		</h1>
 		<div>
 			<la:info id="msg" message="true">
 				<div class="alert alert-info">${msg}</div>

--- a/src/main/webapp/WEB-INF/view/admin/accesstoken/admin_accesstoken.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/accesstoken/admin_accesstoken.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="accessToken"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/accesstoken/admin_accesstoken_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/accesstoken/admin_accesstoken_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="accessToken"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/accesstoken/admin_accesstoken_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/accesstoken/admin_accesstoken_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="accessToken"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/backup/admin_backup.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/backup/admin_backup.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="backup"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/badword/admin_badword.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/badword/admin_badword.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="badWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/badword/admin_badword_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/badword/admin_badword_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="badWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/badword/admin_badword_download.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/badword/admin_badword_download.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="badWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/badword/admin_badword_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/badword/admin_badword_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="badWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/badword/admin_badword_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/badword/admin_badword_upload.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="badWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="boostDocumentRule"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="boostDocumentRule"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/boostdoc/admin_boostdoc_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="boostDocumentRule"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/crawlinginfo/admin_crawlinginfo.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/crawlinginfo/admin_crawlinginfo.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="crawlingInfo"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/crawlinginfo/admin_crawlinginfo_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/crawlinginfo/admin_crawlinginfo_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="crawlingInfo"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dashboard/admin_dashboard.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dashboard/admin_dashboard.jsp
@@ -14,7 +14,7 @@ ${fe:html(true)}
         <jsp:param name="menuType" value="dashboard"/>
     </jsp:include>
 
-    <main class="content-wrapper position-relative">
+    <main id="mainContent" class="content-wrapper position-relative">
         <iframe class="w-100 h-100 position-absolute" style="border: 0;"
                 src="<%=request.getContextPath()%>${serverPath}<%= response.encodeURL("/_plugin/kopf/") %>?lang=${f:u(kopfLang)}"
                 title="<la:message key="labels.dashboard_plugin" />"></iframe>

--- a/src/main/webapp/WEB-INF/view/admin/dataconfig/admin_dataconfig.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dataconfig/admin_dataconfig.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="dataConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dataconfig/admin_dataconfig_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dataconfig/admin_dataconfig_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="dataConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dataconfig/admin_dataconfig_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dataconfig/admin_dataconfig_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="dataConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/design/admin_design.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/design/admin_design.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="design"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/design/admin_design_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/design/admin_design_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="design"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/admin_dict.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/admin_dict.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji_download.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji_download.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/kuromoji/admin_dict_kuromoji_upload.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping_download.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping_download.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/mapping/admin_dict_mapping_upload.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords_download.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords_download.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/protwords/admin_dict_protwords_upload.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride_download.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride_download.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stemmeroverride/admin_dict_stemmeroverride_upload.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords_download.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords_download.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/stopwords/admin_dict_stopwords_upload.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym_download.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym_download.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/dict/synonym/admin_dict_synonym_upload.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="dict"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/duplicatehost/admin_duplicatehost.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/duplicatehost/admin_duplicatehost.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="duplicateHost"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/duplicatehost/admin_duplicatehost_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/duplicatehost/admin_duplicatehost_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="duplicateHost"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/duplicatehost/admin_duplicatehost_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/duplicatehost/admin_duplicatehost_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="duplicateHost"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="elevateWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="elevateWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword_download.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword_download.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="elevateWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="elevateWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/elevateword/admin_elevateword_upload.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="elevateWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/error/admin_error.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/error/admin_error.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuType" value="wizard"/>
     </jsp:include>
 
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/failureurl/admin_failureurl.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/failureurl/admin_failureurl.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="failureUrl"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/failureurl/admin_failureurl_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/failureurl/admin_failureurl_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="failureUrl"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/fileauth/admin_fileauth.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/fileauth/admin_fileauth.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="fileAuthentication"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/fileauth/admin_fileauth_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/fileauth/admin_fileauth_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="fileAuthentication"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/fileauth/admin_fileauth_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/fileauth/admin_fileauth_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="fileAuthentication"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/fileconfig/admin_fileconfig.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/fileconfig/admin_fileconfig.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="fileConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <%-- Content Header --%>
 
         <div class="content-header">

--- a/src/main/webapp/WEB-INF/view/admin/fileconfig/admin_fileconfig_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/fileconfig/admin_fileconfig_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="fileConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/fileconfig/admin_fileconfig_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/fileconfig/admin_fileconfig_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="fileConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/general/admin_general.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/general/admin_general.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="general"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/group/admin_group.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/group/admin_group.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="group"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/group/admin_group_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/group/admin_group_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="group"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/group/admin_group_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/group/admin_group_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="group"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/joblog/admin_joblog.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/joblog/admin_joblog.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="jobLog"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/joblog/admin_joblog_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/joblog/admin_joblog_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="jobLog"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/keymatch/admin_keymatch.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/keymatch/admin_keymatch.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="keyMatch"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/keymatch/admin_keymatch_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/keymatch/admin_keymatch_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="keyMatch"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/keymatch/admin_keymatch_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/keymatch/admin_keymatch_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="keyMatch"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/labeltype/admin_labeltype.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/labeltype/admin_labeltype.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="labelType"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/labeltype/admin_labeltype_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/labeltype/admin_labeltype_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="labelType"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/labeltype/admin_labeltype_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/labeltype/admin_labeltype_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="labelType"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/log/admin_log.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/log/admin_log.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="log"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/maintenance/admin_maintenance.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/maintenance/admin_maintenance.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="maintenance"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/pathmap/admin_pathmap.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/pathmap/admin_pathmap.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="pathMapping"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/pathmap/admin_pathmap_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/pathmap/admin_pathmap_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="pathMapping"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/pathmap/admin_pathmap_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/pathmap/admin_pathmap_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="pathMapping"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/plugin/admin_plugin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/plugin/admin_plugin.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="plugin"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/plugin/admin_plugin_installplugin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/plugin/admin_plugin_installplugin.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="plugin"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/relatedcontent/admin_relatedcontent.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/relatedcontent/admin_relatedcontent.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="relatedContent"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/relatedcontent/admin_relatedcontent_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/relatedcontent/admin_relatedcontent_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="relatedContent"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/relatedcontent/admin_relatedcontent_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/relatedcontent/admin_relatedcontent_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="relatedContent"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/relatedquery/admin_relatedquery.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/relatedquery/admin_relatedquery.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="relatedQuery"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/relatedquery/admin_relatedquery_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/relatedquery/admin_relatedquery_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="relatedQuery"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/relatedquery/admin_relatedquery_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/relatedquery/admin_relatedquery_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="relatedQuery"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/reqheader/admin_reqheader.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/reqheader/admin_reqheader.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="requestHeader"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/reqheader/admin_reqheader_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/reqheader/admin_reqheader_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="requestHeader"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/reqheader/admin_reqheader_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/reqheader/admin_reqheader_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="requestHeader"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/role/admin_role.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/role/admin_role.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="role"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/role/admin_role_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/role/admin_role_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="role"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/role/admin_role_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/role/admin_role_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="role"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/scheduler/admin_scheduler.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/scheduler/admin_scheduler.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="scheduler"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/scheduler/admin_scheduler_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/scheduler/admin_scheduler_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="scheduler"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/scheduler/admin_scheduler_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/scheduler/admin_scheduler_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="scheduler"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/searchlist/admin_searchlist.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/searchlist/admin_searchlist.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="searchList"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/searchlist/admin_searchlist_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/searchlist/admin_searchlist_edit.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="searchList"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/searchlog/admin_searchlog.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/searchlog/admin_searchlog.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="searchLog"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/searchlog/admin_searchlog_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/searchlog/admin_searchlog_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="searchLog"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/sereq/admin_sereq.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/sereq/admin_sereq.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
 			<jsp:param name="menuCategoryType" value="system" />
 			<jsp:param name="menuType" value="sereq" />
 		</jsp:include>
-		<main class="content-wrapper">
+		<main id="mainContent" class="content-wrapper">
 			<div class="content-header">
 				<div class="container-fluid">
 					<div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/storage/admin_storage.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/storage/admin_storage.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="storage"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/storage/admin_storage_tag_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/storage/admin_storage_tag_edit.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
 			<jsp:param name="menuCategoryType" value="system" />
 			<jsp:param name="menuType" value="storage" />
 		</jsp:include>
-		<main class="content-wrapper">
+		<main id="mainContent" class="content-wrapper">
 			<div class="content-header">
 				<div class="container-fluid">
 					<div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/suggest/admin_suggest.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/suggest/admin_suggest.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="suggest"/>
         <jsp:param name="menuType" value="suggestWord"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/systeminfo/admin_systeminfo.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/systeminfo/admin_systeminfo.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="log"/>
         <jsp:param name="menuType" value="systemInfo"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/theme/admin_theme.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/theme/admin_theme.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="theme"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/theme/admin_theme_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/theme/admin_theme_details.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="theme"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/theme/admin_theme_upload.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/theme/admin_theme_upload.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="theme"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/user/admin_user.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/user/admin_user.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="user"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/user/admin_user_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/user/admin_user_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="user"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/user/admin_user_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/user/admin_user_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="user"/>
         <jsp:param name="menuType" value="user"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/webauth/admin_webauth.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/webauth/admin_webauth.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="webAuthentication"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/webauth/admin_webauth_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/webauth/admin_webauth_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="webAuthentication"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/webauth/admin_webauth_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/webauth/admin_webauth_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="webAuthentication"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/webconfig/admin_webconfig.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/webconfig/admin_webconfig.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="webConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/webconfig/admin_webconfig_details.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/webconfig/admin_webconfig_details.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="webConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/webconfig/admin_webconfig_edit.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/webconfig/admin_webconfig_edit.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="crawl"/>
         <jsp:param name="menuType" value="webConfig"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/wizard/admin_wizard.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/wizard/admin_wizard.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="wizard"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/wizard/admin_wizard_config.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/wizard/admin_wizard_config.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="wizard"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/admin/wizard/admin_wizard_start.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/wizard/admin_wizard_start.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
         <jsp:param name="menuCategoryType" value="system"/>
         <jsp:param name="menuType" value="wizard"/>
     </jsp:include>
-    <main class="content-wrapper">
+    <main id="mainContent" class="content-wrapper">
         <div class="content-header">
             <div class="container-fluid">
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/view/advance.jsp
+++ b/src/main/webapp/WEB-INF/view/advance.jsp
@@ -18,6 +18,9 @@ ${fe:html(true)}
 	<la:form styleClass="form-stacked" action="/search/" method="get" styleId="searchForm">
 		${fe:facetForm()}${fe:geoForm()}
 		<header>
+			<a href="#mainContent"
+				class="visually-hidden-focusable position-absolute top-0 start-0 m-2"><la:message
+					key="labels.skip_to_main_content" /></a>
 			<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
 				<div class="container">
 					<la:link styleClass="navbar-brand d-inline-flex" href="/">
@@ -88,7 +91,7 @@ ${fe:html(true)}
 			</nav>
 		</header>
 
-		<main id="content" class="container">
+		<main id="mainContent" class="container">
 			<h2>
 				<la:message key="labels.advance_search_title" />
 			</h2>

--- a/src/main/webapp/WEB-INF/view/chat/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat/chat.jsp
@@ -12,7 +12,7 @@ ${fe:html(true)}
 </head>
 <body>
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="row">
 			<div class="col-12 col-lg-10 offset-lg-1">
 				<div class="card shadow-sm">

--- a/src/main/webapp/WEB-INF/view/common/admin/header.jsp
+++ b/src/main/webapp/WEB-INF/view/common/admin/header.jsp
@@ -1,4 +1,6 @@
 <%@page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8"%>
+<a href="#mainContent" class="sr-only sr-only-focusable"><la:message
+		key="labels.skip_to_main_content" /></a>
 <nav class="main-header navbar navbar-expand navbar-dark navbar-secondary">
 	<ul class="navbar-nav">
 		<li class="nav-item">

--- a/src/main/webapp/WEB-INF/view/error/badRequest.jsp
+++ b/src/main/webapp/WEB-INF/view/error/badRequest.jsp
@@ -15,7 +15,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.request_error_title" />

--- a/src/main/webapp/WEB-INF/view/error/busy.jsp
+++ b/src/main/webapp/WEB-INF/view/error/busy.jsp
@@ -14,7 +14,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.busy_title" />

--- a/src/main/webapp/WEB-INF/view/error/error.jsp
+++ b/src/main/webapp/WEB-INF/view/error/error.jsp
@@ -14,7 +14,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.error_title" />

--- a/src/main/webapp/WEB-INF/view/error/notFound.jsp
+++ b/src/main/webapp/WEB-INF/view/error/notFound.jsp
@@ -14,7 +14,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.page_not_found_title" />

--- a/src/main/webapp/WEB-INF/view/error/system.jsp
+++ b/src/main/webapp/WEB-INF/view/error/system.jsp
@@ -15,7 +15,7 @@ ${fe:html(true)}
 </head>
 <body class="error">
 	<jsp:include page="../header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="text-center">
 			<h2>
 				<la:message key="labels.system_error_title" />

--- a/src/main/webapp/WEB-INF/view/header.jsp
+++ b/src/main/webapp/WEB-INF/view/header.jsp
@@ -3,6 +3,9 @@
 	role="search">
 	${fe:facetForm()}${fe:geoForm()}
 	<header>
+		<a href="#mainContent"
+			class="visually-hidden-focusable position-absolute top-0 start-0 m-2"><la:message
+				key="labels.skip_to_main_content" /></a>
 		<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark d-print-none">
 			<div id="content" class="container">
 				<la:link styleClass="navbar-brand d-inline-flex" href="/">
@@ -15,6 +18,8 @@
 					class="d-flex col-md-6 col-sm-8 col-7 me-auto p-0"
 					role="search">
 					<div class="input-group">
+						<label for="query" class="visually-hidden"><la:message
+								key="labels.search_query_label" /></label>
 						<la:text property="q" maxlength="1000" styleId="query"
 							styleClass="form-control" autocomplete="off" />
 						<button type="submit" name="search" id="searchButton"

--- a/src/main/webapp/WEB-INF/view/help.jsp
+++ b/src/main/webapp/WEB-INF/view/help.jsp
@@ -13,7 +13,7 @@ ${fe:html(true)}
 </head>
 <body>
 	<jsp:include page="header.jsp" />
-	<main class="container">
+	<main id="mainContent" class="container">
 		<div class="row">
 			<div class="col">
 

--- a/src/main/webapp/WEB-INF/view/index.jsp
+++ b/src/main/webapp/WEB-INF/view/index.jsp
@@ -20,6 +20,9 @@ ${fe:html(true)}
 	<la:form action="/search" method="get" styleId="searchForm">
 		${fe:facetForm()}${fe:geoForm()}
 		<header>
+			<a href="#mainContent"
+				class="visually-hidden-focusable position-absolute top-0 start-0 m-2"><la:message
+					key="labels.skip_to_main_content" /></a>
 			<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
 				<div id="content" class="container">
 					<div class="navbar-brand"></div>
@@ -112,7 +115,7 @@ ${fe:html(true)}
 				</div>
 			</div>
 		</div>
-		<main class="container">
+		<main id="mainContent" class="container">
 			<div class="row">
 				<div class="col text-center searchFormBox">
 					<h1 class="mainLogo">
@@ -132,6 +135,8 @@ ${fe:html(true)}
 						<legend><la:message key="labels.search" /></legend>
 						<div class="clearfix">
 							<div class="mx-auto col-10 col-sm-8 col-md-8 col-lg-6">
+								<label for="contentQuery" class="visually-hidden"><la:message
+										key="labels.search_query_label" /></label>
 								<la:text styleClass="query form-control"
 									property="q" size="50" maxlength="1000" styleId="contentQuery"
 									autocomplete="off" />

--- a/src/main/webapp/WEB-INF/view/search.jsp
+++ b/src/main/webapp/WEB-INF/view/search.jsp
@@ -20,7 +20,10 @@ ${fe:html(true)}
 </head>
 <body class="search">
 	<jsp:include page="header.jsp" />
-	<main id="content" class="container">
+	<main id="mainContent" class="container">
+		<h1 class="visually-hidden">
+			<la:message key="labels.search_result_heading" />
+		</h1>
 		<div>
 			<la:info id="msg" message="true">
 				<div class="alert alert-info">${msg}</div>

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -120,7 +120,7 @@ legend{
 }
 
 #result .site cite {
-	color: #093;
+	color: #00852c;
 	font-style: normal;
 }
 


### PR DESCRIPTION
The search box that every visitor types into carried no programmatic name at
all: no label, no aria-label, no title and no placeholder, on both the header
form and the top page. A screen reader announced it as an unnamed edit box,
which is the whole product reduced to a control nobody can identify. A
visually hidden label now names it, so nothing on screen moves.

The result page had no top-level heading either. Its headings began at h3, so
a reader navigating by heading had no way to reach the results and no
statement of what the page is. A visually hidden h1 now opens the main region.

Neither the search screens nor the administration screens offered a way past
the navigation. In document order the language selector and the rest of the
option bar sit ahead of the result list, so reaching the first result meant
tabbing through all of it on every page. Both now start with a skip link that
is invisible until it takes focus and jumps to the main region, matching the
skip link the shipped static theme already has. The main landmark carries the
target id; on the search and advanced screens that id replaces one the header
already used further up the same page, so the duplicate is gone as well.

The result URL was drawn in a green that measures 3.75:1 against the page,
below the 4.5:1 that body text needs, and is now dark enough to pass. The
administration link colour is short of the same threshold, but it is Bootstrap's
own primary colour inside the vendored bundle, so changing it there would move
every button, badge and active state with it; that one is left alone.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
