### PR TITLE
feat!: install Node.js on demand instead of bundling Playwright's copies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1432,6 +1432,20 @@
 			<groupId>org.codelibs.fess</groupId>
 			<artifactId>fess-crawler-playwright</artifactId>
 			<version>${crawler.playwright.version}</version>
+			<exclusions>
+				<exclusion>
+					<!-- driver-bundle is five Node.js binaries, one per platform, and nothing else:
+					     191 MiB of a 410 MiB distribution, for a crawler that is off by default. The
+					     JS driver itself lives in com.microsoft.playwright:driver, which stays.
+					     Playwright finds Node.js through PLAYWRIGHT_NODEJS_PATH instead, which
+					     bin/fess.in.sh sets from bin/fess-setup install nodejs.
+					     NOTE: this split only exists from Playwright 1.62.0. In 1.60 and earlier
+					     DriverJar itself lived in driver-bundle, so excluding it there would take
+					     the driver away with it. -->
+					<groupId>com.microsoft.playwright</groupId>
+					<artifactId>driver-bundle</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>args4j</groupId>

--- a/src/main/assemblies/files/fess-setup
+++ b/src/main/assemblies/files/fess-setup
@@ -38,4 +38,4 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-exec "$JAVA" -jar "$FESS_HOME/bin/fess-setup.jar" "$@"
+exec "$JAVA" -Dfess.home="$FESS_HOME" -jar "$FESS_HOME/bin/fess-setup.jar" "$@"

--- a/src/main/assemblies/files/fess-setup.bat
+++ b/src/main/assemblies/files/fess-setup.bat
@@ -22,7 +22,7 @@ ECHO JAVA_HOME is set to %JAVA_HOME% but %JAVA_EXE% does not exist 1>&2
 EXIT /B 1
 
 :run
-"%JAVA_EXE%" -jar "%FESS_HOME%\bin\fess-setup.jar" %*
+"%JAVA_EXE%" -Dfess.home="%FESS_HOME%" -jar "%FESS_HOME%\bin\fess-setup.jar" %*
 SET EXIT_CODE=%ERRORLEVEL%
 
 ENDLOCAL & EXIT /B %EXIT_CODE%

--- a/src/main/assemblies/files/fess.in.bat
+++ b/src/main/assemblies/files/fess.in.bat
@@ -123,4 +123,13 @@ REM External opensearch cluster
 REM set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
 REM set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=C:\opensearch\config\dictionary
 
+REM Node.js for the Playwright crawler, installed by: bin\fess-setup install nodejs
+REM An environment variable, not a -D option: the crawler runs in a child process that inherits
+REM the environment but not the parent's system properties.
+IF NOT DEFINED PLAYWRIGHT_NODEJS_PATH (
+  FOR /D %%D IN ("%FESS_HOME%\nodejs\*") DO (
+    IF EXIST "%%D\node.exe" SET PLAYWRIGHT_NODEJS_PATH=%%D\node.exe
+  )
+)
+
 set GROOVY_TURN_OFF_JAVA_WARNINGS=true

--- a/src/main/assemblies/files/fess.in.sh
+++ b/src/main/assemblies/files/fess.in.sh
@@ -142,4 +142,19 @@ if [ "x$FESS_DICTIONARY_PATH" != "x" ]; then
   FESS_JAVA_OPTS="$FESS_JAVA_OPTS -Dfess.dictionary.path=$FESS_DICTIONARY_PATH"
 fi
 
