### PR TITLE
feat(semantic): split a narrowed query instead of refusing it

### DIFF
--- a/src/main/java/org/codelibs/fess/query/StructuredQuerySplitter.java
+++ b/src/main/java/org/codelibs/fess/query/StructuredQuerySplitter.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.entity.QueryContext;
+import org.codelibs.fess.query.parser.QueryParser;
+import org.codelibs.fess.util.ComponentUtil;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+
+/**
+ * Splits an assembled query into the plain text to embed and the structured conditions
+ * {@code QueryStringBuilder} folded into it.
+ *
+ * <p>{@code QueryStringBuilder} appends facet and label selections to the query string as
+ * {@code label:"x"}, so a search that started as plain words stops being plain the moment the
+ * user narrows it. A vector branch cannot embed that string as it stands - {@code label:"x"} is
+ * noise to an embedding model, and dropping it would return documents the user had just
+ * excluded. This splitter recovers the two halves, so the free text can be embedded on its own
+ * and the conditions can be applied as real filters.</p>
+ *
+ * <p>The split runs on the parse tree, not on the query string: the string is handed to
+ * {@link QueryParser} and every field-qualified clause is handed back to {@link QueryProcessor},
+ * so a condition becomes exactly the filter the keyword branch would build for it - a prefix
+ * query for {@code site:}, a wildcard on the url field for {@code inurl:}, a range for
+ * {@code timestamp:[..]}, a term or a match phrase depending on whether the field is analyzed.
+ * Pattern-matching the string instead would have to re-implement all of that, and would drift
+ * the moment either side changed.</p>
+ *
+ * <p>Whatever cannot be split this way yields {@code null}, which means the caller should leave
+ * the query alone - for the vector branch that means skipping it. A condition this class can see
+ * is never dropped to make a query splittable: searching without it would return documents the
+ * user had excluded. What the parser itself discards - {@code label:""}, whose value analyzes to
+ * no tokens, never reaches the tree - is discarded from the keyword branch too, so the two
+ * branches still filter alike.</p>
+ */
+public class StructuredQuerySplitter {
+
+    private static final Logger logger = LogManager.getLogger(StructuredQuerySplitter.class);
+
+    /** The pseudo-field that carries an ordering, as {@code TermQueryCommand} spells it. */
+    protected static final String SORT_FIELD = "sort";
+
+    /** How a parse-tree node relates to the text/condition split. */
+    protected enum Kind {
+        /** Free text on the default field. */
+        TEXT,
+        /** A field-qualified clause the {@link QueryProcessor} can turn into a filter. */
+        CONDITION,
+        /** A boolean node holding both. */
+        MIXED,
+        /** Not splittable. */
+        REJECT;
+    }
+
+    /**
+     * Constructs a new StructuredQuerySplitter instance.
+     */
+    public StructuredQuerySplitter() {
+        // Default constructor
+    }
+
+    /** The free text and the conditions recovered from a query. */
+    public static final class Split {
+
+        /** The free text to embed. Never blank. */
+        public final String text;
+
+        /** The conditions as a filter clause, or {@code null} when the query carried none. */
+        public final QueryBuilder conditionFilter;
+
+        Split(final String text, final QueryBuilder conditionFilter) {
+            this.text = text;
+            this.conditionFilter = conditionFilter;
+        }
+    }
+
+    /**
+     * Splits an assembled query.
+     *
+     * @param query the assembled query string
+     * @return the split, or {@code null} when the query is not safe to split
+     */
+    public Split split(final String query) {
+        if (StringUtil.isBlank(query)) {
+            return null;
+        }
+        final QueryContext context;
+        final Query parsed;
+        try {
+            context = createQueryContext(query);
+            if (context.getDefaultField() != null) {
+                // `allintitle:` / `allinurl:` narrow the search to one field. The vector branch
+                // has no way to honour that -- a chunk vector covers the document's text, not a
+                // field -- and running without the narrowing would return the content matches the
+                // user excluded by asking for titles only.
+                return null;
+            }
+            // The context's string rather than the raw one, because its constructor is what
+            // strips those two prefixes. This is not quite the string the keyword branch parses:
+            // QueryHelper appends its configured additionalQuery before building its own
+            // context, and the vector branch never sees that -- the same blind spot it has
+            // had all along, embedding the query text and applying no additionalQuery either.
+            parsed = getQueryParser().parse(context.getQueryString());
+        } catch (final RuntimeException e) {
+            // A query that cannot be parsed fails the keyword branch too, so there is nothing
+            // useful the vector branch could do with it. Logged because everything else that can
+            // go wrong here -- an unavailable component, a broken FessConfig -- arrives as the
+            // same silent "not splittable", and a vector branch that stops firing is otherwise
+            // undiagnosable.
+            if (logger.isDebugEnabled()) {
+                logger.debug("Not splittable, failed to parse: {}", query, e);
+            }
+            return null;
+        }
+        if (parsed == null) {
+            return null;
+        }
+        final List<String> texts = new ArrayList<>();
+        final BoolQueryBuilder conditionFilter = QueryBuilders.boolQuery();
+        if (!walk(parsed, Occur.MUST, context, texts, conditionFilter)) {
+            return null;
+        }
+        final String text = String.join(" ", texts).trim();
+        if (StringUtil.isBlank(text)) {
+            // Conditions with no text of their own: there is nothing to embed.
+            return null;
+        }
+        return new Split(text, conditionFilter.hasClauses() ? conditionFilter : null);
+    }
+
+    /**
+     * Walks one parse-tree node, appending its text to {@code texts} and its conditions to
+     * {@code conditionFilter}.
+     *
+     * @param query the node
+     * @param occur how the node is combined into its parent
+     * @param context the throwaway context conditions are converted against
+     * @param texts collects the free text
+     * @param conditionFilter collects the conditions
+     * @return false when the node is not splittable
+     */
+    protected boolean walk(final Query query, final Occur occur, final QueryContext context, final List<String> texts,
+            final BoolQueryBuilder conditionFilter) {
+        switch (classify(query)) {
+        case TEXT:
+            // A negated term cannot be expressed in an embedding, so it is not splittable.
+            return occur != Occur.MUST_NOT && collectText(query, texts);
+        case CONDITION:
+            return addCondition(query, occur, context, conditionFilter);
+        case MIXED:
+            // A node holding both can only be pulled apart where it is required: in
+            // `(cat label:x) OR dog` the conditions are not a filter over anything.
+            if (occur != Occur.MUST) {
+                return false;
+            }
+            for (final BooleanClause clause : ((BooleanQuery) query).clauses()) {
+                if (!walk(clause.query(), clause.occur(), context, texts, conditionFilter)) {
+                    return false;
+                }
+            }
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Classifies a parse-tree node as text, condition, both or neither.
+     *
+     * @param query the node
+     * @return the kind
+     */
+    protected Kind classify(final Query query) {
+        if (query instanceof final BooleanQuery booleanQuery) {
+            boolean text = false;
+            boolean condition = false;
+            for (final BooleanClause clause : booleanQuery.clauses()) {
+                switch (classify(clause.query())) {
+                case TEXT:
+                    text = true;
+                    break;
+                case CONDITION:
+                    condition = true;
+                    break;
+                case MIXED:
+                    text = true;
+                    condition = true;
+                    break;
+                default:
+                    return Kind.REJECT;
+                }
+            }
+            if (text) {
+                return condition ? Kind.MIXED : Kind.TEXT;
+            }
+            return condition ? Kind.CONDITION : Kind.REJECT;
+        }
+        if (query instanceof final BoostQuery boostQuery) {
+            // `label:x^2` is a condition that can be boosted; `cat^2` is syntax on the text itself,
+            // and the boost would be lost the moment the text became a vector.
+            return classify(boostQuery.getQuery()) == Kind.CONDITION ? Kind.CONDITION : Kind.REJECT;
+        }
+        final String field = extractField(query);
+        if (field == null) {
+            return Kind.REJECT;
+        }
+        if (Constants.DEFAULT_FIELD.equals(field)) {
+            // Only a bare term is text. A phrase, a wildcard or a range on the default field is
+            // query syntax, and dropping it would search for something the user did not ask for.
+            return query instanceof TermQuery ? Kind.TEXT : Kind.REJECT;
+        }
+        if (SORT_FIELD.equals(field)) {
+            // The vector branch cannot apply an ordering, and interleaving score-ordered hits
+            // into an already-sorted result set makes the order meaningless. The
+            // TermQueryCommand converts this clause to null, which addCondition would refuse
+            // anyway; stating the rule here keeps it true regardless of what that returns, and
+            // it matters because QueryStringBuilder appends `sort:` to every query on a
+            // deployment with a default sort configured.
+            return Kind.REJECT;
+        }
+        return Kind.CONDITION;
+    }
+
+    /**
+     * Reads the field a leaf node queries.
+     *
+     * @param query the node
+     * @return the field name, or {@code null} when the node has none
+     */
+    protected String extractField(final Query query) {
+        if (query instanceof final TermQuery termQuery) {
+            return termQuery.getTerm().field();
+        }
+        if (query instanceof final PhraseQuery phraseQuery) {
+            final Term[] terms = phraseQuery.getTerms();
+            return terms.length == 0 ? null : terms[0].field();
+        }
+        if (query instanceof final MultiTermQuery multiTermQuery) {
+            // Covers the prefix, wildcard, regexp, fuzzy and range queries the classic parser
+            // emits. Whether there is a command for one of them is not decided here: a regexp
+            // value has none, and addCondition below refuses the query when the conversion
+            // throws.
+            return multiTermQuery.getField();
+        }
+        return null;
+    }
+
+    /**
+     * Collects the text of a node already classified as {@link Kind#TEXT}.
+     *
+     * @param query the node
+     * @param texts collects the free text
+     * @return false when the node is not splittable
+     */
+    protected boolean collectText(final Query query, final List<String> texts) {
+        if (query instanceof final BooleanQuery booleanQuery) {
+            for (final BooleanClause clause : booleanQuery.clauses()) {
+                if (clause.occur() != Occur.MUST && clause.occur() != Occur.SHOULD) {
+                    return false;
+                }
+                if (!collectText(clause.query(), texts)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (query instanceof final TermQuery termQuery) {
+            final String text = termQuery.getTerm().text();
+            if (StringUtil.isNotBlank(text)) {
+                texts.add(text);
+            }
+            return true;
+        }
+        // Restates the rule classify() applies to a leaf on the default field, for the node
+        // shapes it would already have refused. Nothing else can become text.
+        return false;
+    }
+
+    /**
+     * Converts a node already classified as {@link Kind#CONDITION} and adds it to the filter.
+     *
+     * @param query the node
+     * @param occur how the node is combined into its parent
+     * @param context the throwaway context the conversion runs against
+     * @param conditionFilter collects the conditions
+     * @return false when the node is not splittable
+     */
+    protected boolean addCondition(final Query query, final Occur occur, final QueryContext context,
+            final BoolQueryBuilder conditionFilter) {
+        final QueryBuilder builder;
+        try {
+            builder = getQueryProcessor().execute(context, query, 1.0f);
+        } catch (final RuntimeException e) {
+            // An unsupported or invalid clause -- a regexp value, for which there is no command --
+            // which the keyword branch turns into an error page, so the vector branch has
+            // nothing to add. Logged for the same reason as the parse failure above.
+            if (logger.isDebugEnabled()) {
+                logger.debug("Not splittable, failed to convert: {}", query, e);
+            }
+            return false;
+        }
+        if (builder == null) {
+            // Core returns null for a clause that constrains nothing it can express as a query.
+            // Only `sort:` and an empty boolean do so today, and classify() refuses both before
+            // they reach here; this guards the same rule at the seam, since a null would
+            // otherwise go straight into the filter.
+            return false;
+        }
+        if (occur == Occur.MUST) {
+            conditionFilter.filter(builder);
+            return true;
+        }
+        if (occur == Occur.MUST_NOT) {
+            conditionFilter.mustNot(builder);
+            return true;
+        }
+        // An optional condition -- `+cat dog OR label:x` -- is not a filter: applying it would
+        // exclude documents the query says are merely less preferred.
+        return false;
+    }
+
+    /**
+     * Creates the context conditions are converted against. It is a throwaway: it is built with
+     * {@code isQuery=false} so the conversion's field logs and highlight terms are discarded
+     * rather than written onto the live request, where they would show up as highlights for a
+     * query the keyword branch never ran.
+     *
+     * @param query the assembled query string
+     * @return the context
+     */
+    protected QueryContext createQueryContext(final String query) {
+        return new QueryContext(query, false);
+    }
+
+    /**
+     * Returns the query parser.
+     *
+     * @return the parser
+     */
+    protected QueryParser getQueryParser() {
+        return ComponentUtil.getQueryParser();
+    }
+
+    /**
+     * Returns the query processor.
+     *
+     * @return the processor
+     */
+    protected QueryProcessor getQueryProcessor() {
+        return ComponentUtil.getQueryProcessor();
+    }
+}

--- a/src/main/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcher.java
+++ b/src/main/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcher.java
@@ -40,6 +40,8 @@ import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.client.SearchEngineClient.SearchCondition;
 import org.codelibs.fess.opensearch.query.KnnQueryBuilder;
+import org.codelibs.fess.query.StructuredQuerySplitter;
+import org.codelibs.fess.query.StructuredQuerySplitter.Split;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.optional.OptionalThing;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
@@ -108,9 +110,12 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
     public static final String SEARCH_MIN_SCORE_PROPERTY = "content_chunker.search.min_score";
 
     /**
-     * Matches queries that use Fess/Lucene query syntax; such queries skip the
-     * semantic branch because the whole query string is embedded as one text.
+     * Matches queries that use Fess/Lucene query syntax.
+     *
+     * @deprecated {@link StructuredQuerySplitter} decides this now, by separating the words to
+     *             embed from the conditions to filter on instead of refusing the whole query.
      */
+    @Deprecated
     protected static final Pattern QUERY_SYNTAX_PATTERN =
             Pattern.compile("[\"():\\[\\]{}^~*?\\\\]|&&|\\|\\||(?:^|\\s)[+\\-]\\S|\\b(?:AND|OR|NOT|TO)\\b");
 
@@ -134,6 +139,9 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
 
     /** Cached result of the last {@link #isKnnIndexReady()} probe. */
     private volatile boolean knnReady;
+
+    /** Separates the words to embed from the conditions to filter on. */
+    private final StructuredQuerySplitter querySplitter = new StructuredQuerySplitter();
 
     /**
      * Default constructor.
@@ -209,7 +217,14 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
      * @return the context, or empty when the semantic branch does not apply
      */
     protected OptionalThing<SemanticQueryContext> prepare(final String query, final SearchRequestParams params) {
-        if (!isSearchEnabled() || StringUtil.isBlank(query) || !isPlainQuery(query)) {
+        if (!isSearchEnabled() || StringUtil.isBlank(query)) {
+            return OptionalThing.empty();
+        }
+        // The assembled query is not the user's words: QueryStringBuilder has appended whatever
+        // the user narrowed by, so a search stops being embeddable the moment a facet is
+        // clicked. Split it instead of refusing it - embed the words, filter on the rest.
+        final Split split = getQuerySplitter().split(query);
+        if (split == null) {
             return OptionalThing.empty();
         }
         // Geo and similar-document constraints are hard filters on the default path; the
@@ -231,7 +246,7 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
         embeddingUnavailableWarned.set(false);
         final float[] queryVector;
         try {
-            queryVector = embeddingClientManager.embedQuery(query);
+            queryVector = embeddingClientManager.embedQuery(split.text);
         } catch (final Exception e) {
             logger.warn("Failed to embed query for semantic chunk search; falling back to keyword-only results. query={}", query, e);
             return OptionalThing.empty();
@@ -241,7 +256,17 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
         }
         final boolean annMode = isKnnIndexReady();
         warnExactModeOnce(annMode);
-        return OptionalThing.of(new SemanticQueryContext(queryVector, annMode));
+        return OptionalThing.of(new SemanticQueryContext(queryVector, annMode, split.conditionFilter));
+    }
+
+    /**
+     * Returns the splitter that separates the words to embed from the conditions to filter on.
+     * Overridable so a test can supply one that does not need a container.
+     *
+     * @return the splitter
+     */
+    protected StructuredQuerySplitter getQuerySplitter() {
+        return querySplitter;
     }
 
     /**
@@ -282,16 +307,42 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
      */
     protected QueryBuilder buildSemanticQuery(final SemanticQueryContext context, final SearchRequestParams params) {
         final BoolQueryBuilder permissionQuery = buildPermissionQuery(params);
-        final boolean hasPermissionQuery = permissionQuery.hasClauses();
+        final QueryBuilder conditionFilter = context.getConditionFilter();
         final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-        if (hasPermissionQuery) {
+        if (permissionQuery.hasClauses()) {
             boolQuery.filter(permissionQuery);
+        }
+        if (conditionFilter != null) {
+            boolQuery.filter(conditionFilter);
         }
         final float[] queryVector = context.getQueryVector();
         final QueryBuilder chunkQuery =
-                context.isAnnMode() ? buildKnnChunkQuery(queryVector, params, hasPermissionQuery ? permissionQuery : null)
+                context.isAnnMode() ? buildKnnChunkQuery(queryVector, params, mergeKnnFilter(permissionQuery, conditionFilter))
                         : buildExactChunkQuery(queryVector);
         return boolQuery.must(applyMinScore(chunkQuery, context.isAnnMode()));
+    }
+
+    /**
+     * Combines the constraints handed to the knn query itself.
+     *
+     * <p>The clauses on the surrounding bool are what enforce them; this copy is a recall aid, so
+     * the approximate search does not spend its {@code k} on documents that are about to be
+     * discarded. Both constraints belong in it for the same reason: a user narrowing by label
+     * would otherwise get whichever of the nearest {@code k} chunks happened to carry that label,
+     * which is usually none of them.</p>
+     *
+     * @param permissionQuery the role and virtual-host constraint, possibly with no clauses
+     * @param conditionFilter the conditions recovered from the query, or null
+     * @return the combined filter, or null when there is nothing to constrain by
+     */
+    protected QueryBuilder mergeKnnFilter(final BoolQueryBuilder permissionQuery, final QueryBuilder conditionFilter) {
+        if (!permissionQuery.hasClauses()) {
+            return conditionFilter;
+        }
+        if (conditionFilter == null) {
+            return permissionQuery;
+        }
+        return QueryBuilders.boolQuery().filter(permissionQuery).filter(conditionFilter);
     }
 
     /**
@@ -339,15 +390,39 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
         /** Whether the live index can serve approximate kNN. */
         private final boolean annMode;
 
+        /** The conditions the query carried, as a filter clause, or null when it carried none. */
+        private final QueryBuilder conditionFilter;
+
         /**
-         * Creates a new context.
+         * Creates a new context for a query that carried no conditions.
          *
          * @param queryVector the query embedding
          * @param annMode whether the ann (knn query) mode is active
          */
         public SemanticQueryContext(final float[] queryVector, final boolean annMode) {
+            this(queryVector, annMode, null);
+        }
+
+        /**
+         * Creates a new context.
+         *
+         * @param queryVector the query embedding
+         * @param annMode whether the ann (knn query) mode is active
+         * @param conditionFilter the conditions to filter on, or null
+         */
+        public SemanticQueryContext(final float[] queryVector, final boolean annMode, final QueryBuilder conditionFilter) {
             this.queryVector = queryVector;
             this.annMode = annMode;
+            this.conditionFilter = conditionFilter;
+        }
+
+        /**
+         * Returns the conditions the query carried.
+         *
+         * @return the filter clause, or null when the query carried none
+         */
+        public QueryBuilder getConditionFilter() {
+            return conditionFilter;
         }
 
         /**
@@ -607,7 +682,11 @@ public class SemanticChunkSearcher extends AbstractDocumentSearcher {
      *
      * @param query the assembled query string
      * @return true if the query is plain text
+     * @deprecated {@link StructuredQuerySplitter} decides this now: it separates the words to
+     *             embed from the conditions to filter on, instead of refusing a query for
+     *             carrying conditions at all. Retained because it is an override point.
      */
+    @Deprecated
     protected boolean isPlainQuery(final String query) {
         return !QUERY_SYNTAX_PATTERN.matcher(query).find();
     }

--- a/src/test/java/org/codelibs/fess/query/StructuredQuerySplitterTest.java
+++ b/src/test/java/org/codelibs/fess/query/StructuredQuerySplitterTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.query;
+
+import java.util.List;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.util.ComponentUtil;
+import org.codelibs.fess.query.StructuredQuerySplitter.Split;
+import org.junit.jupiter.api.Test;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+public class StructuredQuerySplitterTest extends UnitFessTestCase {
+
+    // ---- Accepted: the shapes QueryStringBuilder folds into the query string ----
+
+    @Test
+    public void test_plainText_hasNoConditions() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        final Split split = splitter.split("mountain sunset");
+        assertNotNull(split);
+        assertEquals("mountain sunset", split.text);
+        assertNull(split.conditionFilter);
+        assertTrue(splitter.converted.isEmpty());
+    }
+
+    @Test
+    public void test_singleTerm() {
+        final Split split = new StubProcessorSplitter().split("cat");
+        assertNotNull(split);
+        assertEquals("cat", split.text);
+        assertNull(split.conditionFilter);
+    }
+
+    /** ` filetype:"jpeg"` -- what QueryStringBuilder appends for a single facet selection. */
+    @Test
+    public void test_singleValueCondition() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        final Split split = splitter.split("mountain sunset filetype:\"jpeg\"");
+        assertNotNull(split);
+        assertEquals("mountain sunset", split.text);
+        assertEquals(1, splitter.converted.size());
+        assertEquals("filetype:jpeg", splitter.converted.get(0));
+        assertEquals(1, filterClauses(split).size());
+    }
+
+    /**
+     * ` (label:"a" OR label:"b")` -- a multi-value facet selection. The whole OR group must reach
+     * core as ONE sub-query: splitting it into two clauses would turn the user's OR into an AND
+     * and return nothing.
+     */
+    @Test
+    public void test_orGroupReachesCoreAsOneSubQuery() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        final Split split = splitter.split("cat (label:\"a\" OR label:\"b\")");
+        assertNotNull(split);
+        assertEquals("cat", split.text);
+        assertEquals(1, splitter.converted.size());
+        assertTrue(splitter.converted.get(0).contains("label:a"));
+        assertTrue(splitter.converted.get(0).contains("label:b"));
+        assertEquals(1, filterClauses(split).size());
+    }
+
+    @Test
+    public void test_multipleFieldsBecomeMultipleClauses() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        final Split split = splitter.split("cat dog label:\"a\" filetype:\"b\"");
+        assertNotNull(split);
+        assertEquals("cat dog", split.text);
+        assertEquals(2, filterClauses(split).size());
+    }
+
+    /** A negated condition is expressible as a filter, so it is kept rather than refused. */
+    @Test
+    public void test_negatedCondition_becomesMustNot() {
+        final Split split = new StubProcessorSplitter().split("cat -label:\"x\"");
+        assertNotNull(split);
+        assertEquals("cat", split.text);
+        final BoolQueryBuilder filter = (BoolQueryBuilder) split.conditionFilter;
+        assertEquals(0, filter.filter().size());
+        assertEquals(1, filter.mustNot().size());
+    }
+
+    /**
+     * Optional text alongside a required condition. The classic parser leaves the two spellings
+     * of this in different shapes -- a flat clause list here, a nested boolean for the
+     * parenthesised form below -- and both must split the same way, or which queries keep the
+     * vector branch would depend on punctuation the user did not mean to be significant.
+     */
+    @Test
+    public void test_optionalTextWithRequiredCondition() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        final Split split = splitter.split("cat OR dog label:\"x\"");
+        assertNotNull(split);
+        assertEquals("cat dog", split.text);
+        assertEquals(1, filterClauses(split).size());
+    }
+
+    @Test
+    public void test_optionalTextWithRequiredCondition_parenthesised() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        final Split split = splitter.split("(cat OR dog) label:\"x\"");
+        assertNotNull(split);
+        assertEquals("cat dog", split.text);
+        assertEquals(1, filterClauses(split).size());
+    }
+
+    @Test
+    public void test_cjkText() {
+        final Split split = new StubProcessorSplitter().split("赤い車 label:\"写真\"");
+        assertNotNull(split);
+        assertEquals("赤い車", split.text);
+        assertNotNull(split.conditionFilter);
+    }
+
+    // ---- Accepted because core's QueryProcessor has a command for them. The previous
+    // pattern-matching implementation refused all three: it recognised only an allowlist of
+    // fields, and only bare or quoted values.
+
+    @Test
+    public void test_rangeCondition() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        final Split split = splitter.split("cat timestamp:[now/d-1d TO *]");
+        assertNotNull(split);
+        assertEquals("cat", split.text);
+        assertEquals(1, splitter.converted.size());
+        assertTrue(splitter.converted.get(0).startsWith("timestamp:"));
+    }
+
+    @Test
+    public void test_inurlCondition() {
+        final Split split = new StubProcessorSplitter().split("cat inurl:\"foo\"");
+        assertNotNull(split);
+        assertEquals("cat", split.text);
+        assertNotNull(split.conditionFilter);
+    }
+
+    @Test
+    public void test_boostedCondition() {
+        final Split split = new StubProcessorSplitter().split("cat label:\"x\"^2");
+        assertNotNull(split);
+        assertEquals("cat", split.text);
+        assertNotNull(split.conditionFilter);
+    }
+
+    // ---- Refused ----
+
+    /** Nothing to embed: the vector branch has no query of its own. */
+    @Test
+    public void test_conditionsWithoutText() {
+        assertNull(new StubProcessorSplitter().split("label:\"x\""));
+    }
+
+    /** Syntax on the text itself cannot survive being turned into a vector. */
+    @Test
+    public void test_phraseOnDefaultField() {
+        assertNull(new StubProcessorSplitter().split("\"mountain sunset\""));
+    }
+
+    @Test
+    public void test_prefixOnDefaultField() {
+        assertNull(new StubProcessorSplitter().split("cat*"));
+    }
+
+    @Test
+    public void test_boostOnDefaultField() {
+        assertNull(new StubProcessorSplitter().split("cat^2"));
+    }
+
+    /** A term the user excluded cannot be expressed in an embedding. */
+    @Test
+    public void test_negatedText() {
+        assertNull(new StubProcessorSplitter().split("cat -dog"));
+    }
+
+    /**
+     * The same, alongside a condition. Worth its own case: this is the shape where an excluded
+     * term would otherwise be collected into the text and embedded as something to look for.
+     */
+    @Test
+    public void test_negatedTextAlongsideACondition() {
+        assertNull(new StubProcessorSplitter().split("cat -dog label:\"x\""));
+    }
+
+    /** `cat OR label:x` has no reading in which the condition is a filter over the text. */
+    @Test
+    public void test_textOrCondition() {
+        assertNull(new StubProcessorSplitter().split("cat OR label:\"x\""));
+    }
+
+    /**
+     * An optional condition is not a filter: in `+cat dog OR label:x` the label is what the query
+     * calls preferable, and filtering on it would drop documents the user asked to keep.
+     */
+    @Test
+    public void test_optionalCondition() {
+        assertNull(new StubProcessorSplitter().split("+cat dog OR label:\"x\""));
+    }
+
+    /** The conditions in `(cat label:x) OR dog` are not a filter over anything. */
+    @Test
+    public void test_conditionInsideAnOptionalGroup() {
+        assertNull(new StubProcessorSplitter().split("(cat label:\"x\") OR dog"));
+    }
+
+    /**
+     * An ordering cannot be applied to a score-ordered branch. This matters in practice: a
+     * deployment with a default sort configured has `sort:` on every single query.
+     */
+    @Test
+    public void test_sort() {
+        assertNull(new StubProcessorSplitter().split("cat sort:filename.asc"));
+        assertNull(new StubProcessorSplitter().split("cat label:\"a\" sort:filename.asc"));
+    }
+
+    /**
+     * `allintitle:` narrows the search to one field, which a whole-document chunk vector cannot
+     * express. Running without the narrowing would return exactly the content matches the user
+     * asked to exclude.
+     */
+    @Test
+    public void test_allInTitle() {
+        // QueryContext resolves the prefix against the configured title field, so this is the one
+        // case that reads FessConfig at all.
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getIndexFieldTitle() {
+                return "title";
+            }
+        });
+        try {
+            assertNull(new StubProcessorSplitter().split("allintitle:cat"));
+            assertNull(new StubProcessorSplitter().split("allintitle:cat label:\"x\""));
+        } finally {
+            ComponentUtil.setFessConfig(null);
+        }
+    }
+
+    /** A query core itself cannot parse fails core's keyword branch too. */
+    @Test
+    public void test_unparseable() {
+        assertNull(new StubProcessorSplitter().split("cat ("));
+    }
+
+    /**
+     * A condition core converts to null carries a constraint that would be lost. Searching
+     * without it would return documents the user had excluded, so the whole query is refused.
+     */
+    @Test
+    public void test_conditionCoreCannotConvert() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        splitter.convertToNull = true;
+        assertNull(splitter.split("cat filetype:\"jpeg\""));
+    }
+
+    @Test
+    public void test_conditionCoreRejects() {
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        splitter.convertThrows = true;
+        assertNull(splitter.split("cat filetype:\"jpeg\""));
+    }
+
+    @Test
+    public void test_blank() {
+        assertNull(new StubProcessorSplitter().split(null));
+        assertNull(new StubProcessorSplitter().split(""));
+        assertNull(new StubProcessorSplitter().split("   "));
+    }
+
+    private List<QueryBuilder> filterClauses(final Split split) {
+        assertNotNull(split.conditionFilter);
+        return ((BoolQueryBuilder) split.conditionFilter).filter();
+    }
+}

