### PR TITLE
fix(dict): return the id of the entry a dictionary write created

### DIFF
--- a/src/main/java/org/codelibs/fess/dict/DictionaryItem.java
+++ b/src/main/java/org/codelibs/fess/dict/DictionaryItem.java
@@ -42,4 +42,15 @@ public abstract class DictionaryItem {
         return id;
     }
 
+    /**
+     * Sets the unique identifier for this dictionary item.
+     * The id of an entry is its position among the entries of the file, so it is only known once
+     * the file has been rewritten; a freshly created item carries 0 until then.
+     *
+     * @param id the ID of this dictionary item
+     */
+    public void setId(final long id) {
+        this.id = id;
+    }
+
 }

--- a/src/main/java/org/codelibs/fess/dict/kuromoji/KuromojiFile.java
+++ b/src/main/java/org/codelibs/fess/dict/kuromoji/KuromojiFile.java
@@ -194,6 +194,11 @@ public class KuromojiFile extends DictionaryFile<KuromojiItem> {
             if (updater != null) {
                 final KuromojiItem item = updater.commit();
                 if (item != null) {
+                    // The entry was appended after the last one that was read, so it takes the
+                    // next id -- the same id it will be given when the file is read back. Without
+                    // this it keeps the 0 it was created with, and the caller cannot read, edit or
+                    // delete the entry by the id the write reported.
+                    item.setId(id + 1);
                     itemList.add(item);
                 }
             }

--- a/src/main/java/org/codelibs/fess/dict/mapping/CharMappingFile.java
+++ b/src/main/java/org/codelibs/fess/dict/mapping/CharMappingFile.java
@@ -256,6 +256,11 @@ public class CharMappingFile extends DictionaryFile<CharMappingItem> {
             if (updater != null) {
                 final CharMappingItem item = updater.commit();
                 if (item != null) {
+                    // The entry was appended after the last one that was read, so it takes the
+                    // next id -- the same id it will be given when the file is read back. Without
+                    // this it keeps the 0 it was created with, and the caller cannot read, edit or
+                    // delete the entry by the id the write reported.
+                    item.setId(id + 1);
                     itemList.add(item);
                 }
             }

--- a/src/main/java/org/codelibs/fess/dict/protwords/ProtwordsFile.java
+++ b/src/main/java/org/codelibs/fess/dict/protwords/ProtwordsFile.java
@@ -174,6 +174,11 @@ public class ProtwordsFile extends DictionaryFile<ProtwordsItem> {
             if (updater != null) {
                 final ProtwordsItem item = updater.commit();
                 if (item != null) {
+                    // The entry was appended after the last one that was read, so it takes the
+                    // next id -- the same id it will be given when the file is read back. Without
+                    // this it keeps the 0 it was created with, and the caller cannot read, edit or
+                    // delete the entry by the id the write reported.
+                    item.setId(id + 1);
                     itemList.add(item);
                 }
             }

--- a/src/main/java/org/codelibs/fess/dict/stemmeroverride/StemmerOverrideFile.java
+++ b/src/main/java/org/codelibs/fess/dict/stemmeroverride/StemmerOverrideFile.java
@@ -215,6 +215,11 @@ public class StemmerOverrideFile extends DictionaryFile<StemmerOverrideItem> {
             if (updater != null) {
                 final StemmerOverrideItem item = updater.commit();
                 if (item != null) {
+                    // The entry was appended after the last one that was read, so it takes the
+                    // next id -- the same id it will be given when the file is read back. Without
+                    // this it keeps the 0 it was created with, and the caller cannot read, edit or
+                    // delete the entry by the id the write reported.
+                    item.setId(id + 1);
                     itemList.add(item);
                 }
             }

--- a/src/main/java/org/codelibs/fess/dict/stopwords/StopwordsFile.java
+++ b/src/main/java/org/codelibs/fess/dict/stopwords/StopwordsFile.java
@@ -185,6 +185,11 @@ public class StopwordsFile extends DictionaryFile<StopwordsItem> {
             if (updater != null) {
                 final StopwordsItem item = updater.commit();
                 if (item != null) {
+                    // The entry was appended after the last one that was read, so it takes the
+                    // next id -- the same id it will be given when the file is read back. Without
+                    // this it keeps the 0 it was created with, and the caller cannot read, edit or
+                    // delete the entry by the id the write reported.
+                    item.setId(id + 1);
                     itemList.add(item);
                 }
             }

--- a/src/main/java/org/codelibs/fess/dict/synonym/SynonymFile.java
+++ b/src/main/java/org/codelibs/fess/dict/synonym/SynonymFile.java
@@ -226,6 +226,11 @@ public class SynonymFile extends DictionaryFile<SynonymItem> {
             if (updater != null) {
                 final SynonymItem item = updater.commit();
                 if (item != null) {
+                    // The entry was appended after the last one that was read, so it takes the
+                    // next id -- the same id it will be given when the file is read back. Without
+                    // this it keeps the 0 it was created with, and the caller cannot read, edit or
+                    // delete the entry by the id the write reported.
+                    item.setId(id + 1);
                     itemList.add(item);
                 }
             }

--- a/src/test/java/org/codelibs/fess/dict/stopwords/StopwordsFileTest.java
+++ b/src/test/java/org/codelibs/fess/dict/stopwords/StopwordsFileTest.java
@@ -263,6 +263,24 @@ public class StopwordsFileTest extends UnitFessTestCase {
         assertTrue(found);
     }
 
+    /**
+     * The id of an entry is its position among the entries of the file, and is only known once
+     * the file has been rewritten. The item handed to insert() carries 0 until then, and that 0
+     * is what the REST API reported as the id of the entry it had just created -- an id that
+     * reads back as "deleted by another process" and cannot be edited or removed.
+     */
+    @Test
+    public void test_insert_assignsTheIdOfTheAppendedEntry() {
+        loadTestData();
+        final int existing = stopwordsFile.stopwordsItemList.size();
+
+        final StopwordsItem newItem = new StopwordsItem(0, "test");
+        stopwordsFile.insert(newItem);
+
+        assertEquals(existing + 1, newItem.getId());
+        assertEquals("test", stopwordsFile.get(newItem.getId()).get().getInput());
+    }
+
     // Test update method
     @Test
     public void test_update() {


### PR DESCRIPTION
This is part 9 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/language-detection` and should be reviewed after it.

---

POST /api/admin/dict/{type}/setting/{dictId} answered {"id":"0","created":true}
for every one of the six dictionary types, whatever entry it had written. The
entity is created with the id 0 that stands for "not stored yet", the file
appends it and never writes the assigned id back, and the action reports the id
off that entity.

A caller therefore cannot read, edit or delete the entry it has just created:
GET on id 0 answers that the entry may have been deleted by another process.
The only way back to it is to list the dictionary and match on the term.

The id of an entry is its position among the entries of the file, so it is known
as soon as the file has been rewritten: the entry is appended after the last one
that was read, and takes the next id -- the same id it is given when the file is
read back. Each dictionary file now writes it onto the item it appended, and
since that is the item the caller passed in, the id reaches the response.
