### PR TITLE
fix(indexer): give a document the language of its own text

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformer.java
@@ -345,6 +345,18 @@ public abstract class AbstractFessFileTransformer extends AbstractTransformer im
         // lang
         if (StringUtil.isNotBlank(fessConfig.getCrawlerDocumentFileDefaultLang())) {
             putResultDataBody(dataMap, fessConfig.getIndexFieldLang(), fessConfig.getCrawlerDocumentFileDefaultLang());
+        } else {
+            // The extractor metadata is appended to the body above, and language detection reads
+            // only the first indexer.language.detect.length characters of the field it ends up
+            // in. A short document is then classified from its producer metadata rather than
+            // from its own text -- a Japanese .docx written by an English tool is reported as
+            // English, and its body lands in content_en. Detecting from the extracted text alone
+            // settles the language before anything else is mixed into it; LanguageHelper keeps a
+            // value that is already on the document.
+            final String detectedLang = ComponentUtil.getLanguageHelper().detectLanguage(content);
+            if (detectedLang != null) {
+                putResultDataBody(dataMap, fessConfig.getIndexFieldLang(), detectedLang);
+            }
         }
         // id
         putResultDataBody(dataMap, fessConfig.getIndexFieldId(), crawlingInfoHelper.generateId(dataMap));

--- a/src/main/java/org/codelibs/fess/helper/LanguageHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/LanguageHelper.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.helper;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -113,7 +114,7 @@ public class LanguageHelper {
      * @param text The text to detect the language from.
      * @return The detected language.
      */
-    protected String detectLanguage(final String text) {
+    public String detectLanguage(final String text) {
         if (StringUtil.isBlank(text)) {
             return null;
         }
@@ -143,6 +144,17 @@ public class LanguageHelper {
 
     /**
      * Returns the supported language for a given language.
+     * <p>
+     * The same language reaches this method written more than one way: the detector reports
+     * zh-CN, a document may carry zh_CN of its own, and supported.languages is written in the
+     * java locale form because it also names the languages the user interface offers. So the tag
+     * is matched without regard to case or to the separator before the region.
+     * </p>
+     * <p>
+     * What comes back is the normalized tag, not the configured spelling: the index declares
+     * content_zh-cn, and query.language.mapping resolves a request locale to the same value.
+     * Copying the content into content_zh_CN would put it in a field nothing searches.
+     * </p>
      *
      * @param lang The language to check.
      * @return The supported language, or null if not supported.
@@ -151,12 +163,24 @@ public class LanguageHelper {
         if (StringUtil.isBlank(lang)) {
             return null;
         }
+        final String normalized = normalizeLanguageTag(lang);
         for (final String l : supportedLanguages) {
-            if (l.equals(lang)) {
-                return l;
+            if (normalizeLanguageTag(l).equals(normalized)) {
+                return normalizeLanguageTag(l);
             }
         }
         return null;
+    }
+
+    /**
+     * Reduces a language tag to the form the comparison is made on: lower case, and hyphen as the
+     * separator before the region.
+     *
+     * @param lang The language tag.
+     * @return The normalized tag.
+     */
+    protected String normalizeLanguageTag(final String lang) {
+        return lang.toLowerCase(Locale.ROOT).replace('_', '-');
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/helper/LanguageHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/LanguageHelperTest.java
@@ -293,11 +293,26 @@ public class LanguageHelperTest extends UnitFessTestCase {
 
     @Test
     public void test_getSupportedLanguage_caseInsensitive() {
-        // Test that method is case sensitive (as per implementation)
-        assertNull(languageHelper.getSupportedLanguage("JA"));
-        assertNull(languageHelper.getSupportedLanguage("EN"));
+        // The same tag arrives written several ways -- the detector reports zh-CN, a document may
+        // carry zh_CN of its own -- so the match ignores case, and the configured spelling is
+        // what comes back.
+        assertEquals("ja", languageHelper.getSupportedLanguage("JA"));
+        assertEquals("en", languageHelper.getSupportedLanguage("EN"));
         assertEquals("ja", languageHelper.getSupportedLanguage("ja"));
         assertEquals("en", languageHelper.getSupportedLanguage("en"));
+    }
+
+    @Test
+    public void test_getSupportedLanguage_regionTagSeparator() {
+        // The detector reports zh-CN and pt-BR; supported.languages is written zh_CN because it
+        // also names the languages the user interface offers. Both resolve, and what comes back
+        // is the suffix the index declares its content_<lang> fields with.
+        languageHelper.supportedLanguages = new String[] { "ja", "en", "zh_CN", "zh_TW", "pt_BR" };
+        assertEquals("zh-cn", languageHelper.getSupportedLanguage("zh-CN"));
+        assertEquals("zh-cn", languageHelper.getSupportedLanguage("zh_CN"));
+        assertEquals("zh-tw", languageHelper.getSupportedLanguage("zh-TW"));
+        assertEquals("pt-br", languageHelper.getSupportedLanguage("pt-BR"));
+        assertNull(languageHelper.getSupportedLanguage("ckb-iq"));
     }
 
     @Test


### PR DESCRIPTION
This is part 8 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/v2-health-unavailable` and should be reviewed after it.

---

Two separate defects left the lang field wrong for whole classes of document.

Chinese documents were never given one. The detector reports zh-CN and zh-TW,
supported.languages declares zh_CN and zh_TW -- it is written in the java locale
form because it also names the languages the user interface offers -- and the
two were compared with String.equals, so neither ever matched and detection fell
through to null. The same holds for ckb_IQ, en_IE and pt_BR. The lookup now
ignores case and the separator before the region, and answers with the
normalized tag, because that is the suffix the index declares its fields with:
content_zh-cn, content_pt-br. Copying the text into content_zh_CN would put it
in a field nothing searches, and query.language.mapping already resolves a
request locale to the same normalized value.

Japanese .docx and .pdf files came out as en. The extractor metadata is appended
to the body, and language detection reads only the first
indexer.language.detect.length characters of the field it ends up in, so a short
document is classified from its producer metadata -- and the body is then copied
into content_en, where the Japanese analyzer never sees it. The file transformer
now detects from the extracted text alone, before anything is appended to it,
and LanguageHelper keeps a language that is already on the document. An explicit
crawler.document.file.default.lang still wins.
