### PR TITLE
fix(script): report a script that could not be evaluated

### DIFF
--- a/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
+++ b/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.opensearch.config.exentity.BoostDocumentRule;
+import org.codelibs.fess.exception.ScriptEngineException;
 import org.codelibs.fess.util.ComponentUtil;
 
 /**
@@ -84,12 +85,37 @@ public class DocBoostMatcher {
             return false;
         }
 
-        final Object value = ComponentUtil.getScriptEngineFactory().getScriptEngine(scriptType).evaluate(matchExpression, map);
+        final Object value = evaluate(matchExpression, map);
         if (value instanceof Boolean) {
             return (Boolean) value;
         }
 
         return false;
+    }
+
+    /**
+     * Evaluates one of the expressions against a document.
+     * <p>
+     * A boost document is matched against every crawled document, and its expression names
+     * fields that most of them do not carry, so an expression that cannot be evaluated is an
+     * ordinary "this document does not match" rather than a failure: it must not stop the
+     * document from being indexed. This is the one caller for which that holds; everywhere else
+     * a script that cannot be evaluated is reported.
+     * </p>
+     *
+     * @param expression the expression to evaluate
+     * @param map the document data
+     * @return the result, or null when the expression did not apply to this document
+     */
+    protected Object evaluate(final String expression, final Map<String, Object> map) {
+        try {
+            return ComponentUtil.getScriptEngineFactory().getScriptEngine(scriptType).evaluate(expression, map);
+        } catch (final ScriptEngineException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("The boost expression did not apply to the document: expression={}", expression, e);
+            }
+            return null;
+        }
     }
 
     /**
@@ -105,7 +131,7 @@ public class DocBoostMatcher {
             return 0.0f;
         }
 
-        final Object value = ComponentUtil.getScriptEngineFactory().getScriptEngine(scriptType).evaluate(boostExpression, map);
+        final Object value = evaluate(boostExpression, map);
         if (value instanceof Integer) {
             return ((Integer) value).floatValue();
         }

--- a/src/main/java/org/codelibs/fess/script/ScriptEngine.java
+++ b/src/main/java/org/codelibs/fess/script/ScriptEngine.java
@@ -31,7 +31,10 @@ public interface ScriptEngine {
      *
      * @param template the template string to evaluate
      * @param paramMap the map of parameters to substitute into the template
-     * @return the result of evaluating the template, or null if evaluation fails
+     * @return the result of evaluating the template, which may be null when the script itself
+     *         evaluates to null
+     * @throws org.codelibs.fess.exception.ScriptEngineException if the template cannot be
+     *         evaluated
      */
     Object evaluate(final String template, final Map<String, Object> paramMap);
 }

--- a/src/main/java/org/codelibs/fess/script/javascript/JavaScriptEngine.java
+++ b/src/main/java/org/codelibs/fess/script/javascript/JavaScriptEngine.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.exception.JobProcessingException;
+import org.codelibs.fess.exception.ScriptEngineException;
 import org.codelibs.fess.opensearch.config.exentity.ScheduledJob;
 import org.codelibs.fess.script.AbstractScriptEngine;
 import org.codelibs.fess.util.ComponentUtil;
@@ -166,7 +167,13 @@ public class JavaScriptEngine extends AbstractScriptEngine {
             logger.warn("Failed to evaluate JavaScript: job={}, script(length={})={}, parameterKeys={}", describeCurrentJob(),
                     template.length(), truncatedScript, safeParamMap.keySet(), e);
             logScriptExecution(template, "failure:" + e.getClass().getSimpleName());
-            return null;
+            // A failure has to leave the method as a failure. Returning null made it
+            // indistinguishable from a script that evaluates to null, and a scheduled job whose
+            // script does not even compile was recorded as ok in the job log. The message names
+            // the script rather than repeating the cause, which is carried by the cause itself
+            // and logged above; ScriptExecutorJob puts this message in the job log's
+            // script_result, where naming the script that failed is what identifies it.
+            throw new ScriptEngineException("Failed to evaluate the script: " + truncatedScript, e);
         }
     }
 

