### PR TITLE
build: bundle the Neural Search plugin with the embedded search engine

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,6 +56,18 @@
 			<param name="plugin.version" value="3.8.0.0" />
 			<param name="plugin.zip.version" value="3.8.0.0" />
 		</antcall>
+		<!-- neural-search: provides the hybrid query and the search-phase processors that
+		     normalize and combine its subquery scores. It declares opensearch-knn (installed
+		     above) and transport-grpc (installed by module.xml) as extended plugins, and is
+		     published without the opensearch- prefix the other plugins carry. -->
+		<antcall target="install.plugin">
+			<param name="repo.url" value="${maven.release.repo.url}" />
+			<param name="plugin.groupId" value="org/opensearch/plugin" />
+			<param name="plugin.name.prefix" value="" />
+			<param name="plugin.name" value="neural-search" />
+			<param name="plugin.version" value="3.8.0.0" />
+			<param name="plugin.zip.version" value="3.8.0.0" />
+		</antcall>
 
 		<antcall target="remove.jars" />
 	</target>
@@ -90,6 +102,14 @@
 				<include name="knn/httpclient5-*" />
 				<include name="knn/httpcore5-*" />
 				<include name="knn/slf4j-api-*" />
+				<include name="neural-search/commons-collections4-*" />
+				<include name="neural-search/commons-math3-*" />
+				<include name="neural-search/commons-text-*" />
+				<include name="neural-search/gson-*" />
+				<include name="neural-search/jackson-annotations-*" />
+				<include name="neural-search/jackson-databind-*" />
+				<include name="neural-search/javassist-*" />
+				<include name="neural-search/json-smart-*" />
 				<include name="minhash/guava-*" />
 				<include name="minhash/failureaccess-*" />
 				<include name="minhash/jspecify-*" />


### PR DESCRIPTION
Stacked on #3401.

## Why

Rank fusion performed by the search engine needs the `hybrid` query and the search-phase
processors that normalize its subquery scores. Both come from the Neural Search plugin.
The Fess OpenSearch image already ships it, but the ZIP distribution starts its own
OpenSearch from the plugins `plugin.xml` installs — so without this, the feature added in
#3401 could only ever work against an external cluster, and the integration tests, which
run against the ZIP, could not cover it at all.

## What it needs

The plugin declares `extended.plugins=opensearch-knn,transport-grpc`. Both are already
there: `opensearch-knn` is installed by this file, and `transport-grpc` by `module.xml`.
It is published without the `opensearch-` prefix the other plugins carry, so it is
installed with an empty `plugin.name.prefix`.

## Verification

Built the ZIP (`mvn antrun:run` then `mvn package`) and started it:

```
$ curl -s "http://localhost:9201/_cat/plugins?v"
name   component                version
Node 1 analysis-extension       3.8.0
Node 1 analysis-fess            3.8.0
Node 1 configsync               3.8.0
Node 1 minhash                  3.8.0
Node 1 opensearch-knn           3.8.0.0
Node 1 opensearch-neural-search 3.8.0.0
```

Then ran the request shape #3401 produces — a `hybrid` query with named branches, an
inline `search_pipeline` carrying `score-ranker-processor`, and an aggregation — against
that embedded node. It is accepted, `matched_queries` reports which branch matched each
hit, the aggregation is returned, and a document excluded by the branches' role filter
stays out of both.

## Not included

Integration tests for the fused path. They would need an embedding provider so the vector
branch has a query vector to search with, and the ZIP bundles none — the shipped provider
is backed by ML Commons, which is not among the bundled plugins. Adding that is a larger
change than bundling one plugin, so it is left for its own PR.
