### PR TITLE
fix(api): report an unreachable search engine as service_unavailable

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java
@@ -35,11 +35,27 @@ public class HealthHandler {
 
     private static final Logger logger = LogManager.getLogger(HealthHandler.class);
 
+    /** The engine status reported when the search engine cannot be reached at all. */
+    protected static final String UNAVAILABLE_STATUS = "UNAVAILABLE";
+
+    /** The ping status reported when there was no response to read one from. */
+    protected static final int PING_STATUS_ERROR = 1;
+
     /**
      * Default constructor used by the DI container.
      */
     public HealthHandler() {
         // default constructor
+    }
+
+    /**
+     * Asks the search engine for its cluster health. Separated so a test can drive the
+     * unreachable path without a search engine.
+     *
+     * @return the ping response
+     */
+    protected PingResponse ping() {
+        return ComponentUtil.getSearchEngineClient().ping();
     }
 
     /**
@@ -56,7 +72,7 @@ public class HealthHandler {
             return;
         }
         try {
-            final PingResponse ping = ComponentUtil.getSearchEngineClient().ping();
+            final PingResponse ping = ping();
             final String clusterStatus = ping.getClusterStatus();
             final Map<String, Object> engine = new LinkedHashMap<>();
             // The OpenSearch cluster name is intentionally omitted from this anonymous endpoint
@@ -72,7 +88,17 @@ public class HealthHandler {
                 ComponentUtil.getV2EnvelopeWriter().writeSuccess(response, Map.of("engine", engine));
             }
         } catch (final Exception e) {
-            ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2/health");
+            // The engine could not be reached at all. Fess cannot answer a search either way,
+            // so this is reported like a red cluster rather than as an internal error: the
+            // documented response set for this endpoint has no 500, and a monitoring client
+            // reading error.details.engine has nothing to show when the snapshot is dropped.
+            logger.warn("/api/v2/health: the search engine is not reachable", e);
+            final Map<String, Object> engine = new LinkedHashMap<>();
+            engine.put("status", UNAVAILABLE_STATUS);
+            engine.put("ping_status", PING_STATUS_ERROR);
+            ComponentUtil.getV2EnvelopeWriter()
+                    .writeErrorWithDetails(response, V2ErrorCode.SERVICE_UNAVAILABLE, "search engine is not reachable",
+                            Map.of("engine", engine));
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerTest.java
@@ -282,18 +282,20 @@ public class SearchApiV2ManagerTest extends UnitFessTestCase {
 
     @Test
     public void test_handleHealth_does_not_leak_exception_message() throws Exception {
-        // Source-level assertion: the HealthHandler catch block must not pass e.getMessage()
-        // to writeError. Uses writeInternalError which logs and emits a generic message.
-        final java.nio.file.Path src = java.nio.file.Paths.get("src/main/java/org/codelibs/fess/api/v2/handlers/HealthHandler.java");
-        org.junit.jupiter.api.Assumptions.assumeTrue(java.nio.file.Files.exists(src),
-                "skipping: source file not present at runtime cwd=" + java.nio.file.Paths.get(".").toAbsolutePath());
-        final String source = java.nio.file.Files.readString(src);
-        final int healthIdx = source.indexOf("public void handle");
-        assertTrue(healthIdx >= 0, "HealthHandler.handle not found in source");
-        final String healthSection = source.substring(healthIdx, Math.min(source.length(), healthIdx + 2000));
-        // The catch must use writeInternalError, not writeError with e.getMessage()
-        assertTrue(healthSection.contains("writeInternalError"), "HealthHandler catch must use writeInternalError: " + healthSection);
-        assertFalse(healthSection.contains("e.getMessage()"), "HealthHandler must not leak e.getMessage(): " + healthSection);
+        // Why the engine could not be reached can name hosts and credentials, so the reason is
+        // logged and never written to the wire: the body carries a fixed message instead.
+        final org.codelibs.fess.api.v2.handlers.HealthHandler handler = new org.codelibs.fess.api.v2.handlers.HealthHandler() {
+            @Override
+            protected org.codelibs.fess.entity.PingResponse ping() {
+                throw new IllegalStateException("s3cr3tEngineDetail");
+            }
+        };
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/health"), res);
+        assertEquals(503, res.status);
+        final String body = res.body();
+        assertFalse(body.contains("s3cr3tEngineDetail"), body);
+        assertTrue(body.contains("\"code\":\"service_unavailable\""), body);
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/HealthHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/HealthHandlerTest.java
@@ -93,11 +93,36 @@ public class HealthHandlerTest extends UnitFessTestCase {
             assertTrue(body.contains("\"engine\""), body);
             assertTrue(body.contains("\"ping_status\""), body);
         } else {
-            // No engine in this JVM → handler emits a structured 503 (cluster red /
-            // unavailable) or 500 (ping threw). Accept both so the test stays stable.
-            assertTrue(res.status == 503 || res.status == 500, "unexpected status " + res.status + ": " + body);
-            assertTrue(body.contains("\"code\":\"service_unavailable\"") || body.contains("\"code\":\"internal_error\""), body);
+            // No engine in this JVM. A red cluster and an unreachable engine are both reported
+            // as 503 service_unavailable, and both keep the engine snapshot in the details, so
+            // a monitoring client always has a status to show. This endpoint never answers 500.
+            assertEquals(503, res.status, body);
+            assertTrue(body.contains("\"code\":\"service_unavailable\""), body);
+            assertTrue(body.contains("\"engine\""), body);
+            assertTrue(body.contains("\"ping_status\""), body);
         }
+    }
+
+    /**
+     * An unreachable engine is the outcome an operator most needs the endpoint to report, and
+     * the one the exception path used to turn into an undocumented 500 with no engine details.
+     */
+    @Test
+    public void test_health_unreachableEngine_isServiceUnavailableWithDetails() throws Exception {
+        final HealthHandler handler = new HealthHandler() {
+            @Override
+            protected org.codelibs.fess.entity.PingResponse ping() {
+                throw new IllegalStateException("node is not available");
+            }
+        };
+        final CapturingResponse res = new CapturingResponse();
+        handler.handle(new StubRequest("/api/v2/health"), res);
+        final String body = res.body();
+        assertEquals(503, res.status, body);
+        assertTrue(body.contains("\"code\":\"service_unavailable\""), body);
+        assertTrue(body.contains("\"status\":\"UNAVAILABLE\""), body);
+        assertTrue(body.contains("\"ping_status\""), body);
+        assertFalse(body.contains("\"cluster_name\""), body);
     }
 
     /** Minimal HttpServletResponse stub — local copy of SearchApiV2ManagerTest.CapturingResponse. */


### PR DESCRIPTION
This is part 7 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/keymatch-service-reload` and should be reviewed after it.

---

GET /api/v2/health answers 503 service_unavailable with the engine snapshot in
error.details.engine when the cluster is red, which is what a monitoring client
reads. When the engine cannot be reached at all -- the process is down, or the
address is wrong -- ping() throws and the request fell through to the generic
catch, so the endpoint answered 500 internal_error with no details at all.

That is the outcome the endpoint most needs to report, and the one where the
answer was least useful: fessctl ping reads response.error.details.engine, so it
had nothing to print, and the shipped OpenAPI document declares 200, 405 and 503
for this path and no 500 at all.

An unreachable engine is now reported the same way as a red cluster, with the
engine status UNAVAILABLE, and the exception is logged once.
