### PR TITLE
fix(admin): localize the search field on the document list screen

### DIFF
--- a/src/main/resources/fess_label.properties
+++ b/src/main/resources/fess_label.properties
@@ -1285,3 +1285,4 @@ labels.searchlist_content_too_large=The content is {0} characters long and too l
 labels.skip_to_main_content=Skip to main content
 labels.search_query_label=Search query
 labels.search_result_heading=Search Results
+labels.searchlist_query_placeholder=Type a search query

--- a/src/main/resources/fess_label_de.properties
+++ b/src/main/resources/fess_label_de.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=Der Inhalt ist {0} Zeichen lang und zu groß
 labels.skip_to_main_content=Zum Hauptinhalt springen
 labels.search_query_label=Suchanfrage
 labels.search_result_heading=Suchergebnisse
+labels.searchlist_query_placeholder=Suchanfrage eingeben

--- a/src/main/resources/fess_label_en.properties
+++ b/src/main/resources/fess_label_en.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=The content is {0} characters long and too l
 labels.skip_to_main_content=Skip to main content
 labels.search_query_label=Search query
 labels.search_result_heading=Search Results
+labels.searchlist_query_placeholder=Type a search query

--- a/src/main/resources/fess_label_es.properties
+++ b/src/main/resources/fess_label_es.properties
@@ -1285,3 +1285,4 @@ labels.searchlist_content_too_large=El contenido tiene {0} caracteres y es demas
 labels.skip_to_main_content=Ir al contenido principal
 labels.search_query_label=Consulta de búsqueda
 labels.search_result_heading=Resultados de búsqueda
+labels.searchlist_query_placeholder=Escriba una consulta de búsqueda

--- a/src/main/resources/fess_label_fr.properties
+++ b/src/main/resources/fess_label_fr.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=Le contenu comporte {0} caractères et est t
 labels.skip_to_main_content=Aller au contenu principal
 labels.search_query_label=Requête de recherche
 labels.search_result_heading=Résultats de recherche
+labels.searchlist_query_placeholder=Saisissez une requête de recherche

--- a/src/main/resources/fess_label_hi.properties
+++ b/src/main/resources/fess_label_hi.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=सामग्री {0} वर्णों
 labels.skip_to_main_content=मुख्य सामग्री पर जाएं
 labels.search_query_label=खोज क्वेरी
 labels.search_result_heading=खोज परिणाम
+labels.searchlist_query_placeholder=खोज क्वेरी टाइप करें

--- a/src/main/resources/fess_label_id.properties
+++ b/src/main/resources/fess_label_id.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=Konten memiliki panjang {0} karakter dan ter
 labels.skip_to_main_content=Lewati ke konten utama
 labels.search_query_label=Kueri pencarian
 labels.search_result_heading=Hasil pencarian
+labels.searchlist_query_placeholder=Ketik kueri pencarian

--- a/src/main/resources/fess_label_it.properties
+++ b/src/main/resources/fess_label_it.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=Il contenuto è lungo {0} caratteri ed è tr
 labels.skip_to_main_content=Vai al contenuto principale
 labels.search_query_label=Query di ricerca
 labels.search_result_heading=Risultati della ricerca
+labels.searchlist_query_placeholder=Digita una query di ricerca

--- a/src/main/resources/fess_label_ja.properties
+++ b/src/main/resources/fess_label_ja.properties
@@ -1285,3 +1285,4 @@ labels.searchlist_content_too_large=content \u306f {0} \u6587\u5b57\u306e\u305f\
 labels.skip_to_main_content=メインコンテンツへスキップ
 labels.search_query_label=検索キーワード
 labels.search_result_heading=検索結果
+labels.searchlist_query_placeholder=検索キーワードを入力

--- a/src/main/resources/fess_label_ko.properties
+++ b/src/main/resources/fess_label_ko.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=콘텐츠 길이가 {0}자로 너무 커서 
 labels.skip_to_main_content=본문으로 건너뛰기
 labels.search_query_label=검색어
 labels.search_result_heading=검색 결과
+labels.searchlist_query_placeholder=검색어를 입력하세요

--- a/src/main/resources/fess_label_nl.properties
+++ b/src/main/resources/fess_label_nl.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=De inhoud is {0} tekens lang en te groot om 
 labels.skip_to_main_content=Ga naar hoofdinhoud
 labels.search_query_label=Zoekopdracht
 labels.search_result_heading=Zoekresultaten
