### PR TITLE
refactor!: replace the fess-lib-* plugin type with fess-storage-* and fess-sso-*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1310,7 +1310,7 @@
 			<!-- Not used by Fess itself: this and google-auth-library-oauth2-http below are here
 			     to supply fess-ds-gsuite, which declares both with scope provided and does not
 			     shade them. They arrived as transitive dependencies of google-cloud-storage until
-			     the GCS client moved to the fess-lib-gcs plugin, so they are declared here to keep
+			     the GCS client moved to the fess-storage-gcs plugin, so they are declared here to keep
 			     that plugin working. The versions are the ones fess-ds-gsuite compiles against.
 			     Fess's own OpenID Connect code uses google-http-client and google-oauth-client
 			     (com.google.api.client.auth/http/json), which are declared separately. -->
@@ -1469,7 +1469,7 @@
 				<exclusion>
 					<!-- The Google Cloud Storage SDK is 18 MiB of the distribution for a protocol
 					     that most installations never crawl, and it moves faster than Fess does.
-					     It ships in the fess-lib-gcs plugin instead, which carries the SDK and
+					     It ships in the fess-storage-gcs plugin instead, which carries the SDK and
 					     registers GcsClient with crawlerClientCreator. fess-crawler still compiles
 					     GcsClient against the SDK, so this exclusion is what keeps the jars out of
 					     the war; the classes stay in fess-crawler.jar and cost a few tens of KiB.

