### PR TITLE
docs(api): match the OpenAPI document to what v2 answers, and ship it

### DIFF
--- a/src/main/assemblies/common-bin.xml
+++ b/src/main/assemblies/common-bin.xml
@@ -113,6 +113,12 @@
 			</excludes>
 			<filtered>false</filtered>
 		</fileSet>
+		<!-- OpenAPI -->
+		<fileSet>
+			<directory>src/main/config/openapi</directory>
+			<outputDirectory>fess-${project.version}/openapi</outputDirectory>
+			<filtered>false</filtered>
+		</fileSet>
 	</fileSets>
 	<files>
 		<file>

--- a/src/main/config/openapi/v2/openapi-user.yaml
+++ b/src/main/config/openapi/v2/openapi-user.yaml
@@ -195,7 +195,7 @@ paths:
           description: |-
             Forwarded to the search engine to control exact hit counting
             (e.g. `true` or an integer threshold). Affects whether
-            `record_count_relation` is `eq` or `gte`.
+            `record_count_relation` is `EQUAL_TO` or `GREATER_THAN_OR_EQUAL_TO`.
           required: false
           schema: { type: string, maxLength: 100 }
         - name: facet.field
@@ -409,7 +409,7 @@ paths:
       tags: [popularword]
       summary: List popular search words
       description: |-
-        Returns `invalid_request` (400) when `web.api.popular.word=false`,
+        Returns `invalid_request` (400) when `web.api.popularword=false`,
         matching v1's "unsupported operation" semantics.
       operationId: popularWordsV2
       parameters:
@@ -1130,7 +1130,10 @@ components:
                   properties:
                     status:
                       type: string
-                      enum: [green, yellow, red]
+                      description: |-
+                        The cluster health as the search engine reports it, or `UNAVAILABLE`
+                        when the engine could not be reached at all.
+                      enum: [GREEN, YELLOW, RED, UNAVAILABLE]
                     ping_status: { type: integer }
 
     # --- Search ------------------------------------------------------
@@ -1145,7 +1148,7 @@ components:
               properties:
                 q: { type: string, nullable: true }
                 query_id: { type: string }
-                exec_time: { type: number, format: double }
+                exec_time: { type: string, description: 'Elapsed time in seconds, as a decimal string.' }
                 query_time: { type: integer, format: int64 }
                 page_size: { type: integer }
                 page_number: { type: integer }
@@ -1153,7 +1156,9 @@ components:
                 record_count_relation:
                   type: string
                   description: |-
-                    `eq` when the count is exact, `gte` when only a lower bound is known.
+                    `EQUAL_TO` when the count is exact, `GREATER_THAN_OR_EQUAL_TO` when only a
+                    lower bound is known.
+                  enum: [EQUAL_TO, GREATER_THAN_OR_EQUAL_TO]
                 page_count: { type: integer }
                 highlight_params: { type: string }
                 next_page: { type: boolean }

--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -77,7 +77,7 @@ public class SearchApiV2Manager extends BaseApiManager {
     // after construction; unit tests that instantiate this manager directly (e.g.
     // {@code new SearchApiV2Manager()}) must set the handler fields they exercise.
 
-    /** Handles {@code POST /api/v2/search}. */
+    /** Handles {@code GET /api/v2/search}. */
     @Resource
     protected SearchHandler searchHandler;
 


### PR DESCRIPTION
This is part 12 of a stacked series of 12, each fixing one finding from the 15.9.0 release
verification. It is based on `fix/report-skipped-content` and should be reviewed after it.

---

The paths in openapi-user.yaml and the paths the v2 dispatcher serves agree
exactly, but four declarations do not describe the responses:

  engine.status           declared enum [green, yellow, red]; the value is
                          ClusterHealthStatus.toString(), so GREEN -- a
                          generated client that validates the enum rejects
                          every health response. UNAVAILABLE is added for an
                          engine that cannot be reached.
  exec_time               declared number/double; the value is the string
                          "0.01".
  record_count_relation   declared eq / gte; the values are EQUAL_TO and
                          GREATER_THAN_OR_EQUAL_TO.
  popular-words           named web.api.popular.word as the property that
                          disables it; the property is web.api.popularword.

The manager's javadoc for the search handler said POST /api/v2/search, which is
answered with 405 and Allow: GET; the document already had it as a get.

The document itself reached nobody: it lives under src/main/config/openapi and
is named by none of the assembly descriptors, so it is in no distribution. It is
now packaged under openapi/ alongside the rest of the installation.
