### PR TITLE
feat(setup): install and remove Fess plugins from the command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,10 @@
 							<archive>
 								<manifest>
 									<mainClass>org.codelibs.fess.setup.FessSetup</mainClass>
+									<!-- Implementation-Version is how `install plugin` learns which plugin
+									     release fits this build, so it does not have to be repeated in
+									     fess-setup.properties and kept in step by hand. -->
+									<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 								</manifest>
 							</archive>
 						</configuration>

--- a/src/main/assemblies/files/fess-setup
+++ b/src/main/assemblies/files/fess-setup
@@ -1,11 +1,17 @@
 #!/bin/sh
 
-# Installs the artifacts Fess needs but does not bundle -- OpenSearch and its Fess plugins.
-# Run it once before starting Fess for the first time:
+# Installs the artifacts Fess needs but does not bundle. Run it once before starting Fess for
+# the first time:
 #
 #     bin/fess-setup install opensearch
 #
-# See bin/fess-setup for the other commands, or run it with no arguments.
+# It also installs Fess plugins and, for the Playwright crawler, Node.js:
+#
+#     bin/fess-setup list plugins
+#     bin/fess-setup install plugin fess-script-groovy
+#     bin/fess-setup install nodejs
+#
+# Run it with no arguments for the full list of commands.
 
 SCRIPT="$0"
 

--- a/src/main/assemblies/files/fess-setup.bat
+++ b/src/main/assemblies/files/fess-setup.bat
@@ -1,9 +1,18 @@
 @echo off
 
-REM Installs the artifacts Fess needs but does not bundle -- OpenSearch and its Fess plugins.
-REM Run it once before starting Fess for the first time:
+REM Installs the artifacts Fess needs but does not bundle. Run it once before starting Fess for
+REM the first time:
 REM
 REM     bin\fess-setup install opensearch
+REM
+REM It also installs the Fess plugins into an OpenSearch you already have, Fess plugins, and
+REM Node.js for the Playwright crawler:
+REM
+REM     bin\fess-setup install opensearch-plugins --opensearch-home C:\opensearch-3.8.0
+REM     bin\fess-setup install plugin fess-script-groovy
+REM     bin\fess-setup install nodejs
+REM
+REM Run it with no arguments for the full list of commands.
 
 SETLOCAL
 

