### PR TITLE
build!: stop bundling the Groovy script plugin

### DIFF
--- a/deps.xml
+++ b/deps.xml
@@ -15,17 +15,6 @@
 	<!-- Maven Repository -->
 	<property name="maven.snapshot.repo.url" value="https://central.sonatype.com/repository/maven-snapshots" />
 	<property name="maven.release.repo.url" value="https://repo1.maven.org/maven2" />
-	<property name="maven.codelibs.release.repo.url" value="https://maven.codelibs.org/release" />
-	<property name="maven.codelibs.snapshot.repo.url" value="https://maven.codelibs.org/snapshot" />
-
-	<!-- webapp plugins bundled with the distribution -->
-	<!-- Hand-bump this for each Fess release: fess-script-groovy is released on its own
-	     cadence, and ${project.version} would resolve to a SNAPSHOT the release repo never serves.
-	     15.9.0 is not going to be published for a while, so this names the snapshot; see
-	     install.webapp.plugins for what to undo once a release exists.
-	     Fess 15.10 drops the plugin: delete this property, the install.webapp.plugins target
-	     below and the install-webapp-plugins execution in pom.xml then, don't bump it. -->
-	<property name="fess.script.groovy.version" value="15.9.0-SNAPSHOT" />
 
 	<target name="install.jars">
 		<mkdir dir="${target.dir}" />
@@ -65,41 +54,6 @@
 		</delete>
 	</target>
 
-	<!-- Fetches the plugins the distribution bundles into WEB-INF/plugin. Kept out of
-	     install.jars, which that directory's jars are deleted by and which runs on every
-	     mvn test through the antrun plugin-level configuration: a test run must not depend
-	     on a plugin release being published. pom.xml calls this at prepare-package. -->
-	<target name="install.webapp.plugins">
-		<mkdir dir="${target.dir}" />
-		<!-- A snapshot is served under a timestamped file name
-		     (fess-script-groovy-15.9.0-20260829.021938-2.jar): the plain -SNAPSHOT.jar is a 404, and
-		     maven-metadata.xml is the only place the real name is written down. Its metadata/version
-		     is still the -SNAPSHOT one and its snapshotVersions hold one entry per artifact, which
-		     xmlproperty joins with commas, so the name is rebuilt from the parts that are single
-		     valued. Once fess-script-groovy has a release, delete these three tasks and pass
-		     maven.codelibs.release.repo.url as repo.url and fess.script.groovy.version as
-		     file.version. -->
-		<get src="${maven.codelibs.snapshot.repo.url}/org/codelibs/fess/fess-script-groovy/${fess.script.groovy.version}/maven-metadata.xml"
-			dest="${target.dir}/fess-script-groovy-maven-metadata.xml" />
-		<xmlproperty file="${target.dir}/fess-script-groovy-maven-metadata.xml" prefix="script.groovy" />
-		<loadresource property="fess.script.groovy.release.version">
-			<string value="${fess.script.groovy.version}" />
-			<filterchain>
-				<tokenfilter>
-					<replacestring from="-SNAPSHOT" to="" />
-				</tokenfilter>
-			</filterchain>
-		</loadresource>
-		<antcall target="install.webapp.plugin">
-			<param name="repo.url" value="${maven.codelibs.snapshot.repo.url}" />
-			<param name="jar.groupId" value="org/codelibs/fess" />
-			<param name="jar.artifactId" value="fess-script-groovy" />
-			<param name="jar.version" value="${fess.script.groovy.version}" />
-			<param name="file.version"
-				value="${fess.script.groovy.release.version}-${script.groovy.metadata.versioning.snapshot.timestamp}-${script.groovy.metadata.versioning.snapshot.buildNumber}" />
-		</antcall>
-	</target>
-
 	<target name="install.env.jar">
 		<get dest="${target.dir}">
 			<url url="${repo.url}/${jar.groupId}/${jar.artifactId}/${jar.version}/${jar.artifactId}-${file.version}.jar" />
@@ -110,13 +64,4 @@
 		<copy file="${target.dir}/${jar.artifactId}-${file.version}.jar" todir="${chunk.dir}/lib" />
 	</target>
 
-	<!-- file.version is the version in the file name on the server, which is not jar.version for a
-	     snapshot; the copy renames it back so what Fess ships is named the same on every build. -->
-	<target name="install.webapp.plugin">
-		<get dest="${target.dir}">
-			<url url="${repo.url}/${jar.groupId}/${jar.artifactId}/${jar.version}/${jar.artifactId}-${file.version}.jar" />
-		</get>
-		<copy file="${target.dir}/${jar.artifactId}-${file.version}.jar"
-			tofile="${webinf.dir}/plugin/${jar.artifactId}-${jar.version}.jar" />
-	</target>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -273,27 +273,6 @@
 							</target>
 						</configuration>
 					</execution>