--- a/src/test/java/org/codelibs/fess/script/javascript/JavaScriptEngineTest.java
+++ b/src/test/java/org/codelibs/fess/script/javascript/JavaScriptEngineTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.codelibs.fess.exception.JobProcessingException;
+import org.codelibs.fess.exception.ScriptEngineException;
 import org.codelibs.fess.opensearch.config.exentity.ScheduledJob;
 import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
@@ -107,15 +108,26 @@ public class JavaScriptEngineTest extends UnitFessTestCase {
     }
 
     @Test
-    public void test_evaluate_compilationFailureReturnsNull() {
+    public void test_evaluate_compilationFailureIsReported() {
+        // A script that does not compile has to leave the method as a failure: returning null
+        // made it indistinguishable from a script that evaluates to null, and a scheduled job
+        // running one was recorded as ok.
         final Map<String, Object> params = new HashMap<>();
-        assertNull(javaScriptEngine.evaluate("this is not ( valid javascript", params));
+        org.junit.jupiter.api.Assertions.assertThrows(ScriptEngineException.class,
+                () -> javaScriptEngine.evaluate("this is not ( valid javascript", params));
     }
 
     @Test
-    public void test_evaluate_runtimeFailureReturnsNull() {
+    public void test_evaluate_runtimeFailureIsReported() {
         final Map<String, Object> params = new HashMap<>();
-        assertNull(javaScriptEngine.evaluate("undefinedVariable", params));
+        org.junit.jupiter.api.Assertions.assertThrows(ScriptEngineException.class,
+                () -> javaScriptEngine.evaluate("undefinedVariable", params));
+    }
+
+    @Test
+    public void test_evaluate_aScriptThatEvaluatesToNullIsNotAFailure() {
+        // The reason the failure could not be reported before: both outcomes were null.
+        assertNull(javaScriptEngine.evaluate("null", new HashMap<>()));
     }
 
     @Test
@@ -205,7 +217,8 @@ public class JavaScriptEngineTest extends UnitFessTestCase {
         engine.init();
         final LogCapturingAppender capture = LogCapturingAppender.attach(JavaScriptEngine.class);
         try {
-            assertNull(engine.evaluate("def x = 1; return \"${x}\";", new HashMap<>()));
+            org.junit.jupiter.api.Assertions.assertThrows(ScriptEngineException.class,
+                    () -> engine.evaluate("def x = 1; return \"${x}\";", new HashMap<>()));
             assertTrue(capture.warnings().stream().anyMatch(m -> m.contains("job=Migrated Crawler(id=J1)")),
                     "the warning must name the job whose script failed: " + capture.warnings());
         } finally {
@@ -219,7 +232,8 @@ public class JavaScriptEngineTest extends UnitFessTestCase {
         // Document boosts, crawler field scripts and path mappings run outside the scheduler.
         final LogCapturingAppender capture = LogCapturingAppender.attach(JavaScriptEngine.class);
         try {
-            assertNull(javaScriptEngine.evaluate("def x = 1; return \"${x}\";", new HashMap<>()));
+            org.junit.jupiter.api.Assertions.assertThrows(ScriptEngineException.class,
+                    () -> javaScriptEngine.evaluate("def x = 1; return \"${x}\";", new HashMap<>()));
             assertTrue(capture.warnings().stream().anyMatch(m -> m.contains("job=none")),
                     "an evaluation outside a scheduled job must say so: " + capture.warnings());
         } finally {


### PR DESCRIPTION
This is part 10 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/dict-create-id` and should be reviewed after it.

---

A scheduled job whose script_data does not even compile was recorded in the Job
Log as ok, with an empty script_result. The Job Log is the only place an
administrator looks, and it said the job had succeeded; the reason was in
audit.log as result:failure and in fess.log as a warning.

The engine caught every exception, logged it and returned null, so the outcome
was indistinguishable from a script that evaluates to null and
ScriptExecutorJob's failure path was unreachable. Evaluating a script that fails
now throws ScriptEngineException, and the job is recorded as failed with the
reason in script_result.

The one caller that must stay tolerant is DocBoostMatcher: a boost document is
matched against every crawled document and its expression names fields most of
them do not carry, so an expression that cannot be evaluated is an ordinary "no
match" and must not stop the document from being indexed. That is now an
explicit catch at that call site rather than a silence for everybody. The other
callers -- data store field scripts, crawler field scripts and path mappings --
report the failure where the document is processed, instead of quietly producing
an empty field.
