### PR TITLE
fix(log): register the server error filter in web.xml, not in the director

### DIFF
--- a/src/main/java/org/codelibs/fess/filter/ServerErrorLoggingFilter.java
+++ b/src/main/java/org/codelibs/fess/filter/ServerErrorLoggingFilter.java
@@ -43,9 +43,18 @@ import jakarta.servlet.http.HttpServletResponse;
  * whose callback the logging filter invokes from {@code sendInternalServerError} — that is, on
  * the 500 path only. Client errors ({@code RequestClientErrorException}, e.g. 404) go through a
  * separate callback and deliberate redirects never raise at all, so neither reaches this class.
- * The handler is per-thread, hence this wrapper: it is registered through
- * {@code FwWebDirection#directServletFilter(filter, false)} so that it runs outside the logging
- * filter, and installs the callback for the duration of the request.</p>
+ * The handler is per-thread, hence this wrapper: {@code web.xml} maps it just ahead of
+ * {@code lastaShowbaseFilter} so that it runs outside the logging filter, and it installs the
+ * callback for the duration of the request.</p>
+ *
+ * <p>The registration lives in {@code web.xml} rather than in
+ * {@code FessFwAssistantDirector#prepareWebDirection}, which is where a LastaFlute application
+ * would normally put it with {@code FwWebDirection#directServletFilter(filter, false)}. The
+ * assistant director is named by {@code lastaflute_director.xml}, which the crawler, thumbnail,
+ * suggest and chunk child processes also read: their classpath is
+ * {@code WEB-INF/classes} plus {@code WEB-INF/lib} plus {@code WEB-INF/env/<type>/lib} and
+ * carries no servlet API, so a servlet type reachable from that class fails its verification
+ * and kills every child process at DI container startup.</p>
  */
 public class ServerErrorLoggingFilter implements Filter {
 

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessFwAssistantDirector.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessFwAssistantDirector.java
@@ -21,7 +21,6 @@ import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.app.web.base.FessAdminAction;
-import org.codelibs.fess.filter.ServerErrorLoggingFilter;
 import org.codelibs.fess.mylasta.direction.sponsor.FessActionAdjustmentProvider;
 import org.codelibs.fess.mylasta.direction.sponsor.FessApiFailureHook;
 import org.codelibs.fess.mylasta.direction.sponsor.FessCookieResourceProvider;
@@ -174,9 +173,6 @@ public class FessFwAssistantDirector extends CachedFwAssistantDirector {
         direction.directAdjustment(createActionAdjustmentProvider());
         direction.directMessage(createMessageNameList(), "fess_label");
         direction.directApiCall(createApiFailureHook());
-        // outside the logging filter (inside=false) so that the per-thread server error handler
-        // is installed before RequestLoggingFilter swallows the exception behind errorLogging=false
-        direction.directServletFilter(createServerErrorLoggingFilter(), false);
         direction.directMultipart(FessMultipartRequestHandler::new);
         direction.directHtmlRendering(new JspHtmlRenderingProvider() {
             @Override
@@ -212,9 +208,5 @@ public class FessFwAssistantDirector extends CachedFwAssistantDirector {
 
     protected FessApiFailureHook createApiFailureHook() {
         return new FessApiFailureHook();
-    }
-
-    protected ServerErrorLoggingFilter createServerErrorLoggingFilter() {
-        return new ServerErrorLoggingFilter();
     }
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -67,6 +67,11 @@
   </filter>
 
   <filter>
+    <filter-name>serverErrorLoggingFilter</filter-name>
+    <filter-class>org.codelibs.fess.filter.ServerErrorLoggingFilter</filter-class>
+  </filter>
+
+  <filter>
     <filter-name>lastaShowbaseFilter</filter-name>
     <filter-class>org.lastaflute.web.servlet.filter.LastaShowbaseFilter</filter-class>
     <init-param>
@@ -160,6 +165,22 @@
 
   <filter-mapping>
     <filter-name>webApiFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+    <dispatcher>REQUEST</dispatcher>
+  </filter-mapping>
+
+  <!--
+    serverErrorLoggingFilter MUST come BEFORE lastaShowbaseFilter: it installs the per-thread
+    server error handler that RequestLoggingFilter - which lastaShowbaseFilter runs inside
+    itself - calls when a request ends as a 500. Mapped after lastaShowbaseFilter it would
+    never be on the thread by the time the handler is looked up, and the 500 would again go
+    unreported. It is declared here rather than through FwWebDirection#directServletFilter
+    because the assistant director is also loaded by the crawler, thumbnail, suggest and chunk
+    child processes, whose classpath has no servlet API: a servlet type reachable from that
+    class kills every child process at DI container startup.
+  -->
+  <filter-mapping>
+    <filter-name>serverErrorLoggingFilter</filter-name>
     <url-pattern>/*</url-pattern>
     <dispatcher>REQUEST</dispatcher>
   </filter-mapping>

--- a/src/test/java/org/codelibs/fess/filter/ServerErrorLoggingFilterTest.java
+++ b/src/test/java/org/codelibs/fess/filter/ServerErrorLoggingFilterTest.java
@@ -15,16 +15,19 @@
  */
 package org.codelibs.fess.filter;
 
+import java.io.File;
 import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.logging.log4j.Level;
 import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
-import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
-import org.lastaflute.core.direction.FwAssistantDirector;
 import org.lastaflute.web.servlet.filter.RequestLoggingFilter;
-import org.lastaflute.web.servlet.filter.hook.FilterHook;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -37,6 +40,14 @@ import jakarta.servlet.http.HttpServletResponse;
  * on the 500 path and only there.</p>
  */
 public class ServerErrorLoggingFilterTest extends UnitFessTestCase {
+
+    private static final String WEB_XML_PATH = "src/main/webapp/WEB-INF/web.xml";
+
+    /** The {@code filter-name} web.xml gives this filter. */
+    private static final String FILTER_NAME = "serverErrorLoggingFilter";
+
+    /** The filter that runs {@link RequestLoggingFilter} inside itself. */
+    private static final String LOGGING_FILTER_NAME = "lastaShowbaseFilter";
 
     @Override
     protected String prepareMockServletPath() {
@@ -90,21 +101,62 @@ public class ServerErrorLoggingFilterTest extends UnitFessTestCase {
         }
     }
 
+    /**
+     * Asserts that {@code web.xml} maps this filter, and maps it ahead of the filter that runs
+     * {@link RequestLoggingFilter}.
+     *
+     * <p>The order is the whole registration: the handler has to be on the thread before the
+     * logging filter looks it up, so a mapping placed after {@code lastaShowbaseFilter} would
+     * leave the 500 unreported again -- with nothing failing anywhere to say so.</p>
+     */
     @Test
-    public void test_registeredOutsideTheLoggingFilter() throws Exception {
-        final List<FilterHook> hooks =
-                ComponentUtil.getComponent(FwAssistantDirector.class).assistWebDirection().assistOutsideFilterHookList();
-        assertEquals("expected one outside filter hook, got " + hooks, 1, hooks.size());
-        final LogCapturingAppender appender = LogCapturingAppender.attach(ServerErrorLoggingFilter.class);
-        try {
-            final ExposedLoggingFilter loggingFilter = new ExposedLoggingFilter();
-            hooks.get(0)
-                    .hook(getMockRequest(), getMockResponse(),
-                            (req, res) -> loggingFilter.fireServerError(req, res, new IllegalStateException("registered hook")));
-            assertEquals("the registered hook must produce the WARN line, got " + appender.events(), 1, appender.warnings().size());
-        } finally {
-            appender.detach();
+    public void test_mappedAheadOfTheLoggingFilter() throws Exception {
+        final Document webXml = parseWebXml();
+        assertEquals("web.xml should declare the filter", ServerErrorLoggingFilter.class.getName(), filterClassOf(webXml, FILTER_NAME));
+        final int ownIndex = mappingIndexOf(webXml, FILTER_NAME);
+        final int loggingIndex = mappingIndexOf(webXml, LOGGING_FILTER_NAME);
+        assertTrue(FILTER_NAME + " should be mapped in web.xml", ownIndex >= 0);
+        assertTrue(LOGGING_FILTER_NAME + " should be mapped in web.xml", loggingIndex >= 0);
+        assertTrue(FILTER_NAME + " (" + ownIndex + ") must be mapped before " + LOGGING_FILTER_NAME + " (" + loggingIndex + ")",
+                ownIndex < loggingIndex);
+    }
+
+    private Document parseWebXml() throws Exception {
+        final File file = new File(WEB_XML_PATH);
+        assertTrue(WEB_XML_PATH + " should exist", file.exists());
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        // web.xml carries a schema rather than a DOCTYPE today, so nothing external is fetched;
+        // the guard is here so that adding one can never make this test reach the network.
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        return factory.newDocumentBuilder().parse(file);
+    }
+
+    /** Returns the {@code filter-class} declared for the given {@code filter-name}, or null. */
+    private String filterClassOf(final Document webXml, final String filterName) {
+        final NodeList filters = webXml.getElementsByTagName("filter");
+        for (int i = 0; i < filters.getLength(); i++) {
+            final Element filter = (Element) filters.item(i);
+            if (filterName.equals(textOf(filter, "filter-name"))) {
+                return textOf(filter, "filter-class");
+            }
         }
+        return null;
+    }
+
+    /** Returns the position of the given filter in the {@code filter-mapping} order, or -1. */
+    private int mappingIndexOf(final Document webXml, final String filterName) {
+        final NodeList mappings = webXml.getElementsByTagName("filter-mapping");
+        for (int i = 0; i < mappings.getLength(); i++) {
+            if (filterName.equals(textOf((Element) mappings.item(i), "filter-name"))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private String textOf(final Element parent, final String tagName) {
+        final NodeList elements = parent.getElementsByTagName(tagName);
+        return elements.getLength() == 0 ? null : elements.item(0).getTextContent().trim();
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/mylasta/direction/FessFwAssistantDirectorTest.java
+++ b/src/test/java/org/codelibs/fess/mylasta/direction/FessFwAssistantDirectorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.mylasta.direction;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Asserts that every component {@code lastaflute_director.xml} names can be loaded without the
+ * servlet API on the classpath.
+ *
+ * <p>That file is included by {@code lastaflute_assist.xml}, which the crawler, thumbnail,
+ * suggest and chunk child processes read when they build their own DI container. Those
+ * processes run with {@code WEB-INF/classes} plus {@code WEB-INF/lib} plus
+ * {@code WEB-INF/env/<type>/lib} on the classpath -- the servlet API is not there, because
+ * Tomcat hands it to the webapp from the server's own {@code lib} directory instead. So a
+ * servlet type reachable from one of these components fails verification in the child process,
+ * and every crawl, thumbnail and suggest job then dies at DI container startup with a
+ * {@code NoClassDefFoundError} that the webapp itself never sees. Nothing else in the build
+ * catches that: the classes compile, the webapp starts, and only a crawl reveals it.</p>
+ */
+public class FessFwAssistantDirectorTest extends UnitFessTestCase {
+
+    private static final String DIRECTOR_XML_PATH = "src/main/resources/lastaflute_director.xml";
+
+    /** Prefix of the API the child processes do not have; see this class' javadoc. */
+    private static final String MISSING_PACKAGE_PREFIX = "jakarta.servlet.";
+
+    @Test
+    public void test_directorComponentsLoadWithoutServletApi() throws Exception {
+        final List<String> componentClassNames = readComponentClassNames();
+        assertTrue(DIRECTOR_XML_PATH + " should name at least one component", !componentClassNames.isEmpty());
+        for (final String className : componentClassNames) {
+            final ClassLoader loader = new ServletFreeClassLoader(getClass().getClassLoader());
+            try {
+                Class.forName(className, true, loader);
+            } catch (final NoClassDefFoundError | ClassNotFoundException e) {
+                fail(className + " is named by " + DIRECTOR_XML_PATH
+                        + " and must load in a child process, which has no servlet API on its classpath: " + e);
+            }
+        }
+    }
+
+    /** Reads the {@code class} attribute of every {@code component} element in the director XML. */
+    private List<String> readComponentClassNames() throws Exception {
+        final File file = new File(DIRECTOR_XML_PATH);
+        assertTrue(DIRECTOR_XML_PATH + " should exist", file.exists());
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        // the DOCTYPE points at dbflute.org; the DTD adds nothing this test needs
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        final Document document = factory.newDocumentBuilder().parse(file);
+        final NodeList components = document.getElementsByTagName("component");
+        final List<String> classNames = new ArrayList<>();
+        for (int i = 0; i < components.getLength(); i++) {
+            final String className = ((Element) components.item(i)).getAttribute("class");
+            if (!className.isEmpty()) {
+                classNames.add(className);
+            }
+        }
+        return classNames;
+    }
+
+    /**
+     * Loads the application's own classes itself so that they resolve their dependencies through
+     * this loader, and refuses the servlet API the way a child process' classpath refuses it.
+     *
+     * <p>Only the classes this loader defines see that refusal. Anything outside
+     * {@link #APPLICATION_PACKAGE_PREFIX} -- LastaFlute, DBFlute, the libraries -- is defined by
+     * the parent loader and keeps resolving its own references against the parent's classpath,
+     * which does have the servlet API. So this catches a servlet type reachable from Fess' own
+     * code, which is where the components in {@code lastaflute_director.xml} live and where the
+     * regression this guards against happened; it would not catch one introduced through a
+     * framework class.</p>
+     */
+    private static class ServletFreeClassLoader extends ClassLoader {
+
+        /** Loaded by this loader rather than delegated, so that they see the refusal below. */
+        private static final String APPLICATION_PACKAGE_PREFIX = "org.codelibs.fess.";
+
+        ServletFreeClassLoader(final ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith(MISSING_PACKAGE_PREFIX)) {
+                throw new ClassNotFoundException(name + " is not on a child process' classpath");
+            }
+            if (!name.startsWith(APPLICATION_PACKAGE_PREFIX)) {
+                return super.loadClass(name, resolve);
+            }
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> clazz = findLoadedClass(name);
+                if (clazz == null) {
+                    clazz = defineFromParentResource(name);
+                }
+                if (resolve) {
+                    resolveClass(clazz);
+                }
+                return clazz;
+            }
+        }
+
+        private Class<?> defineFromParentResource(final String name) throws ClassNotFoundException {
+            try (InputStream in = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {
+                if (in == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                final byte[] bytes = in.readAllBytes();
+                return defineClass(name, bytes, 0, bytes.length);
+            } catch (final IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #3383. Fixes the `build` job failure that every PR from #3371 onward inherits.

## What fails

`CrawlerLogTests` and `FailureUrlTests` fail in the `Run Integration Test` step:

```
CrawlerLogTests.crawlingInfoTest:133->testReadCrawlingInfo:221 expected: <1> but was: <0>
CrawlerLogTests.failureUrlTest:148->testReadFailureUrl:286 expected: <1> but was: <0>
CrawlerLogTests.searchListTest:156->testReadSearchList:305 expected: <true> but was: <false>
FailureUrlTests.crudTest:104->testReadFailureUrlLogs:130 Should have at least one failure URL log
```

The tests are reporting a symptom: no crawl runs at all. The server log in the same
step shows every child process dying at DI container startup:

```
JobProcessingException: Exit Code: 1
DiXmlParseFailureException: lastaflute_director.xml included by lastaflute_assist.xml
Caused by: java.lang.NoClassDefFoundError: jakarta/servlet/Filter
```

## Why

`ServerErrorLoggingFilter` (#3371) was registered through
`FwWebDirection#directServletFilter` in `FessFwAssistantDirector`. That class is the one
`lastaflute_director.xml` names, and `lastaflute_assist.xml` includes that file into the
container the crawler, thumbnail, suggest and chunk child processes build for themselves.

Those processes run with `WEB-INF/classes` + `WEB-INF/lib` + `WEB-INF/env/<type>/lib` on
the classpath and no servlet API — Tomcat hands that to the webapp from the server's own
`lib` directory. Verifying the director loads the filter class, whose superinterface
`jakarta.servlet.Filter` is missing there, so the container fails to build and the job
exits 1. The webapp itself is unaffected, which is why nothing else in the build noticed.

Not caused by #3383, or by anything else in the stack: the same four failures appear on
every run from #3371 (`pr/06-log-server-error`) onward, including the docs-only #3381,
while #3370 is green.

## Fix

- Declare the filter in `web.xml`, mapped just ahead of `lastaShowbaseFilter`, so it still
  installs the per-thread server error handler outside `RequestLoggingFilter`.
- Drop the `directServletFilter` call, the factory method and the import from
  `FessFwAssistantDirector`, so no servlet type is reachable from it again.

## Tests

- `FessFwAssistantDirectorTest` loads every component `lastaflute_director.xml` names
  through a class loader that refuses `jakarta.servlet.*` the way a child process'
  classpath refuses it. Reverting the main-code change makes it fail with the same
  `NoClassDefFoundError: jakarta/servlet/Filter` the CI log shows.
- `ServerErrorLoggingFilterTest.test_registeredOutsideTheLoggingFilter` is replaced by
  `test_mappedAheadOfTheLoggingFilter`, which asserts the `web.xml` declaration and that
  the mapping precedes `lastaShowbaseFilter`. The three behavioural tests are unchanged.
- Verified separately that `FessFwAssistantDirector` now loads on a classpath without
  `jakarta.servlet.Filter` (the child-process classpath) and failed to before.
- `mvn test -Dtest='org.codelibs.fess.filter.*Test,org.codelibs.fess.webapp.*Test,org.codelibs.fess.mylasta.direction.*Test'`: 240 tests, 0 failures.