-					<execution>
-						<!-- The plugins the distribution bundles. This is a separate execution because
-						     the fetch must not run during mvn test: the plugin release it downloads is
-						     published on its own cadence and may not exist yet. It is bound to
-						     prepare-package so it runs after install.jars, which empties WEB-INF/plugin
-						     and which the plugin-level target below runs. combine.self="override" keeps
-						     the plugin-level target out of this one. Maven merges it into every execution
-						     otherwise, and what survives that merge depends on how Xpp3Dom pairs
-						     same-named children: today this ant task wins and the plugin-level ones are
-						     dropped, but renaming or reordering the tasks below changes that silently. -->
-						<id>install-webapp-plugins</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target combine.self="override">
-								<ant antfile="${basedir}/deps.xml" target="install.webapp.plugins" />
-							</target>
-						</configuration>
-					</execution>
 				</executions>
 				<configuration>
 					<target>

--- a/src/test/java/org/codelibs/fess/it/CrawlTestBase.java
+++ b/src/test/java/org/codelibs/fess/it/CrawlTestBase.java
@@ -146,14 +146,32 @@ public class CrawlTestBase extends ITBase {
         return response;
     }
 
+    /**
+     * Builds the job script for a web crawl of one config.
+     *
+     * <p>JavaScript, not Groovy: Groovy ships as a plugin from 15.9 and is not in the
+     * distribution. The array literal is passed straight to {@code webConfigIds(String[])} --
+     * the engine converts it, so Groovy's {@code as String[]} cast has no equivalent and needs
+     * none. {@code JavaScriptEngineTest#test_arrayLiteralBecomesAJavaArray} pins that.</p>
+     *
+     * @param webCofigId the web config to crawl
+     * @return the script
+     */
     protected static String buildWebConfigJobScript(final String webCofigId) {
         return String.format("return container.getComponent(\"crawlJob\")" + ".logLevel(\"info\")" + ".sessionId(\"%s\")"
-                + ".webConfigIds([\"%s\"] as String[])" + ".jobExecutor(executor).execute();", webCofigId, webCofigId);
+                + ".webConfigIds([\"%s\"])" + ".jobExecutor(executor).execute();", webCofigId, webCofigId);
     }
 