--- a/src/test/java/org/codelibs/fess/query/StubProcessorSplitter.java
+++ b/src/test/java/org/codelibs/fess/query/StubProcessorSplitter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+import org.codelibs.fess.entity.QueryContext;
+import org.codelibs.fess.query.parser.QueryParser;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+
+/**
+ * A {@link StructuredQuerySplitter} wired to the <em>real</em> {@link QueryParser} and a
+ * recording stub in place of the {@link QueryProcessor}.
+ *
+ * <p>The parser is the real one because the parse tree is exactly what the splitter reasons
+ * about: stubbing it would test nothing. The processor is stubbed because standing up the real
+ * {@code QueryCommand}s outside a Lasta Di container means stubbing most of {@code FessConfig} -
+ * {@code FessConfig.SimpleImpl} throws on the decimal boost getters and returns null index field
+ * names, both of which the commands dereference. What the stub does pin is the split itself:
+ * which Lucene sub-query is handed over for conversion, and where each converted clause lands in
+ * the filter. How a clause is then converted is the query command's own contract, covered by its
+ * own tests.</p>
+ */
+public class StubProcessorSplitter extends StructuredQuerySplitter {
+
+    /** Every Lucene sub-query handed to the processor, in the order it was handed over. */
+    public final List<String> converted = new ArrayList<>();
+
+    /** When true the stub returns null, as the processor does for a clause it cannot express. */
+    public boolean convertToNull;
+
+    /** When true the stub throws, as the processor does for a clause it rejects outright. */
+    public boolean convertThrows;
+
+    private final QueryParser queryParser = new QueryParser();
+
+    private final QueryProcessor queryProcessor = new QueryProcessor() {
+        @Override
+        public QueryBuilder execute(final QueryContext context, final Query query, final float boost) {
+            converted.add(query.toString());
+            if (convertThrows) {
+                throw new IllegalStateException("stubbed conversion failure");
+            }
+            if (convertToNull) {
+                return null;
+            }
+            return QueryBuilders.termQuery("converted", query.toString());
+        }
+    };
+
+    /**
+     * Constructs a splitter with a real parser and a recording stub processor.
+     */
+    public StubProcessorSplitter() {
+        queryParser.init();
+    }
+
+    @Override
+    protected QueryParser getQueryParser() {
+        return queryParser;
+    }
+
+    @Override
+    protected QueryProcessor getQueryProcessor() {
+        return queryProcessor;
+    }
+}

