### PR TITLE
fix(boostdoc): report a boost rule whose script engine is missing

### DIFF
--- a/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
+++ b/src/main/java/org/codelibs/fess/indexer/DocBoostMatcher.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.indexer;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,6 +24,7 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.opensearch.config.exentity.BoostDocumentRule;
 import org.codelibs.fess.exception.ScriptEngineException;
+import org.codelibs.fess.script.ScriptEngineFactory;
 import org.codelibs.fess.util.ComponentUtil;
 
 /**
@@ -43,6 +45,9 @@ public class DocBoostMatcher {
 
     /** The script engine type used for expression evaluation */
     private final String scriptType;
+
+    /** Guards the missing-engine warning so a rule reports it once, not once per document. */
+    private final AtomicBoolean missingEngineReported = new AtomicBoolean();
 
     /**
      * Default constructor that creates a DocBoostMatcher with default script type.
@@ -102,14 +107,29 @@ public class DocBoostMatcher {
      * document from being indexed. This is the one caller for which that holds; everywhere else
      * a script that cannot be evaluated is reported.
      * </p>
+     * <p>
+     * A missing engine is the other thing entirely. The rule then matches nothing, ever, and no
+     * expression the administrator writes can change that -- a rule saved before 15.9 carries no
+     * script type and so runs on Groovy, which now ships as a plugin. Left at debug it looks
+     * exactly like a rule whose expressions never fit, so it is reported at warn instead, once
+     * per rule rather than once per crawled document.
+     * </p>
      *
      * @param expression the expression to evaluate
      * @param map the document data
      * @return the result, or null when the expression did not apply to this document
      */
     protected Object evaluate(final String expression, final Map<String, Object> map) {
+        final ScriptEngineFactory scriptEngineFactory = ComponentUtil.getScriptEngineFactory();
+        if (!scriptEngineFactory.hasScriptEngine(scriptType)) {
+            if (missingEngineReported.compareAndSet(false, true)) {
+                logger.warn("No script engine is registered for {}, so the document boost rule \"{}\" boosts nothing."
+                        + " Install the plugin providing it, such as fess-script-groovy for groovy.", scriptType, matchExpression);
+            }
+            return null;
+        }
         try {
-            return ComponentUtil.getScriptEngineFactory().getScriptEngine(scriptType).evaluate(expression, map);
+            return scriptEngineFactory.getScriptEngine(scriptType).evaluate(expression, map);
         } catch (final ScriptEngineException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("The boost expression did not apply to the document: expression={}", expression, e);

--- a/src/test/java/org/codelibs/fess/indexer/DocBoostMatcherTest.java
+++ b/src/test/java/org/codelibs/fess/indexer/DocBoostMatcherTest.java
@@ -16,12 +16,16 @@
 package org.codelibs.fess.indexer;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.Level;
 import org.codelibs.fess.Constants;
+import org.codelibs.fess.exception.ScriptEngineException;
 import org.codelibs.fess.opensearch.config.exentity.BoostDocumentRule;
 import org.codelibs.fess.script.ScriptEngineFactory;
 import org.codelibs.fess.script.javascript.JavaScriptEngine;
+import org.codelibs.fess.unit.LogCapturingAppender;
 import org.codelibs.fess.unit.UnitFessTestCase;
 import org.codelibs.fess.util.ComponentUtil;
 import org.junit.jupiter.api.Test;
@@ -261,5 +265,70 @@ public class DocBoostMatcherTest extends UnitFessTestCase {
         legacy.setUrlExpr("url != null");
         legacy.setBoostExpr("1");
         assertEquals(Constants.LEGACY_SCRIPT, new DocBoostMatcher(legacy).getScriptType());
+    }
+
+    /**
+     * A rule saved before 15.9 carries no script type, so it runs on Groovy, and Groovy now
+     * ships as a plugin. With the plugin absent the rule can never match: that has to be said
+     * out loud, and said once rather than once per crawled document.
+     */
+    @Test
+    public void test_missingEngineIsReportedOncePerRule() {
+        final ScriptEngineFactory factory = new ScriptEngineFactory();
+        factory.add(Constants.DEFAULT_SCRIPT, (template, paramMap) -> Boolean.TRUE);
+        ComponentUtil.register(factory, "scriptEngineFactory");
+
+        final BoostDocumentRule rule = new BoostDocumentRule();
+        rule.setUrlExpr("url != null");
+        rule.setBoostExpr("100");
+        final DocBoostMatcher docBoostMatcher = new DocBoostMatcher(rule);
+        assertEquals(Constants.LEGACY_SCRIPT, docBoostMatcher.getScriptType());
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put("url", "http://example.com/");
+
+        final LogCapturingAppender appender = LogCapturingAppender.attach(DocBoostMatcher.class.getName(), Level.WARN);
+        try {
+            assertFalse(docBoostMatcher.match(map));
+            assertTrue(0.0f == docBoostMatcher.getValue(map));
+            assertFalse(docBoostMatcher.match(map));
+
+            final List<String> warnings = appender.warnings();
+            assertEquals(1, warnings.size());
+            assertTrue(warnings.get(0).contains(Constants.LEGACY_SCRIPT));
+            assertTrue(warnings.get(0).contains("fess-script-groovy"));
+        } finally {
+            appender.detach();
+        }
+    }
+
+    /**
+     * The engine is there and the expression simply does not fit this document. Every crawled
+     * document is offered to every rule, so that is the ordinary case and must stay quiet.
+     */
+    @Test
+    public void test_expressionThatDoesNotApplyIsNotReported() {
+        final ScriptEngineFactory factory = new ScriptEngineFactory();
+        factory.add(Constants.LEGACY_SCRIPT, (template, paramMap) -> {
+            throw new ScriptEngineException("data1 is not defined");
+        });
+        ComponentUtil.register(factory, "scriptEngineFactory");
+
+        final BoostDocumentRule rule = new BoostDocumentRule();
+        rule.setUrlExpr("data1 > 10");
+        rule.setBoostExpr("100");
+        final DocBoostMatcher docBoostMatcher = new DocBoostMatcher(rule);
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put("url", "http://example.com/");
+
+        final LogCapturingAppender appender = LogCapturingAppender.attach(DocBoostMatcher.class.getName(), Level.WARN);
+        try {
+            assertFalse(docBoostMatcher.match(map));
+            assertTrue(0.0f == docBoostMatcher.getValue(map));
+            assertTrue(appender.warnings().isEmpty());
+        } finally {
+            appender.detach();
+        }
     }
 }


### PR DESCRIPTION
## Problem

A document boost rule saved before 15.9 carries no script type, so `DocBoostMatcher`
falls back to `Constants.LEGACY_SCRIPT` (`groovy`). Groovy ships as a plugin rather
than in the core, so on an installation without `fess-script-groovy` every such rule
matches nothing.

`ScriptEngineFactory#getScriptEngine` throws a helpful `ScriptEngineException` naming
the missing plugin, but `DocBoostMatcher#evaluate` caught it and logged at debug. At
the default log level the rule just quietly stopped boosting.

## Change

`evaluate` now separates the two failure modes that were sharing one catch block:

- **The expression did not apply to this document.** Every crawled document is offered
  to every rule, and most expressions name fields the document does not carry, so this
  is the ordinary case. Unchanged: debug, and the document is still indexed.
- **No engine is registered for the rule's script type.** No expression the
  administrator writes can fix this. Checked with `hasScriptEngine` before evaluation
  and reported at warn, naming the plugin that would provide the engine.

The warning fires once per rule, guarded by an `AtomicBoolean`. A rule is consulted for
every document in the crawl, so reporting per evaluation would bury the log.

`PathMappingHelper#resolveEngineMatcher` already reports its own missing engine and is
unchanged.

## Tests

Two tests in `DocBoostMatcherTest`, both using the existing `LogCapturingAppender`:

- `test_missingEngineIsReportedOncePerRule` — a rule with no script type against a
  factory holding only JavaScript: three evaluations produce exactly one warning, which
  names `groovy` and `fess-script-groovy`. Fails on the previous code with 0 warnings.
- `test_expressionThatDoesNotApplyIsNotReported` — the engine is registered and throws:
  no warning. This is the regression guard for the quiet path.

`mvn test -Dtest='DocBoostMatcherTest,PathMappingHelperTest,IndexUpdaterTest,ScriptEngineFactoryTest'`
→ 107 tests, 0 failures.