+# Node.js for the Playwright crawler, installed by: bin/fess-setup install nodejs
+# This has to be an exported environment variable rather than a -D option: the crawler runs in a
+# child process that inherits the environment but not the parent's system properties.
+if [ "x$PLAYWRIGHT_NODEJS_PATH" = "x" ]; then
+  for fess_node_candidate in "$FESS_HOME"/nodejs/*/bin/node ; do
+    if [ -x "$fess_node_candidate" ]; then
+      PLAYWRIGHT_NODEJS_PATH="$fess_node_candidate"
+      break
+    fi
+  done
+fi
+if [ "x$PLAYWRIGHT_NODEJS_PATH" != "x" ]; then
+  export PLAYWRIGHT_NODEJS_PATH
+fi
+
 GROOVY_TURN_OFF_JAVA_WARNINGS=true

--- a/src/main/java/org/codelibs/fess/setup/ComponentDefinition.java
+++ b/src/main/java/org/codelibs/fess/setup/ComponentDefinition.java
@@ -85,6 +85,33 @@ public record ComponentDefinition(String name, Map<String, String> attrs) {
     }
 
     /**
+     * Returns the token this component's publisher uses for an operating system in its artifact
+     * names. Projects disagree: OpenSearch says {@code windows} where Node.js says {@code win},
+     * and Node.js publishes {@code darwin} builds where OpenSearch publishes none at all, so the
+     * mapping belongs to the definition rather than to this tool.
+     *
+     * @param os the operating system
+     * @return the token, or {@code null} when the component publishes no build for it
+     */
+    public String osToken(final Platform.Os os) {
+        return attrs.get("os." + os.name().toLowerCase(java.util.Locale.ROOT));
+    }
+
+    /**
+     * Returns the path of this component's executable relative to its extracted directory.
+     * An {@code executable.<os>} attribute overrides the plain {@code executable} -- Node.js puts
+     * {@code node} under {@code bin/} everywhere except Windows, where {@code node.exe} sits at
+     * the root of the archive.
+     *
+     * @param os the operating system
+     * @return the relative path, or {@code null} when the component declares no executable
+     */
+    public String executable(final Platform.Os os) {
+        final String specific = attrs.get("executable." + os.name().toLowerCase(java.util.Locale.ROOT));
+        return specific != null ? specific : attrs.get("executable");
+    }
+
+    /**
      * Returns a comma-separated attribute as a list, trimming each element and dropping empties.
      *
      * @param key the attribute key

--- a/src/main/java/org/codelibs/fess/setup/FessSetup.java
+++ b/src/main/java/org/codelibs/fess/setup/FessSetup.java
@@ -36,6 +36,9 @@ public final class FessSetup {
 
     private static final String DEFINITION_RESOURCE = "/fess-setup.properties";
 
+    /** Post-install hook that installs the Fess plugins and writes configsync.config_path. */
+    private static final String POST_OPENSEARCH = "opensearch";
+
     private static final int EXIT_OK = 0;
 
     private static final int EXIT_FAILED = 1;