--- a/src/test/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcherTest.java
+++ b/src/test/java/org/codelibs/fess/rank/fusion/SemanticChunkSearcherTest.java
@@ -29,6 +29,8 @@ import org.codelibs.fess.helper.RoleQueryHelper;
 import org.codelibs.fess.helper.VirtualHostHelper;
 import org.codelibs.fess.mylasta.action.FessUserBean;
 import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.query.StructuredQuerySplitter;
+import org.codelibs.fess.query.StubProcessorSplitter;
 import org.codelibs.fess.opensearch.client.SearchEngineClient;
 import org.codelibs.fess.opensearch.client.SearchEngineClient.SearchCondition;
 import org.codelibs.fess.unit.LogCapturingAppender;
@@ -286,6 +288,63 @@ public class SemanticChunkSearcherTest extends UnitFessTestCase {
     }
 
     // -------------------------------------------------------------------------------------
+    //                                                                     conditions in a query
+    //                                                                     ---------------------
+
+    @Test
+    public void test_prepare_narrowedQueryStillReachesTheVectorBranch() {
+        final GuardedSearcher searcher = new GuardedSearcher();
+        // Clicking a facet appends label:"news" to the query. Refusing the whole string for
+        // carrying syntax is what used to make the vector branch disappear the moment a user
+        // narrowed a search.
+        final OptionalThing<SemanticChunkSearcher.SemanticQueryContext> context =
+                searcher.prepare("opensearch label:\"news\"", new StubSearchRequestParams(0, 10));
+        assertTrue(context.isPresent(), "a narrowed search must still reach the vector branch");
+        assertNotNull(context.get().getConditionFilter(), "the narrowing must survive as a filter");
+        assertEquals(1, searcher.splitter.converted.size(), searcher.splitter.converted.toString());
+    }
+
+    @Test
+    public void test_prepare_embedsTheWordsWithoutTheConditions() {
+        final GuardedSearcher searcher = new GuardedSearcher();
+        searcher.prepare("opensearch label:\"news\"", new StubSearchRequestParams(0, 10));
+        // label:"news" is noise to an embedding model
+        assertEquals("opensearch", searcher.embeddedQuery);
+    }
+
+    @Test
+    public void test_prepare_skipsWhatCannotBeSplit() {
+        final GuardedSearcher searcher = new GuardedSearcher();
+        // allintitle: narrows to one field, and a chunk vector covers the document rather than a
+        // field, so the branch cannot honour it and must not run without it
+        assertFalse(searcher.prepare("allintitle:opensearch", new StubSearchRequestParams(0, 10)).isPresent());
+    }
+
+    @Test
+    public void test_buildSemanticQuery_appliesConditionsToBothPlaces() {
+        givenPermissionContext();
+        final GuardedSearcher searcher = new GuardedSearcher();
+        final QueryBuilder conditionFilter = QueryBuilders.termQuery("label", "news");
+        final SemanticChunkSearcher.SemanticQueryContext context =
+                new SemanticChunkSearcher.SemanticQueryContext(new float[] { 0.1f, 0.2f }, true, conditionFilter);
+        final String json = searcher.buildSemanticQuery(context, new StubSearchRequestParams(0, 10)).toString().replaceAll("\\s", "");
+        // the outer clause enforces the narrowing; the copy inside the knn query keeps the
+        // approximate search from spending its k on documents that are about to be discarded
+        assertEquals(2, countOccurrences(json, "\"label\":{\"value\":\"news\""), json);
+    }
+
+    @Test
+    public void test_buildSemanticQuery_leavesTheFilterAloneWithoutConditions() {
+        givenPermissionContext();
+        final GuardedSearcher searcher = new GuardedSearcher();
+        final SemanticChunkSearcher.SemanticQueryContext context =
+                new SemanticChunkSearcher.SemanticQueryContext(new float[] { 0.1f, 0.2f }, true, null);
+        final String json = searcher.buildSemanticQuery(context, new StubSearchRequestParams(0, 10)).toString().replaceAll("\\s", "");
+        assertFalse(json.contains("\"label\""), json);
+        assertEquals(2, countOccurrences(json, "\"role\":{\"value\":\"Rguest\""), json);
+    }
+
+    // -------------------------------------------------------------------------------------
     //                                                                               min_score
     //                                                                               ---------
 