--- a/src/main/java/org/codelibs/fess/helper/PluginHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PluginHelper.java
@@ -603,10 +603,18 @@ public class PluginHelper {
         /** LLM plugins */
         LLM("fess-llm"), //
         /**
-         * Library plugins: a third-party client and its dependencies, shipped so that the
-         * distribution does not have to carry them for every installation. fess-lib-gcs is one.
+         * Object storage backend plugins. Each one bundles the {@code <type>StorageClient} that
+         * {@code storage.type} selects and the crawler client that reads the same backend, plus
+         * the third-party SDK they need, so the distribution does not carry it for every
+         * installation. fess-storage-gcs is one.
          */
-        LIB("fess-lib"), //
+        STORAGE("fess-storage"), //
+        /**
+         * Single sign-on plugins, contributing the {@code SsoAuthenticator} that {@code sso.type}
+         * selects. No such plugin exists as of 15.9 - the authenticators still ship in core - so
+         * this reserves the prefix for when they are split out.
+         */
+        SSO("fess-sso"), //
         /** Unknown/generic JAR files */
         UNKNOWN("jar");
 
@@ -662,8 +670,11 @@ public class PluginHelper {
             if (name.startsWith(LLM.getId())) {
                 return LLM;
             }
-            if (name.startsWith(LIB.getId())) {
-                return LIB;
+            if (name.startsWith(STORAGE.getId())) {
+                return STORAGE;
+            }
+            if (name.startsWith(SSO.getId())) {
+                return SSO;
             }
             return UNKNOWN;
         }

--- a/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
+++ b/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
@@ -40,7 +40,7 @@ public final class FessPluginInstaller {
 
     /** The prefixes {@code PluginHelper.ArtifactType} recognises, which is what Fess can load. */
     private static final String[] PLUGIN_PREFIXES = { "fess-ds", "fess-theme", "fess-ingest", "fess-script", "fess-webapp",
-            "fess-thumbnail", "fess-crawler", "fess-llm", "fess-lib" };
+            "fess-thumbnail", "fess-crawler", "fess-llm", "fess-storage", "fess-sso" };
 
     private static final String JAR = ".jar";
 

--- a/src/main/java/org/codelibs/fess/setup/PluginRepository.java
+++ b/src/main/java/org/codelibs/fess/setup/PluginRepository.java
@@ -50,7 +50,7 @@ public final class PluginRepository {
      * -- {@code fess} itself, {@code fess-parent} -- is not installable.
      */
     private static final String[] PLUGIN_PREFIXES = { "fess-ds", "fess-theme", "fess-ingest", "fess-script", "fess-webapp",
-            "fess-thumbnail", "fess-crawler", "fess-llm", "fess-lib" };
+            "fess-thumbnail", "fess-crawler", "fess-llm", "fess-storage", "fess-sso" };
 
     /**
      * Crawler artifacts that are libraries rather than plugins. PluginHelper hides these from

--- a/src/main/java/org/codelibs/fess/storage/StorageClientFactory.java
+++ b/src/main/java/org/codelibs/fess/storage/StorageClientFactory.java
@@ -73,7 +73,7 @@ public final class StorageClientFactory {
         final String componentName = componentName(fessConfig.getStorageType(), fessConfig.getStorageEndpoint());
         if (!ComponentUtil.hasComponent(componentName)) {
             throw new StorageException("No storage client is registered as " + componentName + " for storage.type="
-                    + fessConfig.getStorageType() + ". Install the plugin that provides it, such as fess-lib-gcs for gcs.");
+                    + fessConfig.getStorageType() + ". Install the plugin that provides it, such as fess-storage-gcs for gcs.");
         }
         if (logger.isDebugEnabled()) {
             logger.debug("Creating {} for endpoint: {}", componentName, fessConfig.getStorageEndpoint());

--- a/src/main/resources/fess_storage.xml
+++ b/src/main/resources/fess_storage.xml
@@ -4,9 +4,9 @@
 <components>
 	<!-- Storage clients, resolved by StorageClientFactory as "<storage.type>StorageClient".
 	     The mapping from a storage.type value to a class lives here rather than in Java so that
-	     the clients can ship as fess-lib-* plugins: a plugin contributes its component through
+	     the clients can ship as fess-storage-* plugins: a plugin contributes its component through
 	     fess_storage++.xml, which merges from every jar on the classpath, and setting
-	     storage.type to its name is enough to reach it. fess-lib-gcs registers gcsStorageClient
+	     storage.type to its name is enough to reach it. fess-storage-gcs registers gcsStorageClient
 	     that way; storage.type=gcs without that plugin installed is a configuration error the
 	     factory reports rather than a missing class.
 

--- a/src/test/java/org/codelibs/fess/helper/PluginHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/PluginHelperTest.java
@@ -534,6 +534,9 @@ public class PluginHelperTest extends UnitFessTestCase {
         assertEquals(ArtifactType.WEBAPP, ArtifactType.getType("fess-webapp-test"));
         assertEquals(ArtifactType.THUMBNAIL, ArtifactType.getType("fess-thumbnail-test"));
         assertEquals(ArtifactType.CRAWLER, ArtifactType.getType("fess-crawler-test"));
+        assertEquals(ArtifactType.LLM, ArtifactType.getType("fess-llm-test"));
+        assertEquals(ArtifactType.STORAGE, ArtifactType.getType("fess-storage-gcs"));
+        assertEquals(ArtifactType.SSO, ArtifactType.getType("fess-sso-saml"));
         assertEquals(ArtifactType.UNKNOWN, ArtifactType.getType("unknown-test"));
     }
 

--- a/src/test/java/org/codelibs/fess/helper/ProtocolHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/ProtocolHelperTest.java
@@ -754,7 +754,7 @@ public class ProtocolHelperTest extends UnitFessTestCase {
         assertTrue(protocolHelper.isValidFileProtocol("ftp://ftp.example.com/file"));
         assertTrue(protocolHelper.isValidFileProtocol("s3://bucket/key"));
 
-        // gcs is not in the shipped default: fess-lib-gcs adds it with addFileProtocol when the
+        // gcs is not in the shipped default: fess-storage-gcs adds it with addFileProtocol when the
         // plugin is installed, which test_s3_gcs_protocols_add_dynamically covers.
         assertFalse(protocolHelper.isValidFileProtocol("gcs://bucket/object"));
 

--- a/src/test/java/org/codelibs/fess/setup/FessPluginInstallerTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessPluginInstallerTest.java
@@ -91,11 +91,11 @@ public class FessPluginInstallerTest {
     }
 
     @Test
-    public void test_installed_includesLibraryPlugins() throws Exception {
-        touch("fess-lib-gcs-15.9.0.jar");
+    public void test_installed_includesStoragePlugins() throws Exception {
+        touch("fess-storage-gcs-15.9.0.jar");
         touch("fess-ds-git-15.9.0.jar");
 
-        assertEquals(List.of("fess-ds-git-15.9.0.jar", "fess-lib-gcs-15.9.0.jar"),
+        assertEquals(List.of("fess-ds-git-15.9.0.jar", "fess-storage-gcs-15.9.0.jar"),
                 FessPluginInstaller.installed(tempDir).stream().map(p -> p.getFileName().toString()).toList());
     }
 

--- a/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
+++ b/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
@@ -105,9 +105,9 @@ public class PluginRepositoryTest {
     }
 
     @Test
-    public void test_namesFromListing_includesLibraryPlugins() {
-        final String html = "<a href=\"fess-lib-gcs/\">x</a><a href=\"fess-lib-s3/\">x</a><a href=\"fess-parent/\">x</a>";
-        assertEquals(List.of("fess-lib-gcs", "fess-lib-s3"), PluginRepository.namesFromListing(html));
+    public void test_namesFromListing_includesStoragePlugins() {
+        final String html = "<a href=\"fess-storage-gcs/\">x</a><a href=\"fess-storage-s3/\">x</a><a href=\"fess-parent/\">x</a>";
+        assertEquals(List.of("fess-storage-gcs", "fess-storage-s3"), PluginRepository.namesFromListing(html));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fess/storage/StorageClientFactoryTest.java
+++ b/src/test/java/org/codelibs/fess/storage/StorageClientFactoryTest.java
@@ -63,7 +63,7 @@ public class StorageClientFactoryTest extends UnitFessTestCase {
     }
 
     /**
-     * GCS is deliberately not in that list. Its client ships in fess-lib-gcs, together with the
+     * GCS is deliberately not in that list. Its client ships in fess-storage-gcs, together with the
      * Google Cloud Storage SDK the distribution no longer carries, so what core keeps is the name
      * the plugin registers under and the endpoint detection that produces it. Registering a
      * component here again would pull the SDK back into the war.
@@ -72,7 +72,7 @@ public class StorageClientFactoryTest extends UnitFessTestCase {
     public void test_gcsIsServedByAPluginRatherThanCore() {
         assertEquals("gcsStorageClient", StorageClientFactory.componentName(StorageType.GCS.name(), null));
         assertFalse(org.codelibs.fess.util.ComponentUtil.hasComponent("gcsStorageClient"),
-                "gcsStorageClient belongs to fess-lib-gcs, which contributes it through fess_storage++.xml");
+                "gcsStorageClient belongs to fess-storage-gcs, which contributes it through fess_storage++.xml");
     }
 
     /**


### PR DESCRIPTION
Eight of the nine `ArtifactType` prefixes name an extension point: `fess-ds` is a `DataStore`, `fess-script` a `ScriptEngine`, `fess-llm` an LLM client, `fess-thumbnail` a `ThumbnailGenerator`. `LIB("fess-lib")`, added in #3418, named the content instead — "a third-party client and its dependencies". The admin Plugin page renders the constant verbatim through `${f:h(artifact.type)}` (`admin_plugin.jsp:72`), so an administrator saw `LIB`, which says nothing about what installing the plugin enables.

#3418 is not contained in any release tag (the latest is `fess-15.8.0`) and no `fess-lib-*` artifact was ever published, so this replaces the type rather than migrating it.

## `STORAGE("fess-storage")`

An object storage plugin bundles the `<type>StorageClient` that `storage.type` selects together with the crawler client that reads the same backend, in **one** jar. That is a constraint rather than a preference:

* `PluginHelper#install` downloads a single jar and does no dependency resolution, so a plugin cannot depend on another plugin;
* these plugins cannot relocate — `GcsClient` lives in fess-crawler, outside the jar, and binds the SDK by its real package names;
* `FessWebResourceRoot#processWebInfLib` mounts every `Fess-WebAppJar` flat at `/WEB-INF/classes`.

Two artifacts for one backend would therefore put two copies of the SDK on one class path, where the winner is decided by scan order and the loser is silently ignored.

`fess-lib-gcs` is renamed to `fess-storage-gcs`, so `StorageClientFactory`'s "install the plugin that provides it" message and the comments naming it follow.

## `SSO("fess-sso")`

This reserves the prefix. **No such plugin exists yet** and the javadoc says so — `saml`, `entraid`, `spnego` and `oic` still ship in core. It is here rather than in the release that splits them because the prefix list is duplicated in three places and the documentation carries a plugin-type table in seven languages; adding it later means touching all of that twice inside one release cycle.

The split is already shaped for it: `SsoManager#getAuthenticator` resolves `<sso.type>Authenticator` by DI component name, exactly as `StorageClientFactory` resolves `<storage.type>StorageClient`, and the core packages are already `org.codelibs.fess.sso.<type>`, so extracting an authenticator would need no package change. `oic` would stay in core, since nimbus and google-oauth-client are used by Fess's own OpenID Connect code.

## The duplicated prefix list

`FessPluginInstaller.PLUGIN_PREFIXES` and `PluginRepository.PLUGIN_PREFIXES` both document that they track `ArtifactType`, and both are updated in the same order. I checked fessctl, docker-fess and fess-crawler for a fourth copy; there is none.

## Tests

`PluginHelperTest#test_ArtifactType_getType` gains the two new prefixes and `fess-llm-test`, which was uncovered. Two test methods whose names had become false (`..._includesLibraryPlugins`) are renamed after the type they exercise.

108 tests across `PluginHelperTest`, `FessPluginInstallerTest`, `PluginRepositoryTest`, `StorageClientFactoryTest` and `ProtocolHelperTest` pass.
