### PR TITLE
fix: drop the removed storage protocol from the compiled default

### DIFF
--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -443,7 +443,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. http,https */
     String CRAWLER_WEB_PROTOCOLS = "crawler.web.protocols";
 
-    /** The key of the configuration. e.g. file,smb,smb1,ftp,storage,s3,gcs */
+    /** The key of the configuration. e.g. file,smb,smb1,ftp,s3,gcs */
     String CRAWLER_FILE_PROTOCOLS = "crawler.file.protocols";
 
     /** The key of the configuration. e.g. ^FESS_ENV_.* */
@@ -14560,7 +14560,7 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.CRAWLER_DOCUMENT_FULLSTOP_CHARS, "u002eu06d4u2e3cu3002");
             defaultMap.put(FessConfig.CRAWLER_CRAWLING_DATA_ENCODING, "UTF-8");
             defaultMap.put(FessConfig.CRAWLER_WEB_PROTOCOLS, "http,https");
-            defaultMap.put(FessConfig.CRAWLER_FILE_PROTOCOLS, "file,smb,smb1,ftp,storage,s3,gcs");
+            defaultMap.put(FessConfig.CRAWLER_FILE_PROTOCOLS, "file,smb,smb1,ftp,s3,gcs");
             defaultMap.put(FessConfig.CRAWLER_DATA_ENV_PARAM_KEY_PATTERN, "^FESS_ENV_.*");
             defaultMap.put(FessConfig.CRAWLER_IGNORE_ROBOTS_TXT, "false");
             defaultMap.put(FessConfig.CRAWLER_IGNORE_ROBOTS_TAGS, "false");


### PR DESCRIPTION
## Summary

15.9 removed the `storage` crawl protocol and updated `fess_config.properties` accordingly, but the default compiled into `FessConfig` still lists it.

| source | value |
|---|---|
| `fess_config.properties:386` | `file,smb,smb1,ftp,s3,gcs` |
| `FessConfig.java:14563` | `file,smb,smb1,ftp,`**`storage`**`,s3,gcs` |

The javadoc for the same key disagrees with itself too: line 446 says `storage` is in the default, line 3574 says it is not.

## Why it matters

The shipped properties file normally answers this key, so a stock installation never sees the compiled value. It shows up where the file does not answer:

- an installation that carried an older `fess_config.properties` across an upgrade, which is exactly what the upgrade guide tells people to do
- a deployment that supplies only its own overrides

Those get a protocol the product no longer implements. Nothing crashes — `ProtocolHelper` ignores a protocol with no registered handler — but it is the value an operator reads when they check what the default is, and it is wrong.

## Scope

Found while auditing the 15.9 tree for [#3408](https://github.com/codelibs/fess/pull/3408); it predates that branch and is independent of it, so it is here on its own.

`FessPropTest` and the rest of the `direction` package pass (145 tests).