@@ -172,16 +175,13 @@ public final class FessSetup {
     private static int installComponent(final ComponentDefinition definition, final Map<String, String> options, final PrintStream out,
             final PrintStream err) throws SetupException {
         final Platform.Os os = Platform.current();
-        final String osToken = Platform.token(os);
+        final String osToken = definition.osToken(os);
         if (osToken == null) {
-            err.println("""
-                    error: OpenSearch publishes no official build for this platform.
-                           Install it another way, then point fess-setup at it:
-
-                             macOS:  brew install opensearch
-                                     bin/fess-setup install plugins --opensearch-home $(brew --prefix opensearch)
-
-                             Docker: use the compose files instead of a local install.""");
+            err.println("error: " + definition.name() + " publishes no official build for this platform.");
+            final String hint = definition.get("hint.unavailable");
+            if (hint != null) {
+                hint.lines().forEach(err::println);
+            }
             return EXIT_FAILED;
         }
         final String arch = Platform.archFrom(System.getProperty("os.arch"));
@@ -195,6 +195,7 @@ public final class FessSetup {
         vars.put("arch", arch);
         vars.put("archive.ext", Platform.archiveExt(os));
         vars.put("version", version);
+        vars.put("fess.home", fessHome());
 
         final String url = definition.resolve("url", vars);
         final Path dest = Path.of(options.getOrDefault("dest", definition.resolve("dest", vars)));
@@ -205,19 +206,56 @@ public final class FessSetup {
         } else {
             final Path archive = dest.resolve(url.substring(url.lastIndexOf('/') + 1));
             out.println("Downloading " + url);
-            Downloader.download(URI.create(url), archive, (bytes, total) -> reportProgress(out, bytes, total));
+            final int[] lastPercent = { -1 };
+            Downloader.download(URI.create(url), archive, (bytes, total) -> reportProgress(out, bytes, total, lastPercent));
             out.println();
             out.println("Extracting " + archive.getFileName());
             Archiver.extract(archive, dest);
         }
-        installPlugins(definition, home, options, out);
-        out.println("Configuring " + home);
-        OpenSearchConfigurer.configure(home);
+
+        if (POST_OPENSEARCH.equals(definition.get("post"))) {
+            installPlugins(definition, home, options, out);
+            out.println("Configuring " + home);
+            OpenSearchConfigurer.configure(home);
+            out.println();
+            out.println("Done. Start OpenSearch, then tell Fess where it is:");
+            out.println("  SEARCH_ENGINE_HTTP_URL=http://localhost:9200");
+            out.println("  FESS_DICTIONARY_PATH=" + OpenSearchConfigurer.dictionaryPath(home));
+            return EXIT_OK;
+        }
+
         out.println();
-        out.println("Done. Start OpenSearch, then tell Fess where it is:");
-        out.println("  SEARCH_ENGINE_HTTP_URL=http://localhost:9200");
-        out.println("  FESS_DICTIONARY_PATH=" + OpenSearchConfigurer.dictionaryPath(home));
+        out.println("Done. Installed to " + home);
+        reportExecutable(definition, home, os, out);
         return EXIT_OK;
+    }
+
+    /**
+     * Prints how to point Fess at a component's executable, when the definition names one.
+     *
+     * @param definition the component
+     * @param home the extracted directory
+     * @param os the operating system
+     * @param out the stream for normal output
+     */
+    private static void reportExecutable(final ComponentDefinition definition, final Path home, final Platform.Os os,
+            final PrintStream out) {
+        final String executable = definition.executable(os);
+        final String envName = definition.get("env");
+        if (executable == null || envName == null) {
+            return;
+        }
+        final Path path = home.resolve(executable).toAbsolutePath().normalize();
+        final Path fessHomePath = Path.of(fessHome()).toAbsolutePath().normalize();
+        out.println();
+        if (path.startsWith(fessHomePath)) {
+            out.println("bin/fess.in.sh finds this on its own, so there is nothing else to do.");
+            out.println("  " + envName + "=" + path);
+        } else {
+            out.println("It is outside the Fess directory, so bin/fess.in.sh will not find it. Add this");
+            out.println("to bin/fess.in.sh (bin\\fess.in.bat on Windows) so Fess and its crawler processes can:");
+            out.println("  export " + envName + "=" + path);
+        }
     }
 
     private static void installPlugins(final ComponentDefinition definition, final Path home, final Map<String, String> options,
@@ -232,11 +270,47 @@ public final class FessSetup {
         }
     }
 
-    private static void reportProgress(final PrintStream out, final long bytes, final long total) {
+    /**
+     * Returns the Fess installation directory, which the launcher passes in.
+     *
+     * <p>Falls back to the working directory so the jar stays usable when invoked directly with
+     * {@code java -jar}, but the launcher always sets it: the default destinations are written
+     * relative to it, and bin/fess.in.sh looks for an installed Node.js under it.</p>
+     *
+     * @return the Fess home directory
+     */
+    static String fessHome() {
+        final String home = System.getProperty("fess.home");
+        return home == null || home.isBlank() ? Path.of("").toAbsolutePath().toString() : home;
+    }
+
+    /**
+     * Reports download progress, one line rewrite per completed percent.
+     *
+     * <p>The carriage return keeps a terminal on one line. Redrawing on every buffer instead
+     * would emit tens of thousands of updates for a gigabyte, which is invisible on a terminal
+     * but fills a log file when the output is redirected.</p>
+     *
+     * @param out the stream for normal output
+     * @param bytes bytes written so far
+     * @param total the total size, or -1 when unknown
+     * @param lastPercent single-element holder of the last percentage reported
+     */
+    private static void reportProgress(final PrintStream out, final long bytes, final long total, final int[] lastPercent) {
         if (total > 0) {
-            out.printf("\r  %d%% (%d/%d MiB)", bytes * 100 / total, bytes >> 20, total >> 20);
+            final int percent = (int) (bytes * 100 / total);
+            if (percent == lastPercent[0]) {
+                return;
+            }
+            lastPercent[0] = percent;
+            out.printf("\r  %d%% (%d/%d MiB)", percent, bytes >> 20, total >> 20);
         } else {
-            out.printf("\r  %d MiB", bytes >> 20);
+            final int megabytes = (int) (bytes >> 20);
+            if (megabytes == lastPercent[0]) {
+                return;
+            }
+            lastPercent[0] = megabytes;
+            out.printf("\r  %d MiB", megabytes);
         }
     }
 }

--- a/src/main/java/org/codelibs/fess/setup/Platform.java
+++ b/src/main/java/org/codelibs/fess/setup/Platform.java
@@ -90,21 +90,8 @@ public final class Platform {
     }
 
     /**
-     * Returns the OS token used in OpenSearch artifact names.
-     *
-     * @param os the operating system
-     * @return {@code "linux"} or {@code "windows"}, or {@code null} when no official build exists
-     */
-    public static String token(final Os os) {
-        return switch (os) {
-        case LINUX -> "linux";
-        case WINDOWS -> "windows";
-        default -> null;
-        };
-    }
-
-    /**
-     * Returns the archive extension OpenSearch publishes for the given OS.
+     * Returns the archive extension publishers use for the given OS. Windows gets zip; everything
+     * else gets a gzipped tar. This holds for both OpenSearch and Node.js.
      *
      * @param os the operating system
      * @return {@code "zip"} on Windows, {@code "tar.gz"} otherwise

--- a/src/main/resources/fess-setup.properties
+++ b/src/main/resources/fess-setup.properties
@@ -1,13 +1,24 @@
 # Definition of the artifacts fess-setup installs.
 #
 # Variables usable in a value: ${os} ${arch} ${archive.ext}, plus this component's own
-# attributes. Point the downloads at a mirror by editing this file inside bin/fess-setup.jar,
-# or by passing --version on the command line.
+# attributes. ${os} resolves through this component's own os.<platform> entries, because
+# publishers disagree on the token: OpenSearch says "windows" where Node.js says "win", and
+# Node.js ships darwin builds where OpenSearch ships none.
+#
+# Point the downloads at a mirror by editing this file inside bin/fess-setup.jar, or pass
+# --version on the command line.
 
 component.opensearch.version = 3.8.0
+component.opensearch.os.linux = linux
+component.opensearch.os.windows = windows
 component.opensearch.url = https://artifacts.opensearch.org/releases/bundle/opensearch/${version}/opensearch-${version}-${os}-${arch}.${archive.ext}
 component.opensearch.dir = opensearch-${version}
-component.opensearch.dest = opensearch
+component.opensearch.dest = ${fess.home}/opensearch
+component.opensearch.post = opensearch
+component.opensearch.hint.unavailable = Install it another way, then point fess-setup at it:\n\
+\  macOS:  brew install opensearch\n\
+\          bin/fess-setup install plugins --opensearch-home $(brew --prefix opensearch)\n\
+\  Docker: use the compose files instead of a local install.
 
 # The Fess-specific plugins. k-NN and Neural Search are deliberately absent: the official
 # OpenSearch bundle already ships both, and its build carries the JNI native libraries that the
@@ -18,3 +29,22 @@ component.opensearch.plugin.artifacts = org.codelibs.opensearch:opensearch-analy
                                         org.codelibs.opensearch:opensearch-analysis-extension, \
                                         org.codelibs.opensearch:opensearch-minhash, \
                                         org.codelibs.opensearch:opensearch-configsync
+
+# Node.js, needed only by the Playwright crawler. The distribution no longer bundles the five
+# Node.js binaries Playwright's driver-bundle carries (191 MiB of the zip), so a crawl
+# configured with client.crawlerClients=playwright:... needs one installed here.
+#
+# Playwright 1.62 requires Node.js 20 or later; this is the version its own bundle shipped.
+component.nodejs.version = 24.20.0
+component.nodejs.os.linux = linux
+component.nodejs.os.macos = darwin
+component.nodejs.os.windows = win
+component.nodejs.url = https://nodejs.org/dist/v${version}/node-v${version}-${os}-${arch}.${archive.ext}
+component.nodejs.dir = node-v${version}-${os}-${arch}
+component.nodejs.dest = ${fess.home}/nodejs
+# Windows puts node.exe at the root of the archive; every other platform puts it under bin/.
+component.nodejs.executable = bin/node
+component.nodejs.executable.windows = node.exe
+# Playwright reads this environment variable. A system property would not do: the crawler runs
+# in a child process that inherits the environment but not the parent's -D options.
+component.nodejs.env = PLAYWRIGHT_NODEJS_PATH

--- a/src/test/java/org/codelibs/fess/setup/DefinitionLoaderTest.java
+++ b/src/test/java/org/codelibs/fess/setup/DefinitionLoaderTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.setup;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -87,4 +88,42 @@ public class DefinitionLoaderTest {
         final Map<String, ComponentDefinition> defs = load("component.p.version=1\n");
         assertTrue(defs.get("p").list("artifacts").isEmpty());
     }
+
+    @Test
+    public void test_osToken_comesFromTheDefinition() throws Exception {
+        final Map<String, ComponentDefinition> defs =
+                load("component.nodejs.os.linux=linux\ncomponent.nodejs.os.macos=darwin\ncomponent.nodejs.os.windows=win\n");
+        final ComponentDefinition nodejs = defs.get("nodejs");
+        assertEquals("linux", nodejs.osToken(Platform.Os.LINUX));
+        assertEquals("darwin", nodejs.osToken(Platform.Os.MACOS));
+        assertEquals("win", nodejs.osToken(Platform.Os.WINDOWS));
+    }
+
+    @Test
+    public void test_osToken_absentMeansNoBuildForThatPlatform() throws Exception {
+        final Map<String, ComponentDefinition> defs =
+                load("component.opensearch.os.linux=linux\ncomponent.opensearch.os.windows=windows\n");
+        final ComponentDefinition opensearch = defs.get("opensearch");
+        assertEquals("linux", opensearch.osToken(Platform.Os.LINUX));
+        assertEquals("windows", opensearch.osToken(Platform.Os.WINDOWS));
+        assertNull(opensearch.osToken(Platform.Os.MACOS), "OpenSearch publishes no macOS build");
+        assertNull(opensearch.osToken(Platform.Os.UNKNOWN));
+    }
+
+    @Test
+    public void test_executable_perOsOverride() throws Exception {
+        final Map<String, ComponentDefinition> defs =
+                load("component.nodejs.executable=bin/node\ncomponent.nodejs.executable.windows=node.exe\n");
+        final ComponentDefinition nodejs = defs.get("nodejs");
+        assertEquals("bin/node", nodejs.executable(Platform.Os.LINUX));
+        assertEquals("bin/node", nodejs.executable(Platform.Os.MACOS));
+        assertEquals("node.exe", nodejs.executable(Platform.Os.WINDOWS));
+    }
+
+    @Test
+    public void test_executable_absentIsNull() throws Exception {
+        final Map<String, ComponentDefinition> defs = load("component.opensearch.version=3.8.0\n");
+        assertNull(defs.get("opensearch").executable(Platform.Os.LINUX));
+    }
+
 }

--- a/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
@@ -16,6 +16,8 @@
 package org.codelibs.fess.setup;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -95,4 +97,83 @@ public class FessSetupTest {
         assertEquals("3.8.0", defs.get("opensearch").get("version"));
         assertEquals(4, defs.get("opensearch").list("plugin.artifacts").size());
     }
+
+    @Test
+    public void test_loadDefinitions_opensearchPlatforms() throws Exception {
+        final ComponentDefinition opensearch = FessSetup.loadDefinitions().get("opensearch");
+        assertEquals("linux", opensearch.osToken(Platform.Os.LINUX));
+        assertEquals("windows", opensearch.osToken(Platform.Os.WINDOWS));
+        assertNull(opensearch.osToken(Platform.Os.MACOS), "OpenSearch publishes no macOS build");
+        assertNotNull(opensearch.get("hint.unavailable"), "macOS users need a way forward");
+        assertTrue(opensearch.get("hint.unavailable").contains("brew"), opensearch.get("hint.unavailable"));
+    }
+
+    @Test
+    public void test_loadDefinitions_nodejsForPlaywright() throws Exception {
+        final Map<String, ComponentDefinition> defs = FessSetup.loadDefinitions();
+        assertTrue(defs.containsKey("nodejs"), defs.keySet().toString());
+        final ComponentDefinition nodejs = defs.get("nodejs");
+        assertEquals("linux", nodejs.osToken(Platform.Os.LINUX));
+        assertEquals("darwin", nodejs.osToken(Platform.Os.MACOS));
+        assertEquals("win", nodejs.osToken(Platform.Os.WINDOWS));
+        assertEquals("bin/node", nodejs.executable(Platform.Os.LINUX));
+        assertEquals("node.exe", nodejs.executable(Platform.Os.WINDOWS));
+        assertEquals("PLAYWRIGHT_NODEJS_PATH", nodejs.get("env"));
+    }
+
+    @Test
+    public void test_loadDefinitions_nodejsUrlResolves() throws Exception {
+        final ComponentDefinition nodejs = FessSetup.loadDefinitions().get("nodejs");
+        final String url =
+                nodejs.resolve("url", Map.of("os", "darwin", "arch", "arm64", "archive.ext", "tar.gz", "version", nodejs.get("version")));
+        assertTrue(url.startsWith("https://nodejs.org/dist/v"), url);
+        assertTrue(url.endsWith("-darwin-arm64.tar.gz"), url);
+    }
+
+    @Test
+    public void test_list_showsBothComponents() {
+        assertEquals(0, run("list"));
+        assertTrue(out().contains("opensearch"), out());
+        assertTrue(out().contains("nodejs"), out());
+    }
+
+    @Test
+    public void test_fessHome_comesFromTheLauncher() {
+        final String original = System.getProperty("fess.home");
+        try {
+            System.setProperty("fess.home", "/opt/fess");
+            assertEquals("/opt/fess", FessSetup.fessHome());
+        } finally {
+            if (original == null) {
+                System.clearProperty("fess.home");
+            } else {
+                System.setProperty("fess.home", original);
+            }
+        }
+    }
+
+    @Test
+    public void test_fessHome_fallsBackToTheWorkingDirectory() {
+        final String original = System.getProperty("fess.home");
+        try {
+            System.clearProperty("fess.home");
+            final String home = FessSetup.fessHome();
+            assertNotNull(home);
+            assertTrue(java.nio.file.Path.of(home).isAbsolute(), home);
+        } finally {
+            if (original != null) {
+                System.setProperty("fess.home", original);
+            }
+        }
+    }
+
+    @Test
+    public void test_destinationsAreRelativeToFessHome() throws Exception {
+        final Map<String, ComponentDefinition> defs = FessSetup.loadDefinitions();
+        for (final String name : new String[] { "opensearch", "nodejs" }) {
+            final String dest = defs.get(name).resolve("dest", Map.of("fess.home", "/opt/fess"));
+            assertTrue(dest.startsWith("/opt/fess/"), name + " -> " + dest);
+        }
+    }
+
 }

--- a/src/test/java/org/codelibs/fess/setup/PlatformTest.java
+++ b/src/test/java/org/codelibs/fess/setup/PlatformTest.java
@@ -42,14 +42,6 @@ public class PlatformTest {
     }
 
     @Test
-    public void test_token_macosHasNoOfficialBuild() {
-        assertEquals("linux", Platform.token(Platform.Os.LINUX));
-        assertEquals("windows", Platform.token(Platform.Os.WINDOWS));
-        assertNull(Platform.token(Platform.Os.MACOS));
-        assertNull(Platform.token(Platform.Os.UNKNOWN));
-    }
-
-    @Test
     public void test_archiveExt() {
         assertEquals("tar.gz", Platform.archiveExt(Platform.Os.LINUX));
         assertEquals("zip", Platform.archiveExt(Platform.Os.WINDOWS));


### PR DESCRIPTION
> Stacked on #3408. Review that one first; this branch is a single commit on top of it.

## Summary

`driver-bundle` is five Node.js binaries, one per platform, and nothing else. It was **191 MiB of a 410 MiB distribution, for a crawler that does nothing unless a crawl config names it**. The zip drops to **218.9 MiB — half its original 438.5 MiB**.

| | zip |
|---|---:|
| 15.9 base | 438.5 MiB |
| after #3408 (OpenSearch decoupled) | 410.1 MiB |
| **after this PR** | **218.9 MiB (−50.1%)** |

## Why this is safe now and would not have been before

From Playwright **1.62.0**, `DriverJar` and `driver/package` live in `com.microsoft.playwright:driver`, and `driver-bundle` carries only the node executables. In **1.60 and earlier the split was the other way round** — excluding `driver-bundle` there would have taken the driver itself away. The exclusion carries that note, because a downgrade of `crawler.playwright.version` would silently break it.

## How Node.js gets there

```
bin/fess-setup install nodejs
```

`bin/fess.in.sh` then finds it under `FESS_HOME/nodejs` and exports `PLAYWRIGHT_NODEJS_PATH`.

It has to be an **environment variable**, not a `-D` option: `CrawlJob` runs the crawler in a child process that passes through only `fess.config.*` and `fess.system.*` system properties, while `ProcessBuilder` inherits the parent environment wholesale. Playwright also never consults `PATH` — it wants a full path to the executable.

## What generalising the setup tool required

Adding a second component exposed three things that were OpenSearch-shaped:

- **The OS token moved into the definition file.** Publishers disagree: OpenSearch says `windows` where Node.js says `win`, and Node.js ships `darwin` builds where OpenSearch ships none. `Platform` no longer decides this.
- **The executable path moved there too.** Windows puts `node.exe` at the root of the archive; every other platform puts `node` under `bin/`.
- **`FESS_HOME` now reaches the jar** as `-Dfess.home`. Default destinations resolve against it, so installing from another directory no longer puts files where `fess.in.sh` will not look.

Download progress redraws once per completed percent. Redrawing on every buffer is invisible on a terminal but produced about 160,000 lines when piped to a file.

## Verification

Built the zip and ran it against a real OpenSearch (`ghcr.io/codelibs/fess-opensearch:3.8.0`) on macOS arm64.

| Check | Result |
|---|---|
| `driver-bundle` absent, `driver-1.62.0.jar` (3.1 MB) present | pass |
| `bin/fess-setup install nodejs` | downloaded 50 MiB, extracted under `FESS_HOME/nodejs` |
| `node --version` from the installed copy | `v24.20.0` |
| `fess.in.sh` auto-discovers and exports it | pass |
| An explicitly set `PLAYWRIGHT_NODEJS_PATH` wins | pass |
| The value is visible to a child process | pass |
| `Playwright.create()` **without** the variable | fails with the upstream message naming both fixes |
| `Playwright.create()` **with** the exported value | `Playwright created OK without driver-bundle` |
| Setup unit tests | 53 pass |

## Upgrade note

This is breaking for anyone using the Playwright crawler: without a Node.js the first crawl fails. The error names both remedies, and `bin/fess-setup install nodejs` is one command. Everyone else is unaffected — the crawler is opt-in via `client.crawlerClients=playwright:...`.
