### PR TITLE
fix(semantic): carry the similarity cutoff in the query rather than on the request

### DIFF
--- a/src/main/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcher.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcher.java
@@ -129,9 +129,6 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
     /** One-time warn latch for the exact (full-scan) mode, reset when the ann mode becomes available. */
     private final AtomicBoolean exactModeWarned = new AtomicBoolean(false);
 
-    /** One-time notice latch for opting out of engine-side fusion because a min_score cutoff is set. */
-    private final AtomicBoolean minScoreOptOutNoticed = new AtomicBoolean(false);
-
     /** Timestamp of the last {@link #isKnnIndexReady()} probe. */
     private volatile long knnReadyCheckedAt;
 
@@ -191,17 +188,6 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
     @Override
     protected Optional<QueryBuilder> buildSubQuery(final String query, final SearchRequestParams params,
             final OptionalThing<FessUserBean> userBean) {
-        if (getMinScore().isPresent()) {
-            // The cutoff is a request-level min_score today, and a fused request has a single
-            // min_score that the engine applies after it has combined the branches - there it
-            // cannot mean "this branch's own cosine floor". Rather than drop the cutoff without
-            // saying so, stay out of the fused request while it is configured.
-            if (minScoreOptOutNoticed.compareAndSet(false, true)) {
-                logger.info("{} is set, so semantic chunk search does not take part in rank fusion performed by the search engine: "
-                        + "a fused request has one min_score for the whole result, not one per branch.", SEARCH_MIN_SCORE_PROPERTY);
-            }
-            return Optional.empty();
-        }
         final OptionalThing<SemanticQueryContext> contextOpt = prepare(query, params);
         if (!contextOpt.isPresent()) {
             return Optional.empty();
@@ -276,8 +262,6 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
                     .setFrom(params.getStartPosition())
                     .setSize(params.getPageSize())
                     .setFetchSource(params.getResponseFields(), null);
-            getMinScore().ifPresent(
-                    minScore -> resolveEngineMinScore(minScore, context.isAnnMode()).ifPresent(searchRequestBuilder::setMinScore));
             if (logger.isDebugEnabled()) {
                 logger.debug("Semantic chunk search mode: {}", context.isAnnMode() ? "ann" : "exact");
             }
@@ -307,7 +291,40 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
         final QueryBuilder chunkQuery =
                 context.isAnnMode() ? buildKnnChunkQuery(queryVector, params, hasPermissionQuery ? permissionQuery : null)
                         : buildExactChunkQuery(queryVector);
-        return boolQuery.must(chunkQuery);
+        return boolQuery.must(applyMinScore(chunkQuery, context.isAnnMode()));
+    }
+
+    /**
+     * Applies the configured similarity cutoff to the chunk query.
+     *
+     * <p>The cutoff is expressed inside the query rather than as the request's {@code min_score}
+     * so that it means the same thing however the request is run. A request that fuses several
+     * searchers has one {@code min_score} for the combined result, applied after the engine has
+     * normalized the branches, so there it could not mean "this branch's own similarity floor" -
+     * the cutoff has to travel with the branch it belongs to.</p>
+     *
+     * <p>Wrapping keeps retrieval bounded: the chunk query still returns its {@code k} nearest
+     * neighbors and the cutoff then discards the ones that are not close enough, which is what
+     * this cutoff has always meant. Asking the engine for every chunk above a threshold instead
+     * ({@code knn} radial search) would drop {@code k} entirely, because the two cannot both be
+     * set.</p>
+     *
+     * @param chunkQuery the chunk query to bound
+     * @param annMode whether the ann (knn query) mode is active
+     * @return the chunk query, wrapped when a usable cutoff is configured
+     */
+    protected QueryBuilder applyMinScore(final QueryBuilder chunkQuery, final boolean annMode) {
+        final OptionalThing<Float> minScore = getMinScore();
+        if (!minScore.isPresent()) {
+            return chunkQuery;
+        }
+        final OptionalThing<Float> engineMinScore = resolveEngineMinScore(minScore.get().floatValue(), annMode);
+        if (!engineMinScore.isPresent()) {
+            return chunkQuery;
+        }
+        // function_score with no functions leaves the score alone and only applies the cutoff,
+        // so this needs no script.
+        return QueryBuilders.functionScoreQuery(chunkQuery).setMinScore(engineMinScore.get().floatValue());
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcherTest.java
+++ b/src/test/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcherTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.rank.fusion;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,6 +42,8 @@ import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequestBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.settings.Settings;
@@ -280,6 +283,60 @@ public class SemanticChunkSearcherTest extends UnitFessTestCase {
                 "track_total_hits must not be requested: " + builder.request().source());
         assertFalse(builder.request().source().toString().replaceAll("\\s", "").contains("track_total_hits"),
                 builder.request().source().toString());
+    }
+
+    // -------------------------------------------------------------------------------------
+    //                                                                               min_score
+    //                                                                               ---------
+
+    @Test
+    public void test_applyMinScore_leavesTheQueryAloneWhenUnset() {
+        final GuardedSearcher searcher = new GuardedSearcher();
+        final QueryBuilder chunkQuery = QueryBuilders.matchAllQuery();
+        assertSame(chunkQuery, searcher.applyMinScore(chunkQuery, false));
+    }
+
+    @Test
+    public void test_applyMinScore_boundsTheQueryRatherThanTheRequest() {
+        final GuardedSearcher searcher = new GuardedSearcher();
+        searcher.minScore = Float.valueOf(0.4f);
+        // The cutoff has to travel with the branch it belongs to: a request that fuses several
+        // searchers has one min_score for the combined result, applied after normalization.
+        final String json = searcher.applyMinScore(QueryBuilders.matchAllQuery(), false).toString().replaceAll("\\s", "");
+        assertTrue(json.contains("\"function_score\""), json);
+        // exact mode scores cosine + 1
+        assertTrue(json.contains("\"min_score\":1.4"), json);
+    }
+
+    @Test
+    public void test_applyMinScore_usesTheEngineScale() {
+        final GuardedSearcher searcher = new GuardedSearcher();
+        searcher.minScore = Float.valueOf(0.4f);
+        // ann mode on lucene/cosinesimil scores (1 + cos) / 2
+        final String json = searcher.applyMinScore(QueryBuilders.matchAllQuery(), true).toString().replaceAll("\\s", "");
+        assertTrue(json.contains("\"min_score\":0.7"), json);
+    }
+
+    @Test
+    public void test_createSemanticSearchCondition_carriesTheCutoffInTheQuery() {
+        givenPermissionContext();
+        final GuardedSearcher searcher = new GuardedSearcher();
+        searcher.minScore = Float.valueOf(0.4f);
+        final SearchRequestBuilder builder = buildRequest(searcher, false, new StubSearchRequestParams(0, 10));
+        assertNull(builder.request().source().minScore(), "the cutoff no longer rides on the request");
+        assertTrue(builder.request().source().query().toString().replaceAll("\\s", "").contains("\"min_score\":1.4"),
+                builder.request().source().query().toString());
+    }
+
+    @Test
+    public void test_buildSubQuery_takesPartEvenWithACutoffConfigured() {
+        givenPermissionContext();
+        final GuardedSearcher searcher = new GuardedSearcher();
+        searcher.minScore = Float.valueOf(0.4f);
+        final Optional<QueryBuilder> subQuery =
+                searcher.buildSubQuery("plain query", new StubSearchRequestParams(0, 10), OptionalThing.empty());
+        assertTrue(subQuery.isPresent(), "a configured cutoff must not keep the branch out of a fused request");
+        assertTrue(subQuery.get().toString().replaceAll("\\s", "").contains("\"min_score\":1.4"), subQuery.get().toString());
     }
 
     // -------------------------------------------------------------------------------------
@@ -554,10 +611,16 @@ public class SemanticChunkSearcherTest extends UnitFessTestCase {
         boolean enabled = true;
         boolean available = true;
         boolean managerTouched = false;
+        Float minScore = null;
 
         @Override
         protected boolean isSearchEnabled() {
             return enabled;
+        }
+
+        @Override
+        protected OptionalThing<Float> getMinScore() {
+            return minScore == null ? OptionalThing.empty() : OptionalThing.of(minScore);
         }
 
         @Override


### PR DESCRIPTION
Stacked on #3402.

## Problem

`content_chunker.search.min_score` was applied as the *request's* `min_score`. That works
for a request the semantic searcher issues on its own, but a request that fuses several
searchers has a single `min_score` for the combined result, applied after the engine has
normalized the branches — there it cannot mean "the vector branch's own similarity floor".

So #3401 had the semantic searcher decline to join a fused request whenever a cutoff was
configured, and say so once. This removes that restriction.

## Change

The cutoff moves inside the branch: the chunk query is wrapped in a `function_score` that
carries it. It now means the same thing however the request is run.

A `function_score` with no functions leaves the score alone and only applies the cutoff, so
no script is involved.

## Why not radial search

`knn` radial search (`min_score` instead of `k`) is the other way to express a threshold,
and it was the original plan. It is worse here on two counts:

- `k` and `min_score` are mutually exclusive in a `knn` query, so
  `content_chunker.search.knn.k` would silently stop having any effect.
- It changes what the property means. Today the cutoff discards documents from the `k`
  nearest neighbors; radial search retrieves *everything* above the threshold instead, so a
  loose threshold would turn a bounded retrieval into an unbounded one for anyone already
  using the property.

Wrapping keeps the existing semantics exactly: still `k` nearest neighbors, then the cutoff.

## Verification

- `mvn test`: **7539 tests, 0 failures, 0 errors.**
- Five new unit tests: the cutoff is absent when unset, is converted to the engine's score
  scale for each mode (`cos + 1` for exact, `(1 + cos) / 2` for ann on lucene/cosinesimil),
  no longer rides on the request, and no longer keeps the branch out of a fused request.
- Checked against a real OpenSearch 3.8.0: as a subquery of a `hybrid` query, a
  `function_score` wrapping a `nested` `knn` applies the cutoff correctly and the `knn`
  clause's own filter still pre-filters. With the cutoff at 0.98 only the one document above
  it comes from the vector branch; lowering it to 0.4 brings the others back, so the cutoff
  is demonstrably being applied inside the branch rather than being ignored.

## Note on the emitted request

The request changes shape — `min_score` moves from the top level into the query — but selects
the same documents, because the branch's document score is the chunk query's score either way.