@@ -511,6 +570,12 @@ public class SemanticChunkSearcherTest extends UnitFessTestCase {
         RuntimeException probeFailure;
         private Settings settings = Settings.EMPTY;
         private Map<String, Object> properties = Map.of();
+        private final StubProcessorSplitter splitter = new StubProcessorSplitter();
+
+        @Override
+        protected StructuredQuerySplitter getQuerySplitter() {
+            return splitter;
+        }
 
         ProbeSearcher withSettings(final Settings settings) {
             this.settings = settings;
@@ -612,6 +677,8 @@ public class SemanticChunkSearcherTest extends UnitFessTestCase {
         boolean available = true;
         boolean managerTouched = false;
         Float minScore = null;
+        final StubProcessorSplitter splitter = new StubProcessorSplitter();
+        String embeddedQuery;
 
         @Override
         protected boolean isSearchEnabled() {
@@ -621,6 +688,13 @@ public class SemanticChunkSearcherTest extends UnitFessTestCase {
         @Override
         protected OptionalThing<Float> getMinScore() {
             return minScore == null ? OptionalThing.empty() : OptionalThing.of(minScore);
+        }
+
+        @Override
+        protected StructuredQuerySplitter getQuerySplitter() {
+            // the real one needs the query command container; the split itself is covered by
+            // StructuredQuerySplitterTest
+            return splitter;
         }
 
         @Override
@@ -639,6 +713,7 @@ public class SemanticChunkSearcherTest extends UnitFessTestCase {
 
                 @Override
                 public float[] embedQuery(final String query) {
+                    embeddedQuery = query;
                     return new float[] { 0.1f, 0.2f };
                 }
             };


### PR DESCRIPTION
Stacked on #3403.

## Problem

The semantic branch embeds the assembled query string, and refuses any query carrying
search syntax. But the assembled string is not the user's words — `QueryStringBuilder`
appends whatever the user narrowed by:

```
/search?q=opensearch&ex_q=label%3anews   ->   opensearch label:"news"
```

That string contains a `:`, so `QUERY_SYNTAX_PATTERN` matched and the vector branch was
skipped. **Clicking a facet made hybrid search disappear** — the search silently became
keyword-only at the exact moment the user asked for something more specific. A sort
selection (` sort:last_modified.desc`) and a label dropdown (`label:"news"`) did the same.

Embedding the string as it stands is not an option either: `label:"news"` is noise to an
embedding model. And dropping it would return documents the user had just excluded.

## Change

Split the query instead of refusing it. `StructuredQuerySplitter` parses the assembled
string and separates the words to embed from the conditions to filter on:

- The words are embedded on their own.
- Each field-qualified clause is handed back to the `QueryProcessor`, so a condition
  becomes exactly the filter the keyword branch would build for it — a prefix query for
  `site:`, a wildcard on the url field for `inurl:`, a range for `timestamp:[..]`, a term
  or a match phrase depending on whether the field is analyzed. Pattern-matching the
  string instead would have to re-implement all of that, and would drift the moment
  either side changed.
- The conditions are applied twice: on the surrounding `bool`, which enforces them, and
  inside the `knn` query, so the approximate search does not spend its `k` on documents
  that are about to be discarded. A user narrowing by label would otherwise get whichever
  of the nearest `k` chunks happened to carry that label, which is usually none of them.

A query that cannot be split still skips the branch — `allintitle:`, which narrows to a
field a chunk vector cannot represent, or one the parser rejects. A condition this class
can see is never dropped to make a query splittable.

## Where the splitter comes from

`fess-webapp-multimodal`, where it was written against these same core classes
(`QueryParser`, `QueryProcessor`, `QueryContext`) to solve this same problem for the CLIP
branch. Moving it into core lets both branches share it.

It also lets the plugin shrink: `ClipChunkSearcher` overrides `search()`,
`isPlainQuery()`, `buildKnnChunkQuery()` and `buildExactChunkQuery()`, and all four exist
only to carry the split and its conditions across — the CLIP embedding itself comes from
`fess_embedding++.xml`, not from the searcher. Once core does the splitting, those
overrides and the two thread locals behind them can go, leaving the `getName()` override
the mosaic theme's badges depend on. That is a follow-up PR in that repository; the plugin
keeps working unmodified against this change in the meantime, because it splits before
calling `super.search`, and the conditions it recovers are applied by its own overrides.

`isPlainQuery` and `QUERY_SYNTAX_PATTERN` are deprecated rather than removed, since they
are override points of a class that has already shipped.

## Verification

- `mvn test`: **7571 tests, 0 failures, 0 errors.**
- The splitter's 27 tests came across with it and pass unchanged in core.
- 5 new tests on the wiring: a narrowed query still reaches the branch, only the words are
  embedded, an unsplittable query is still skipped, and the conditions land in both the
  surrounding filter and the `knn` filter (and nothing lands there when there are none).
- The query this produces was captured from a unit test and sent to a real OpenSearch
  3.8.0 as a subquery of a `hybrid` query. It is accepted, and with a role that matches no
  document the branch contributes nothing — the permission filter closing rather than
  opening.