+labels.searchlist_query_placeholder=Typ een zoekopdracht

--- a/src/main/resources/fess_label_pl.properties
+++ b/src/main/resources/fess_label_pl.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=Treść ma długość {0} znaków i jest zby
 labels.skip_to_main_content=Przejdź do głównej treści
 labels.search_query_label=Zapytanie wyszukiwania
 labels.search_result_heading=Wyniki wyszukiwania
+labels.searchlist_query_placeholder=Wpisz zapytanie wyszukiwania

--- a/src/main/resources/fess_label_pt_BR.properties
+++ b/src/main/resources/fess_label_pt_BR.properties
@@ -1285,3 +1285,4 @@ labels.searchlist_content_too_large=O conteúdo tem {0} caracteres e é grande d
 labels.skip_to_main_content=Ir para o conteúdo principal
 labels.search_query_label=Consulta de pesquisa
 labels.search_result_heading=Resultados da pesquisa
+labels.searchlist_query_placeholder=Digite uma consulta de pesquisa

--- a/src/main/resources/fess_label_ru.properties
+++ b/src/main/resources/fess_label_ru.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=Длина содержимого — {0} с
 labels.skip_to_main_content=Перейти к основному содержанию
 labels.search_query_label=Поисковый запрос
 labels.search_result_heading=Результаты поиска
+labels.searchlist_query_placeholder=Введите поисковый запрос

--- a/src/main/resources/fess_label_tr.properties
+++ b/src/main/resources/fess_label_tr.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=İçerik {0} karakter uzunluğunda ve görü
 labels.skip_to_main_content=Ana içeriğe atla
 labels.search_query_label=Arama sorgusu
 labels.search_result_heading=Arama sonuçları
+labels.searchlist_query_placeholder=Bir arama sorgusu yazın

--- a/src/main/resources/fess_label_zh_CN.properties
+++ b/src/main/resources/fess_label_zh_CN.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=内容长度为 {0} 个字符，过大无法
 labels.skip_to_main_content=跳转到主内容
 labels.search_query_label=搜索查询
 labels.search_result_heading=搜索结果
+labels.searchlist_query_placeholder=输入搜索查询

--- a/src/main/resources/fess_label_zh_TW.properties
+++ b/src/main/resources/fess_label_zh_TW.properties
@@ -1286,3 +1286,4 @@ labels.searchlist_content_too_large=內容長度為 {0} 個字元，過大無法
 labels.skip_to_main_content=跳至主要內容
 labels.search_query_label=搜尋查詢
 labels.search_result_heading=搜尋結果
+labels.searchlist_query_placeholder=輸入搜尋查詢

--- a/src/main/webapp/WEB-INF/view/admin/searchlist/admin_searchlist.jsp
+++ b/src/main/webapp/WEB-INF/view/admin/searchlist/admin_searchlist.jsp
@@ -62,9 +62,11 @@ ${fe:html(true)}
                             </div>
                             <la:form action="/admin/searchlist" styleClass="form-inline" method="GET">
                                 <div class="form-group">
+                                    <c:set var="title_query"><la:message key="labels.search"/></c:set>
+                                    <c:set var="ph_query"><la:message key="labels.searchlist_query_placeholder"/></c:set>
                                     <la:text styleClass="query form-control" property="q"
-                                             title="Search" size="50" maxlength="1000"
-                                             placeholder="Type a search query"/>
+                                             title="${title_query}" size="50" maxlength="1000"
+                                             placeholder="${ph_query}"/>
                                 </div>
                                 <div class="form-group ml-sm-2">
                                     <button type="submit" class="btn btn-primary" id="submit"


### PR DESCRIPTION
The query box on the administration document list carried its tooltip and its
placeholder as literal English text, so a Japanese administrator working in a
fully Japanese screen still read "Search" and "Type a search query" on the one
control that screen exists for. Both now come from message keys, the tooltip
from the key the adjacent search button already uses and the placeholder from
a new key defined in every locale bundle.

A custom tag cannot be nested inside another tag's attribute, so the two
strings are resolved into page variables first, the same way the crawling
information screen resolves its own placeholder.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
