### PR TITLE
docs(readme): point the documentation links at the stable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Fess is an enterprise search server that you can install and run on any platform with a Java runtime. It is built on [OpenSearch](https://github.com/opensearch-project/OpenSearch), but prior OpenSearch knowledge is not required: Fess is configured through a browser-based administration UI.
 
-A built-in crawler collects documents from [web sites](https://fess.codelibs.org/15.8/admin/webconfig-guide.html), [file systems](https://fess.codelibs.org/15.8/admin/fileconfig-guide.html), and [data stores](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html) such as databases and CSV files. Many file formats are supported, including Microsoft Office, PDF, and ZIP archives.
+A built-in crawler collects documents from [web sites](https://fess.codelibs.org/stable/admin/webconfig-guide.html), [file systems](https://fess.codelibs.org/stable/admin/fileconfig-guide.html), and [data stores](https://fess.codelibs.org/stable/admin/dataconfig-guide.html) such as databases and CSV files. Many file formats are supported, including Microsoft Office, PDF, and ZIP archives.
 
 [Fess Site Search](https://github.com/codelibs/fess-site-search) is a free alternative to Google Site Search that you can embed in your own website. For details, see the [FSS JS Generator documentation](https://fss-generator.codelibs.org/docs/manual).
 
@@ -27,7 +27,7 @@ A built-in crawler collects documents from [web sites](https://fess.codelibs.org
 - Java 21 or later, for the ZIP, RPM, and DEB packages
 - OpenSearch as the search engine backend. The Docker images bundle it; for other installations you set it up separately.
 
-See the [Installation Guide](https://fess.codelibs.org/15.8/install/index.html) for supported versions and setup details.
+See the [Installation Guide](https://fess.codelibs.org/stable/install/index.html) for supported versions and setup details.
 
 ## Getting Started
 
@@ -35,15 +35,15 @@ There are two ways to try Fess: download and install it yourself, or run it with
 
 ### Download and Install/Run
 
-Fess 15.8 can be downloaded from the [Releases page](https://github.com/codelibs/fess/releases). Downloads are available in three formats: DEB, RPM, and ZIP.
+Fess can be downloaded from the [Releases page](https://github.com/codelibs/fess/releases). Downloads are available in three formats: DEB, RPM, and ZIP.
 
 The following commands show how to use the ZIP download:
 
-    $ unzip fess-15.8.x.zip
-    $ cd fess-15.8.x
+    $ unzip fess-<version>.zip
+    $ cd fess-<version>
     $ ./bin/fess
 
-For more details, see the [Installation Guide](https://fess.codelibs.org/15.8/install/index.html).
+For more details, see the [Installation Guide](https://fess.codelibs.org/stable/install/index.html).
 
 ### Docker
 
@@ -59,7 +59,7 @@ Docker images are published on [ghcr.io](https://github.com/orgs/codelibs/packag
 
 ![Admin UI](https://fess.codelibs.org/_images/fess_admin_dashboard.png)
 
-Register crawling targets on the Web, File, or Data Store configuration pages in the Admin UI, then start the crawler from the [Scheduler page](https://fess.codelibs.org/15.8/admin/scheduler-guide.html).
+Register crawling targets on the Web, File, or Data Store configuration pages in the Admin UI, then start the crawler from the [Scheduler page](https://fess.codelibs.org/stable/admin/scheduler-guide.html).
 
 ## Migration from Another Search Provider
 
@@ -67,7 +67,7 @@ See [MIGRATION.md](MIGRATION.md).
 
 ## Data Store
 
-Fess can crawl the following [storage locations and APIs](https://fess.codelibs.org/15.8/admin/dataconfig-guide.html):
+Fess can crawl the following [storage locations and APIs](https://fess.codelibs.org/stable/admin/dataconfig-guide.html):
 
  - [Confluence/Jira](https://github.com/codelibs/fess-ds-atlassian)
  - [Box](https://github.com/codelibs/fess-ds-box)


### PR DESCRIPTION
The README is packaged into the release archive, so it is the first thing a
new user reads after unzipping. Its documentation links and its download
instructions were pinned to a release number, which every release has to
remember to move; the last one moved this file but had already left the seven
translated copies two versions behind, which is how a link ends up describing
software the reader does not have.

The documentation site publishes the current release under a version-less
stable path, and every versioned page — including the one the README pointed
at — names that path as its canonical URL. The sitemap, the machine-readable
index and the site's own documentation menu link nothing else. The five pages
the README references all answer there, so the links now use it and stop
needing a release to keep them true.

The download instructions no longer name a version either. They named the
previous release while the tree they ship from is the next one, so they were
wrong in the archive and wrong on the branch at the same time; the archive
name is now written as a placeholder, which is what the trailing wildcard
already meant.


---

Found while verifying 15.9.0 on a running server. Not a 15.9 regression unless the body says otherwise.
