### PR TITLE
fix(crawler): report a document that was indexed without its content

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformer.java
+++ b/src/main/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformer.java
@@ -467,9 +467,13 @@ public abstract class AbstractFessFileTransformer extends AbstractTransformer im
             if (!fessConfig.isCrawlerIgnoreContentException()) {
                 throw e;
             }
-            if (logger.isDebugEnabled()) {
-                logger.debug("Could not get a text.", e);
-            }
+            // The document is still indexed, with no text at all, and nothing downstream says
+            // so: the crawl is not failed, so no failure url is recorded either. A document that
+            // exceeds the maximum content length ends here too, which is the common case. This
+            // is the only place the loss can be reported, so it is reported at a level an
+            // operator watching the crawler log will see.
+            logger.warn("Could not extract a text, indexing the document without content: url={}, extractor={}",
+                    params.get(ExtractData.URL), extractor.getClass().getSimpleName(), e);
         }
         return new ExtractData();
     }

--- a/src/test/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformerTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/transformer/AbstractFessFileTransformerTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.crawler.transformer;
 
+import java.io.ByteArrayInputStream;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,10 +23,13 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.Constants;
+import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.entity.ResponseData;
 import org.codelibs.fess.crawler.exception.CrawlingAccessException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 import org.codelibs.fess.crawler.extractor.Extractor;
 import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
@@ -212,6 +216,30 @@ public class AbstractFessFileTransformerTest extends UnitFessTestCase {
     /**
      * Testable implementation of AbstractFessFileTransformer for unit testing.
      */
+    /**
+     * A document whose text cannot be extracted -- because it exceeds the maximum content
+     * length, most often -- is still indexed, with no text at all. The crawl is not failed, so
+     * no failure url is recorded either, and nothing downstream reports the loss. The warning is
+     * the only record of it.
+     */
+    @Test
+    public void test_getExtractData_reportsADocumentIndexedWithoutContent() {
+        final Map<String, String> params = new HashMap<>();
+        params.put(ExtractData.URL, "file:/share/huge.pdf");
+        final Extractor failing = (in, p) -> {
+            throw new MaxLengthExceededException("Content length (20000000 bytes) exceeds the maximum allowed length (10485760 bytes).");
+        };
+        final LogCapturingAppender capture = LogCapturingAppender.attach(AbstractFessFileTransformer.class);
+        try {
+            final ExtractData extractData = transformer.getExtractData(failing, new ByteArrayInputStream(new byte[0]), params);
+            assertTrue(extractData.getContent() == null || extractData.getContent().isEmpty());
+            assertTrue(capture.warnings().stream().anyMatch(m -> m.contains("file:/share/huge.pdf")),
+                    "the document that lost its content must be named: " + capture.warnings());
+        } finally {
+            capture.detach();
+        }
+    }
+
     private static class TestableAbstractFessFileTransformer extends AbstractFessFileTransformer {
 
         private static final Logger logger = LogManager.getLogger(TestableAbstractFessFileTransformer.class);


### PR DESCRIPTION
This is part 11 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/script-failure-propagation` and should be reviewed after it.

---

A file larger than the maximum content length -- 10 MiB by default -- is
rejected by the extractor, and crawler.ignore.content.exception, which is on by
default, turns that into an empty extraction. The document is then indexed with
no text at all: it is in the index and it is findable by nothing.

Nothing said so. The crawl is not failed, so no failure url is recorded either,
and the only trace was a debug line reading "Could not get a text." with no URL
on it, below the level a crawler log is read at. Watching the log was therefore
no way to notice that documents were losing their content.

The loss is now reported once per document at warning level, naming the URL and
the extractor, which is the only place it can be reported at all.
