### PR TITLE
feat(plugin): recognise fess-lib-* as an artifact type

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/PluginHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PluginHelper.java
@@ -602,6 +602,11 @@ public class PluginHelper {
         CRAWLER("fess-crawler"), //
         /** LLM plugins */
         LLM("fess-llm"), //
+        /**
+         * Library plugins: a third-party client and its dependencies, shipped so that the
+         * distribution does not have to carry them for every installation. fess-lib-gcs is one.
+         */
+        LIB("fess-lib"), //
         /** Unknown/generic JAR files */
         UNKNOWN("jar");
 
@@ -656,6 +661,9 @@ public class PluginHelper {
             }
             if (name.startsWith(LLM.getId())) {
                 return LLM;
+            }
+            if (name.startsWith(LIB.getId())) {
+                return LIB;
             }
             return UNKNOWN;
         }

--- a/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
+++ b/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
@@ -39,8 +39,8 @@ import java.util.stream.Stream;
 public final class FessPluginInstaller {
 
     /** The prefixes {@code PluginHelper.ArtifactType} recognises, which is what Fess can load. */
-    private static final String[] PLUGIN_PREFIXES =
-            { "fess-ds", "fess-theme", "fess-ingest", "fess-script", "fess-webapp", "fess-thumbnail", "fess-crawler", "fess-llm" };
+    private static final String[] PLUGIN_PREFIXES = { "fess-ds", "fess-theme", "fess-ingest", "fess-script", "fess-webapp",
+            "fess-thumbnail", "fess-crawler", "fess-llm", "fess-lib" };
 
     private static final String JAR = ".jar";
 

--- a/src/main/java/org/codelibs/fess/setup/PluginRepository.java
+++ b/src/main/java/org/codelibs/fess/setup/PluginRepository.java
@@ -49,8 +49,8 @@ public final class PluginRepository {
      * The artifact name prefixes Fess treats as plugins. Anything else in the group directory
      * -- {@code fess} itself, {@code fess-parent} -- is not installable.
      */
-    private static final String[] PLUGIN_PREFIXES =
-            { "fess-ds", "fess-theme", "fess-ingest", "fess-script", "fess-webapp", "fess-thumbnail", "fess-crawler", "fess-llm" };
+    private static final String[] PLUGIN_PREFIXES = { "fess-ds", "fess-theme", "fess-ingest", "fess-script", "fess-webapp",
+            "fess-thumbnail", "fess-crawler", "fess-llm", "fess-lib" };
 
     /**
      * Crawler artifacts that are libraries rather than plugins. PluginHelper hides these from

--- a/src/test/java/org/codelibs/fess/setup/FessPluginInstallerTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessPluginInstallerTest.java
@@ -91,6 +91,15 @@ public class FessPluginInstallerTest {
     }
 
     @Test
+    public void test_installed_includesLibraryPlugins() throws Exception {
+        touch("fess-lib-gcs-15.9.0.jar");
+        touch("fess-ds-git-15.9.0.jar");
+
+        assertEquals(List.of("fess-ds-git-15.9.0.jar", "fess-lib-gcs-15.9.0.jar"),
+                FessPluginInstaller.installed(tempDir).stream().map(p -> p.getFileName().toString()).toList());
+    }
+
+    @Test
     public void test_remove() throws Exception {
         touch("fess-ds-git-15.9.0.jar");
         touch("fess-ds-slack-15.9.0.jar");

--- a/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
+++ b/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
@@ -105,6 +105,12 @@ public class PluginRepositoryTest {
     }
 
     @Test
+    public void test_namesFromListing_includesLibraryPlugins() {
+        final String html = "<a href=\"fess-lib-gcs/\">x</a><a href=\"fess-lib-s3/\">x</a><a href=\"fess-parent/\">x</a>";
+        assertEquals(List.of("fess-lib-gcs", "fess-lib-s3"), PluginRepository.namesFromListing(html));
+    }
+
+    @Test
     public void test_namesFromListing_skipsNonPluginArtifacts() {
         final String html = "<a href=\"fess/\">fess/</a><a href=\"fess-parent/\">fess-parent/</a><a href=\"fess-ds-git/\">x</a>";
         final List<String> names = PluginRepository.namesFromListing(html);


### PR DESCRIPTION
Stacked on #3417. Groundwork for shipping the cloud storage clients as plugins.

## Why

`google-cloud-storage` and `software.amazon.awssdk:s3` are **26 MiB of `WEB-INF/lib`** that an
installation crawling neither `gcs:` nor `s3:` never loads. The plan is to ship them as
plugins — `fess-lib-gcs`, `fess-lib-s3` — installed with `bin/fess-setup install plugin`.

Nothing recognises that name yet. `PluginHelper.ArtifactType` matches eight prefixes and falls
through to `UNKNOWN`, so a `fess-lib-*` artifact would not appear in the admin plugin list, and
`fess-setup` would neither list nor install it.

## What this does

Adds the prefix in the three places that enumerate it:

- `PluginHelper.ArtifactType.LIB("fess-lib")` and its branch in `getType`
- `FessPluginInstaller.PLUGIN_PREFIXES` (what `list installed` and `check` recognise)
- `PluginRepository.PLUGIN_PREFIXES` (what `list plugins` offers)

`LIB` needs no special install handling — unlike `THEME`, which `installArtifact` hands to
`ThemeHelper` — so it takes the default path: the jar is copied into `WEB-INF/plugin` and read
from there on the next start.

## What this does not do

It moves nothing. Extraction is blocked on a registration point that does not exist:

- `StorageClientFactory.java:88-93` constructs `new GcsStorageClient(...)` /
  `new S3StorageClient(...)` directly, and there is **no DI entry for `StorageClient` anywhere** —
  no XML mentions it and `ComponentUtil` has no accessor. Core will not compile once the classes
  leave.
- `StorageType` (core enum listing `S3`/`GCS`/`S3_COMPAT`), the endpoint sniffing in
  `StorageClientFactory:43-63`, `SystemHelper.isStorageEnabled` and the literal
  `url.startsWith("s3:")` / `("gcs:")` in four `ProtocolHelper` methods all embed vendor
  knowledge in core.

The crawler half is in better shape: no Java source in either repo names `GcsClient` or
`S3Client` — the only naming site is `fess-crawler-lasta`'s `crawler/client.xml`, and the URL
stream handlers resolve by package name through `java.protocol.handler.pkgs`, so a plugin jar
shipping `org.codelibs.fess.net.protocol.gcs.Handler` is found without a registry.

The interface layer is already clean: `StorageClient`, `StorageItem` and `StorageException`
contain no Google or AWS types.

## Tests

`mvn test -Dtest='org.codelibs.fess.setup.*Test,PluginHelperTest'` → **147 tests, 0 failures**,
including two new ones covering a `fess-lib-*` artifact in a repository listing and in the
installed-plugin scan.