--- a/src/main/java/org/codelibs/fess/setup/Downloader.java
+++ b/src/main/java/org/codelibs/fess/setup/Downloader.java
@@ -23,6 +23,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
@@ -53,6 +54,35 @@ public final class Downloader {
     }
 
     private Downloader() {
+    }
+
+    /**
+     * Reads {@code uri} into a string.
+     *
+     * <p>For the small documents that describe what to download -- a {@code maven-metadata.xml},
+     * a repository's directory index -- rather than the artifacts themselves.</p>
+     *
+     * @param uri the source
+     * @return the body, decoded as UTF-8
+     * @throws SetupException if the request fails or the server does not answer 200
+     */
+    public static String readString(final URI uri) throws SetupException {
+        try (HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build()) {
+            final HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+            final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            if (response.statusCode() != 200) {
+                throw new SetupException("Failed to read " + uri + ": HTTP " + response.statusCode());
+            }
+            return response.body();
+        } catch (final IOException e) {
+            throw new SetupException("Failed to read " + uri, e);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SetupException("Interrupted while reading " + uri, e);
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
+++ b/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Installs Fess plugins as jars under the webapp's plugin directory.
+ *
+ * <p>Nothing unpacks or registers them: Fess scans {@code WEB-INF/plugin} at context start and
+ * the admin UI installs them by copying the jar there, so this does the same thing from the
+ * command line. Unlike an OpenSearch plugin there is no installer tool to delegate to, and
+ * unlike the other components in {@code fess-setup.properties} there is no archive to extract.</p>
+ *
+ * <p>The jars are deliberately not inspected. A plugin that contributes classes to the webapp
+ * carries a {@code Fess-WebAppJar} manifest attribute, but a data store, a theme, an ingester and
+ * a thumbnail generator do not, so requiring the attribute would reject most of the catalogue.</p>
+ */
+public final class FessPluginInstaller {
+
+    /** The prefixes {@code PluginHelper.ArtifactType} recognises, which is what Fess can load. */
+    private static final String[] PLUGIN_PREFIXES =
+            { "fess-ds", "fess-theme", "fess-ingest", "fess-script", "fess-webapp", "fess-thumbnail", "fess-crawler", "fess-llm" };
+
+    private static final String JAR = ".jar";
+
+    private FessPluginInstaller() {
+    }
+
+    /**
+     * Returns the directory Fess loads plugins from.
+     *
+     * @param fessHome the Fess installation directory
+     * @return the plugin directory
+     */
+    public static Path directory(final String fessHome) {
+        return Path.of(fessHome, "app", "WEB-INF", "plugin");
+    }
+
+    /**
+     * Returns the file name a plugin jar is installed under, which is the Maven layout's.
+     *
+     * @param artifactId the plugin name
+     * @param version the plugin version
+     * @return the file name
+     */
+    public static String jarName(final String artifactId, final String version) {
+        return artifactId + "-" + version + JAR;
+    }
+
+    /**
+     * Reports whether a file name is a jar of the given plugin.
+     *
+     * <p>A prefix test alone is not enough. {@code fess-webapp-mcp-client-1.0.jar} starts with
+     * {@code fess-webapp-mcp-}, so matching on the prefix would make
+     * {@code remove plugin fess-webapp-mcp} delete a different plugin. What follows the name has
+     * to look like a version, which for these artifacts means it starts with a digit.</p>
+     *
+     * @param fileName the file name to test
+     * @param artifactId the plugin name
+     * @return true if the file is a jar of that plugin
+     */
+    public static boolean isJarOf(final String fileName, final String artifactId) {
+        final String prefix = artifactId + "-";
+        if (!fileName.endsWith(JAR) || !fileName.startsWith(prefix)) {
+            return false;
+        }
+        final String version = fileName.substring(prefix.length(), fileName.length() - JAR.length());
+        return !version.isEmpty() && Character.isDigit(version.charAt(0));
+    }
+
+    /**
+     * Returns the version part of a plugin jar's file name.
+     *
+     * @param fileName the file name
+     * @param artifactId the plugin name
+     * @return the version, or {@code null} when the file is not a jar of that plugin
+     */
+    public static String versionOf(final String fileName, final String artifactId) {
+        if (!isJarOf(fileName, artifactId)) {
+            return null;
+        }
+        return fileName.substring(artifactId.length() + 1, fileName.length() - JAR.length());
+    }
+
+    /**
+     * Lists the installed jars of one plugin, in file name order.
+     *
+     * <p>More than one is possible: nothing stops two versions of a plugin sitting side by side,
+     * and both would then load.</p>
+     *
+     * @param directory the plugin directory
+     * @param artifactId the plugin name
+     * @return the jars, empty when the plugin or the directory is absent
+     * @throws SetupException if the directory cannot be read
+     */
+    public static List<Path> installedJars(final Path directory, final String artifactId) throws SetupException {
+        return list(directory, path -> isJarOf(path.getFileName().toString(), artifactId));
+    }
+
+    /**
+     * Lists every installed plugin jar, in file name order.
+     *
+     * @param directory the plugin directory
+     * @return the jars, empty when the directory is absent
+     * @throws SetupException if the directory cannot be read
+     */
+    public static List<Path> installed(final Path directory) throws SetupException {
+        return list(directory, path -> {
+            final String name = path.getFileName().toString();
+            if (!name.endsWith(JAR)) {
+                return false;
+            }
+            for (final String prefix : PLUGIN_PREFIXES) {
+                if (name.startsWith(prefix + "-")) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    private static List<Path> list(final Path directory, final Predicate<Path> accepted) throws SetupException {
+        if (!Files.isDirectory(directory)) {
+            return List.of();
+        }
+        try (Stream<Path> entries = Files.list(directory)) {
+            return entries.filter(Files::isRegularFile)
+                    .filter(accepted)
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .toList();
+        } catch (final IOException e) {
+            throw new SetupException("Failed to read the plugin directory " + directory, e);
+        }
+    }
+
+    /**
+     * Deletes every installed jar of one plugin.
+     *
+     * @param directory the plugin directory
+     * @param artifactId the plugin name
+     * @return the jars that were deleted, empty when the plugin was not installed
+     * @throws SetupException if a jar cannot be deleted
+     */
+    public static List<Path> remove(final Path directory, final String artifactId) throws SetupException {
+        final List<Path> removed = new ArrayList<>();
+        for (final Path jar : installedJars(directory, artifactId)) {
+            try {
+                Files.delete(jar);
+                removed.add(jar);
+            } catch (final IOException e) {
+                throw new SetupException("Failed to delete " + jar, e);
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Deletes the other installed versions of a plugin, keeping one jar.
+     *
+     * <p>Two versions of a plugin in the directory both load, so an install has to leave only
+     * one behind. The jar to keep is named rather than derived so that this runs <em>after</em>
+     * the download: deleting first would leave an installation with no plugin at all when the
+     * download then fails.</p>
+     *
+     * @param directory the plugin directory
+     * @param artifactId the plugin name
+     * @param keep the jar to leave in place
+     * @return the jars that were deleted
+     * @throws SetupException if a jar cannot be deleted
+     */
+    public static List<Path> removeOtherVersions(final Path directory, final String artifactId, final Path keep) throws SetupException {
+        final List<Path> removed = new ArrayList<>();
+        for (final Path jar : installedJars(directory, artifactId)) {
+            if (jar.equals(keep)) {
+                continue;
+            }
+            try {
+                Files.delete(jar);
+                removed.add(jar);
+            } catch (final IOException e) {
+                throw new SetupException("Failed to delete " + jar, e);
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Reduces a Fess version to the {@code major.minor} a plugin release is published against.
+     *
+     * @param fessVersion the Fess version, such as {@code 15.9.0} or {@code 15.9.0-SNAPSHOT}
+     * @return the major.minor part
+     * @throws SetupException if the version is not in that shape
+     */
+    public static String productVersion(final String fessVersion) throws SetupException {
+        final String[] parts = fessVersion.split("[.\\-]");
+        if (parts.length >= 2 && isNumber(parts[0]) && isNumber(parts[1])) {
+            return parts[0] + "." + parts[1];
+        }
+        throw new SetupException("Could not tell which plugin version fits Fess " + fessVersion + ". Name one with --version <version>.");
+    }
+
+    private static boolean isNumber(final String part) {
+        return !part.isEmpty() && part.chars().allMatch(Character::isDigit);
+    }
+}

--- a/src/main/java/org/codelibs/fess/setup/FessSetup.java
+++ b/src/main/java/org/codelibs/fess/setup/FessSetup.java
@@ -21,6 +21,7 @@ import java.io.PrintStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -39,6 +40,9 @@ public final class FessSetup {
     /** Post-install hook that installs the Fess plugins and writes configsync.config_path. */
     private static final String POST_OPENSEARCH = "opensearch";
 
+    /** The definition holding where Fess plugins come from and go, rather than a download. */
+    private static final String PLUGIN_COMPONENT = "plugin";
+
     private static final int EXIT_OK = 0;
 
     private static final int EXIT_FAILED = 1;
@@ -53,11 +57,24 @@ public final class FessSetup {
                   Download OpenSearch, install the Fess plugins into it and configure it.
                   Official builds exist for Linux and Windows only.
 
-              install plugins --opensearch-home <dir> [--version <version>]
-                  Install the Fess plugins into an OpenSearch you already have.
+              install opensearch-plugins --opensearch-home <dir> [--version <version>]
+                  Install the Fess plugins into an OpenSearch you already have, in place of
+                  running its bin/opensearch-plugin four times by hand.
+
+              install nodejs [--dest <dir>] [--version <version>]
+                  Download Node.js, which the Playwright crawler needs.
+
+              install plugin <name>... [--version <version>] [--repository <url>]
+                  Install Fess plugins, for example fess-script-groovy or fess-ds-git.
+
+              remove plugin <name>...
+                  Delete installed Fess plugins.
 
               list
                   Show the components this build knows how to install.
+
+              list plugins [--repository <url>]
+                  Show the Fess plugins published for this version, and which are installed.
             """;
 
     private FessSetup() {
@@ -88,8 +105,9 @@ public final class FessSetup {
         try {
             final Map<String, ComponentDefinition> definitions = loadDefinitions();
             return switch (args[0]) {
-            case "list" -> list(definitions, out);
+            case "list" -> list(args, definitions, out, err);
             case "install" -> install(args, definitions, out, err);
+            case "remove" -> remove(args, definitions, out, err);
             default -> {
                 err.println(USAGE);
                 yield EXIT_USAGE;
@@ -119,12 +137,79 @@ public final class FessSetup {
         }
     }
 
-    private static int list(final Map<String, ComponentDefinition> definitions, final PrintStream out) {
+    private static int list(final String[] args, final Map<String, ComponentDefinition> definitions, final PrintStream out,
+            final PrintStream err) throws SetupException {
+        if (args.length > 1) {
+            if (!"plugins".equals(args[1])) {
+                err.println("error: unknown list target: " + args[1]);
+                err.println(USAGE);
+                return EXIT_USAGE;
+            }
+            return listPlugins(definitions, parseOptions(args, 2), out);
+        }
         definitions.forEach((name, definition) -> {
+            // A definition without a URL describes where something comes from rather than a
+            // download of its own: the plugin definition is one, and `install plugin` uses it.
+            if (definition.get("url") == null) {
+                return;
+            }
             final String version = definition.get("version");
             out.println(version == null ? name : name + "  " + version);
         });
         return EXIT_OK;
+    }
+
+    /**
+     * Prints the plugins the repository publishes for this Fess, marking the installed ones.
+     *
+     * @param definitions the setup definition
+     * @param options the command line options
+     * @param out the stream for normal output
+     * @return 0
+     * @throws SetupException if the repository or the plugin directory cannot be read
+     */
+    private static int listPlugins(final Map<String, ComponentDefinition> definitions, final Map<String, String> options,
+            final PrintStream out) throws SetupException {
+        final ComponentDefinition definition = definitions.get(PLUGIN_COMPONENT);
+        final String repository = options.getOrDefault("repository", definition.get("repository"));
+        final Path directory = pluginDirectory(definition, options);
+        final List<String> published = PluginRepository.namesFromListing(Downloader.readString(URI.create(repository)));
+        for (final String name : published) {
+            final String versions = installedVersions(directory, name);
+            out.println(versions == null ? "  " + name : "  " + name + "  (installed: " + versions + ")");
+        }
+
+        // A plugin built locally, or one published somewhere else, is installed but not listed
+        // above. Saying nothing about it would make `list plugins` look as though it had lost it.
+        final List<String> unlisted = new ArrayList<>();
+        for (final Path jar : FessPluginInstaller.installed(directory)) {
+            if (published.stream().noneMatch(name -> FessPluginInstaller.isJarOf(jar.getFileName().toString(), name))) {
+                unlisted.add(jar.getFileName().toString());
+            }
+        }
+        if (!unlisted.isEmpty()) {
+            out.println();
+            out.println("Installed but not published by " + repository + ":");
+            unlisted.forEach(name -> out.println("  " + name));
+        }
+        return EXIT_OK;
+    }
+
+    /**
+     * Returns the installed versions of a plugin as a comma-separated string.
+     *
+     * @param directory the plugin directory
+     * @param artifactId the plugin name
+     * @return the versions, or {@code null} when the plugin is not installed
+     * @throws SetupException if the plugin directory cannot be read
+     */
+    private static String installedVersions(final Path directory, final String artifactId) throws SetupException {
+        final List<Path> jars = FessPluginInstaller.installedJars(directory, artifactId);
+        if (jars.isEmpty()) {
+            return null;
+        }
+        return String.join(", ",
+                jars.stream().map(jar -> FessPluginInstaller.versionOf(jar.getFileName().toString(), artifactId)).toList());
     }
 
     private static int install(final String[] args, final Map<String, ComponentDefinition> definitions, final PrintStream out,
@@ -135,15 +220,18 @@ public final class FessSetup {
         }
         final String target = args[1];
         final Map<String, String> options = parseOptions(args, 2);
-        if ("plugins".equals(target)) {
+        if ("opensearch-plugins".equals(target)) {
             final String home = options.get("opensearch-home");
             if (home == null) {
-                err.println("error: install plugins requires --opensearch-home <dir>");
+                err.println("error: install opensearch-plugins requires --opensearch-home <dir>");
                 err.println(USAGE);
                 return EXIT_USAGE;
             }
             installPlugins(definitions.get("opensearch"), Path.of(home), options, out);
             return EXIT_OK;
+        }
+        if (PLUGIN_COMPONENT.equals(target)) {
+            return installFessPlugins(args, definitions, options, out, err);
         }
         final ComponentDefinition definition = definitions.get(target);
         if (definition == null) {
@@ -151,6 +239,155 @@ public final class FessSetup {
             return EXIT_FAILED;
         }
         return installComponent(definition, options, out, err);
+    }
+
+    /**
+     * Installs Fess plugins into the webapp's plugin directory.
+     *
+     * <p>The version is resolved from the repository unless the caller names one, so that
+     * {@code install plugin fess-ds-git} picks the latest release built for this Fess rather
+     * than whatever is newest.</p>
+     *
+     * @param args the command line
+     * @param definitions the setup definition
+     * @param options the parsed options
+     * @param out the stream for normal output
+     * @param err the stream for errors
+     * @return 0 on success, 2 when no plugin was named
+     * @throws SetupException if a download or a file operation fails
+     */
+    private static int installFessPlugins(final String[] args, final Map<String, ComponentDefinition> definitions,
+            final Map<String, String> options, final PrintStream out, final PrintStream err) throws SetupException {
+        final List<String> artifactIds = positionals(args, 2);
+        if (artifactIds.isEmpty()) {
+            err.println("error: install plugin requires at least one plugin name, for example:");
+            err.println("  fess-setup install plugin fess-script-groovy");
+            err.println("Run `fess-setup list plugins` to see what is published.");
+            return EXIT_USAGE;
+        }
+        final ComponentDefinition definition = definitions.get(PLUGIN_COMPONENT);
+        final String repository = options.getOrDefault("repository", definition.get("repository"));
+        final Path directory = pluginDirectory(definition, options);
+        for (final String artifactId : artifactIds) {
+            final String version = options.containsKey("version") ? options.get("version") : resolveVersion(repository, artifactId);
+            final Path jar = directory.resolve(FessPluginInstaller.jarName(artifactId, version));
+            final String url = PluginRepository.jarUrl(repository, artifactId, version);
+            out.println("Downloading " + url);
+            final int[] lastPercent = { -1 };
+            Downloader.download(URI.create(url), jar, (bytes, total) -> reportProgress(out, bytes, total, lastPercent));
+            out.println();
+            for (final Path previous : FessPluginInstaller.removeOtherVersions(directory, artifactId, jar)) {
+                out.println("Removed the previous " + previous.getFileName());
+            }
+            out.println("Installed " + jar);
+        }
+        out.println();
+        out.println("Restart Fess to load " + (artifactIds.size() == 1 ? "it." : "them."));
+        return EXIT_OK;
+    }
+
+    /**
+     * Deletes installed Fess plugins.
+     *
+     * @param args the command line
+     * @param definitions the setup definition
+     * @param out the stream for normal output
+     * @param err the stream for errors
+     * @return 0 on success, 2 on a usage error
+     * @throws SetupException if a jar cannot be deleted
+     */
+    private static int remove(final String[] args, final Map<String, ComponentDefinition> definitions, final PrintStream out,
+            final PrintStream err) throws SetupException {
+        if (args.length < 2 || !PLUGIN_COMPONENT.equals(args[1])) {
+            err.println(USAGE);
+            return EXIT_USAGE;
+        }
+        final List<String> artifactIds = positionals(args, 2);
+        if (artifactIds.isEmpty()) {
+            err.println("error: remove plugin requires at least one plugin name");
+            return EXIT_USAGE;
+        }
+        final Path directory = pluginDirectory(definitions.get(PLUGIN_COMPONENT), parseOptions(args, 2));
+        boolean removedAny = false;
+        for (final String artifactId : artifactIds) {
+            final List<Path> removed = FessPluginInstaller.remove(directory, artifactId);
+            if (removed.isEmpty()) {
+                out.println(artifactId + " is not installed.");
+            } else {
+                removed.forEach(jar -> out.println("Removed " + jar));
+                removedAny = true;
+            }
+        }
+        if (removedAny) {
+            out.println();
+            out.println("Restart Fess for the change to take effect.");
+        }
+        return EXIT_OK;
+    }
+
+    /**
+     * Picks the plugin version that fits this Fess, reading the artifact's Maven metadata.
+     *
+     * @param repository the plugin repository URL
+     * @param artifactId the plugin name
+     * @return the version to install
+     * @throws SetupException if the metadata cannot be read or holds no matching version
+     */
+    private static String resolveVersion(final String repository, final String artifactId) throws SetupException {
+        final String productVersion = FessPluginInstaller.productVersion(fessVersion());
+        final String metadata = Downloader.readString(URI.create(PluginRepository.metadataUrl(repository, artifactId)));
+        return PluginRepository.selectVersion(PluginRepository.versionsFromMetadata(metadata), productVersion);
+    }
+
+    /**
+     * Returns the directory Fess loads plugins from, which {@code --dest} overrides.
+     *
+     * @param definition the plugin definition
+     * @param options the command line options
+     * @return the plugin directory
+     */
+    private static Path pluginDirectory(final ComponentDefinition definition, final Map<String, String> options) {
+        final String dest = options.get("dest");
+        if (dest != null) {
+            return Path.of(dest);
+        }
+        final String configured = definition.resolve("dest", Map.of("fess.home", fessHome()));
+        return configured != null ? Path.of(configured) : FessPluginInstaller.directory(fessHome());
+    }
+
+    /**
+     * Returns this build's version, which the jar's manifest carries.
+     *
+     * <p>Empty when there is no manifest, which is how the class runs under test and from an
+     * IDE. {@link FessPluginInstaller#productVersion} then reports that {@code --version} is
+     * needed rather than guessing one.</p>
+     *
+     * @return the version, or an empty string
+     */
+    static String fessVersion() {
+        final String version = FessSetup.class.getPackage().getImplementationVersion();
+        return version == null ? "" : version;
+    }
+
+    /**
+     * Collects the arguments that are neither an option nor an option's value.
+     *
+     * @param args the command line
+     * @param from the index to start at
+     * @return the positional arguments, in order
+     */
+    static List<String> positionals(final String[] args, final int from) {
+        final List<String> values = new ArrayList<>();
+        for (int i = from; i < args.length; i++) {
+            if (args[i].startsWith("--")) {
+                if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+                    i++;
+                }
+                continue;
+            }
+            values.add(args[i]);
+        }
+        return values;
     }
 
     /**
@@ -264,9 +501,9 @@ public final class FessSetup {
         final String version = options.getOrDefault("version", definition.get("plugin.version"));
         final List<String> artifacts = definition.list("plugin.artifacts");
         for (final String coordinate : artifacts) {
-            final String url = PluginInstaller.zipUrl(repository, coordinate, version);
+            final String url = OpenSearchPluginInstaller.zipUrl(repository, coordinate, version);
             out.println("Installing " + coordinate + ":" + version);
-            PluginInstaller.install(home, url);
+            OpenSearchPluginInstaller.install(home, url);
         }
     }
 
@@ -303,14 +540,51 @@ public final class FessSetup {
                 return;
             }
             lastPercent[0] = percent;
-            out.printf("\r  %d%% (%d/%d MiB)", percent, bytes >> 20, total >> 20);
+            out.printf("\r  %d%% (%s)", percent, sizes(bytes, total));
         } else {
             final int megabytes = (int) (bytes >> 20);
             if (megabytes == lastPercent[0]) {
                 return;
             }
             lastPercent[0] = megabytes;
-            out.printf("\r  %d MiB", megabytes);
+            out.printf("\r  %s", size(bytes));
         }
+    }
+
+    /**
+     * Formats a byte count in the largest unit that does not round it to zero.
+     *
+     * @param bytes the count
+     * @return the formatted size
+     */
+    static String size(final long bytes) {
+        if (bytes >= 1L << 20) {
+            return (bytes >> 20) + " MiB";
+        }
+        if (bytes >= 1L << 10) {
+            return (bytes >> 10) + " KiB";
+        }
+        return bytes + " B";
+    }
+
+    /**
+     * Formats a progress pair, both figures in the unit that suits the total.
+     *
+     * <p>Choosing the unit per figure would print "0 B/9 KiB" at the start of a small download,
+     * and choosing MiB always -- which is what the OpenSearch bundle needs -- prints "0/0 MiB"
+     * for a plugin jar of a few kilobytes.</p>
+     *
+     * @param bytes bytes so far
+     * @param total the total size
+     * @return the formatted pair
+     */
+    static String sizes(final long bytes, final long total) {
+        if (total >= 1L << 20) {
+            return (bytes >> 20) + "/" + (total >> 20) + " MiB";
+        }
+        if (total >= 1L << 10) {
+            return (bytes >> 10) + "/" + (total >> 10) + " KiB";
+        }
+        return bytes + "/" + total + " B";
     }
 }

--- a/src/main/java/org/codelibs/fess/setup/OpenSearchPluginInstaller.java
+++ b/src/main/java/org/codelibs/fess/setup/OpenSearchPluginInstaller.java
@@ -27,9 +27,9 @@ import java.nio.file.Path;
  * the CodeLibs plugins are not always published there -- 3.8.1 is absent from both Central and
  * maven.codelibs.org at the time of writing -- so the URL has to stay overridable.</p>
  */
-public final class PluginInstaller {
+public final class OpenSearchPluginInstaller {
 
-    private PluginInstaller() {
+    private OpenSearchPluginInstaller() {
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/setup/PluginRepository.java
+++ b/src/main/java/org/codelibs/fess/setup/PluginRepository.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Resolves Fess plugins in a Maven repository.
+ *
+ * <p>Mirrors what {@code org.codelibs.fess.helper.PluginHelper} does for the admin UI, because
+ * that class lives in the webapp and cannot be reached from this jar: a plugin listing comes
+ * from the repository's directory index, and a version comes from the artifact's
+ * {@code maven-metadata.xml}.</p>
+ */
+public final class PluginRepository {
+
+    /**
+     * The artifact name prefixes Fess treats as plugins. Anything else in the group directory
+     * -- {@code fess} itself, {@code fess-parent} -- is not installable.
+     */
+    private static final String[] PLUGIN_PREFIXES =
+            { "fess-ds", "fess-theme", "fess-ingest", "fess-script", "fess-webapp", "fess-thumbnail", "fess-crawler", "fess-llm" };
+
+    /**
+     * Crawler artifacts that are libraries rather than plugins. PluginHelper hides these from
+     * the admin list, and offering them here would let someone install a jar that cannot work.
+     */
+    private static final Set<String> EXCLUDED = Set.of("fess-crawler", "fess-crawler-db", "fess-crawler-db-h2", "fess-crawler-db-mysql",
+            "fess-crawler-es", "fess-crawler-opensearch", "fess-crawler-lasta", "fess-crawler-parent", "fess-crawler-playwright",
+            "fess-crawler-webdriver");
+
+    private static final Pattern HREF = Pattern.compile("href=\"[^\"]*?([a-zA-Z0-9\\-]+)/?\"");
+
+    private PluginRepository() {
+    }
+
+    /**
+     * Returns the {@code maven-metadata.xml} URL for an artifact.
+     *
+     * @param repository the group directory URL
+     * @param artifactId the artifact name
+     * @return the metadata URL
+     */
+    public static String metadataUrl(final String repository, final String artifactId) {
+        return base(repository) + artifactId + "/maven-metadata.xml";
+    }
+
+    /**
+     * Returns the jar URL for an artifact version.
+     *
+     * @param repository the group directory URL
+     * @param artifactId the artifact name
+     * @param version the version
+     * @return the jar URL
+     */
+    public static String jarUrl(final String repository, final String artifactId, final String version) {
+        return base(repository) + artifactId + "/" + version + "/" + artifactId + "-" + version + ".jar";
+    }
+
+    private static String base(final String repository) {
+        return repository.endsWith("/") ? repository : repository + "/";
+    }
+
+    /**
+     * Extracts the version list from a {@code maven-metadata.xml} document.
+     *
+     * @param xml the metadata document
+     * @return the versions, in the order the document lists them
+     * @throws SetupException if the document cannot be parsed
+     */
+    public static List<String> versionsFromMetadata(final String xml) throws SetupException {
+        try {
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            final DocumentBuilder builder = factory.newDocumentBuilder();
+            final Document document = builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            final NodeList nodes = document.getElementsByTagName("version");
+            final List<String> versions = new ArrayList<>();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                final String v = nodes.item(i).getTextContent().trim();
+                if (!v.isEmpty()) {
+                    versions.add(v);
+                }
+            }
+            return versions;
+        } catch (final ParserConfigurationException | SAXException | IOException e) {
+            throw new SetupException("Failed to read maven-metadata.xml", e);
+        }
+    }
+
+    /**
+     * Picks the highest version matching the product version, comparing numerically so that
+     * 15.9.10 sorts above 15.9.9.
+     *
+     * @param versions the available versions
+     * @param productVersion the major.minor this Fess accepts, for example {@code 15.9}
+     * @return the selected version
+     * @throws SetupException when no version matches
+     */
+    public static String selectVersion(final List<String> versions, final String productVersion) throws SetupException {
+        final String prefix = productVersion + ".";
+        final List<String> matching = new ArrayList<>();
+        for (final String v : versions) {
+            if (v.equals(productVersion) || v.startsWith(prefix)) {
+                matching.add(v);
+            }
+        }
+        if (matching.isEmpty()) {
+            throw new SetupException("No release matches Fess " + productVersion + ". Available versions: " + String.join(", ", versions));
+        }
+        matching.sort(Comparator.comparing(PluginRepository::sortKey));
+        return matching.get(matching.size() - 1);
+    }
+
+    private static String sortKey(final String version) {
+        final StringBuilder key = new StringBuilder();
+        for (final String part : version.split("[.\\-]")) {
+            if (part.chars().allMatch(Character::isDigit) && !part.isEmpty()) {
+                key.append(String.format("%08d", Integer.parseInt(part)));
+            } else {
+                key.append(part);
+            }
+            key.append('.');
+        }
+        return key.toString();
+    }
+
+    /**
+     * Extracts installable plugin names from a repository directory listing.
+     *
+     * @param html the directory index
+     * @return the plugin names, in listing order, without duplicates
+     */
+    public static List<String> namesFromListing(final String html) {
+        final Set<String> names = new LinkedHashSet<>();
+        final Matcher matcher = HREF.matcher(html);
+        while (matcher.find()) {
+            final String name = matcher.group(1);
+            if (EXCLUDED.contains(name)) {
+                continue;
+            }
+            for (final String prefix : PLUGIN_PREFIXES) {
+                if (name.startsWith(prefix + "-")) {
+                    names.add(name);
+                    break;
+                }
+            }
+        }
+        return new ArrayList<>(names);
+    }
+}

--- a/src/main/resources/fess-setup.properties
+++ b/src/main/resources/fess-setup.properties
@@ -17,7 +17,7 @@ component.opensearch.dest = ${fess.home}/opensearch
 component.opensearch.post = opensearch
 component.opensearch.hint.unavailable = Install it another way, then point fess-setup at it:\n\
 \  macOS:  brew install opensearch\n\
-\          bin/fess-setup install plugins --opensearch-home $(brew --prefix opensearch)\n\
+\          bin/fess-setup install opensearch-plugins --opensearch-home $(brew --prefix opensearch)\n\
 \  Docker: use the compose files instead of a local install.
 
 # The Fess-specific plugins. k-NN and Neural Search are deliberately absent: the official
@@ -48,3 +48,12 @@ component.nodejs.executable.windows = node.exe
 # Playwright reads this environment variable. A system property would not do: the crawler runs
 # in a child process that inherits the environment but not the parent's -D options.
 component.nodejs.env = PLAYWRIGHT_NODEJS_PATH
+
+# Fess plugins, which "install plugin" fetches and drops into the webapp's plugin directory.
+# There is no url here on purpose: the artifact is named on the command line, and "list" shows
+# only the components that have one. The version comes from the artifact's maven-metadata.xml,
+# narrowed to the major.minor of this build, so it is not repeated here either.
+#
+# The admin UI reads the same repository through plugin.repositories in fess_config.properties.
+component.plugin.repository = https://maven.codelibs.org/release/org/codelibs/fess/
+component.plugin.dest = ${fess.home}/app/WEB-INF/plugin

--- a/src/test/java/org/codelibs/fess/setup/FessPluginInstallerTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessPluginInstallerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class FessPluginInstallerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void test_directory() {
+        assertEquals(Path.of("/opt/fess", "app", "WEB-INF", "plugin"), FessPluginInstaller.directory("/opt/fess"));
+    }
+
+    @Test
+    public void test_jarName() {
+        assertEquals("fess-ds-git-15.9.0.jar", FessPluginInstaller.jarName("fess-ds-git", "15.9.0"));
+    }
+
+    @Test
+    public void test_isJarOf() {
+        assertTrue(FessPluginInstaller.isJarOf("fess-ds-git-15.9.0.jar", "fess-ds-git"));
+        assertTrue(FessPluginInstaller.isJarOf("fess-ds-git-15.9.0-SNAPSHOT.jar", "fess-ds-git"));
+        assertFalse(FessPluginInstaller.isJarOf("fess-ds-github-15.9.0.jar", "fess-ds-git"));
+        assertFalse(FessPluginInstaller.isJarOf("fess-ds-git-15.9.0.jar.part", "fess-ds-git"));
+        assertFalse(FessPluginInstaller.isJarOf("fess-ds-slack-15.9.0.jar", "fess-ds-git"));
+    }
+
+    /**
+     * The name a longer artifact shares with a shorter one is the trap here: the file
+     * {@code fess-webapp-mcp-client-1.0.jar} begins with {@code fess-webapp-mcp-}, so a prefix
+     * test alone would let {@code remove plugin fess-webapp-mcp} delete somebody else's plugin.
+     */
+    @Test
+    public void test_isJarOf_requiresAVersionAfterTheName() {
+        assertFalse(FessPluginInstaller.isJarOf("fess-webapp-mcp-client-1.0.jar", "fess-webapp-mcp"));
+        assertTrue(FessPluginInstaller.isJarOf("fess-webapp-mcp-15.9.0.jar", "fess-webapp-mcp"));
+    }
+
+    @Test
+    public void test_installedJars_findsEveryVersionOfOneArtifact() throws Exception {
+        touch("fess-ds-git-15.9.0.jar");
+        touch("fess-ds-git-15.9.1.jar");
+        touch("fess-ds-slack-15.9.0.jar");
+        touch("notes.txt");
+
+        final List<Path> jars = FessPluginInstaller.installedJars(tempDir, "fess-ds-git");
+        assertEquals(List.of("fess-ds-git-15.9.0.jar", "fess-ds-git-15.9.1.jar"),
+                jars.stream().map(p -> p.getFileName().toString()).toList());
+    }
+
+    @Test
+    public void test_installedJars_onAMissingDirectory() throws Exception {
+        assertEquals(List.of(), FessPluginInstaller.installedJars(tempDir.resolve("absent"), "fess-ds-git"));
+    }
+
+    @Test
+    public void test_installed_listsEveryPluginJar() throws Exception {
+        touch("fess-ds-git-15.9.0.jar");
+        touch("fess-script-groovy-15.9.0.jar");
+        touch("README");
+
+        assertEquals(List.of("fess-ds-git-15.9.0.jar", "fess-script-groovy-15.9.0.jar"),
+                FessPluginInstaller.installed(tempDir).stream().map(p -> p.getFileName().toString()).toList());
+    }
+
+    @Test
+    public void test_remove() throws Exception {
+        touch("fess-ds-git-15.9.0.jar");
+        touch("fess-ds-slack-15.9.0.jar");
+
+        final List<Path> removed = FessPluginInstaller.remove(tempDir, "fess-ds-git");
+
+        assertEquals(List.of("fess-ds-git-15.9.0.jar"), removed.stream().map(p -> p.getFileName().toString()).toList());
+        assertFalse(Files.exists(tempDir.resolve("fess-ds-git-15.9.0.jar")));
+        assertTrue(Files.exists(tempDir.resolve("fess-ds-slack-15.9.0.jar")));
+    }
+
+    @Test
+    public void test_remove_reportsNothingWhenTheArtifactIsNotInstalled() throws Exception {
+        assertEquals(List.of(), FessPluginInstaller.remove(tempDir, "fess-ds-git"));
+    }
+
+    /**
+     * The version this Fess accepts a plugin for. Plugins track the major.minor of the release
+     * they were built against, so the patch level and the SNAPSHOT suffix have to come off.
+     */
+    @Test
+    public void test_productVersion() throws Exception {
+        assertEquals("15.9", FessPluginInstaller.productVersion("15.9.0"));
+        assertEquals("15.9", FessPluginInstaller.productVersion("15.9.0-SNAPSHOT"));
+        assertEquals("15.9", FessPluginInstaller.productVersion("15.9.10"));
+    }
+
+    @Test
+    public void test_productVersion_rejectsWhatItCannotRead() {
+        for (final String version : List.of("", "15", "x.y.z")) {
+            try {
+                FessPluginInstaller.productVersion(version);
+                throw new AssertionError("expected a SetupException for: " + version);
+            } catch (final SetupException expected) {
+                assertTrue(expected.getMessage().contains("--version"), expected.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void test_versionOf() {
+        assertEquals("15.9.0", FessPluginInstaller.versionOf("fess-ds-git-15.9.0.jar", "fess-ds-git"));
+        assertEquals("15.9.0-SNAPSHOT", FessPluginInstaller.versionOf("fess-ds-git-15.9.0-SNAPSHOT.jar", "fess-ds-git"));
+        assertNull(FessPluginInstaller.versionOf("fess-ds-slack-15.9.0.jar", "fess-ds-git"));
+    }
+
+    @Test
+    public void test_removeOtherVersions() throws Exception {
+        touch("fess-ds-git-15.9.0.jar");
+        touch("fess-ds-git-15.9.1.jar");
+        touch("fess-ds-slack-15.9.0.jar");
+
+        final Path keep = tempDir.resolve("fess-ds-git-15.9.1.jar");
+        final List<Path> removed = FessPluginInstaller.removeOtherVersions(tempDir, "fess-ds-git", keep);
+
+        assertEquals(List.of("fess-ds-git-15.9.0.jar"), removed.stream().map(p -> p.getFileName().toString()).toList());
+        assertTrue(Files.exists(keep));
+        assertTrue(Files.exists(tempDir.resolve("fess-ds-slack-15.9.0.jar")));
+    }
+
+    private void touch(final String name) throws IOException {
+        Files.writeString(tempDir.resolve(name), "x");
+    }
+}

--- a/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
@@ -18,16 +18,22 @@ package org.codelibs.fess.setup;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class FessSetupTest {
+
+    @TempDir
+    Path tempDir;
 
     private final ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -65,8 +71,8 @@ public class FessSetupTest {
     }
 
     @Test
-    public void test_installPlugins_requiresOpensearchHome() {
-        assertEquals(2, run("install", "plugins"));
+    public void test_installOpensearchPlugins_requiresOpensearchHome() {
+        assertEquals(2, run("install", "opensearch-plugins"));
         assertTrue(err().contains("--opensearch-home"), err());
     }
 
@@ -137,6 +143,99 @@ public class FessSetupTest {
         assertTrue(out().contains("nodejs"), out());
     }
 
+    /**
+     * The plugin definition holds a repository rather than a download of its own, so
+     * {@code install plugin} uses it but {@code list} must not offer it as a component:
+     * {@code install plugin} is the command, and there is nothing to download without a name.
+     */
+    @Test
+    public void test_list_omitsThePluginDefinition() {
+        assertEquals(0, run("list"));
+        for (final String line : out().split("\n")) {
+            assertTrue(!"plugin".equals(line.trim()), out());
+        }
+    }
+
+    @Test
+    public void test_loadDefinitions_pluginRepository() throws Exception {
+        final ComponentDefinition plugin = FessSetup.loadDefinitions().get("plugin");
+        assertNotNull(plugin, "install plugin needs a repository to read");
+        assertTrue(plugin.get("repository").startsWith("https://"), plugin.get("repository"));
+        assertNull(plugin.get("url"), "a plugin is named on the command line, not by the definition");
+        assertEquals("/opt/fess/app/WEB-INF/plugin", plugin.resolve("dest", Map.of("fess.home", "/opt/fess")));
+    }
+
+    @Test
+    public void test_installPlugin_withoutAName_saysSo() {
+        assertEquals(2, run("install", "plugin"));
+        assertTrue(err().contains("list plugins"), err());
+    }
+
+    @Test
+    public void test_removePlugin_withoutAName_saysSo() {
+        assertEquals(2, run("remove", "plugin"));
+        assertTrue(err().contains("plugin name"), err());
+    }
+
+    @Test
+    public void test_remove_withoutTarget_printsUsage() {
+        assertEquals(2, run("remove"));
+        assertTrue(err().contains("Usage:"), err());
+    }
+
+    @Test
+    public void test_removePlugin_reportsAPluginThatIsNotInstalled() {
+        assertEquals(0, run("remove", "plugin", "fess-ds-git", "--dest", tempDir.toString()));
+        assertTrue(out().contains("fess-ds-git is not installed"), out());
+    }
+
+    @Test
+    public void test_removePlugin_deletesTheJarAndAsksForARestart() throws Exception {
+        java.nio.file.Files.writeString(tempDir.resolve("fess-ds-git-15.9.0.jar"), "x");
+        java.nio.file.Files.writeString(tempDir.resolve("fess-ds-slack-15.9.0.jar"), "x");
+
+        assertEquals(0, run("remove", "plugin", "fess-ds-git", "--dest", tempDir.toString()));
+
+        assertTrue(out().contains("fess-ds-git-15.9.0.jar"), out());
+        assertTrue(out().contains("Restart Fess"), out());
+        assertTrue(!java.nio.file.Files.exists(tempDir.resolve("fess-ds-git-15.9.0.jar")));
+        assertTrue(java.nio.file.Files.exists(tempDir.resolve("fess-ds-slack-15.9.0.jar")));
+    }
+
+    @Test
+    public void test_list_rejectsAnUnknownTarget() {
+        assertEquals(2, run("list", "widgets"));
+        assertTrue(err().contains("widgets"), err());
+    }
+
+    @Test
+    public void test_sizes_useTheUnitThatSuitsTheTotal() {
+        assertEquals("512/1024 MiB", FessSetup.sizes(512L << 20, 1024L << 20));
+        assertEquals("4/9 KiB", FessSetup.sizes(4096L, 9728L));
+        assertEquals("100/512 B", FessSetup.sizes(100L, 512L));
+    }
+
+    @Test
+    public void test_size_picksTheLargestUnitThatDoesNotRoundToZero() {
+        assertEquals("2 MiB", FessSetup.size(2L << 20));
+        assertEquals("3 KiB", FessSetup.size(3072L));
+        assertEquals("7 B", FessSetup.size(7L));
+    }
+
+    @Test
+    public void test_positionals_skipOptionsAndTheirValues() {
+        assertEquals(java.util.List.of("fess-ds-git", "fess-ds-slack"), FessSetup
+                .positionals(new String[] { "install", "plugin", "fess-ds-git", "--version", "15.9.0", "fess-ds-slack", "--force" }, 2));
+    }
+
+    @Test
+    public void test_fessVersion_isEmptyWithoutAManifest() {
+        // Under test the class comes from target/classes, which has no manifest. The install
+        // path then reports that --version is needed rather than guessing a plugin version.
+        final SetupException e = assertThrows(SetupException.class, () -> FessPluginInstaller.productVersion(FessSetup.fessVersion()));
+        assertTrue(e.getMessage().contains("--version"), e.getMessage());
+    }
+
     @Test
     public void test_fessHome_comesFromTheLauncher() {
         final String original = System.getProperty("fess.home");
@@ -159,7 +258,7 @@ public class FessSetupTest {
             System.clearProperty("fess.home");
             final String home = FessSetup.fessHome();
             assertNotNull(home);
-            assertTrue(java.nio.file.Path.of(home).isAbsolute(), home);
+            assertTrue(Path.of(home).isAbsolute(), home);
         } finally {
             if (original != null) {
                 System.setProperty("fess.home", original);

--- a/src/test/java/org/codelibs/fess/setup/OpenSearchPluginInstallerTest.java
+++ b/src/test/java/org/codelibs/fess/setup/OpenSearchPluginInstallerTest.java
@@ -24,7 +24,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class PluginInstallerTest {
+public class OpenSearchPluginInstallerTest {
 
     @TempDir
     Path tempDir;
@@ -33,37 +33,41 @@ public class PluginInstallerTest {
     public void test_zipUrl() throws Exception {
         assertEquals(
                 "https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-analysis-fess/3.8.0/opensearch-analysis-fess-3.8.0.zip",
-                PluginInstaller.zipUrl("https://repo1.maven.org/maven2", "org.codelibs.opensearch:opensearch-analysis-fess", "3.8.0"));
+                OpenSearchPluginInstaller.zipUrl("https://repo1.maven.org/maven2", "org.codelibs.opensearch:opensearch-analysis-fess",
+                        "3.8.0"));
     }
 
     @Test
     public void test_zipUrl_trailingSlashOnRepository() throws Exception {
         assertEquals("https://example.org/m2/org/codelibs/opensearch/opensearch-minhash/3.8.0/opensearch-minhash-3.8.0.zip",
-                PluginInstaller.zipUrl("https://example.org/m2/", "org.codelibs.opensearch:opensearch-minhash", "3.8.0"));
+                OpenSearchPluginInstaller.zipUrl("https://example.org/m2/", "org.codelibs.opensearch:opensearch-minhash", "3.8.0"));
     }
 
     @Test
     public void test_zipUrl_rejectsMalformedCoordinate() {
-        final SetupException e =
-                assertThrows(SetupException.class, () -> PluginInstaller.zipUrl("https://example.org/m2", "no-colon-here", "3.8.0"));
+        final SetupException e = assertThrows(SetupException.class,
+                () -> OpenSearchPluginInstaller.zipUrl("https://example.org/m2", "no-colon-here", "3.8.0"));
         assertTrue(e.getMessage().contains("no-colon-here"), e.getMessage());
     }
 
     @Test
     public void test_zipUrl_rejectsEmptyArtifactId() {
-        assertThrows(SetupException.class, () -> PluginInstaller.zipUrl("https://example.org/m2", "org.codelibs.opensearch:", "3.8.0"));
+        assertThrows(SetupException.class,
+                () -> OpenSearchPluginInstaller.zipUrl("https://example.org/m2", "org.codelibs.opensearch:", "3.8.0"));
     }
 
     @Test
     public void test_pluginCommand_perOs() {
         final Path home = Path.of("/opt/opensearch");
-        assertEquals(home.resolve("bin").resolve("opensearch-plugin.bat"), PluginInstaller.pluginCommand(home, Platform.Os.WINDOWS));
-        assertEquals(home.resolve("bin").resolve("opensearch-plugin"), PluginInstaller.pluginCommand(home, Platform.Os.LINUX));
+        assertEquals(home.resolve("bin").resolve("opensearch-plugin.bat"),
+                OpenSearchPluginInstaller.pluginCommand(home, Platform.Os.WINDOWS));
+        assertEquals(home.resolve("bin").resolve("opensearch-plugin"), OpenSearchPluginInstaller.pluginCommand(home, Platform.Os.LINUX));
     }
 
     @Test
     public void test_install_reportsMissingPluginTool() {
-        final SetupException e = assertThrows(SetupException.class, () -> PluginInstaller.install(tempDir, "https://example.org/a.zip"));
+        final SetupException e =
+                assertThrows(SetupException.class, () -> OpenSearchPluginInstaller.install(tempDir, "https://example.org/a.zip"));
         assertTrue(e.getMessage().contains("opensearch-plugin"), e.getMessage());
         assertTrue(e.getMessage().contains("--opensearch-home"), e.getMessage());
     }

--- a/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
+++ b/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class PluginRepositoryTest {
+
+    private static final String METADATA = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <metadata>
+              <groupId>org.codelibs.fess</groupId>
+              <artifactId>fess-ds-git</artifactId>
+              <versioning>
+                <latest>15.8.0</latest>
+                <release>15.8.0</release>
+                <versions>
+                  <version>14.19.0</version>
+                  <version>15.7.0</version>
+                  <version>15.9.0</version>
+                  <version>15.9.1</version>
+                </versions>
+              </versioning>
+            </metadata>
+            """;
+
+    @Test
+    public void test_versionsFromMetadata() throws Exception {
+        final List<String> versions = PluginRepository.versionsFromMetadata(METADATA);
+        assertEquals(List.of("14.19.0", "15.7.0", "15.9.0", "15.9.1"), versions);
+    }
+
+    @Test
+    public void test_selectVersion_picksTheHighestMatchingTheProductVersion() throws Exception {
+        assertEquals("15.9.1", PluginRepository.selectVersion(PluginRepository.versionsFromMetadata(METADATA), "15.9"));
+    }
+
+    @Test
+    public void test_selectVersion_reportsWhenNothingMatches() {
+        final SetupException e =
+                assertThrows(SetupException.class, () -> PluginRepository.selectVersion(List.of("14.19.0", "15.7.0"), "15.9"));
+        assertTrue(e.getMessage().contains("15.9"), e.getMessage());
+        assertTrue(e.getMessage().contains("14.19.0"), e.getMessage());
+    }
+
+    @Test
+    public void test_selectVersion_ordersNumerically() throws Exception {
+        assertEquals("15.9.10", PluginRepository.selectVersion(List.of("15.9.9", "15.9.10", "15.9.2"), "15.9"));
+    }
+
+    @Test
+    public void test_jarUrl() {
+        assertEquals("https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar",
+                PluginRepository.jarUrl("https://maven.codelibs.org/release/org/codelibs/fess/", "fess-ds-git", "15.9.0"));
+    }
+
+    @Test
+    public void test_jarUrl_addsTheMissingSlash() {
+        assertEquals("https://example.org/m2/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar",
+                PluginRepository.jarUrl("https://example.org/m2", "fess-ds-git", "15.9.0"));
+    }
+
+    @Test
+    public void test_metadataUrl() {
+        assertEquals("https://example.org/m2/fess-ds-git/maven-metadata.xml",
+                PluginRepository.metadataUrl("https://example.org/m2", "fess-ds-git"));
+    }
+
+    @Test
+    public void test_namesFromListing() {
+        final String html = """
+                <html><body>
+                <a href="../">../</a>
+                <a href="fess-ds-git/">fess-ds-git/</a>
+                <a href="fess-ds-slack/">fess-ds-slack/</a>
+                <a href="fess-script-groovy/">fess-script-groovy/</a>
+                <a href="fess-theme-classic/">fess-theme-classic/</a>
+                <a href="fess-crawler-playwright/">fess-crawler-playwright/</a>
+                <a href="fess/">fess/</a>
+                </body></html>
+                """;
+        final List<String> names = PluginRepository.namesFromListing(html);
+        assertTrue(names.contains("fess-ds-git"), names.toString());
+        assertTrue(names.contains("fess-script-groovy"), names.toString());
+        assertTrue(names.contains("fess-theme-classic"), names.toString());
+    }
+
+    @Test
+    public void test_namesFromListing_skipsNonPluginArtifacts() {
+        final String html = "<a href=\"fess/\">fess/</a><a href=\"fess-parent/\">fess-parent/</a><a href=\"fess-ds-git/\">x</a>";
+        final List<String> names = PluginRepository.namesFromListing(html);
+        assertEquals(List.of("fess-ds-git"), names);
+    }
+
+    @Test
+    public void test_namesFromListing_excludesCrawlerInternals() {
+        // PluginHelper hides these from the admin list; fess-setup must not offer them either.
+        final String html =
+                "<a href=\"fess-crawler-playwright/\">x</a><a href=\"fess-crawler-lasta/\">x</a>" + "<a href=\"fess-ds-git/\">x</a>";
+        assertEquals(List.of("fess-ds-git"), PluginRepository.namesFromListing(html));
+    }
+}

--- a/src/test/java/org/codelibs/fess/setup/SetupPackageDependencyTest.java
+++ b/src/test/java/org/codelibs/fess/setup/SetupPackageDependencyTest.java
@@ -36,6 +36,18 @@ import org.junit.jupiter.api.Test;
  */
 public class SetupPackageDependencyTest {
 
+    /**
+     * org.w3c.dom and org.xml.sax belong to the JDK's java.xml module despite not living under
+     * java.* or javax.*. test_allowedNonJavaxPackagesAreReallyJdkSupplied proves that.
+     *
+     * @param imported the imported type name
+     * @return whether the JDK supplies it
+     */
+    private static boolean isJdkPackage(final String imported) {
+        return imported.startsWith("java.") || imported.startsWith("javax.") || imported.startsWith("org.w3c.dom")
+                || imported.startsWith("org.xml.sax");
+    }
+
     @Test
     public void test_onlyJdkImports() throws IOException {
         final Path dir = Path.of("src/main/java/org/codelibs/fess/setup");
@@ -55,12 +67,25 @@ public class SetupPackageDependencyTest {
                     continue;
                 }
                 final String imported = trimmed.substring("import ".length()).replace("static ", "").replace(";", "").trim();
-                if (imported.startsWith("java.") || imported.startsWith("javax.") || imported.startsWith("org.codelibs.fess.setup.")) {
+                if (isJdkPackage(imported) || imported.startsWith("org.codelibs.fess.setup.")) {
                     continue;
                 }
                 violations.add(source.getFileName() + ": " + imported);
             }
         }
         assertTrue(violations.isEmpty(), "org.codelibs.fess.setup must depend on the JDK only, but found: " + violations);
+    }
+
+    /**
+     * Guards the allowance above: were any of these to stop being JDK-supplied, the setup jar
+     * would break at runtime while the import check still passed.
+     */
+    @Test
+    public void test_allowedNonJavaxPackagesAreReallyJdkSupplied() throws ClassNotFoundException {
+        for (final String name : new String[] { "org.w3c.dom.Document", "org.xml.sax.SAXException" }) {
+            final Class<?> type = Class.forName(name);
+            assertTrue(type.getClassLoader() == null, name + " is not loaded by the bootstrap loader");
+            assertTrue("java.xml".equals(type.getModule().getName()), name + " is not in java.xml");
+        }
     }
 }


### PR DESCRIPTION
Stacked on #3412.

## Why

The distribution is being trimmed to what every installation needs, which leaves the
rest to be added afterwards. Until now that meant the admin UI, so anything that has
to be in place *before* the first start — a script engine, a data store a scheduled
crawl depends on — had no route.

```
bin/fess-setup list plugins
bin/fess-setup install plugin fess-script-groovy
bin/fess-setup remove plugin fess-ds-git
```

## How the version is chosen

From the artifact's `maven-metadata.xml`, narrowed to the `major.minor` this build reads
from its own manifest. So `install plugin fess-ds-git` picks the release built for this
Fess rather than the newest one published. `--version` overrides it; `--repository`
points the whole thing at a mirror.

On a Fess whose plugins are not published yet, the failure names what is there:

```
$ bin/fess-setup install plugin fess-ds-json
error: No release matches Fess 15.9. Available versions: 15.8.0
```

## Two decisions worth reviewing

**No `Fess-WebAppJar` check.** My first cut rejected jars without that manifest
attribute. That is wrong: only plugins contributing classes to the webapp carry it.
`fess-ds-slack`, `fess-theme-simple`, `fess-ingest-example` and
`fess-thumbnail-playwright` do not, so the check would have rejected most of the
catalogue. The jars are installed unexamined, exactly as `PluginHelper#install` does.

**A name prefix is not a match.** `fess-webapp-mcp-client-1.0.jar` begins with
`fess-webapp-mcp-`, so a prefix test would make `remove plugin fess-webapp-mcp` delete a
different plugin. What follows the name has to start with a digit.

## Install replaces, and does it in the safe order

Two versions of a plugin in `WEB-INF/plugin` both load, so installing removes the
others. It removes them *after* the download, so a download that fails leaves the
working plugin in place. Verified against a real 404:

```
$ bin/fess-setup install plugin fess-ds-json --version 15.7.0
Downloading .../fess-ds-json/15.7.0/fess-ds-json-15.7.0.jar
error: Failed to download ...: HTTP 404
$ ls app/WEB-INF/plugin/
fess-ds-json-15.8.0.jar        # still there
```

## Rename

`install plugins` becomes `install opensearch-plugins`, and `PluginInstaller` becomes
`OpenSearchPluginInstaller`. The tool now installs two unrelated kinds of plugin and
calling both "plugins" was going to be a support burden. 15.9 has not shipped, so no
released command name changes.

`install opensearch-plugins --opensearch-home <dir>` is the single command that replaces
running `bin/opensearch-plugin install` four times by hand against an OpenSearch you
installed yourself:

```
C:\> bin\fess-setup install opensearch-plugins --opensearch-home C:\opensearch-3.8.0
```

## Smaller things

- `Downloader.readString` for the small documents that describe what to download.
- Progress switches unit by size — a 9 KiB plugin jar was reporting `0/0 MiB`.
- The setup jar's manifest now carries `Implementation-Version`, which is where the
  product version comes from; there is no second copy of the version to keep in step.
- `list` skips definitions with no `url`, so the plugin repository entry does not appear
  as an installable component.

## Tests

`mvn test -Dtest='org.codelibs.fess.setup.*Test'` → **89 tests, 0 failures**
(`FessPluginInstallerTest` 13, `FessSetupTest` 27, `PluginRepositoryTest` 10, rest existing).

Verified end to end against the real repository on macOS: `list plugins` returns the 21
published plugins with `fess`, `fess-parent`, `fess-suggest` and the crawler internals
excluded exactly as `PluginHelper#isExcludedName` excludes them; install, upgrade,
replace, remove, the 404 case above, and the "installed but not published" section for a
locally built jar.
