### PR TITLE
fix(api): answer /api/v2/documents/favorite with not_found, not a 500

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -251,7 +251,11 @@ public class SearchApiV2Manager extends BaseApiManager {
                 scrollSearchHandler.handle(request, response);
                 return;
             }
-            if (sub.startsWith("/documents/") && sub.endsWith("/favorite")) {
+            // "/documents/favorite" satisfies both ends of the pattern while leaving no doc id
+            // between them, so the length is checked before the id is cut out. It falls through
+            // to the not_found arm below with every other unknown path under /documents/.
+            if (sub.startsWith("/documents/") && sub.endsWith("/favorite")
+                    && sub.length() > "/documents/".length() + "/favorite".length()) {
                 final String docId = sub.substring("/documents/".length(), sub.length() - "/favorite".length());
                 if ("POST".equalsIgnoreCase(request.getMethod())) {
                     favoritePostHandler.handle(request, response, docId);

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
@@ -209,6 +209,19 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
     }
 
     @Test
+    public void test_process_documentsFavoriteWithoutADocIdIsNotFound() throws Exception {
+        // "/documents/favorite" satisfies both ends of the favorite pattern and leaves no doc id
+        // between them. Cutting the id out of it used to ask for substring(11, 10) and answer
+        // with 500 internal_error, without any authentication.
+        final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
+        final CapturingResponse res = new CapturingResponse();
+        m.process(new StubRequest("/api/v2/documents/favorite"), res, new NopChain());
+        assertEquals(404, res.status);
+        final String body = res.body();
+        assertTrue(body.contains("\"code\":\"not_found\""), body);
+    }
+
+    @Test
     public void test_process_documentsFavoriteRejectsMalformedDocId() throws Exception {
         final SearchApiV2Manager m = SearchApiV2ManagerTestSupport.newManagerWithHandlers();
         final CapturingResponse res = new CapturingResponse();


### PR DESCRIPTION
This is part 3 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/thumbnail-generator-path` and should be reviewed after it.

---

GET /api/v2/documents/favorite returns 500 internal_error to an unauthenticated
caller. The path satisfies both ends of the /documents/{id}/favorite pattern --
it starts with "/documents/" and ends with "/favorite" -- but the two overlap,
so cutting the id out of it asks for substring(11, 10) and the request fails
with StringIndexOutOfBoundsException.

The neighbouring /cache/ and /chat/sessions/ arms cannot overlap the same way,
so this is the only path with the defect.

The length is now checked before the id is cut out, which lets the path fall
through to the arm that already answers "unknown action on document" with 404
not_found for every other unrecognised path under /documents/.
