### PR TITLE
refactor(storage): resolve the storage client through DI instead of new

### DIFF
--- a/src/main/java/org/codelibs/fess/storage/GcsStorageClient.java
+++ b/src/main/java/org/codelibs/fess/storage/GcsStorageClient.java
@@ -33,6 +33,8 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.exception.StorageException;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.util.ComponentUtil;
 
 import com.google.api.gax.paging.Page;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -55,8 +57,8 @@ public class GcsStorageClient implements StorageClient {
 
     private static final String DEFAULT_GCS_HOST = "storage.googleapis.com";
 
-    private final Storage storage;
-    private final String bucket;
+    private Storage storage;
+    private String bucket;
 
     /**
      * Constructor for subclasses that customize behavior without initializing the GCS client.
@@ -64,8 +66,7 @@ public class GcsStorageClient implements StorageClient {
      * {@code storage} or {@code bucket}.
      */
     protected GcsStorageClient() {
-        this.storage = null;
-        this.bucket = null;
+        // configured by init(), or by a subclass that overrides everything using storage
     }
 
     /**
@@ -77,6 +78,17 @@ public class GcsStorageClient implements StorageClient {
      * @param credentialsPath the path to the credentials JSON file (optional)
      */
     public GcsStorageClient(final String projectId, final String bucket, final String endpoint, final String credentialsPath) {
+        configure(projectId, bucket, endpoint, credentialsPath);
+    }
+
+    @Override
+    public void init() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        configure(fessConfig.getStorageProjectId(), fessConfig.getStorageBucket(), fessConfig.getStorageEndpoint(),
+                fessConfig.getStorageCredentialsPath());
+    }
+
+    private void configure(final String projectId, final String bucket, final String endpoint, final String credentialsPath) {
         this.bucket = bucket;
 
         final StorageOptions.Builder builder = StorageOptions.newBuilder();

--- a/src/main/java/org/codelibs/fess/storage/S3StorageClient.java
+++ b/src/main/java/org/codelibs/fess/storage/S3StorageClient.java
@@ -30,6 +30,8 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.exception.StorageException;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.util.ComponentUtil;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -61,8 +63,16 @@ public class S3StorageClient implements StorageClient {
 
     private static final Logger logger = LogManager.getLogger(S3StorageClient.class);
 
-    private final S3Client s3Client;
-    private final String bucket;
+    private S3Client s3Client;
+    private String bucket;
+
+    /**
+     * Creates an unconfigured client, which is how LastaDi builds the prototype component.
+     * {@link #init()} reads the configuration and opens the connection.
+     */
+    public S3StorageClient() {
+        // configured by init()
+    }
 
     /**
      * Creates a new S3StorageClient instance.
@@ -74,6 +84,18 @@ public class S3StorageClient implements StorageClient {
      * @param region the AWS region
      */
     public S3StorageClient(final String endpoint, final String accessKey, final String secretKey, final String bucket,
+            final String region) {
+        configure(endpoint, accessKey, secretKey, bucket, region);
+    }
+
+    @Override
+    public void init() {
+        final FessConfig fessConfig = ComponentUtil.getFessConfig();
+        configure(fessConfig.getStorageEndpoint(), fessConfig.getStorageAccessKey(), fessConfig.getStorageSecretKey(),
+                fessConfig.getStorageBucket(), fessConfig.getStorageRegion());
+    }
+
+    private void configure(final String endpoint, final String accessKey, final String secretKey, final String bucket,
             final String region) {
         this.bucket = bucket;
 

--- a/src/main/java/org/codelibs/fess/storage/StorageClient.java
+++ b/src/main/java/org/codelibs/fess/storage/StorageClient.java
@@ -27,6 +27,17 @@ import java.util.Map;
 public interface StorageClient extends AutoCloseable {
 
     /**
+     * Configures this client and opens its connection.
+     *
+     * <p>An implementation is registered as a LastaDi prototype component and is therefore
+     * created through a no-argument constructor, so this is where it reads the {@code storage.*}
+     * configuration. {@link StorageClientFactory} calls it once per instance, before any other
+     * method. It is not a default method on purpose: a client that forgot to read its
+     * configuration would fail at the first request instead of failing to compile.</p>
+     */
+    void init();
+
+    /**
      * Uploads an object to storage.
      *
      * @param objectName the name/path for the object

--- a/src/main/java/org/codelibs/fess/storage/StorageClientFactory.java
+++ b/src/main/java/org/codelibs/fess/storage/StorageClientFactory.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
+import org.codelibs.fess.exception.StorageException;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
@@ -69,28 +70,40 @@ public final class StorageClientFactory {
      * @return configured StorageClient
      */
     public static StorageClient createClient(final FessConfig fessConfig) {
-        final String endpoint = fessConfig.getStorageEndpoint();
-        final String accessKey = fessConfig.getStorageAccessKey();
-        final String secretKey = fessConfig.getStorageSecretKey();
-        final String bucket = fessConfig.getStorageBucket();
-
-        // Get explicit type or auto-detect
-        final String typeStr = fessConfig.getStorageType();
-        final StorageType type;
-        if (StringUtil.isBlank(typeStr) || "auto".equalsIgnoreCase(typeStr)) {
-            type = detectStorageType(endpoint);
-            if (logger.isDebugEnabled()) {
-                logger.debug("Auto-detected storage type: {} for endpoint: {}", type, endpoint);
-            }
-        } else {
-            type = parseStorageType(typeStr);
+        final String componentName = componentName(fessConfig.getStorageType(), fessConfig.getStorageEndpoint());
+        if (!ComponentUtil.hasComponent(componentName)) {
+            throw new StorageException("No storage client is registered as " + componentName + " for storage.type="
+                    + fessConfig.getStorageType() + ". Install the plugin that provides it, such as fess-lib-gcs for gcs.");
         }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Creating {} for endpoint: {}", componentName, fessConfig.getStorageEndpoint());
+        }
+        final StorageClient client = ComponentUtil.getComponent(componentName);
+        client.init();
+        return client;
+    }
 
-        return switch (type) {
-        case GCS -> new GcsStorageClient(fessConfig.getStorageProjectId(), bucket, endpoint, fessConfig.getStorageCredentialsPath());
-        case S3, S3_COMPAT -> new S3StorageClient(endpoint, accessKey, secretKey, bucket, fessConfig.getStorageRegion());
-        default -> new S3StorageClient(endpoint, accessKey, secretKey, bucket, fessConfig.getStorageRegion());
-        };
+    /**
+     * Returns the name of the DI component that serves a storage type.
+     *
+     * <p>The mapping from a {@code storage.type} value to an implementation lives in the DI
+     * definition rather than here, which is what lets the clients ship as plugins: core no longer
+     * names GcsStorageClient or S3StorageClient, and a plugin registering
+     * {@code <type>StorageClient} is reachable by setting {@code storage.type=<type>}. The
+     * components are prototypes because every caller closes the client it was handed.</p>
+     *
+     * @param typeStr the configured type, blank or {@code auto} to detect from the endpoint
+     * @param endpoint the storage endpoint, used only when detecting
+     * @return the component name
+     */
+    static String componentName(final String typeStr, final String endpoint) {
+        final String type;
+        if (StringUtil.isBlank(typeStr) || "auto".equalsIgnoreCase(typeStr)) {
+            type = detectStorageType(endpoint).name().toLowerCase(Locale.ROOT);
+        } else {
+            type = typeStr.trim().toLowerCase(Locale.ROOT);
+        }
+        return type + "StorageClient";
     }
 
     /**
@@ -102,19 +115,4 @@ public final class StorageClientFactory {
         return createClient(ComponentUtil.getFessConfig());
     }
 
-    /**
-     * Parses a storage type string to StorageType enum.
-     *
-     * @param typeStr the type string (s3, gcs, s3_compat, auto)
-     * @return parsed StorageType
-     */
-    private static StorageType parseStorageType(final String typeStr) {
-        final String upper = typeStr.toUpperCase(Locale.ROOT);
-        try {
-            return StorageType.valueOf(upper);
-        } catch (final IllegalArgumentException e) {
-            logger.warn("Unknown storage type: {}, defaulting to S3_COMPAT", typeStr);
-            return StorageType.S3_COMPAT;
-        }
-    }
 }

--- a/src/main/resources/fess.xml
+++ b/src/main/resources/fess.xml
@@ -5,6 +5,7 @@
 	<include path="fess_config.xml"/>
 	<include path="fess_ds.xml"/>
 	<include path="fess_se.xml"/>
+	<include path="fess_storage.xml"/>
 	<include path="esflute_config.xml"/>
 	<include path="esflute_user.xml"/>
 	<include path="esflute_log.xml"/>

--- a/src/main/resources/fess_storage.xml
+++ b/src/main/resources/fess_storage.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+	"http://dbflute.org/meta/lastadi10.dtd">
+<components>
+	<!-- Storage clients, resolved by StorageClientFactory as "<storage.type>StorageClient".
+	     The mapping from a storage.type value to a class lives here rather than in Java so that
+	     the clients can ship as fess-lib-* plugins: a plugin contributes its component through
+	     fess_storage++.xml, which merges from every jar on the classpath, and setting
+	     storage.type to its name is enough to reach it.
+
+	     They are prototypes, not singletons: every caller takes the client in a
+	     try-with-resources and closes it, which would shut down a shared instance. -->
+	<component name="s3StorageClient" class="org.codelibs.fess.storage.S3StorageClient" instance="prototype">
+	</component>
+	<!-- S3_COMPAT is the auto-detection result for MinIO and the like, and it is served by the
+	     same client as s3. It is a separate component rather than a branch in Java because that
+	     keeps the type-to-class mapping in one place. -->
+	<component name="s3_compatStorageClient" class="org.codelibs.fess.storage.S3StorageClient" instance="prototype">
+	</component>
+	<component name="gcsStorageClient" class="org.codelibs.fess.storage.GcsStorageClient" instance="prototype">
+	</component>
+</components>

--- a/src/test/java/org/codelibs/fess/storage/StorageClientFactoryTest.java
+++ b/src/test/java/org/codelibs/fess/storage/StorageClientFactoryTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.storage;
+
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.junit.jupiter.api.Test;
+
+public class StorageClientFactoryTest extends UnitFessTestCase {
+
+    @Test
+    public void test_componentName_fromAnExplicitType() {
+        assertEquals("s3StorageClient", StorageClientFactory.componentName("s3", null));
+        assertEquals("gcsStorageClient", StorageClientFactory.componentName("gcs", null));
+        assertEquals("gcsStorageClient", StorageClientFactory.componentName("GCS", null));
+        assertEquals("s3_compatStorageClient", StorageClientFactory.componentName("s3_compat", null));
+        assertEquals("s3StorageClient", StorageClientFactory.componentName("  s3  ", null));
+    }
+
+    /**
+     * The point of resolving by name: a type nobody in core knows about still maps to a
+     * component name, so a plugin registering it is reachable through storage.type alone.
+     */
+    @Test
+    public void test_componentName_fromATypeCoreDoesNotKnow() {
+        assertEquals("azureStorageClient", StorageClientFactory.componentName("azure", null));
+    }
+
+    @Test
+    public void test_componentName_detectsFromTheEndpoint() {
+        assertEquals("gcsStorageClient", StorageClientFactory.componentName(null, "https://storage.googleapis.com"));
+        assertEquals("gcsStorageClient", StorageClientFactory.componentName("auto", "https://bucket.storage.cloud.google.com"));
+        assertEquals("s3StorageClient", StorageClientFactory.componentName("auto", "https://s3.us-east-1.amazonaws.com"));
+        assertEquals("s3StorageClient", StorageClientFactory.componentName("", null));
+        // MinIO and friends: no vendor host, so the S3-compatible client.
+        assertEquals("s3_compatStorageClient", StorageClientFactory.componentName("auto", "http://minio.internal:9000"));
+    }
+
+    /**
+     * Every name {@link #test_componentName_detectsFromTheEndpoint} and the shipped
+     * storage.type values can produce has to exist in fess_storage.xml, or the admin storage
+     * screen fails at runtime for a configuration the UI offers.
+     */
+    @Test
+    public void test_everyShippedTypeHasAComponent() {
+        for (final StorageType type : StorageType.values()) {
+            final String name = StorageClientFactory.componentName(type.name(), null);
+            assertTrue(org.codelibs.fess.util.ComponentUtil.hasComponent(name), name + " is not registered in fess_storage.xml");
+        }
+        assertTrue(org.codelibs.fess.util.ComponentUtil.hasComponent(StorageClientFactory.componentName("auto", null)));
+    }
+
+    /**
+     * A prototype, not a singleton: every caller closes the client it was handed, so a shared
+     * instance would be shut down for everybody by the first caller to finish.
+     */
+    @Test
+    public void test_theComponentsArePrototypes() {
+        final Object first = org.codelibs.fess.util.ComponentUtil.getComponent("s3StorageClient");
+        final Object second = org.codelibs.fess.util.ComponentUtil.getComponent("s3StorageClient");
+        assertNotNull(first);
+        assertNotNull(second);
+        assertFalse(first == second, "s3StorageClient must be instance=\"prototype\"");
+    }
+}

--- a/src/test/resources/test_app.xml
+++ b/src/test/resources/test_app.xml
@@ -5,6 +5,13 @@
 	<include path="convention.xml" />
 	<include path="lastaflute.xml" />
 
+	<!-- The storage clients, so that fess_storage.xml is parsed by the test container. Nothing
+	     else in the suite loads fess.xml, so without this the file is never verified: a typo in
+	     a class name or a missing component would only surface on the admin storage screen at
+	     runtime. The components are prototypes with no postConstruct, so including them costs
+	     nothing and needs no running engine. -->
+	<include path="fess_storage.xml" />
+
 	<!-- Register systemProperties for test environment -->
 	<component name="systemProperties" class="org.codelibs.fess.unit.TestSystemProperties" />
 


### PR DESCRIPTION
Stacked on #3418. This is the change that makes `fess-lib-gcs` / `fess-lib-s3` possible.

## The blocker

`StorageClientFactory` constructed both clients with `new`, inside a switch over a core enum:

```java
return switch (type) {
case GCS -> new GcsStorageClient(...);
case S3, S3_COMPAT -> new S3StorageClient(...);
default -> new S3StorageClient(...);
};
```

That is a compile-time dependency from core on both vendor clients, so
`google-cloud-storage` and the AWS SDK cannot leave the distribution — core stops compiling.
And there was **no DI entry for `StorageClient` anywhere**: no XML mentioned it, `ComponentUtil`
had no accessor, so nothing could contribute one.

## The change

The factory resolves `"<storage.type>StorageClient"` through the container, and the mapping from
a type value to a class lives in `fess_storage.xml`. Core names neither client any more.

```
storage.type=gcs   -> gcsStorageClient
storage.type=s3    -> s3StorageClient
storage.type=auto  -> detected from the endpoint, unchanged
```

**The names are open-ended, which is the point.** A plugin shipping `fess_storage++.xml` with an
`azureStorageClient` component is reachable by setting `storage.type=azure`, with no core change.
`++` files merge from *every* jar on the classpath (`classLoader.getResources()`), so
`fess-lib-gcs` and `fess-lib-s3` can each ship one without colliding.

## Two details that shaped it

**Prototypes, not singletons.** Every caller takes the client in a try-with-resources
(`AdminStorageAction` has six such sites), so a shared instance would be closed for everybody by
the first caller to finish.

**Hence `StorageClient.init()`.** A prototype is built through a no-argument constructor, so the
client reads `storage.*` itself. It is deliberately *not* a `default` method: a plugin author who
forgets to read their configuration gets a compile error instead of an NPE on the first request.
The existing parameterised constructors are kept, so `GcsStorageClientTest` is untouched.

## A silent fallback removed

The old `default ->` branch handed back an S3 client for any unrecognised `storage.type` — and
`parseStorageType` logged one warning and fell through to `S3_COMPAT`. So a typo in `storage.type`
produced a working-looking S3 client against a GCS endpoint. Now it says:

```
No storage client is registered as azureStorageClient for storage.type=azure.
Install the plugin that provides it, such as fess-lib-gcs for gcs.
```

## Test coverage for a file CI never parsed

`test_app.xml` now includes `fess_storage.xml`. Nothing in the suite loaded `fess.xml`, so a typo
in a class name in a DI file surfaced only on the admin storage screen at runtime. Two of the new
tests exist because of that: one asserts every `StorageType` value and the `auto` result resolve
to a registered component, one asserts `s3StorageClient` really is a prototype.

`mvn test` → **7696 tests, 0 failures, 0 errors.**

## Still to do (not in this PR)

The classes have not moved. Remaining core coupling, from a full audit:

- `StorageType` enum, and the endpoint sniffing in `StorageClientFactory:43-63`
- `SystemHelper.isStorageEnabled` compares against `StorageType.GCS`
- four `ProtocolHelper` methods with literal `url.startsWith("s3:")` / `("gcs:")`
- the default `crawler.file.protocols` lists `s3,gcs`
- the admin general JSP hard-codes the `auto`/`s3`/`gcs` dropdown
- `fess-crawler-lasta`'s `crawler/client.xml` names `GcsClient` and `S3Client` — a plugin can
  override this with `crawler/client++.xml`
- `fess-crawler` declares both SDKs at compile scope, so removing them from this pom alone does
  not remove them from the WAR
