### PR TITLE
build: drop the Nashorn engine Handlebars pulls but Fess never reaches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1512,6 +1512,18 @@
 			<groupId>com.github.jknack</groupId>
 			<artifactId>handlebars</artifactId>
 			<version>${handlebars.version}</version>
+			<!-- Handlebars pulls Nashorn (2.1 MiB) for one feature: Handlebars#precompileInline,
+			     which evaluates handlebars.js through javax.script to turn a template into
+			     JavaScript. ViewHelper only calls compile and apply, and no other class in the
+			     distribution or in a plugin names Nashorn, so nothing can reach it. Handlebars
+			     itself never names the engine either (it asks ScriptEngineManager), so this
+			     removes the jar without removing a code path. -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.openjdk.nashorn</groupId>
+					<artifactId>nashorn-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Tomcat -->


### PR DESCRIPTION
## Why

Handlebars declares `org.openjdk.nashorn:nashorn-core` — 2.1 MiB in `WEB-INF/lib` — for one
feature: `Handlebars#precompileInline` evaluates `handlebars.js` through `javax.script` to
turn a template into JavaScript. `ViewHelper` only calls `compile` and `apply`.

## Why it is safe

Reading the constant pools of `handlebars-4.5.4.jar`:

- `javax.script` appears in exactly two classes, `Handlebars` and `DefaultHelperRegistry`.
- The only method reaching an engine is the `precompileInline` lambda
  (`lambda$precompileInline$1` → `ScriptEngine.eval`).
- Neither class names Nashorn. The engine comes from `ScriptEngineManager`, so this removes
  a jar rather than a code path — and if something did ask for a JavaScript engine, the Sai
  engine Fess registers in 15.9 would answer.

No class in the distribution names Nashorn, and neither does any plugin in the workspace
(`fess-ds-*`, `fess-llm-*`, `fess-webapp-*`, `fess-script-*`, themes).

## Verification

`mvn test -Dtest=ViewHelperTest` → **30 tests, 0 failures**, including
`test_createCacheContent`, which is the one place that builds a `Handlebars` instance and
compiles a template.

## Not done, and why

While looking for similar dead weight I checked `okhttp-jvm` + `okio-jvm` + `kotlin-stdlib`
(2.9 MiB), which fess-crawler declares at compile scope with no `okhttp3` import of its own.
**They are not dead weight and must stay.** `fess-ds-microsoft365` uses okhttp in its main
code and deliberately does not shade it — its pom says so:

> Kiota pulls okhttp 4.12.0, but this plugin does not shade okhttp: at runtime it uses the
> okhttp-jvm 5.x that Fess supplies.

So the declaration in fess-crawler is how Fess supplies okhttp 5.x to plugins. Removing it
would break the Microsoft 365 data store at runtime. Worth a comment in fess-crawler's pom
so the next person does not delete it; that is a separate PR.
