### PR TITLE
fix(thumbnail): find the generator scripts in the unpacked installation

### DIFF
--- a/src/main/java/org/codelibs/fess/Constants.java
+++ b/src/main/java/org/codelibs/fess/Constants.java
@@ -816,6 +816,9 @@ public class Constants extends CoreLibConstants {
     /** Fess variable path configuration key. */
     public static final String FESS_VAR_PATH = "fess.var.path";
 
+    /** Fess installation directory configuration key. */
+    public static final String FESS_HOME = "fess.home";
+
     /** Fess log level configuration key. */
     public static final String FESS_LOG_LEVEL = "fess.log.level";
 

--- a/src/main/java/org/codelibs/fess/job/CrawlJob.java
+++ b/src/main/java/org/codelibs/fess/job/CrawlJob.java
@@ -385,6 +385,7 @@ public class CrawlJob extends ExecJob {
         addFessSystemProperties(cmdList);
         addFessCustomSystemProperties(cmdList, fessConfig.getJobSystemPropertyFilterPattern());
         addSystemProperty(cmdList, Constants.FESS_CONF_PATH, null, null);
+        addSystemProperty(cmdList, Constants.FESS_HOME, null, null);
         cmdList.add("-Dfess." + getExecuteType() + ".process=true");
         cmdList.add("-Dfess.log.path=" + (logFilePath != null ? logFilePath : systemHelper.getLogFilePath()));
         addSystemProperty(cmdList, "fess.log.name", getLogName("fess"), getLogName(StringUtil.EMPTY));

--- a/src/main/java/org/codelibs/fess/job/GenerateThumbnailJob.java
+++ b/src/main/java/org/codelibs/fess/job/GenerateThumbnailJob.java
@@ -198,6 +198,7 @@ public class GenerateThumbnailJob extends ExecJob {
         addFessSystemProperties(cmdList);
         addFessCustomSystemProperties(cmdList, fessConfig.getJobSystemPropertyFilterPattern());
         addSystemProperty(cmdList, Constants.FESS_CONF_PATH, null, null);
+        addSystemProperty(cmdList, Constants.FESS_HOME, null, null);
         cmdList.add("-Dfess." + getExecuteType() + ".process=true");
         if (logFilePath == null) {
             final String value = System.getProperty("fess.log.path");

--- a/src/main/java/org/codelibs/fess/thumbnail/impl/BaseThumbnailGenerator.java
+++ b/src/main/java/org/codelibs/fess/thumbnail/impl/BaseThumbnailGenerator.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.Tuple3;
+import org.codelibs.fess.Constants;
 import org.codelibs.fess.crawler.builder.RequestDataBuilder;
 import org.codelibs.fess.crawler.client.CrawlerClient;
 import org.codelibs.fess.crawler.client.CrawlerClientFactory;
@@ -120,24 +121,45 @@ public abstract class BaseThumbnailGenerator implements ThumbnailGenerator {
         return false;
     }
 
+    /**
+     * Builds the directories a {@code ${path}} generator command is looked for in.
+     * <p>
+     * The bin directory of this installation comes first: the packages put the generator scripts
+     * next to the startup script, and the ZIP -- which is unpacked anywhere and started with
+     * {@code bin/fess} -- has no other way of being found. {@code /usr/share/fess/bin} keeps the
+     * RPM and DEB layout working when {@code fess.home} is not set, and {@code PATH} is searched
+     * last so a generator installed system-wide is still picked up.
+     * </p>
+     *
+     * @return the directories to search, in order
+     */
+    protected List<String> getSearchPathList() {
+        final List<String> pathList = new ArrayList<>();
+        final String fessHome = System.getProperty(Constants.FESS_HOME);
+        if (StringUtil.isNotBlank(fessHome)) {
+            pathList.add(new File(fessHome, "bin").getAbsolutePath());
+        }
+        pathList.add("/usr/share/fess/bin");
+        String path = System.getenv("PATH");
+        if (path == null) {
+            path = System.getenv("Path");
+        }
+        if (path == null) {
+            path = System.getenv("path");
+        }
+        if (path != null) {
+            stream(path.split(File.pathSeparator)).of(stream -> stream.map(String::trim).forEach(pathList::add));
+        }
+        return pathList;
+    }
+
     @Override
     public boolean isAvailable() {
         if (available != null) {
             return available;
         }
         if (generatorList != null && !generatorList.isEmpty()) {
-            String path = System.getenv("PATH");
-            if (path == null) {
-                path = System.getenv("Path");
-            }
-            if (path == null) {
-                path = System.getenv("path");
-            }
-            final List<String> pathList = new ArrayList<>();
-            pathList.add("/usr/share/fess/bin");
-            if (path != null) {
-                stream(path.split(File.pathSeparator)).of(stream -> stream.map(String::trim).forEach(s -> pathList.add(s)));
-            }
+            final List<String> pathList = getSearchPathList();
             if (logger.isDebugEnabled()) {
                 logger.debug("search paths: {}", pathList);
             }

--- a/src/test/java/org/codelibs/fess/thumbnail/impl/BaseThumbnailGeneratorTest.java
+++ b/src/test/java/org/codelibs/fess/thumbnail/impl/BaseThumbnailGeneratorTest.java
@@ -17,8 +17,10 @@ package org.codelibs.fess.thumbnail.impl;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.codelibs.fess.Constants;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
@@ -445,6 +447,46 @@ public class BaseThumbnailGeneratorTest extends UnitFessTestCase {
             assertFalse("SVG should NOT match with unescaped + pattern", generator.isTarget(svgDocMap));
         } finally {
             ComponentUtil.setFessConfig(null);
+        }
+    }
+
+    /**
+     * The generator commands are declared as ${path}/generate-thumbnail, so the directories
+     * ${path} stands for decide whether a thumbnail is ever produced. An installation unpacked
+     * from the ZIP keeps them in its own bin directory, which is neither the packaged location
+     * nor on PATH, so that directory is searched first.
+     */
+    @Test
+    public void test_getSearchPathList_startsAtTheInstallationBinDirectory() {
+        final String previous = System.getProperty(Constants.FESS_HOME);
+        System.setProperty(Constants.FESS_HOME, "/opt/fess-example");
+        try {
+            final List<String> pathList = new CommandGenerator().getSearchPathList();
+            assertEquals(new File("/opt/fess-example", "bin").getAbsolutePath(), pathList.get(0));
+            assertTrue(pathList.contains("/usr/share/fess/bin"));
+        } finally {
+            if (previous == null) {
+                System.clearProperty(Constants.FESS_HOME);
+            } else {
+                System.setProperty(Constants.FESS_HOME, previous);
+            }
+        }
+    }
+
+    /**
+     * Without fess.home the packaged location is still searched first, so an RPM or DEB install
+     * keeps working.
+     */
+    @Test
+    public void test_getSearchPathList_keepsThePackagedLocation() {
+        final String previous = System.getProperty(Constants.FESS_HOME);
+        System.clearProperty(Constants.FESS_HOME);
+        try {
+            assertEquals("/usr/share/fess/bin", new CommandGenerator().getSearchPathList().get(0));
+        } finally {
+            if (previous != null) {
+                System.setProperty(Constants.FESS_HOME, previous);
+            }
         }
     }
 }


### PR DESCRIPTION
This is part 2 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/dict-duplicate-entry` and should be reviewed after it.

---

The generator commands are declared as ${path}/generate-thumbnail, and ${path}
was resolved against /usr/share/fess/bin -- where the RPM and the DEB put the
scripts -- and the PATH environment variable. The ZIP is unpacked anywhere and
started with bin/fess, so the scripts it ships in its own bin directory are in
neither place and are never found.

isAvailable() then answers false for every generator, so nothing is queued and
nothing is generated: fess_config.thumbnail_queue stays empty, no document gets
a thumbnail field, and fess-thumbnail.log only ever says there are no tasks to
process. Nothing reports that the command was not found.

The bin directory of the running installation is searched first, taken from the
fess.home property bin/fess.in.sh already sets, and that property is passed on
to the crawler and thumbnail processes, which queue and generate on their own.
The packaged location and PATH are still searched after it, so the RPM, the DEB
and a generator installed system-wide keep working.
