### PR TITLE
fix(api): report a document delete that removed nothing

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/ApiAdminSearchlistAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/api/admin/searchlist/ApiAdminSearchlistAction.java
@@ -277,14 +277,24 @@ public class ApiAdminSearchlistAction extends FessApiAdminAction {
     // DELETE /api/admin/searchlist/doc/{doc_id}
     @Execute
     public JsonResponse<ApiResult> delete$doc(final String id) {
+        final long count;
         try {
             final QueryBuilder query = QueryBuilders.termQuery(fessConfig.getIndexFieldDocId(), id);
-            searchEngineClient.deleteByQuery(fessConfig.getIndexDocumentUpdateIndex(), query);
-            saveInfo(messages -> messages.addSuccessDeleteDocFromIndex(GLOBAL));
+            count = searchEngineClient.deleteByQuery(fessConfig.getIndexDocumentUpdateIndex(), query);
         } catch (final Exception e) {
             logger.warn("Failed to process a request.", e);
             throwValidationErrorApi(messages -> messages.addErrorsFailedToDeleteDocInAdmin(GLOBAL));
+            return null; // ignore
         }
+        if (count == 0) {
+            // A query that matched nothing is a successful delete by query, so an id that is not
+            // a doc_id -- the _id the document list reports, for one -- used to be answered with
+            // status 0 while the document stayed in the index. Automation built on that could
+            // not tell a delete from a no-op.
+            logger.debug("No document was deleted: doc_id={}", id);
+            throwValidationErrorApi(messages -> messages.addErrorsCrudCouldNotFindCrudTable(GLOBAL, id));
+        }
+        saveInfo(messages -> messages.addSuccessDeleteDocFromIndex(GLOBAL));
         return asJson(new ApiResponse().status(Status.OK).result());
     }
 

--- a/src/test/java/org/codelibs/fess/app/web/api/admin/searchlist/ApiAdminSearchlistActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/api/admin/searchlist/ApiAdminSearchlistActionTest.java
@@ -27,6 +27,7 @@ import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalEntity;
 import org.junit.jupiter.api.Test;
+import org.lastaflute.web.validation.exception.ValidationErrorException;
 
 /**
  * Contract tests for the raw-document admin REST API.
@@ -173,6 +174,35 @@ public class ApiAdminSearchlistActionTest extends UnitFessTestCase {
     }
 
     /**
+     * Deleting by an id no document carries is a delete by query that matches nothing. It used to
+     * answer with status 0, so automation that listed documents and deleted them by the reported
+     * _id was told every delete had succeeded while nothing left the index.
+     */
+    @Test
+    public void test_delete$doc_reportsAnIdThatMatchedNoDocument() throws Exception {
+        final FakeSearchEngineClient client = new FakeSearchEngineClient();
+        client.deletedCount = 0L;
+        final ApiAdminSearchlistAction action = createInjectedAction(client, buildFullFessConfig());
+        try {
+            action.delete$doc("nosuchdocid");
+            fail("a delete that removed nothing must be reported");
+        } catch (final ValidationErrorException e) {
+            // expected
+        }
+    }
+
+    /**
+     * A delete that did remove a document still answers with status 0.
+     */
+    @Test
+    public void test_delete$doc_acceptsAnIdThatMatchedADocument() throws Exception {
+        final FakeSearchEngineClient client = new FakeSearchEngineClient();
+        client.deletedCount = 1L;
+        final ApiAdminSearchlistAction action = createInjectedAction(client, buildFullFessConfig());
+        assertNotNull(action.delete$doc("adocid"));
+    }
+
+    /**
      * Mirrors {@code AdminSearchlistActionTest#createInjectedAction}: UTFlute {@code inject()} for
      * the framework fields that {@code validateApi()}/{@code throwValidationErrorApi()}/
      * {@code saveInfo()} need, then the fess-specific collaborators that {@code fess.xml} (not
@@ -314,6 +344,7 @@ public class ApiAdminSearchlistActionTest extends UnitFessTestCase {
     private static final class FakeSearchEngineClient extends SearchEngineClient {
         Map<String, Object> documentToReturn;
         Map<String, Object> lastStoredDoc;
+        long deletedCount;
 
         @Override
         public OptionalEntity<Map<String, Object>> getDocument(final String index,
@@ -332,6 +363,11 @@ public class ApiAdminSearchlistActionTest extends UnitFessTestCase {
         @Override
         public boolean delete(final String index, final String id, final Number seqNo, final Number primaryTerm) {
             return true;
+        }
+
+        @Override
+        public long deleteByQuery(final String index, final org.opensearch.index.query.QueryBuilder queryBuilder) {
+            return deletedCount;
         }
     }
 }


### PR DESCRIPTION
This is part 4 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/v2-documents-favorite-500` and should be reviewed after it.

---

DELETE /api/admin/searchlist/doc/{doc_id} answered with status 0 whatever it
deleted. It matches on the doc_id field only, and a delete by query that matches
nothing is a successful delete by query, so an id that is not a doc_id -- the
_id the document list reports, or an id that simply does not exist -- was
reported as deleted while the document stayed in the index.

Automation built on the list-then-delete pair therefore could not tell a delete
from a no-op, and a caller that never re-read the index would not find out.

The number of deleted documents is now checked, and a delete that removed
nothing is answered with status 1 naming the id, the way the read of the same
document already answers when the id matches nothing.