+    /**
+     * Builds the job script for a file crawl of one config. JavaScript, for the reason given on
+     * {@link #buildWebConfigJobScript}.
+     *
+     * @param fileConfigId the file config to crawl
+     * @return the script
+     */
     protected static String buildFileConfigJobScript(final String fileConfigId) {
         return String.format("return container.getComponent(\"crawlJob\")" + ".logLevel(\"info\")" + ".sessionId(\"%s\")"
-                + ".fileConfigIds([\"%s\"] as String[])" + ".jobExecutor(executor).execute();", fileConfigId, fileConfigId);
+                + ".fileConfigIds([\"%s\"])" + ".jobExecutor(executor).execute();", fileConfigId, fileConfigId);
     }
 
     protected static Map<String, Object> getSchedulerItem(final String namePrefix) {

--- a/src/test/java/org/codelibs/fess/it/admin/CrawlerLogTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/CrawlerLogTests.java
@@ -183,7 +183,7 @@ public class CrawlerLogTests extends CrawlTestBase {
         final Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", NAME_PREFIX + "Scheduler");
         requestBody.put("target", "all");
-        requestBody.put("script_type", "groovy");
+        requestBody.put("script_type", "javascript");
         requestBody.put("sort_order", 0);
         requestBody.put("crawler", true);
         requestBody.put("job_logging", true);

--- a/src/test/java/org/codelibs/fess/it/admin/FailureUrlTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/FailureUrlTests.java
@@ -341,7 +341,7 @@ public class FailureUrlTests extends CrawlTestBase {
         final Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", NAME_PREFIX + "Scheduler");
         requestBody.put("target", "all");
-        requestBody.put("script_type", "groovy");
+        requestBody.put("script_type", "javascript");
         requestBody.put("sort_order", 0);
         requestBody.put("crawler", true);
         requestBody.put("job_logging", true);

--- a/src/test/java/org/codelibs/fess/it/admin/JobLogTests.java
+++ b/src/test/java/org/codelibs/fess/it/admin/JobLogTests.java
@@ -278,7 +278,7 @@ public class JobLogTests extends CrawlTestBase {
         final Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", NAME_PREFIX + "Scheduler");
         requestBody.put("target", "all");
-        requestBody.put("script_type", "groovy");
+        requestBody.put("script_type", "javascript");
         requestBody.put("sort_order", 0);
         requestBody.put("crawler", true);
         requestBody.put("job_logging", true);

--- a/src/test/java/org/codelibs/fess/script/javascript/JavaScriptEngineTest.java
+++ b/src/test/java/org/codelibs/fess/script/javascript/JavaScriptEngineTest.java
@@ -241,6 +241,50 @@ public class JavaScriptEngineTest extends UnitFessTestCase {
         }
     }
 
+    /**
+     * A crawl job script narrows the crawl with {@code webConfigIds(String[])}, and in Groovy
+     * that was written {@code ["id"] as String[]}. There is no such cast in JavaScript, and the
+     * scripts the integration tests build rely on the engine converting a plain array literal
+     * instead. If that ever stops holding, those jobs fail at run time with no compile error, so
+     * it is pinned here rather than discovered in a crawl that never finishes.
+     */
+    @Test
+    public void test_arrayLiteralBecomesAJavaArray() {
+        final Map<String, Object> params = new HashMap<>();
+        final ArrayTarget target = new ArrayTarget();
+        params.put("t", target);
+
+        assertEquals("a,b", javaScriptEngine.evaluate("return t.take([\"a\",\"b\"]).joined();", params));
+        assertEquals("", javaScriptEngine.evaluate("return t.take([]).joined();", params));
+        // The explicit form works too, and is what to reach for when the target is ambiguous.
+        assertEquals("c", javaScriptEngine.evaluate("return t.take(Java.to([\"c\"], \"java.lang.String[]\")).joined();", params));
+    }
+
+    /** Stands in for CrawlJob, whose webConfigIds/fileConfigIds take a String array. */
+    public static class ArrayTarget {
+        private String[] values;
+
+        /**
+         * Records the array it was handed.
+         *
+         * @param values the array
+         * @return this
+         */
+        public ArrayTarget take(final String[] values) {
+            this.values = values;
+            return this;
+        }
+
+        /**
+         * Joins what was recorded, so a script can return a plain string.
+         *
+         * @return the joined values
+         */
+        public String joined() {
+            return values == null ? "null" : String.join(",", values);
+        }
+    }
+
     @Test
     public void test_getNameAndAliases() {
         assertEquals("javascript", javaScriptEngine.getName());


### PR DESCRIPTION
Stacked on #3413.

## Why

The build fetched `fess-script-groovy` at `prepare-package` and shipped it in
`WEB-INF/plugin`, so every installation carried a script engine most of them never
call. 15.9 registers JavaScript as the default engine, which leaves Groovy as what it
now is: one script plugin among others, wanted by installations whose existing crawl
configs and boost rules are written in it.

It is no longer special in the build, so it should not be special in the distribution:

```
bin/fess-setup install plugin fess-script-groovy
```

## What goes away

- `fess.script.groovy.version` and its hand-bump comment
- the `install.webapp.plugins` and `install.webapp.plugin` targets in `deps.xml`
- the `install-webapp-plugins` execution in `pom.xml`
- `maven.codelibs.release.repo.url` and `maven.codelibs.snapshot.repo.url`, which had no
  other caller

76 lines deleted, nothing added. That machinery existed only to work around a snapshot's
timestamped file name — `maven-metadata.xml` is the only place the real file name is
written down — and the version had to be hand-bumped every release because the plugin
ships on its own cadence. Both problems go away instead of being carried into 15.10.

## Verification

Clean build (`mvn -o clean package -DskipTests`), `BUILD SUCCESS`:

| | zip | `app/WEB-INF/plugin/` |
|---|---|---|
| before | 218.9 MiB | `.keep`, `fess-script-groovy-15.9.0-SNAPSHOT.jar` (7.3 MiB) |
| after | 212.4 MiB | `.keep` |

`grep -c groovy` over the zip listing goes from 1 to 0.

Note for anyone reproducing this: an *incremental* `mvn package` still shows the jar.
`maven-war-plugin` does not remove stale files from the exploded webapp it builds up in
`target/`, so the jar from an earlier build survives into the war and then the zip. Only
a clean build shows the real result — I checked the incremental one first and it was
misleading.

`mvn -o antrun:run` also succeeds on its own, which is the step that has to keep working
because `install.jars` empties `WEB-INF/plugin`.

## Behaviour change

A boost rule or crawl config whose script type is unset runs on Groovy, so an
installation that has one and does not install the plugin loses it. #3412 makes those
rules say so in the log rather than failing quietly, which is why this is stacked on it.

Unit tests are unaffected: nothing on the test classpath ever had the Groovy engine — the
jar was fetched into `WEB-INF/plugin` at `prepare-package`, never as a Maven dependency —
and every test that mentions Groovy either stubs an engine or asserts on
`Constants.LEGACY_SCRIPT`.

## Follow-up, not in this PR

The upgrade notes in fess-docs need an entry: an installation upgrading from 15.8 with
Groovy scripts must run `bin/fess-setup install plugin fess-script-groovy`.
