### PR TITLE
feat(setup): add check, upgrade plugins and list installed

### DIFF
--- a/src/main/java/org/codelibs/fess/setup/Diagnostics.java
+++ b/src/main/java/org/codelibs/fess/setup/Diagnostics.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * The checks behind {@code fess-setup check}.
+ *
+ * <p>Now that OpenSearch, Node.js and the plugins are installed separately, an installation can
+ * be wrong in ways Fess only reports once a crawl or a search has already failed: an engine
+ * missing one of its plugins, a plugin jar built for another release, two versions of the same
+ * plugin loading at once. Each of those is cheap to observe from outside, which is what this
+ * does.</p>
+ *
+ * <p>The parts that read the engine take text rather than making the request, so the reasoning
+ * is testable without a cluster. The {@code _cat} APIs answer in plain text, which is why they
+ * are used here in preference to the JSON endpoints: this jar carries no JSON parser, and
+ * picking fields out of JSON with a regular expression is how a health check starts lying.</p>
+ */
+public final class Diagnostics {
+
+    /** How a single check came out. */
+    public enum Status {
+        /** Nothing to do. */
+        OK,
+        /** Works, but not as intended. */
+        WARN,
+        /** Something is broken or missing. */
+        FAIL
+    }
+
+    /**
+     * One line of the report.
+     *
+     * @param status how it came out
+     * @param name what was checked
+     * @param detail what was found
+     */
+    public record Check(Status status, String name, String detail) {
+    }
+
+    private Diagnostics() {
+    }
+
+    /**
+     * Splits a {@code _cat} response into distinct non-empty lines, in first-seen order.
+     *
+     * <p>{@code _cat} answers per node, so a three-node cluster repeats every plugin and every
+     * version three times.</p>
+     *
+     * @param text the response body
+     * @return the distinct lines
+     */
+    public static List<String> distinctLines(final String text) {
+        final Set<String> lines = new LinkedHashSet<>();
+        for (final String line : text.split("\n")) {
+            final String trimmed = line.trim();
+            if (!trimmed.isEmpty()) {
+                lines.add(trimmed);
+            }
+        }
+        return new ArrayList<>(lines);
+    }
+
+    /**
+     * Reports the engine version, and whether the cluster agrees on one.
+     *
+     * @param versions the distinct versions the nodes report
+     * @return the check
+     */
+    public static Check engineVersion(final List<String> versions) {
+        if (versions.isEmpty()) {
+            return new Check(Status.FAIL, "engine version", "no node reported a version");
+        }
+        if (versions.size() > 1) {
+            // Fess talks to whichever node answers, so a mixed cluster is not a detail.
+            return new Check(Status.WARN, "engine version", "nodes disagree: " + String.join(", ", versions));
+        }
+        return new Check(Status.OK, "engine version", versions.get(0));
+    }
+
+    /**
+     * Reports which of the plugins Fess needs are installed in the engine.
+     *
+     * @param required the plugin names Fess needs
+     * @param installed the plugin names the engine reports
+     * @return the check
+     */
+    public static Check enginePlugins(final List<String> required, final List<String> installed) {
+        final List<String> missing = required.stream().filter(name -> !isInstalled(name, installed)).toList();
+        if (missing.isEmpty()) {
+            return new Check(Status.OK, "engine plugins", String.join(", ", required));
+        }
+        return new Check(Status.FAIL, "engine plugins", "missing: " + String.join(", ", missing)
+                + " (install with: fess-setup install opensearch-plugins --opensearch-home <dir>)");
+    }
+
+    /**
+     * Reports whether one required plugin is among the installed ones.
+     *
+     * <p>The two lists are named differently on purpose. {@code plugin.artifacts} holds Maven
+     * artifact names, while {@code _cat/plugins} reports the name in each plugin's
+     * plugin-descriptor.properties, and for the CodeLibs plugins those differ by the
+     * {@code opensearch-} prefix: the artifact {@code opensearch-analysis-fess} installs as the
+     * component {@code analysis-fess}. Comparing the two verbatim reports every plugin missing
+     * on a correctly installed engine.</p>
+     *
+     * @param artifactId the Maven artifact name
+     * @param installed the component names the engine reports
+     * @return true if the plugin is installed
+     */
+    static boolean isInstalled(final String artifactId, final List<String> installed) {
+        if (installed.contains(artifactId)) {
+            return true;
+        }
+        final String prefix = "opensearch-";
+        return artifactId.startsWith(prefix) && installed.contains(artifactId.substring(prefix.length()));
+    }
+
+    /**
+     * Reports the installed Fess plugins, one check each.
+     *
+     * @param directory the plugin directory
+     * @param productVersion the major.minor this Fess accepts plugins for
+     * @return one check per installed plugin, in name order
+     * @throws SetupException if the directory cannot be read
+     */
+    public static List<Check> installedPlugins(final Path directory, final String productVersion) throws SetupException {
+        final List<Check> checks = new ArrayList<>();
+        for (final String artifactId : installedArtifactIds(directory)) {
+            final List<Path> jars = FessPluginInstaller.installedJars(directory, artifactId);
+            final List<String> versions =
+                    jars.stream().map(jar -> FessPluginInstaller.versionOf(jar.getFileName().toString(), artifactId)).toList();
+            if (versions.size() > 1) {
+                // Both jars load and which one wins is undefined, so this is not a warning.
+                checks.add(new Check(Status.FAIL, "plugin " + artifactId, "installed twice: " + String.join(", ", versions)
+                        + " (remove one with: fess-setup remove plugin " + artifactId + ", then install the version you want)"));
+                continue;
+            }
+            final String version = versions.get(0);
+            if (productVersion != null && !version.equals(productVersion) && !version.startsWith(productVersion + ".")) {
+                checks.add(new Check(Status.WARN, "plugin " + artifactId,
+                        version + " was built for another release (this Fess is " + productVersion + ")"));
+                continue;
+            }
+            checks.add(new Check(Status.OK, "plugin " + artifactId, version));
+        }
+        return checks;
+    }
+
+    /**
+     * Returns the artifact names installed in the plugin directory, in name order.
+     *
+     * @param directory the plugin directory
+     * @return the artifact names
+     * @throws SetupException if the directory cannot be read
+     */
+    public static List<String> installedArtifactIds(final Path directory) throws SetupException {
+        final Set<String> names = new LinkedHashSet<>();
+        for (final Path jar : FessPluginInstaller.installed(directory)) {
+            final String artifactId = FessPluginInstaller.artifactIdOf(jar.getFileName().toString());
+            if (artifactId != null) {
+                names.add(artifactId);
+            }
+        }
+        return new ArrayList<>(names);
+    }
+
+    /**
+     * Reports whether Node.js is installed, which only matters to the Playwright crawler.
+     *
+     * @param fessHome the Fess installation directory
+     * @param playwrightRequired whether the caller knows a crawl uses the Playwright client
+     * @return the check
+     * @throws SetupException if the Node.js directory cannot be read
+     */
+    public static Check nodejs(final Path fessHome, final boolean playwrightRequired) throws SetupException {
+        final Path root = fessHome.resolve("nodejs");
+        final String found = firstInstallation(root);
+        if (found != null) {
+            return new Check(Status.OK, "Node.js", found);
+        }
+        // Whether a crawl actually uses the Playwright client lives in the engine, not on disk,
+        // so this does not claim to know: it reports the fact and says who needs it.
+        // --playwright turns that into a failure for an installation that does use it.
+        final String detail = "not installed; only the Playwright crawler needs it (install with: fess-setup install nodejs)";
+        return new Check(playwrightRequired ? Status.FAIL : Status.OK, "Node.js", detail);
+    }
+
+    private static String firstInstallation(final Path root) throws SetupException {
+        if (!Files.isDirectory(root)) {
+            return null;
+        }
+        try (Stream<Path> entries = Files.list(root)) {
+            return entries.filter(Files::isDirectory)
+                    .filter(dir -> Files.isRegularFile(dir.resolve("bin/node")) || Files.isRegularFile(dir.resolve("node.exe")))
+                    .map(dir -> dir.getFileName().toString())
+                    .sorted()
+                    .findFirst()
+                    .orElse(null);
+        } catch (final IOException e) {
+            throw new SetupException("Failed to read " + root, e);
+        }
+    }
+
+    /**
+     * Returns the worst status in a set of checks, which is the exit status of the report.
+     *
+     * @param checks the checks
+     * @return the worst status, OK when there are none
+     */
+    public static Status worst(final List<Check> checks) {
+        Status worst = Status.OK;
+        for (final Check check : checks) {
+            if (check.status().ordinal() > worst.ordinal()) {
+                worst = check.status();
+            }
+        }
+        return worst;
+    }
+}

