### PR TITLE
chore(build): take yuicompressor-maven-plugin 2.0.1 from fess-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,6 @@
 			<plugin>
 				<groupId>org.codelibs.maven</groupId>
 				<artifactId>yuicompressor-maven-plugin</artifactId>
-				<version>2.0.0</version>
 				<executions>
 					<execution>
 						<phase>compile</phase>


### PR DESCRIPTION
Drops the pinned `yuicompressor-maven-plugin` version so this POM takes 2.0.1 from `fess-parent` (codelibs/fess-parent#78, merged).

## Why remove the pin rather than bump it

Of the eighteen plugins in this POM's `build/plugins`, this was the only one carrying its own `<version>`:

```
inherits     maven-compiler-plugin
inherits     maven-war-plugin
inherits     formatter-maven-plugin
PINS 2.0.0   yuicompressor-maven-plugin
inherits     dbflute-maven-plugin
...
```

`fess-parent` has always declared the plugin in `pluginManagement`, but the local pin won, so that entry was inherited by nothing — bumping the parent alone would have left this build on the old version without saying so.

## What changes in the output

The plugin's own fixes that reach this build:

- A `nosuffix` build (which this POM uses, without `force`) no longer skips compression when the output path is newer than the input.
- A file whose extension has no compressor is copied through unchanged rather than written out as 0 bytes.
- A failed compression no longer leaves a `.tmp` scratch file in the output tree for a later successful build to package into the WAR.

The dependency moves from `org.codelibs:yuicompressor` 2.4.10 to 2.4.11, which is where the output differences come from.

## Before/after

Ran `yuicompressor:compress` on this tree twice from a clean `target/`, once pinned to 2.0.0 and once to 2.0.1, with the POM configuration unchanged. Both builds: `BUILD SUCCESS`, `Warnings: 0, Errors: 0`, same 23 output files.

```
2.0.0  Total: input (197256b) -> output (121257b) [61%]
2.0.1  Total: input (197256b) -> output (102123b) [51%]
```

JavaScript — nested function scopes are munged again (a scope-traversal gap in 2.4.10 left most of them alone):

| file | 2.0.0 | 2.0.1 |
| --- | --- | --- |
| suggestor.js | 7,290b | 4,739b |
| chat.js | 23,944b | 19,461b |
| search.js | 6,336b | 4,743b |
| index.js | 1,858b | 1,639b |

CSS — the whole diff across the four stylesheets is two corrections, and the output grows slightly as a result:

- `@media(max-width:768px)` -> `@media (max-width:768px)` (11 occurrences)
- `--fess-card-radius:.5rem` -> `--fess-card-radius:0.5rem` — a custom property value is now preserved verbatim instead of being minified

## Checks

- All 18 minified `.js` files pass `node --check`.
- Every string literal in each source file is still present in its minified output (checked mechanically; the only apparent misses were regex artifacts spanning two adjacent literals, plus one literal that exists solely inside a comment).
- No source under `src/main/webapp/js` uses `eval` or `with`, the two constructs that make munging unsafe.
- With the pin removed, the version actually resolved from `fess-parent` was confirmed to be 2.0.1.

A full `mvn package` was not run locally; CI covers it.
