### PR TITLE
fix(deps): pin google-http-client-gson with the rest of the family

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1182,6 +1182,16 @@
 			<artifactId>google-http-client-jackson2</artifactId>
 			<version>${google.http.client.version}</version>
 		</dependency>
+		<!-- OpenIdConnectAuthenticator uses GsonFactory from here, and this is the only one of the
+		     four google-http-client artifacts that was not declared. It arrived transitively from
+		     google-oauth-client instead, which asks for an older line than the core jar: two paths
+		     at the same depth, so declaration order decided it and the gson helper ran against a
+		     core jar of a different major version. Declaring it keeps all four on one version. -->
+		<dependency>
+			<groupId>com.google.http-client</groupId>
+			<artifactId>google-http-client-gson</artifactId>
+			<version>${google.http.client.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>com.google.http-client</groupId>
 			<artifactId>google-http-client-xml</artifactId>


### PR DESCRIPTION
Companion to codelibs/fess-parent#79, which fixes the GCS client failing to start. This half is
correct under either value of the property and can merge in either order.

## The split

Three of the four `google-http-client` artifacts are declared here at
`${google.http.client.version}` — `google-http-client`, `-jackson2`, `-xml`. `-gson` is not, so it
arrives transitively:

```
+- com.google.oauth-client:google-oauth-client:jar:1.39.0
|  \- com.google.http-client:google-http-client-gson:jar:1.43.3      <- wins
\- com.google.cloud:google-cloud-storage:jar:2.71.0
   \- (com.google.http-client:google-http-client-gson:jar:2.2.0 - omitted for conflict)
```

Two paths at the same depth, so declaration order decided it. `OpenIdConnectAuthenticator` uses
`GsonFactory` from that jar, so this is not theoretical.

It matters more once fess-parent#79 lands: the core jar goes to 2.2.0 while the gson helper stays
on 1.43.3 — a major version apart. After this change all four resolve together:

```
com.google.http-client:google-http-client:jar:2.2.0
com.google.http-client:google-http-client-jackson2:jar:2.2.0
com.google.http-client:google-http-client-gson:jar:2.2.0
com.google.http-client:google-http-client-xml:jar:2.2.0
```

## Verification

`mvn test` against a locally installed fess-parent#79 → **7634 tests, 0 failures**, including
`OpenIdConnectAuthenticatorTest` (41).

`GcsStorageClient` then drives a real `fsouza/fake-gcs-server` end to end — upload, download with
the content compared, list, tags, delete — which is what fails today with `NoSuchMethodError`
before any request is made.

## A note on this PR's CI

The workflow installs fess-parent from `main` (`PARENT_BRANCH: main`), so **this PR's green build
does not exercise the 2.x version**: it will resolve 1.47.0 for all four artifacts, which is
internally consistent and passes. The evidence for the 2.x combination is the local run above and
fess-parent#79.