--- a/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
+++ b/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
@@ -104,6 +104,29 @@ public final class FessPluginInstaller {
     }
 
     /**
+     * Returns the artifact name a plugin jar's file name carries.
+     *
+     * <p>The split is at the first hyphen followed by a digit, which is where a Maven file name
+     * turns from name into version. Doing it the other way round, by trying each known prefix,
+     * would cut {@code fess-webapp-mcp-client} down to {@code fess-webapp-mcp}.</p>
+     *
+     * @param fileName the file name
+     * @return the artifact name, or {@code null} when the name does not look like a plugin jar
+     */
+    public static String artifactIdOf(final String fileName) {
+        if (!fileName.endsWith(JAR)) {
+            return null;
+        }
+        final String stem = fileName.substring(0, fileName.length() - JAR.length());
+        for (int i = 1; i < stem.length() - 1; i++) {
+            if (stem.charAt(i) == '-' && Character.isDigit(stem.charAt(i + 1))) {
+                return stem.substring(0, i);
+            }
+        }
+        return null;
+    }
+
+    /**
      * Lists the installed jars of one plugin, in file name order.
      *
      * <p>More than one is possible: nothing stops two versions of a plugin sitting side by side,

--- a/src/main/java/org/codelibs/fess/setup/FessSetup.java
+++ b/src/main/java/org/codelibs/fess/setup/FessSetup.java
@@ -75,6 +75,16 @@ public final class FessSetup {
 
               list plugins [--repository <url>]
                   Show the Fess plugins published for this version, and which are installed.
+
+              list installed
+                  Show the installed Fess plugins, without asking the repository.
+
+              upgrade plugins [--repository <url>]
+                  Re-install every installed Fess plugin at the version that fits this Fess.
+
+              check [--url <engine url>] [--playwright]
+                  Report on the installation: the engine, its plugins, and the installed
+                  plugins. Exit 0 when everything is in order, 1 when something is wrong.
             """;
 
     private FessSetup() {
@@ -108,6 +118,8 @@ public final class FessSetup {
             case "list" -> list(args, definitions, out, err);
             case "install" -> install(args, definitions, out, err);
             case "remove" -> remove(args, definitions, out, err);
+            case "upgrade" -> upgrade(args, definitions, out, err);
+            case "check" -> check(parseOptions(args, 1), definitions, out, err);
             default -> {
                 err.println(USAGE);
                 yield EXIT_USAGE;
@@ -140,6 +152,9 @@ public final class FessSetup {
     private static int list(final String[] args, final Map<String, ComponentDefinition> definitions, final PrintStream out,
             final PrintStream err) throws SetupException {
         if (args.length > 1) {
+            if ("installed".equals(args[1])) {
+                return listInstalled(definitions, parseOptions(args, 2), out);
+            }
             if (!"plugins".equals(args[1])) {
                 err.println("error: unknown list target: " + args[1]);
                 err.println(USAGE);
@@ -270,20 +285,38 @@ public final class FessSetup {
         final Path directory = pluginDirectory(definition, options);
         for (final String artifactId : artifactIds) {
             final String version = options.containsKey("version") ? options.get("version") : resolveVersion(repository, artifactId);
-            final Path jar = directory.resolve(FessPluginInstaller.jarName(artifactId, version));
-            final String url = PluginRepository.jarUrl(repository, artifactId, version);
-            out.println("Downloading " + url);
-            final int[] lastPercent = { -1 };
-            Downloader.download(URI.create(url), jar, (bytes, total) -> reportProgress(out, bytes, total, lastPercent));
-            out.println();
-            for (final Path previous : FessPluginInstaller.removeOtherVersions(directory, artifactId, jar)) {
-                out.println("Removed the previous " + previous.getFileName());
-            }
-            out.println("Installed " + jar);
+            installOne(repository, artifactId, version, directory, out);
         }
         out.println();
         out.println("Restart Fess to load " + (artifactIds.size() == 1 ? "it." : "them."));
         return EXIT_OK;
+    }
+
+    /**
+     * Downloads one plugin jar into the plugin directory and removes the other versions of it.
+     *
+     * <p>The removal happens after the download on purpose: doing it first would leave an
+     * installation with no plugin at all when the download then fails.</p>
+     *
+     * @param repository the plugin repository URL
+     * @param artifactId the plugin name
+     * @param version the version to install
+     * @param directory the plugin directory
+     * @param out the stream for normal output
+     * @throws SetupException if the download or a file operation fails
+     */
+    private static void installOne(final String repository, final String artifactId, final String version, final Path directory,
+            final PrintStream out) throws SetupException {
+        final Path jar = directory.resolve(FessPluginInstaller.jarName(artifactId, version));
+        final String url = PluginRepository.jarUrl(repository, artifactId, version);
+        out.println("Downloading " + url);
+        final int[] lastPercent = { -1 };
+        Downloader.download(URI.create(url), jar, (bytes, total) -> reportProgress(out, bytes, total, lastPercent));
+        out.println();
+        for (final Path previous : FessPluginInstaller.removeOtherVersions(directory, artifactId, jar)) {
+            out.println("Removed the previous " + previous.getFileName());
+        }
+        out.println("Installed " + jar);
     }
 
     /**
@@ -323,6 +356,201 @@ public final class FessSetup {
             out.println("Restart Fess for the change to take effect.");
         }
         return EXIT_OK;
+    }
+
+    /**
+     * Prints the installed plugins without asking the repository.
+     *
+     * <p>The first question about a broken installation is what is installed, and the answer
+     * must not depend on the machine having a route to the repository.</p>
+     *
+     * @param definitions the setup definition
+     * @param options the command line options
+     * @param out the stream for normal output
+     * @return 0
+     * @throws SetupException if the plugin directory cannot be read
+     */
+    private static int listInstalled(final Map<String, ComponentDefinition> definitions, final Map<String, String> options,
+            final PrintStream out) throws SetupException {
+        final Path directory = pluginDirectory(definitions.get(PLUGIN_COMPONENT), options);
+        final List<String> artifactIds = Diagnostics.installedArtifactIds(directory);
+        if (artifactIds.isEmpty()) {
+            out.println("No plugins are installed in " + directory);
+            return EXIT_OK;
+        }
+        for (final String artifactId : artifactIds) {
+            out.println("  " + artifactId + "  " + installedVersions(directory, artifactId));
+        }
+        return EXIT_OK;
+    }
+
+    /**
+     * Re-installs every installed plugin at the version that fits this Fess.
+     *
+     * <p>This is the chore a Fess upgrade creates: the plugins in WEB-INF/plugin were built
+     * against the previous release and stay behind until each is reinstalled by hand.</p>
+     *
+     * @param args the command line
+     * @param definitions the setup definition
+     * @param out the stream for normal output
+     * @param err the stream for errors
+     * @return 0 on success, 2 on a usage error
+     * @throws SetupException if a download or a file operation fails
+     */
+    private static int upgrade(final String[] args, final Map<String, ComponentDefinition> definitions, final PrintStream out,
+            final PrintStream err) throws SetupException {
+        if (args.length < 2 || !"plugins".equals(args[1])) {
+            err.println(USAGE);
+            return EXIT_USAGE;
+        }
+        final Map<String, String> options = parseOptions(args, 2);
+        final ComponentDefinition definition = definitions.get(PLUGIN_COMPONENT);
+        final String repository = options.getOrDefault("repository", definition.get("repository"));
+        final Path directory = pluginDirectory(definition, options);
+        final List<String> artifactIds = Diagnostics.installedArtifactIds(directory);
+        if (artifactIds.isEmpty()) {
+            out.println("No plugins are installed in " + directory);
+            return EXIT_OK;
+        }
+        int upgraded = 0;
+        for (final String artifactId : artifactIds) {
+            final String current = installedVersions(directory, artifactId);
+            final String wanted = resolveVersion(repository, artifactId);
+            if (wanted.equals(current)) {
+                out.println(artifactId + " is already at " + current);
+                continue;
+            }
+            out.println(artifactId + " " + current + " -> " + wanted);
+            installOne(repository, artifactId, wanted, directory, out);
+            upgraded++;
+        }
+        out.println();
+        if (upgraded == 0) {
+            out.println("Nothing to do.");
+        } else {
+            out.println("Restart Fess to load the new versions.");
+        }
+        return EXIT_OK;
+    }
+
+    /**
+     * Reports on the installation: the engine, its plugins, and the installed Fess plugins.
+     *
+     * @param options the command line options
+     * @param definitions the setup definition
+     * @param out the stream for normal output
+     * @param err the stream for errors
+     * @return 0 when nothing failed, 1 otherwise
+     * @throws SetupException if the plugin directory cannot be read
+     */
+    private static int check(final Map<String, String> options, final Map<String, ComponentDefinition> definitions, final PrintStream out,
+            final PrintStream err) throws SetupException {
+        final List<Diagnostics.Check> checks = new ArrayList<>();
+        final String url = engineUrl(options);
+
+        out.println("Engine  " + url);
+        try {
+            Downloader.readString(URI.create(url));
+            checks.add(new Diagnostics.Check(Diagnostics.Status.OK, "reachable", "yes"));
+            checks.add(
+                    Diagnostics.engineVersion(Diagnostics.distinctLines(Downloader.readString(URI.create(url + "/_cat/nodes?h=version")))));
+            final ComponentDefinition opensearch = definitions.get("opensearch");
+            final List<String> required = opensearch.list("plugin.artifacts").stream().map(FessSetup::artifactIdOf).toList();
+            checks.add(Diagnostics.enginePlugins(required,
+                    Diagnostics.distinctLines(Downloader.readString(URI.create(url + "/_cat/plugins?h=component")))));
+            checks.add(configsync(url));
+        } catch (final SetupException e) {
+            // Every later engine check would repeat this one failure, so stop after saying it.
+            checks.add(new Diagnostics.Check(Diagnostics.Status.FAIL, "reachable",
+                    e.getMessage() + " (set SEARCH_ENGINE_HTTP_URL, or start the engine)"));
+        }
+        checks.forEach(check -> print(out, check));
+
+        final Path directory = pluginDirectory(definitions.get(PLUGIN_COMPONENT), options);
+        out.println();
+        out.println("Fess    " + fessHome());
+        final List<Diagnostics.Check> local = new ArrayList<>();
+        local.add(pluginDirectoryCheck(directory));
+        local.addAll(Diagnostics.installedPlugins(directory, productVersionOrNull()));
+        local.add(Diagnostics.nodejs(Path.of(fessHome()), options.containsKey("playwright")));
+        local.forEach(check -> print(out, check));
+
+        checks.addAll(local);
+        final Diagnostics.Status worst = Diagnostics.worst(checks);
+        out.println();
+        if (worst == Diagnostics.Status.FAIL) {
+            err.println("Something is wrong. See the FAIL lines above.");
+            return EXIT_FAILED;
+        }
+        out.println(worst == Diagnostics.Status.WARN ? "Usable, with warnings." : "Everything checks out.");
+        return EXIT_OK;
+    }
+
+    private static Diagnostics.Check configsync(final String url) {
+        try {
+            Downloader.readString(URI.create(url + "/_configsync/file"));
+            return new Diagnostics.Check(Diagnostics.Status.OK, "configsync", "responding");
+        } catch (final SetupException e) {
+            return new Diagnostics.Check(Diagnostics.Status.FAIL, "configsync",
+                    "not responding; dictionaries will not reach the engine (" + e.getMessage() + ")");
+        }
+    }
+
+    private static Diagnostics.Check pluginDirectoryCheck(final Path directory) {
+        if (!Files.isDirectory(directory)) {
+            return new Diagnostics.Check(Diagnostics.Status.FAIL, "plugin directory", directory + " does not exist");
+        }
+        if (!Files.isWritable(directory)) {
+            return new Diagnostics.Check(Diagnostics.Status.FAIL, "plugin directory", directory + " is not writable");
+        }
+        return new Diagnostics.Check(Diagnostics.Status.OK, "plugin directory", directory.toString());
+    }
+
+    private static void print(final PrintStream out, final Diagnostics.Check check) {
+        out.printf("  %-4s  %-28s  %s%n", check.status(), check.name(), check.detail());
+    }
+
+    /**
+     * Returns the engine URL: {@code --url}, else the environment variable the launcher sets,
+     * else the default the shipped configuration uses.
+     *
+     * @param options the command line options
+     * @return the URL, without a trailing slash
+     */
+    static String engineUrl(final Map<String, String> options) {
+        String url = options.get("url");
+        if (url == null) {
+            url = System.getenv("SEARCH_ENGINE_HTTP_URL");
+        }
+        if (url == null || url.isBlank()) {
+            url = "http://localhost:9200";
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /**
+     * Returns the artifact name of a {@code groupId:artifactId} coordinate.
+     *
+     * @param coordinate the coordinate
+     * @return the artifact name
+     */
+    static String artifactIdOf(final String coordinate) {
+        final int separator = coordinate.indexOf(':');
+        return separator < 0 ? coordinate : coordinate.substring(separator + 1);
+    }
+
+    /**
+     * Returns the plugin version this build accepts, or {@code null} when it cannot be told,
+     * which is the case when the jar has no manifest.
+     *
+     * @return the major.minor, or null
+     */
+    private static String productVersionOrNull() {
+        try {
+            return FessPluginInstaller.productVersion(fessVersion());
+        } catch (final SetupException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/setup/DiagnosticsTest.java
+++ b/src/test/java/org/codelibs/fess/setup/DiagnosticsTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.codelibs.fess.setup.Diagnostics.Check;
+import org.codelibs.fess.setup.Diagnostics.Status;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class DiagnosticsTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * _cat returns one line per node, so a three-node cluster reports every plugin three
+     * times and its version three times.
+     */
+    @Test
+    public void test_distinctLines() {
+        assertEquals(List.of("3.8.0"), Diagnostics.distinctLines("3.8.0\n3.8.0\n3.8.0\n"));
+        assertEquals(List.of("opensearch-configsync", "opensearch-minhash"),
+                Diagnostics.distinctLines("opensearch-configsync\nopensearch-minhash\nopensearch-configsync\n"));
+        assertEquals(List.of(), Diagnostics.distinctLines("  \n\n"));
+    }
+
+    /**
+     * A cluster running two versions at once is a rolling upgrade, or a mistake. Either way
+     * Fess talks to whichever node answers, so it must not be reported as fine.
+     */
+    @Test
+    public void test_engineVersion_reportsAMixedCluster() {
+        final Check ok = Diagnostics.engineVersion(List.of("3.8.0"));
+        assertEquals(Status.OK, ok.status());
+        assertTrue(ok.detail().contains("3.8.0"), ok.detail());
+
+        final Check mixed = Diagnostics.engineVersion(List.of("3.8.0", "2.19.1"));
+        assertEquals(Status.WARN, mixed.status());
+        assertTrue(mixed.detail().contains("2.19.1"), mixed.detail());
+
+        assertEquals(Status.FAIL, Diagnostics.engineVersion(List.of()).status());
+    }
+
+    @Test
+    public void test_enginePlugins_namesTheMissingOnes() {
+        final List<String> required = List.of("opensearch-analysis-fess", "opensearch-configsync", "opensearch-minhash");
+
+        final Check all = Diagnostics.enginePlugins(required,
+                List.of("opensearch-minhash", "opensearch-analysis-fess", "opensearch-configsync", "opensearch-knn"));
+        assertEquals(Status.OK, all.status());
+
+        final Check some = Diagnostics.enginePlugins(required, List.of("opensearch-analysis-fess"));
+        assertEquals(Status.FAIL, some.status());
+        assertTrue(some.detail().contains("opensearch-configsync"), some.detail());
+        assertTrue(some.detail().contains("opensearch-minhash"), some.detail());
+        assertTrue(!some.detail().contains("opensearch-analysis-fess"), some.detail());
+    }
+
+    /**
+     * The names on the two sides differ. plugin.artifacts holds Maven artifact names; _cat
+     * reports the name from each plugin's descriptor, and for the CodeLibs plugins those drop
+     * the opensearch- prefix. This list is what a real fess-opensearch 3.8.0 image reports.
+     */
+    @Test
+    public void test_enginePlugins_matchesDescriptorNamesAgainstArtifactNames() {
+        final List<String> required =
+                List.of("opensearch-analysis-fess", "opensearch-analysis-extension", "opensearch-minhash", "opensearch-configsync");
+        final List<String> reported =
+                List.of("analysis-extension", "analysis-fess", "configsync", "minhash", "opensearch-knn", "opensearch-security");
+
+        final Check check = Diagnostics.enginePlugins(required, reported);
+        assertEquals(Status.OK, check.status(), check.detail());
+    }
+
+    @Test
+    public void test_enginePlugins_stillNoticesAGenuinelyMissingPlugin() {
+        final Check check =
+                Diagnostics.enginePlugins(List.of("opensearch-configsync", "opensearch-minhash"), List.of("configsync", "opensearch-knn"));
+        assertEquals(Status.FAIL, check.status());
+        assertTrue(check.detail().contains("opensearch-minhash"), check.detail());
+        assertTrue(!check.detail().contains("configsync"), check.detail());
+    }
+
+    /**
+     * Two jars of one plugin both load, and which one wins is not defined. That is a failure,
+     * not a warning: the installation behaves differently from the one the operator described.
+     */
+    @Test
+    public void test_installedPlugins_reportsTwoVersionsOfOnePlugin() throws Exception {
+        Files.writeString(tempDir.resolve("fess-ds-git-15.9.0.jar"), "x");
+        Files.writeString(tempDir.resolve("fess-ds-git-15.9.1.jar"), "x");
+
+        final List<Check> checks = Diagnostics.installedPlugins(tempDir, "15.9");
+        assertEquals(1, checks.size());
+        assertEquals(Status.FAIL, checks.get(0).status());
+        assertTrue(checks.get(0).detail().contains("15.9.0"), checks.get(0).detail());
+        assertTrue(checks.get(0).detail().contains("15.9.1"), checks.get(0).detail());
+    }
+
+    @Test
+    public void test_installedPlugins_warnsWhenAPluginIsForAnotherRelease() throws Exception {
+        Files.writeString(tempDir.resolve("fess-ds-git-15.8.0.jar"), "x");
+        Files.writeString(tempDir.resolve("fess-ds-slack-15.9.0.jar"), "x");
+
+        final List<Check> checks = Diagnostics.installedPlugins(tempDir, "15.9");
+        assertEquals(2, checks.size());
+        final Check git = checks.stream().filter(c -> c.name().contains("fess-ds-git")).findFirst().orElseThrow();
+        assertEquals(Status.WARN, git.status());
+        assertTrue(git.detail().contains("15.8.0"), git.detail());
+        final Check slack = checks.stream().filter(c -> c.name().contains("fess-ds-slack")).findFirst().orElseThrow();
+        assertEquals(Status.OK, slack.status());
+    }
+
+    @Test
+    public void test_installedPlugins_onAnEmptyDirectory() throws Exception {
+        assertEquals(List.of(), Diagnostics.installedPlugins(tempDir, "15.9"));
+    }
+
+    /**
+     * Node.js is only needed by the Playwright crawler, so a missing one is reported without
+     * being called a failure -- until the caller says this installation does use Playwright.
+     */
+    @Test
+    public void test_nodejs_isOnlyAFailureWhenTheCallerSaysItIsNeeded() throws Exception {
+        final Check absent = Diagnostics.nodejs(tempDir, false);
+        assertEquals(Status.OK, absent.status());
+        assertTrue(absent.detail().contains("Playwright"), absent.detail());
+        assertEquals(Status.FAIL, Diagnostics.nodejs(tempDir, true).status());
+
+        final Path node = tempDir.resolve("nodejs/node-v24.20.0-darwin-arm64/bin/node");
+        Files.createDirectories(node.getParent());
+        Files.writeString(node, "#!/bin/sh\n");
+        final Check found = Diagnostics.nodejs(tempDir, true);
+        assertEquals(Status.OK, found.status());
+        assertTrue(found.detail().contains("node-v24.20.0"), found.detail());
+    }
+
+    @Test
+    public void test_worst() {
+        assertEquals(Status.OK, Diagnostics.worst(List.of(check(Status.OK), check(Status.OK))));
+        assertEquals(Status.WARN, Diagnostics.worst(List.of(check(Status.OK), check(Status.WARN))));
+        assertEquals(Status.FAIL, Diagnostics.worst(List.of(check(Status.WARN), check(Status.FAIL), check(Status.OK))));
+        assertEquals(Status.OK, Diagnostics.worst(List.of()));
+    }
+
+    private static Check check(final Status status) {
+        return new Check(status, "n", "d");
+    }
+}

--- a/src/test/java/org/codelibs/fess/setup/FessPluginInstallerTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessPluginInstallerTest.java
@@ -131,6 +131,15 @@ public class FessPluginInstallerTest {
     }
 
     @Test
+    public void test_artifactIdOf() {
+        assertEquals("fess-ds-git", FessPluginInstaller.artifactIdOf("fess-ds-git-15.9.0.jar"));
+        assertEquals("fess-webapp-mcp-client", FessPluginInstaller.artifactIdOf("fess-webapp-mcp-client-1.0.jar"));
+        assertEquals("fess-ds-git", FessPluginInstaller.artifactIdOf("fess-ds-git-15.9.0-SNAPSHOT.jar"));
+        assertNull(FessPluginInstaller.artifactIdOf("README"));
+        assertNull(FessPluginInstaller.artifactIdOf("no-version-here.jar"));
+    }
+
+    @Test
     public void test_versionOf() {
         assertEquals("15.9.0", FessPluginInstaller.versionOf("fess-ds-git-15.9.0.jar", "fess-ds-git"));
         assertEquals("15.9.0-SNAPSHOT", FessPluginInstaller.versionOf("fess-ds-git-15.9.0-SNAPSHOT.jar", "fess-ds-git"));

--- a/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
@@ -209,6 +209,50 @@ public class FessSetupTest {
     }
 
     @Test
+    public void test_engineUrl_prefersTheOptionThenTheEnvironment() {
+        assertEquals("http://es:9200", FessSetup.engineUrl(Map.of("url", "http://es:9200")));
+        assertEquals("http://es:9200", FessSetup.engineUrl(Map.of("url", "http://es:9200/")), "a trailing slash would double up");
+        // With neither option nor environment variable, the default matches the shipped config.
+        if (System.getenv("SEARCH_ENGINE_HTTP_URL") == null) {
+            assertEquals("http://localhost:9200", FessSetup.engineUrl(Map.of()));
+        }
+    }
+
+    @Test
+    public void test_artifactIdOf_dropsTheGroup() {
+        assertEquals("opensearch-analysis-fess", FessSetup.artifactIdOf("org.codelibs.opensearch:opensearch-analysis-fess"));
+        assertEquals("already-bare", FessSetup.artifactIdOf("already-bare"));
+    }
+
+    @Test
+    public void test_listInstalled_onAnEmptyDirectory() {
+        assertEquals(0, run("list", "installed", "--dest", tempDir.toString()));
+        assertTrue(out().contains("No plugins are installed"), out());
+    }
+
+    @Test
+    public void test_listInstalled_namesEachPluginOnce() throws Exception {
+        java.nio.file.Files.writeString(tempDir.resolve("fess-ds-git-15.9.0.jar"), "x");
+        java.nio.file.Files.writeString(tempDir.resolve("fess-script-groovy-15.9.0.jar"), "x");
+
+        assertEquals(0, run("list", "installed", "--dest", tempDir.toString()));
+        assertTrue(out().contains("fess-ds-git  15.9.0"), out());
+        assertTrue(out().contains("fess-script-groovy  15.9.0"), out());
+    }
+
+    @Test
+    public void test_upgrade_withoutTarget_printsUsage() {
+        assertEquals(2, run("upgrade"));
+        assertTrue(err().contains("Usage:"), err());
+    }
+
+    @Test
+    public void test_upgrade_withNothingInstalled_saysSo() {
+        assertEquals(0, run("upgrade", "plugins", "--dest", tempDir.toString()));
+        assertTrue(out().contains("No plugins are installed"), out());
+    }
+
+    @Test
     public void test_sizes_useTheUnitThatSuitsTheTotal() {
         assertEquals("512/1024 MiB", FessSetup.sizes(512L << 20, 1024L << 20));
         assertEquals("4/9 KiB", FessSetup.sizes(4096L, 9728L));


### PR DESCRIPTION
Stacked on #3413.

Decoupling OpenSearch, Node.js and the plugins moved work to the operator, and with it a set
of failure modes Fess only reports once a crawl or a search has already failed. Each is cheap
to observe from outside.

## `check`

```
$ bin/fess-setup check --playwright
Engine  http://localhost:19200
  OK    reachable                     yes
  OK    engine version                3.8.0
  OK    engine plugins                opensearch-analysis-fess, opensearch-analysis-extension, opensearch-minhash, opensearch-configsync
  OK    configsync                    responding

Fess    /opt/fess
  OK    plugin directory              /opt/fess/app/WEB-INF/plugin
  FAIL  plugin fess-ds-git            installed twice: 15.9.0, 15.9.1 (remove one with: fess-setup remove plugin fess-ds-git, then install the version you want)
  WARN  plugin fess-ds-slack          15.8.0 was built for another release (this Fess is 15.9)
  OK    plugin fess-script-groovy     15.9.0
  FAIL  Node.js                       not installed; only the Playwright crawler needs it (install with: fess-setup install nodejs)

Something is wrong. See the FAIL lines above.
$ echo $?
1
```

Exit 1 on any FAIL, so it can gate a deployment. An unreachable engine reports once and skips
the checks that would only repeat it:

```
Engine  http://localhost:19299
  FAIL  reachable   Failed to read http://localhost:19299 (set SEARCH_ENGINE_HTTP_URL, or start the engine)
```

## `upgrade plugins`

Re-resolves every installed plugin to the version that fits this Fess — the chore an upgrade
creates, since the jars in `WEB-INF/plugin` were built against the previous release.

```
$ bin/fess-setup upgrade plugins
fess-ds-json 15.7.0 -> 15.9.0
Downloading .../fess-ds-json/15.9.0/fess-ds-json-15.9.0.jar
Removed the previous fess-ds-json-15.7.0.jar
Installed /opt/fess/app/WEB-INF/plugin/fess-ds-json-15.9.0.jar

Restart Fess to load the new versions.
```

Idempotent — a second run prints `fess-ds-json is already at 15.9.0` / `Nothing to do.`

## `list installed`

The first question about a broken installation, answered without needing a route to the
repository (which `list plugins` does need).

## Two things the live run corrected

Both would have shipped as bugs if I had reasoned from the dependency data instead of running
it against `ghcr.io/codelibs/fess-opensearch:3.8.0`:

1. **`_cat/plugins` reports descriptor names, not artifact names.** A real engine answers
   `analysis-fess`, `analysis-extension`, `configsync`, `minhash` — the artifacts are
   `opensearch-analysis-fess` and friends. Comparing verbatim reported **all four missing on a
   correctly installed engine**. `Diagnostics.isInstalled` now matches either form, and the
   test uses the exact list a real image reports.
2. **The Node.js check was claiming to know something it cannot.** Whether a crawl uses the
   Playwright client lives in the engine, not on disk. It now reports the fact and names who
   needs it; `--playwright` turns that into a failure for an installation that does use it.

## Why `_cat` and not the JSON endpoints

`_cat` answers in plain text. This jar carries no JSON parser by design
(`SetupPackageDependencyTest` holds the package to the JDK), and picking fields out of JSON
with a regular expression is how a health check starts lying. `distinctLines` handles the
per-node repetition `_cat` produces.

## Tests

`mvn test -Dtest='org.codelibs.fess.setup.*Test'` → **106 tests, 0 failures**
(`DiagnosticsTest` 10 new, `FessSetupTest` 33, rest existing).

Verified end to end on macOS against `ghcr.io/codelibs/fess-opensearch:3.8.0`: healthy engine,
missing plugins, unreachable engine, duplicate plugin versions, a plugin from the wrong
release, and an `upgrade plugins` round trip against a local Maven-layout repository (upgrade,
then a second run that finds nothing to do).
