### PR TITLE
fix(keymatch): apply a key match written through the REST API at once

### DIFF
--- a/src/main/java/org/codelibs/fess/app/service/KeyMatchService.java
+++ b/src/main/java/org/codelibs/fess/app/service/KeyMatchService.java
@@ -25,6 +25,7 @@ import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.config.cbean.KeyMatchCB;
 import org.codelibs.fess.opensearch.config.exbhv.KeyMatchBhv;
 import org.codelibs.fess.opensearch.config.exentity.KeyMatch;
+import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.cbean.result.PagingResultBean;
 import org.dbflute.optional.OptionalEntity;
 
@@ -83,6 +84,9 @@ public class KeyMatchService extends FessAppService {
 
     /**
      * Store a key match.
+     * After storing, reloads the key match helper so the boost takes effect on the next search.
+     * The helper otherwise keeps the documents it loaded until the Config Reloader job runs, a
+     * crawl finishes or the server restarts, and the change is invisible for up to ten minutes.
      *
      * @param keyMatch The key match to store.
      */
@@ -91,11 +95,12 @@ public class KeyMatchService extends FessAppService {
         keyMatchBhv.insertOrUpdate(keyMatch, op -> {
             op.setRefreshPolicy(Constants.TRUE);
         });
-
+        ComponentUtil.getKeyMatchHelper().update();
     }
 
     /**
      * Delete a key match.
+     * After deletion, reloads the key match helper so the boost stops being applied at once.
      *
      * @param keyMatch The key match to delete.
      */
@@ -104,7 +109,7 @@ public class KeyMatchService extends FessAppService {
         keyMatchBhv.delete(keyMatch, op -> {
             op.setRefreshPolicy(Constants.TRUE);
         });
-
+        ComponentUtil.getKeyMatchHelper().update();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/app/web/admin/keymatch/AdminKeymatchAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/keymatch/AdminKeymatchAction.java
@@ -277,7 +277,6 @@ public class AdminKeymatchAction extends FessAdminAction {
             try {
                 keyMatchService.store(entity);
                 saveInfo(messages -> messages.addSuccessCrudCreateCrudTable(GLOBAL));
-                ComponentUtil.getKeyMatchHelper().update();
             } catch (final Exception e) {
                 logger.warn("Failed to process a request.", e);
                 throwValidationError(messages -> messages.addErrorsCrudFailedToCreateCrudTable(GLOBAL, buildThrowableMessage(e)),
@@ -305,7 +304,6 @@ public class AdminKeymatchAction extends FessAdminAction {
             try {
                 keyMatchService.store(entity);
                 saveInfo(messages -> messages.addSuccessCrudUpdateCrudTable(GLOBAL));
-                ComponentUtil.getKeyMatchHelper().update();
             } catch (final Exception e) {
                 logger.warn("Failed to process a request.", e);
                 throwValidationError(messages -> messages.addErrorsCrudFailedToUpdateCrudTable(GLOBAL, buildThrowableMessage(e)),
@@ -334,7 +332,6 @@ public class AdminKeymatchAction extends FessAdminAction {
             try {
                 keyMatchService.delete(entity);
                 saveInfo(messages -> messages.addSuccessCrudDeleteCrudTable(GLOBAL));
-                ComponentUtil.getKeyMatchHelper().update();
             } catch (final Exception e) {
                 logger.warn("Failed to process a request.", e);
                 throwValidationError(messages -> messages.addErrorsCrudFailedToDeleteCrudTable(GLOBAL, buildThrowableMessage(e)),


### PR DESCRIPTION
This is part 6 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/favorite-idempotent` and should be reviewed after it.

---

KeyMatchHelper#update() was called from the three administration screen actions
only, so a key match created, updated or deleted through
/api/admin/keymatch/setting was written to the index and then ignored: the
helper kept the documents it had already loaded. The boost only started
applying when the Config Reloader job next ran -- its default cron is every ten
minutes -- or when a crawl finished, or after a restart.

Tuning relevance from a script therefore looks like it did nothing, with no way
to tell an ineffective boost from one that has not been picked up yet.

The reload moves into KeyMatchService#store and #delete, next to the write, the
way RelatedContentService and RelatedQueryService already do it, so both the
screens and the API apply the change immediately.
