### PR TITLE
fix(favorite): stop one user from raising favorite_count on their own

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
@@ -27,6 +27,7 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.api.v2.V2ErrorCode;
 import org.codelibs.fess.app.service.FavoriteLogService;
+import org.codelibs.fess.app.service.FavoriteLogService.FavoriteResult;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.helper.SearchHelper;
 import org.codelibs.fess.helper.SystemHelper;
@@ -264,20 +265,23 @@ public class FavoritePostHandler {
                         final Long existingCount = DocumentUtil.getValue(doc, cfg.getIndexFieldFavoriteCount(), Long.class);
                         favoriteCountHolder[0] = existingCount == null ? 0L : existingCount;
 
-                        // M-9: addUrl returns false when the (user, url) pair already exists
-                        // (or the user info cannot be resolved). Treat the duplicate case as
-                        // an idempotent no-op success — re-POSTing the same favorite should
-                        // not be a 500. We signal "already favorited" via a dedicated marker
-                        // exception so the outer catch can short-circuit the favorite-count
-                        // bump and emit a 200 success envelope.
-                        if (!favoriteLogService.addUrl(userCode, (userInfo, favoriteLog) -> {
+                        // M-9: re-POSTing the same favorite is an idempotent no-op success, not
+                        // a 500. The duplicate is signalled via a marker exception so the outer
+                        // catch can short-circuit the favorite-count bump and emit a 200 success
+                        // envelope. A user code that resolves to no user is a different outcome:
+                        // nothing was written, so it must not be reported as already favorited.
+                        final FavoriteResult result = favoriteLogService.addUrl(userCode, (userInfo, favoriteLog) -> {
                             favoriteLog.setUserInfoId(userInfo.getId());
                             favoriteLog.setUrl(favoriteUrl);
                             favoriteLog.setDocId(docId);
                             favoriteLog.setQueryId(queryId);
                             favoriteLog.setCreatedAt(systemHelper.getCurrentTimeAsLocalDateTime());
-                        })) {
+                        });
+                        if (result == FavoriteResult.ALREADY_ADDED) {
                             throw new AlreadyFavoritedException();
+                        }
+                        if (result == FavoriteResult.NO_SUCH_USER) {
+                            throw new FavoriteAddFailedException("no user for the given user code");
                         }
                         // Optimistically bump the count for the fresh-add case.
                         favoriteCountHolder[0] = favoriteCountHolder[0] + 1L;

--- a/src/main/java/org/codelibs/fess/app/service/FavoriteLogService.java
+++ b/src/main/java/org/codelibs/fess/app/service/FavoriteLogService.java
@@ -62,24 +62,49 @@ public class FavoriteLogService {
     protected FessConfig fessConfig;
 
     /**
+     * The outcome of adding a URL to a user's favorite list.
+     */
+    public enum FavoriteResult {
+        /** The URL was added to the user's favorites. */
+        ADDED,
+        /** The user already had the URL in their favorites, and nothing was written. */
+        ALREADY_ADDED,
+        /** The user code resolved to no user, and nothing was written. */
+        NO_SUCH_USER
+    }
+
+    /**
      * Adds a URL to a user's favorite list.
      * This method looks up the user by their code and creates a new favorite log entry
      * using the provided lambda function to populate the favorite log data.
+     * <p>
+     * A URL the user has already marked is not written again. favorite_count is a documented
+     * sort key, so a repeated request -- a double click, or a client retrying -- would otherwise
+     * move a document up the ranking without anyone else favoriting it. The index is refreshed
+     * after an insert so that a repeat sees the entry that was just written.
+     * </p>
      *
      * @param userCode the unique code identifying the user
      * @param favoriteLogLambda a lambda function that accepts UserInfo and FavoriteLog to populate the favorite log data
-     * @return true if the URL was successfully added to favorites, false if the user was not found
+     * @return what happened: the URL was added, the user already had it, or the user was not found
      */
-    public boolean addUrl(final String userCode, final BiConsumer<UserInfo, FavoriteLog> favoriteLogLambda) {
+    public FavoriteResult addUrl(final String userCode, final BiConsumer<UserInfo, FavoriteLog> favoriteLogLambda) {
         return userInfoBhv.selectByPK(userCode).map(userInfo -> {
             final FavoriteLog favoriteLog = new FavoriteLog();
             favoriteLogLambda.accept(userInfo, favoriteLog);
+            if (favoriteLogBhv.selectCount(cb -> {
+                cb.query().setUserInfoId_Equal(userInfo.getId());
+                cb.query().setUrl_Equal(favoriteLog.getUrl());
+            }) > 0) {
+                return FavoriteResult.ALREADY_ADDED;
+            }
             favoriteLogBhv.insert(favoriteLog);
+            favoriteLogBhv.refresh();
             if (fessConfig.isLoggingSearchUseLogfile()) {
                 ComponentUtil.getSearchLogHelper().writeSearchLogEvent(favoriteLog);
             }
-            return true;
-        }).orElse(false);
+            return FavoriteResult.ADDED;
+        }).orElse(FavoriteResult.NO_SUCH_USER);
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandlerTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.codelibs.fess.app.service.FavoriteLogService;
+import org.codelibs.fess.app.service.FavoriteLogService.FavoriteResult;
 import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.entity.FessUser;
 import org.codelibs.fess.helper.SearchHelper;
@@ -251,16 +252,16 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
         ComponentUtil.register(searchHelperStub, "searchHelper");
         ComponentUtil.register(searchHelperStub, SearchHelper.class.getCanonicalName());
 
-        // The duplicate-on-second-call FavoriteLogService stub: returns true the first call,
-        // false on every subsequent call. The handler is invoked twice; the second invocation
-        // is the idempotency assertion target.
+        // The duplicate-on-second-call FavoriteLogService stub: reports a fresh add the first
+        // call and an existing entry on every subsequent call. The handler is invoked twice; the
+        // second invocation is the idempotency assertion target.
         final int[] addUrlCalls = { 0 };
         final FavoriteLogService favLogStub = new FavoriteLogService() {
             @Override
-            public boolean addUrl(final String userCode,
+            public FavoriteResult addUrl(final String userCode,
                     final java.util.function.BiConsumer<org.codelibs.fess.opensearch.log.exentity.UserInfo, org.codelibs.fess.opensearch.log.exentity.FavoriteLog> favoriteLogLambda) {
                 addUrlCalls[0]++;
-                return addUrlCalls[0] == 1;
+                return addUrlCalls[0] == 1 ? FavoriteResult.ADDED : FavoriteResult.ALREADY_ADDED;
             }
         };
         ComponentUtil.register(favLogStub, "favoriteLogService");
@@ -302,6 +303,95 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
                     "duplicate POST must carry already_existed:true: " + second.body());
             assertTrue(second.body().contains("\"favorite\":true"), "duplicate POST must carry favorite:true: " + second.body());
             assertTrue(second.body().contains("\"count\":"), "duplicate POST must carry count: " + second.body());
+        } finally {
+            ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
+            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+        }
+    }
+
+    /**
+     * A user code that resolves to no user writes nothing, so it must not be reported as an
+     * idempotent no-op: answering 200 with {@code already_existed: true} would tell the client
+     * the document had been favorited when no favorite log entry exists.
+     */
+    @Test
+    public void favoritePost_unresolvedUser_isNotReportedAsAlreadyFavorited() throws Exception {
+        final FessUserBean userBean = new FessUserBean(new StubFessUser("alice"));
+        final FessLoginAssist loginStub = new FessLoginAssist() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public OptionalThing<FessUserBean> getSavedUserBean() {
+                return OptionalThing.of(userBean);
+            }
+        };
+        ComponentUtil.register(loginStub, "fessLoginAssist");
+        ComponentUtil.register(loginStub, FessLoginAssist.class.getCanonicalName());
+
+        final FessConfig cfgStub = new FavoriteEnabledFessConfig();
+        // Use setFessConfig so ComponentUtil.getFessConfig() returns this stub —
+        // the static cache is checked first and bypasses the DI lookup entirely.
+        ComponentUtil.setFessConfig(cfgStub);
+        ComponentUtil.register(cfgStub, "fessConfig");
+        ComponentUtil.register(cfgStub, FessConfig.class.getCanonicalName());
+
+        final UserInfoHelper userInfoStub = new UserInfoHelper() {
+            @Override
+            public String getUserCode() {
+                return "alice-code";
+            }
+
+            @Override
+            public String[] getResultDocIds(final String queryId) {
+                return new String[] { "abc" };
+            }
+        };
+        ComponentUtil.register(userInfoStub, "userInfoHelper");
+        ComponentUtil.register(userInfoStub, UserInfoHelper.class.getCanonicalName());
+
+        final SearchHelper searchHelperStub = new SearchHelper() {
+            @Override
+            public OptionalEntity<Map<String, Object>> getDocumentByDocId(final String docId, final String[] fields,
+                    final OptionalThing<FessUserBean> ub) {
+                final Map<String, Object> doc = new HashMap<>();
+                doc.put("url", "http://example.com/abc");
+                doc.put("_id", "abc-id");
+                return OptionalEntity.of(doc);
+            }
+        };
+        ComponentUtil.register(searchHelperStub, "searchHelper");
+        ComponentUtil.register(searchHelperStub, SearchHelper.class.getCanonicalName());
+
+        // Nothing is ever written: the user code resolves to no user.
+        final FavoriteLogService favLogStub = new FavoriteLogService() {
+            @Override
+            public FavoriteResult addUrl(final String userCode,
+                    final java.util.function.BiConsumer<org.codelibs.fess.opensearch.log.exentity.UserInfo, org.codelibs.fess.opensearch.log.exentity.FavoriteLog> favoriteLogLambda) {
+                return FavoriteResult.NO_SUCH_USER;
+            }
+        };
+        ComponentUtil.register(favLogStub, "favoriteLogService");
+        ComponentUtil.register(favLogStub, FavoriteLogService.class.getCanonicalName());
+
+        // SystemHelper is fetched before the search try-block — register a minimal stub so
+        // ComponentUtil.getSystemHelper() does not throw ComponentNotFoundException.
+        final org.codelibs.fess.helper.SystemHelper systemHelperStub = new org.codelibs.fess.helper.SystemHelper() {
+            @Override
+            public java.time.LocalDateTime getCurrentTimeAsLocalDateTime() {
+                return java.time.LocalDateTime.now();
+            }
+        };
+        ComponentUtil.register(systemHelperStub, "systemHelper");
+        ComponentUtil.register(systemHelperStub, org.codelibs.fess.helper.SystemHelper.class.getCanonicalName());
+
+        try {
+            final CapturingResponse res = new CapturingResponse();
+            new FavoritePostHandler()
+                    .handle(new StubRequest("POST", "/api/v2/documents/abc/favorite").withJsonBody("{\"query_id\":\"q1\"}"), res, "abc");
+            assertFalse(res.body().contains("\"already_existed\":true"),
+                    "nothing was written, so the request must not be reported as already favorited: " + res.body());
+            assertFalse(res.body().contains("\"ok\":true"), res.body());
+            org.junit.jupiter.api.Assertions.assertEquals(500, res.status, res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
             ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
@@ -371,9 +461,9 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
         // addUrl always succeeds (fresh add).
         final FavoriteLogService favLogStub = new FavoriteLogService() {
             @Override
-            public boolean addUrl(final String userCode,
+            public FavoriteResult addUrl(final String userCode,
                     final java.util.function.BiConsumer<org.codelibs.fess.opensearch.log.exentity.UserInfo, org.codelibs.fess.opensearch.log.exentity.FavoriteLog> favoriteLogLambda) {
-                return true;
+                return FavoriteResult.ADDED;
             }
         };
         ComponentUtil.register(favLogStub, "favoriteLogService");
@@ -602,9 +692,9 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
 
         final FavoriteLogService favLogStub = new FavoriteLogService() {
             @Override
-            public boolean addUrl(final String userCode,
+            public FavoriteResult addUrl(final String userCode,
                     final java.util.function.BiConsumer<org.codelibs.fess.opensearch.log.exentity.UserInfo, org.codelibs.fess.opensearch.log.exentity.FavoriteLog> favoriteLogLambda) {
-                return true;
+                return FavoriteResult.ADDED;
             }
         };
         ComponentUtil.register(favLogStub, "favoriteLogService");


### PR DESCRIPTION
This is part 5 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/admin-searchlist-delete` and should be reviewed after it.

---

Adding a favorite inserted a favorite log row unconditionally. POSTing
/api/v2/documents/{docId}/favorite three times from one session added three rows
and moved the count from 9 to 11, so a double click or a client retry raises
favorite_count -- a sort key the user documentation names -- without anyone else
favoriting the document.

The handler was already written against the contract that adding a URL the user
has already marked reports the duplicate: it turns that into the idempotent 200
carrying already_existed. The service never reported it, so
AlreadyFavoritedException could not be raised for a duplicate at all. It now
checks for an existing entry before inserting, and refreshes afterwards so a
repeat sees the row that was just written.

The other outcome the boolean hid was a user code that resolves to no user:
nothing is written, and that was answered with 200 already_existed as well. The
three outcomes are now distinct, and a request that wrote nothing because there
is no such user is reported as a failure instead of a success.
