### PR TITLE
fix(login): keep the login manager buildable without the search engine client

### DIFF
--- a/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
+++ b/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java
@@ -374,7 +374,7 @@ public class SearchApiV2Manager extends BaseApiManager {
         }
         final OptionalThing<FessUserBean> userBean;
         try {
-            userBean = ComponentUtil.getComponent(FessLoginAssist.class).getSavedUserBean();
+            userBean = ComponentUtil.getFessLoginAssist().getSavedUserBean();
         } catch (final RuntimeException e) {
             logger.warn("/api/v2{}: could not resolve the current user", sub, e);
             ComponentUtil.getV2EnvelopeWriter().writeInternalError(response, e, logger, "/api/v2" + sub);

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/CacheHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/CacheHandler.java
@@ -112,7 +112,7 @@ public class CacheHandler {
         // is DI breakage.
         final FessLoginAssist assist;
         try {
-            assist = ComponentUtil.getComponent(FessLoginAssist.class);
+            assist = ComponentUtil.getFessLoginAssist();
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/cache/{}: could not acquire FessLoginAssist", docId, e);
             ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/cache/" + docId);

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandler.java
@@ -166,7 +166,7 @@ public class FavoritePostHandler {
         // their session expired when DI is broken.
         final FessLoginAssist assist;
         try {
-            assist = ComponentUtil.getComponent(FessLoginAssist.class);
+            assist = ComponentUtil.getFessLoginAssist();
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/documents/{}/favorite POST: could not acquire FessLoginAssist", docId, e);
             ComponentUtil.getV2EnvelopeWriter().writeInternalError(res, e, logger, "/api/v2/documents/" + docId + "/favorite POST");

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LoginHandler.java
@@ -219,7 +219,7 @@ public class LoginHandler {
         // consumed for DI breakage.
         final FessLoginAssist assist;
         try {
-            assist = ComponentUtil.getComponent(FessLoginAssist.class);
+            assist = ComponentUtil.getFessLoginAssist();
         } catch (final RuntimeException e) {
             logger.warn("login failed unexpectedly: could not acquire FessLoginAssist", e);
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/LogoutHandler.java
@@ -74,7 +74,7 @@ public class LogoutHandler {
             return;
         }
         try {
-            final FessLoginAssist assist = ComponentUtil.getComponent(FessLoginAssist.class);
+            final FessLoginAssist assist = ComponentUtil.getFessLoginAssist();
             // Mirror LogoutAction.index(): the LOGOUT record must be written BEFORE logout()
             // drops the user bean, otherwise the audit line degrades to "user:-".
             recordLogoutActivity(assist);

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/MeHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/MeHandler.java
@@ -110,6 +110,6 @@ public class MeHandler {
      * @return the saved user bean, or empty when no user is logged in
      */
     protected OptionalThing<FessUserBean> getSavedUserBean() {
-        return ComponentUtil.getComponent(FessLoginAssist.class).getSavedUserBean();
+        return ComponentUtil.getFessLoginAssist().getSavedUserBean();
     }
 }

--- a/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
+++ b/src/main/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandler.java
@@ -155,7 +155,7 @@ public class PasswordChangeHandler {
         // "please log in again" when the real issue is server-side.
         final FessLoginAssist assist;
         try {
-            assist = ComponentUtil.getComponent(FessLoginAssist.class);
+            assist = ComponentUtil.getFessLoginAssist();
         } catch (final RuntimeException e) {
             logger.warn("/api/v2/auth/password: could not acquire FessLoginAssist", e);
             ComponentUtil.getV2EnvelopeWriter().writeError(res, V2ErrorCode.INTERNAL_ERROR, "internal error");

--- a/src/main/java/org/codelibs/fess/app/web/base/login/FessLoginAssist.java
+++ b/src/main/java/org/codelibs/fess/app/web/base/login/FessLoginAssist.java
@@ -86,9 +86,23 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
     @Resource
     private FessConfig fessConfig;
 
-    /** The user behavior for database operations on user entities. */
-    @Resource
-    private UserBhv userBhv;
+    /**
+     * Returns the behavior for user entities.
+     *
+     * <p>Resolved on demand rather than bound at construction. This component is the login
+     * manager LastaFlute looks up whenever something asks who the current user is, and
+     * answering that question reads the session, not the user index. Binding {@link UserBhv}
+     * as a resource made the whole component unbuildable in any container that has not wired
+     * the search engine client, because the behavior in turn requires that client. LastaFlute
+     * answers "nobody is logged in" when it cannot look the login manager up, but only for a
+     * manager it cannot find - one it finds and cannot build raised the binding failure at the
+     * caller instead.</p>
+     *
+     * @return the behavior for user entities
+     */
+    protected UserBhv getUserBhv() {
+        return ComponentUtil.getComponent(UserBhv.class);
+    }
 
     // ===================================================================================
     //                                                                           Find User
@@ -126,7 +140,7 @@ public class FessLoginAssist extends TypicalLoginAssist<String, FessUserBean, Fe
      */
     @Override
     protected OptionalEntity<FessUser> doFindLoginUser(final String username) {
-        return userBhv.selectEntity(cb -> {
+        return getUserBhv().selectEntity(cb -> {
             cb.query().setName_Equal(username);
         }).map(user -> (FessUser) user);
     }

--- a/src/main/java/org/codelibs/fess/helper/ViewHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ViewHelper.java
@@ -1038,7 +1038,7 @@ public class ViewHelper {
      * @throws FessSystemException if facet data cannot be loaded
      */
     public FacetResponse getCachedFacetResponse(final String query) {
-        final OptionalThing<FessUserBean> userBean = ComponentUtil.getComponent(FessLoginAssist.class).getSavedUserBean();
+        final OptionalThing<FessUserBean> userBean = ComponentUtil.getFessLoginAssist().getSavedUserBean();
         final String permissionKey = userBean.map(user -> StreamUtil.stream(user.getPermissions())
                 .get(stream -> stream.sorted().distinct().collect(Collectors.joining("\n")))).orElse(StringUtil.EMPTY);
 

--- a/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
+++ b/src/main/java/org/codelibs/fess/sso/saml/SamlAuthenticator.java
@@ -1520,7 +1520,7 @@ public class SamlAuthenticator implements SsoAuthenticator {
      * @return The user bean of the session, empty when nobody is logged in.
      */
     protected OptionalThing<FessUserBean> getSavedUserBean() {
-        return ComponentUtil.getComponent(FessLoginAssist.class).getSavedUserBean();
+        return ComponentUtil.getFessLoginAssist().getSavedUserBean();
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/taglib/FessFunctions.java
+++ b/src/main/java/org/codelibs/fess/taglib/FessFunctions.java
@@ -668,7 +668,7 @@ public class FessFunctions {
         } else {
             roles = new String[] { role };
         }
-        final FessLoginAssist loginAssist = ComponentUtil.getComponent(FessLoginAssist.class);
+        final FessLoginAssist loginAssist = ComponentUtil.getFessLoginAssist();
         return loginAssist.getSavedUserBean()
                 .map(user -> user.hasRoles(roles) || user.hasRoles(ComponentUtil.getFessConfig().getAuthenticationAdminRolesAsArray()))
                 .orElse(false);

--- a/src/main/java/org/codelibs/fess/util/ComponentUtil.java
+++ b/src/main/java/org/codelibs/fess/util/ComponentUtil.java
@@ -34,6 +34,7 @@ import org.codelibs.fess.api.v2.handlers.DocIdValidator;
 import org.codelibs.fess.api.v2.handlers.LoginRateLimiter;
 import org.codelibs.fess.api.v2.handlers.UserPayloads;
 import org.codelibs.fess.api.v2.handlers.V2JsonBody;
+import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.auth.AuthenticationManager;
 import org.codelibs.fess.chat.ChatClient;
 import org.codelibs.fess.chat.ChatContentFetcher;
@@ -294,6 +295,9 @@ public final class ComponentUtil {
     private static SystemHelper systemHelper;
 
     private static FessConfig fessConfig;
+
+    /** Login assist supplied by a test, taking precedence over the container. */
+    private static FessLoginAssist fessLoginAssist;
 
     /** List of initialization processes to run after container initialization. */
     private static List<Runnable> initProcesses = new ArrayList<>();
@@ -608,6 +612,23 @@ public final class ComponentUtil {
         }
         fessConfig = getComponent(FessConfig.class);
         return fessConfig;
+    }
+
+    /**
+     * Gets the login assist component.
+     *
+     * <p>This is the single channel for the login assist, so a test can stand in for it with
+     * {@link #setFessLoginAssist(FessLoginAssist)}. {@link #register(Object, String)} cannot:
+     * it only answers for a component the container fails to provide, and the container
+     * provides this one.</p>
+     *
+     * @return The login assist.
+     */
+    public static FessLoginAssist getFessLoginAssist() {
+        if (fessLoginAssist != null) {
+            return fessLoginAssist;
+        }
+        return getComponent(FessLoginAssist.class);
     }
 
     /**
@@ -1186,9 +1207,19 @@ public final class ComponentUtil {
         ComponentUtil.fessConfig = fessConfig;
         if (fessConfig == null) {
             systemHelper = null;
+            fessLoginAssist = null;
             FessProp.propMap.clear();
             componentMap.clear();
         }
+    }
+
+    /**
+     * For test purpose only.
+     *
+     * @param fessLoginAssist fessLoginAssist instance, or null to fall back to the container
+     */
+    public static void setFessLoginAssist(final FessLoginAssist fessLoginAssist) {
+        ComponentUtil.fessLoginAssist = fessLoginAssist;
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerLoginRequiredTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/SearchApiV2ManagerLoginRequiredTest.java
@@ -77,7 +77,7 @@ public class SearchApiV2ManagerLoginRequiredTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(anonymous, "fessLoginAssist");
-        ComponentUtil.register(anonymous, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(anonymous);
     }
 
     @Override

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/CacheHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/CacheHandlerTest.java
@@ -132,7 +132,7 @@ public class CacheHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(throwing, "fessLoginAssist");
-        ComponentUtil.register(throwing, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(throwing);
         try {
             final CapturingResponse res = new CapturingResponse();
             new CacheHandler().handle(new StubRequest("GET", "/api/v2/cache/abc"), res, "abc");
@@ -142,7 +142,7 @@ public class CacheHandlerTest extends UnitFessTestCase {
                     "lookup exception must not be misreported as auth_required: " + res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/FavoritePostHandlerTest.java
@@ -96,7 +96,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(anon, "fessLoginAssist");
-        ComponentUtil.register(anon, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(anon);
     }
 
     @Test
@@ -216,7 +216,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(loginStub, "fessLoginAssist");
-        ComponentUtil.register(loginStub, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(loginStub);
 
         final FessConfig cfgStub = new FavoriteEnabledFessConfig();
         // Use setFessConfig so ComponentUtil.getFessConfig() returns this stub —
@@ -305,7 +305,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             assertTrue(second.body().contains("\"count\":"), "duplicate POST must carry count: " + second.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -326,7 +326,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(loginStub, "fessLoginAssist");
-        ComponentUtil.register(loginStub, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(loginStub);
 
         final FessConfig cfgStub = new FavoriteEnabledFessConfig();
         // Use setFessConfig so ComponentUtil.getFessConfig() returns this stub —
@@ -394,7 +394,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             org.junit.jupiter.api.Assertions.assertEquals(500, res.status, res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -415,7 +415,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(loginStub, "fessLoginAssist");
-        ComponentUtil.register(loginStub, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(loginStub);
 
         final FessConfig cfgStub = new FavoriteEnabledFessConfig();
         ComponentUtil.setFessConfig(cfgStub);
@@ -491,7 +491,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             assertFalse(res.body().contains("\"already_existed\""), "fresh add must NOT carry already_existed: " + res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
             ComponentUtil.register(new UserInfoHelper(), "userInfoHelper");
             ComponentUtil.register(new UserInfoHelper(), UserInfoHelper.class.getCanonicalName());
         }
@@ -511,7 +511,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(throwing, "fessLoginAssist");
-        ComponentUtil.register(throwing, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(throwing);
         try {
             final CapturingResponse res = new CapturingResponse();
             new FavoritePostHandler().handle(new StubRequest("POST", "/api/v2/documents/abc/favorite").withJsonBody("{\"query_id\":\"q\"}"),
@@ -522,7 +522,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
                     "lookup exception must not be misreported as auth_required: " + res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -554,7 +554,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(loginStub, "fessLoginAssist");
-        ComponentUtil.register(loginStub, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(loginStub);
         final FessConfig cfgStub = new FavoriteEnabledFessConfig();
         ComponentUtil.setFessConfig(cfgStub);
         ComponentUtil.register(cfgStub, "fessConfig");
@@ -575,7 +575,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("\"code\":\"payload_too_large\""), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
             ComponentUtil.register(new UserInfoHelper(), "userInfoHelper");
             ComponentUtil.register(new UserInfoHelper(), UserInfoHelper.class.getCanonicalName());
         }
@@ -596,7 +596,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(loginStub, "fessLoginAssist");
-        ComponentUtil.register(loginStub, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(loginStub);
         final FessConfig cfgStub = new FavoriteEnabledFessConfig();
         ComponentUtil.setFessConfig(cfgStub);
         ComponentUtil.register(cfgStub, "fessConfig");
@@ -622,7 +622,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("\"code\":\"unsupported_media_type\""), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
             ComponentUtil.register(new UserInfoHelper(), "userInfoHelper");
             ComponentUtil.register(new UserInfoHelper(), UserInfoHelper.class.getCanonicalName());
         }
@@ -649,7 +649,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(loginStub, "fessLoginAssist");
-        ComponentUtil.register(loginStub, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(loginStub);
 
         final FessConfig cfgStub = new FavoriteEnabledFessConfig();
         ComponentUtil.setFessConfig(cfgStub);
@@ -725,7 +725,7 @@ public class FavoritePostHandlerTest extends UnitFessTestCase {
             assertTrue(Character.isDigit(nextChar), "count value must be a JSON number (got '" + nextChar + "') in: " + body);
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
             ComponentUtil.register(new UserInfoHelper(), "userInfoHelper");
             ComponentUtil.register(new UserInfoHelper(), UserInfoHelper.class.getCanonicalName());
         }

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LoginHandlerTest.java
@@ -288,7 +288,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
      */
     private static void registerSuccessfulLoginComponents(final String username, final List<String> audit) {
         ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
-        ComponentUtil.register(new StubLoginAssist(username, false), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist(username, false));
         ComponentUtil.register(new SessionCsrfTokenManager(), SessionCsrfTokenManager.class.getCanonicalName());
     }
 
@@ -316,7 +316,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // the gates write no activity record, only the credential check does.
         final List<String> audit = new ArrayList<>();
         ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
-        ComponentUtil.register(new StubLoginAssist("u", true), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("u", true));
         // Saturate the IP bucket so the very next request trips the IP gate.
         for (int i = 0; i < ipLimit; i++) {
             assertTrue(rl.allow(LoginRateLimiter.Scope.IP, ip, ipLimit, 60));
@@ -367,7 +367,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // LOGIN_FAILURE — which is what turns the closing assertion into positive proof.
         final List<String> audit = new ArrayList<>();
         ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
-        ComponentUtil.register(new StubLoginAssist("erin", true), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("erin", true));
         // Saturate the (clientIp, username) composite bucket the handler computes.
         final String userKey = handler.userScopeKey(ip, "erin");
         for (int i = 0; i < userLimit; i++) {
@@ -887,14 +887,14 @@ public class LoginHandlerTest extends UnitFessTestCase {
      */
     private static void registerConcurrentlyDrainingAssist(final LoginRateLimiter rl, final String userKey, final int userLimit,
             final int lockoutSec, final boolean armLockout) {
-        ComponentUtil.register(new StubLoginAssist("frank", true).withConcurrentRequestDuringLogin(() -> {
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("frank", true).withConcurrentRequestDuringLogin(() -> {
             for (int i = 0; i < userLimit; i++) {
                 rl.allow(LoginRateLimiter.Scope.USER, userKey, userLimit, 60);
             }
             if (armLockout) {
                 rl.lockOut(LoginRateLimiter.Scope.USER, userKey, lockoutSec);
             }
-        }), FessLoginAssist.class.getCanonicalName());
+        }));
     }
 
     @Test
@@ -1007,7 +1007,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // record is byte-identical to the classic one.
         final List<String> audit = new ArrayList<>();
         ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
-        ComponentUtil.register(new StubLoginAssist("alice", false), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("alice", false));
         ComponentUtil.register(new SessionCsrfTokenManager(), SessionCsrfTokenManager.class.getCanonicalName());
         final CapturingResponse res = new CapturingResponse();
         new LoginHandler(new LoginRateLimiter()).handle(
@@ -1026,7 +1026,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // against the SPA login endpoint are invisible to audit.log.
         final List<String> audit = new ArrayList<>();
         ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
-        ComponentUtil.register(new StubLoginAssist("bob", true), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("bob", true));
         final CapturingResponse res = new CapturingResponse();
         new LoginHandler(new LoginRateLimiter())
                 .handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"wrong\"}"), res);
@@ -1046,7 +1046,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
                 throw new IllegalStateException("audit sink is down");
             }
         }, "activityHelper");
-        ComponentUtil.register(new StubLoginAssist("alice", false), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("alice", false));
         ComponentUtil.register(new SessionCsrfTokenManager(), SessionCsrfTokenManager.class.getCanonicalName());
         final CapturingResponse res = new CapturingResponse();
         new LoginHandler(new LoginRateLimiter()).handle(
@@ -1069,7 +1069,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
                 throw new IllegalStateException("audit sink is down");
             }
         }, "activityHelper");
-        ComponentUtil.register(new StubLoginAssist("bob", true), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("bob", true));
         final CapturingResponse res = new CapturingResponse();
         new LoginHandler(new LoginRateLimiter())
                 .handle(new StubRequest("POST", "/api/v2/auth/login").withJsonBody("{\"username\":\"bob\",\"password\":\"wrong\"}"), res);
@@ -1087,7 +1087,7 @@ public class LoginHandlerTest extends UnitFessTestCase {
         // that leaked a request through into verification would show up as a record here.
         final List<String> audit = new ArrayList<>();
         ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
-        ComponentUtil.register(new StubLoginAssist("gwen", true), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("gwen", true));
         final int ipLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerIpPerMinuteAsInteger();
         final int userLimit = ComponentUtil.getFessConfig().getThemeApiLoginRateLimitPerUserPerMinuteAsInteger();
         final LoginRateLimiter rl = new LoginRateLimiter();

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/LogoutHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/LogoutHandlerTest.java
@@ -106,7 +106,7 @@ public class LogoutHandlerTest extends UnitFessTestCase {
         // FessLoginAssist.logout() drops the user bean — otherwise it would degrade to "user:-".
         final List<String> audit = new ArrayList<>();
         ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
-        ComponentUtil.register(new StubLoginAssist("carol"), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist("carol"));
         final CapturingResponse res = new CapturingResponse();
         new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
         assertEquals(200, res.status, res.body());
@@ -121,7 +121,7 @@ public class LogoutHandlerTest extends UnitFessTestCase {
         // A logout that ended no session is not an event.
         final List<String> audit = new ArrayList<>();
         ComponentUtil.register(recordingActivityHelper(audit), "activityHelper");
-        ComponentUtil.register(new StubLoginAssist(null), FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(new StubLoginAssist(null));
         final CapturingResponse res = new CapturingResponse();
         new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
         assertEquals(200, res.status, res.body());
@@ -140,7 +140,7 @@ public class LogoutHandlerTest extends UnitFessTestCase {
             }
         }, "activityHelper");
         final StubLoginAssist assist = new StubLoginAssist("carol");
-        ComponentUtil.register(assist, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(assist);
         final CapturingResponse res = new CapturingResponse();
         new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
         assertEquals(200, res.status, res.body());
@@ -168,7 +168,7 @@ public class LogoutHandlerTest extends UnitFessTestCase {
             }
         }, "ssoManager");
         final StubLoginAssist assist = new StubLoginAssist("carol");
-        ComponentUtil.register(assist, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(assist);
 
         final CapturingResponse res = new CapturingResponse();
         new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
@@ -192,7 +192,7 @@ public class LogoutHandlerTest extends UnitFessTestCase {
             }
         }, "ssoManager");
         final StubLoginAssist assist = new StubLoginAssist("carol");
-        ComponentUtil.register(assist, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(assist);
 
         final CapturingResponse res = new CapturingResponse();
         new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);
@@ -216,7 +216,7 @@ public class LogoutHandlerTest extends UnitFessTestCase {
         final StubLoginAssist assist = new StubLoginAssist("carol");
         assist.logout();
         assist.logoutCount = 0;
-        ComponentUtil.register(assist, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(assist);
 
         final CapturingResponse res = new CapturingResponse();
         new LogoutHandler().handle(new StubRequest("POST", "/api/v2/auth/logout"), res);

--- a/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
+++ b/src/test/java/org/codelibs/fess/api/v2/handlers/PasswordChangeHandlerTest.java
@@ -105,7 +105,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(anon, "fessLoginAssist");
-        ComponentUtil.register(anon, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(anon);
     }
 
     @Test
@@ -155,7 +155,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
     private static StubFessLoginAssist registerStubLoginAssist(final String userId, final String expectedCurrentPw) {
         final StubFessLoginAssist stub = new StubFessLoginAssist(userId, expectedCurrentPw);
         ComponentUtil.register(stub, "fessLoginAssist");
-        ComponentUtil.register(stub, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(stub);
         return stub;
     }
 
@@ -173,7 +173,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("current_password"), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -190,7 +190,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("\"code\":\"auth_required\""), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -230,7 +230,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(session.invalidateCalled, "session.invalidate() must be called after a successful password change (M-3)");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -264,7 +264,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
                     "response must NOT contain csrf_token after session invalidation (M-3): " + res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -286,7 +286,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertFalse(session.invalidateCalled, "session.invalidate() must NOT be called when password change fails (M-3)");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -319,7 +319,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
                     "response must contain re_login_required:true (MJ-7): " + res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -339,7 +339,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("do not match"), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -375,7 +375,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(changedCalled[0], "expected UserService.changePassword to be invoked");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -411,7 +411,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertFalse(changedCalled[0], "changePassword must NOT be invoked for a weak password");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -442,7 +442,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
                     "bucket must be exhausted after one wrong-pw call consumed the 5th slot");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -472,7 +472,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertNotNull(res.getHeader("Retry-After"), "Retry-After header must be set on 429");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -519,7 +519,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(after.body().contains("\"code\":\"auth_required\""), after.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -556,7 +556,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
                     "the three retries inside the lockout must be logged at DEBUG: " + formatEvents(events));
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -617,7 +617,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
                     "the escalation must arm a lockout that outlives the sliding window");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -647,7 +647,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
                     "the already-locked case must be visible at DEBUG: " + formatEvents(events));
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -729,7 +729,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertFalse(rl.peek(LoginRateLimiter.Scope.USER, "alice", 5, 60), "bucket must now be exhausted on the 6th");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -749,7 +749,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("current_password"), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -767,7 +767,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             }
         };
         ComponentUtil.register(throwing, "fessLoginAssist");
-        ComponentUtil.register(throwing, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(throwing);
         try {
             final CapturingResponse res = new CapturingResponse();
             new PasswordChangeHandler().handle(new StubRequest("POST", "/api/v2/auth/password")
@@ -778,7 +778,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
                     "lookup exception must not be misreported as auth_required: " + res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -803,7 +803,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
         // are recorded — matching the LogoutHandler contract.
         final TrackingStubLoginAssist trackingAssist = new TrackingStubLoginAssist("alice", "secret-current");
         ComponentUtil.register(trackingAssist, "fessLoginAssist");
-        ComponentUtil.register(trackingAssist, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(trackingAssist);
         final boolean[] changedCalled = { false };
         final StubUserService stubSvc = new StubUserService(changedCalled);
         ComponentUtil.register(stubSvc, "userService");
@@ -830,7 +830,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(session.invalidateCalled, "session.invalidate() must still be called after assist.logout()");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -840,7 +840,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
         // the response must still be the normal 200 ok — logout failure must be swallowed.
         final ThrowingLogoutStubLoginAssist throwingAssist = new ThrowingLogoutStubLoginAssist("alice", "secret-current");
         ComponentUtil.register(throwingAssist, "fessLoginAssist");
-        ComponentUtil.register(throwingAssist, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(throwingAssist);
         final boolean[] changedCalled = { false };
         final StubUserService stubSvc = new StubUserService(changedCalled);
         ComponentUtil.register(stubSvc, "userService");
@@ -868,7 +868,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(session.invalidateCalled, "session.invalidate() must be called even when assist.logout() throws (MINOR-4)");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -879,7 +879,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
         // session.invalidate() should be called.
         final TrackingStubLoginAssist trackingAssist = new TrackingStubLoginAssist("alice", "secret-current");
         ComponentUtil.register(trackingAssist, "fessLoginAssist");
-        ComponentUtil.register(trackingAssist, FessLoginAssist.class.getCanonicalName());
+        ComponentUtil.setFessLoginAssist(trackingAssist);
         try {
             final TrackingStubSession session = new TrackingStubSession();
             final CapturingResponse res = new CapturingResponse();
@@ -892,7 +892,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertFalse(session.invalidateCalled, "session.invalidate() must NOT be called on the wrong-password path");
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -911,7 +911,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("\"code\":\"payload_too_large\""), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -934,7 +934,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("\"code\":\"unsupported_media_type\""), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -973,7 +973,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("\"code\":\"invalid_request\""), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 
@@ -991,7 +991,7 @@ public class PasswordChangeHandlerTest extends UnitFessTestCase {
             assertTrue(res.body().contains("\"code\":\"invalid_request\""), res.body());
         } finally {
             ComponentUtil.register(new FessLoginAssist(), "fessLoginAssist");
-            ComponentUtil.register(new FessLoginAssist(), FessLoginAssist.class.getCanonicalName());
+            ComponentUtil.setFessLoginAssist(new FessLoginAssist());
         }
     }
 

--- a/src/test/java/org/codelibs/fess/app/web/admin/dataconfig/CreateFormTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/dataconfig/CreateFormTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.app.web.admin.dataconfig;
 
 import org.codelibs.fess.Constants;
+import org.codelibs.fess.app.web.base.login.FessLoginAssist;
 import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
@@ -44,6 +45,20 @@ public class CreateFormTest extends UnitFessTestCase {
         form.initialize();
         assertNotNull(form.configParameter);
         assertTrue(form.configParameter.contains("config.script.type=" + Constants.DEFAULT_SCRIPT));
+    }
+
+    @Test
+    public void test_initialize_afterTheLoginManagerHasBeenResolved() {
+        // The suite shares one container across test classes in a fork, so whether the login
+        // manager has already been resolved when this form initializes depends on scheduling.
+        // Resolve it first here to pin the order that used to fail: the container could
+        // register the login manager and not build it, and initialize() asks it who is
+        // creating the entry.
+        assertNotNull(ComponentUtil.getComponent(FessLoginAssist.class));
+
+        final CreateForm form = new CreateForm();
+        form.initialize();
+        assertEquals(Constants.GUEST_USER, form.createdBy);
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/app/web/base/login/FessLoginAssistTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/base/login/FessLoginAssistTest.java
@@ -48,7 +48,7 @@ import org.lastaflute.web.login.TypicalLoginAssist;
  */
 public class FessLoginAssistTest extends UnitFessTestCase {
 
-    private FessLoginAssist loginAssist;
+    private StubUserBhvLoginAssist loginAssist;
 
     private PasswordHashHelper passwordHashHelper;
 
@@ -68,7 +68,7 @@ public class FessLoginAssistTest extends UnitFessTestCase {
         ComponentUtil.register(countingPm, "passwordHashHelper");
         ComponentUtil.register(new RecordingUserService(), UserService.class.getCanonicalName());
 
-        loginAssist = new FessLoginAssist();
+        loginAssist = new StubUserBhvLoginAssist();
     }
 
     @Override
@@ -477,6 +477,28 @@ public class FessLoginAssistTest extends UnitFessTestCase {
     }
 
     // ---------------------------------------------------------------------
+    // Container
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void test_container_canBuildTheLoginManager() {
+        // This component is what LastaFlute hands back for "who is the current user", a
+        // question asked far from any user-index lookup - every admin form that records its
+        // creator asks it. It therefore has to be buildable in a container that has not wired
+        // the search engine client, which the user behavior transitively needs.
+        //
+        // Binding the behavior as a resource broke that: the container could register the
+        // component and never build it, and once anything had asked for it the failure was
+        // latched in for the rest of the JVM. LastaFlute only answers "nobody is logged in"
+        // for a login manager it cannot *find*; one it finds and cannot build raised the
+        // binding failure at whatever asked, which is why an admin form initializer failed
+        // depending on what had run before it.
+        final FessLoginAssist assist = ComponentUtil.getComponent(FessLoginAssist.class);
+        assertNotNull(assist);
+        assertEquals(FessUserBean.class, assist.getSaveKeyUserBeanType());
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 
@@ -533,9 +555,9 @@ public class FessLoginAssistTest extends UnitFessTestCase {
         installCountingUserBhv(loginAssist, stored);
     }
 
-    private CountingUserBhv installCountingUserBhv(final FessLoginAssist target, final User stored) {
+    private CountingUserBhv installCountingUserBhv(final StubUserBhvLoginAssist target, final User stored) {
         final CountingUserBhv bhv = new CountingUserBhv(stored);
-        setField(FessLoginAssist.class, target, "userBhv", bhv);
+        target.userBhv = bhv;
         return bhv;
     }
 
@@ -589,7 +611,20 @@ public class FessLoginAssistTest extends UnitFessTestCase {
      * Exposes the protected sync-check entry point of {@code TypicalLoginAssist} and replaces
      * {@code logout()} with a counter, so the whole flow can run without a servlet session.
      */
-    private static class ExposedLoginAssist extends FessLoginAssist {
+    /**
+     * A login assist whose user behavior the test supplies, standing in for the component the
+     * container resolves in production.
+     */
+    private static class StubUserBhvLoginAssist extends FessLoginAssist {
+        UserBhv userBhv;
+
+        @Override
+        protected UserBhv getUserBhv() {
+            return userBhv;
+        }
+    }
+
+    private static class ExposedLoginAssist extends StubUserBhvLoginAssist {
         final AtomicInteger logoutCalls = new AtomicInteger(0);
 
         @Override


### PR DESCRIPTION
## What was wrong

`CreateFormTest` failed intermittently on CI with `AutoBindingFailureException`, and the failure was never in the form.

`FessLoginAssist` is the component LastaFlute hands back whenever something asks who the current user is. Answering that question reads the session, not the user index — but the class bound `UserBhv` as a resource, and `EsAbstractBehavior` in turn binds the search engine `Client`. So the whole component was unbuildable in any container that has not wired `esclient.xml`.

That turns a lookup LastaFlute is prepared for into one it is not. `SimpleRequestManager#findLoginManager` answers "nobody is logged in" for a login manager it cannot *find*:

```java
try {
    manager = ContainerUtil.getComponent(LoginManager.class);
} catch (ComponentNotFoundException ignored) {
    return handleLoginManagerNotFound(userBeanType);
} catch (TooManyRegistrationComponentException e) {
    ...
}
```

A manager it finds and cannot *build* is not covered, and the failure surfaced at whatever had asked.

## Why it was intermittent

Probing the unit container makes the mechanism exact:

| step | result |
| --- | --- |
| look `LoginManager` up | `ComponentNotFoundException` → guest, green |
| look `FessLoginAssist` up | `AutoBindingFailureException` on `userBhv` |
| look `LoginManager` up again | `AutoBindingFailureException` — the same `ComponentDef` is now registered |

Step 2 is reached by ordinary production code: ten call sites resolve `FessLoginAssist` from the container, and the v2 handler tests exercise several of them. Once any of those has run, the definition stays registered and unbuildable for the rest of the JVM, so every later `SystemHelper#getUsername` throws.

CI runs `-Dparallel=classes -DthreadCount=4 -DforkCount=1C -DreuseForks=true`, so one container is shared across test classes in a fork. Whether `CreateForm#initialize()` — which records who is creating the entry — ran before or after the first lookup decided whether it passed.

## The change

Resolve the behavior at its one use site (`doFindLoginUser`) instead of binding it at construction. The component then builds in any container, so the binding failure cannot occur and `findLoginManager` keeps its contract.

Being buildable also puts the login assist out of reach of `ComponentUtil.register`, which by design only answers for a component the container fails to provide:

```java
} catch (final ComponentNotFoundException | AutoBindingFailureException e) {
    if (componentMap.containsKey(...)) {
        return componentMap.get(...);
    }
    throw e;
}
```

Sixty-four stub registrations in six v2 test classes were relying on that fallback — that is, on the container being unable to build the component. They now go through a channel of the login assist's own, `ComponentUtil.getFessLoginAssist()` / `setFessLoginAssist(...)`, shaped like the one `FessConfig` already has and cleared by the same `setFessConfig(null)` reset. The ten production call sites route through the getter.

## Verification

- A probe pinned the three-step sequence above before and after the change: on `master` step 2 throws; with the change all three steps resolve and `getUsername()` answers `guest` in either order.
- `FessLoginAssistTest` gains a test that the container can build the login manager; `CreateFormTest` gains one that runs `initialize()` *after* the login manager has been resolved, which is the order that used to fail.
- Full suite with the CI settings: green.

`CreateForm#initialize()` reaching for the login stack at all is left alone — that is existing behaviour, not the defect here.
