### PR TITLE
fix: report the crawl paths and storage failures that used to pass in silence

### DIFF
--- a/src/main/java/org/codelibs/fess/app/web/admin/storage/AdminStorageAction.java
+++ b/src/main/java/org/codelibs/fess/app/web/admin/storage/AdminStorageAction.java
@@ -25,6 +25,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -323,12 +324,27 @@ public class AdminStorageAction extends FessAdminAction {
     }
 
     /**
-     * Retrieves a list of files and directories from the storage system.
+     * Retrieves a list of files and directories from the storage system, discarding a failure.
      *
      * @param prefix the path prefix to list objects under
-     * @return list of file and directory information maps
+     * @return list of file and directory information maps, empty if the listing failed
      */
     public static List<Map<String, Object>> getFileItems(final String prefix) {
+        return getFileItems(prefix, e -> {});
+    }
+
+    /**
+     * Retrieves a list of files and directories from the storage system, handing a failure to the
+     * given handler. A failure returns an empty list instead of propagating, so the handler is the
+     * only way for a caller to tell an empty bucket from a storage it cannot reach at all: the
+     * message of the exception {@link StorageClientFactory} throws when no client is registered for
+     * the configured storage type names the plugin that provides one.
+     *
+     * @param prefix the path prefix to list objects under
+     * @param failureHandler receives the exception when the listing fails
+     * @return list of file and directory information maps, empty if the listing failed
+     */
+    public static List<Map<String, Object>> getFileItems(final String prefix, final Consumer<Exception> failureHandler) {
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
         final List<Map<String, Object>> list = new ArrayList<>();
         final List<Map<String, Object>> fileList = new ArrayList<>();
@@ -355,9 +371,8 @@ public class AdminStorageAction extends FessAdminAction {
                 }
             }
         } catch (final Exception e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Failed to access storage endpoint: {}", fessConfig.getStorageEndpoint(), e);
-            }
+            logger.warn("Failed to access storage endpoint: {}", fessConfig.getStorageEndpoint(), e);
+            failureHandler.accept(e);
         }
 
         list.addAll(fileList);
@@ -507,7 +522,10 @@ public class AdminStorageAction extends FessAdminAction {
             RenderDataUtil.register(data, "path", path);
             RenderDataUtil.register(data, "pathItems", createPathItems(path));
             RenderDataUtil.register(data, "parentId", createParentId(path));
-            RenderDataUtil.register(data, "fileItems", getFileItems(path));
+            // an unreachable storage otherwise renders as an empty list, so the reason is put on
+            // the screen too; for a missing plugin the message names the plugin to install
+            RenderDataUtil.register(data, "fileItems", getFileItems(path, e -> saveError(messages -> messages
+                    .addErrorsStorageAccessError(GLOBAL, e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()))));
         });
     }
 

--- a/src/main/java/org/codelibs/fess/helper/WebFsIndexHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/WebFsIndexHelper.java
@@ -37,6 +37,7 @@ import org.codelibs.fess.crawler.service.impl.OpenSearchDataService;
 import org.codelibs.fess.crawler.service.impl.OpenSearchUrlFilterService;
 import org.codelibs.fess.crawler.service.impl.OpenSearchUrlQueueService;
 import org.codelibs.fess.indexer.IndexUpdater;
+import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.config.exbhv.BoostDocumentRuleBhv;
 import org.codelibs.fess.opensearch.config.exentity.BoostDocumentRule;
 import org.codelibs.fess.opensearch.config.exentity.CrawlingConfig.ConfigName;
@@ -62,6 +63,13 @@ public class WebFsIndexHelper {
     private static final Logger logger = LogManager.getLogger(WebFsIndexHelper.class);
 
     private static final String DISABLE_URL_ENCODE = "#DISABLE_URL_ENCODE";
+
+    /**
+     * Pattern of a URL scheme of two or more characters, such as {@code s3:} or {@code gcs:}.
+     * A single-character scheme is out so that a Windows drive letter, as in {@code C:\path},
+     * is not read as a protocol.
+     */
+    private static final Pattern SCHEME_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.\\-]+:");
 
     /**
      * Maximum number of URLs to access during crawling.
@@ -195,11 +203,19 @@ public class WebFsIndexHelper {
 
             // set urls
             split(urlsStr, "[\r\n]").of(stream -> stream.filter(StringUtil::isNotBlank).map(String::trim).distinct().forEach(urlValue -> {
-                if (!urlValue.startsWith("#") && protocolHelper.isValidWebProtocol(urlValue)) {
-                    final String u = duplicateHostHelper.convert(urlValue);
-                    crawler.addUrl(u);
-                    if (logger.isInfoEnabled()) {
-                        logger.info("Target URL: {}", u);
+                if (!urlValue.startsWith("#")) {
+                    if (protocolHelper.isValidWebProtocol(urlValue)) {
+                        final String u = duplicateHostHelper.convert(urlValue);
+                        crawler.addUrl(u);
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Target URL: {}", u);
+                        }
+                    } else {
+                        // Unlike a file crawling path, which falls back to file:, a web URL with an
+                        // unusable protocol is dropped, and used to be dropped without a trace: the
+                        // job then succeeded having crawled nothing.
+                        logger.warn("Unsupported protocol in a crawling URL: {}. It is skipped. Available web protocols are {} ({}).",
+                                urlValue, ComponentUtil.getFessConfig().getCrawlerWebProtocols(), FessConfig.CRAWLER_WEB_PROTOCOLS);
                     }
                 }
             }));
@@ -322,6 +338,11 @@ public class WebFsIndexHelper {
                 if (!urlValue.startsWith("#")) {
                     final String u;
                     if (!protocolHelper.isValidFileProtocol(urlValue)) {
+                        if (isUnsupportedProtocol(urlValue, protocolHelper.getFileProtocols())) {
+                            logger.warn(
+                                    "Unsupported protocol in a crawling path: {}. It is crawled as a local file path. Available file protocols are {} ({}). The plugin that provides this protocol may not be installed.",
+                                    urlValue, ComponentUtil.getFessConfig().getCrawlerFileProtocols(), FessConfig.CRAWLER_FILE_PROTOCOLS);
+                        }
                         if (urlValue.startsWith("/")) {
                             u = "file:" + urlValue;
                         } else {
@@ -329,6 +350,16 @@ public class WebFsIndexHelper {
                         }
                     } else {
                         u = urlValue;
+                    }
+                    if (crawler.getClientFactory().getClient(u) == null) {
+                        // The other half of the report above: there, the protocol is not configured
+                        // at all; here it is, but nothing is registered to fetch it. An installation
+                        // that upgrades keeps its own crawler.file.protocols, so this is the shape a
+                        // missing protocol plugin takes for it. fess-crawler only logs the skip at
+                        // info level, per URL, once the crawl is under way.
+                        logger.warn(
+                                "No crawler client is registered for a crawling path: {}. It is not crawled. The plugin that provides this protocol may not be installed.",
+                                u);
                     }
                     crawler.addUrl(u);
                     if (logger.isInfoEnabled()) {
@@ -509,6 +540,26 @@ public class WebFsIndexHelper {
             ComponentUtil.getCrawlingConfigHelper().remove(sid);
             deleteCrawlData(sid);
         }
+    }
+
+    /**
+     * Determines whether the given crawling path carries a protocol that file crawling cannot
+     * handle. It is true only when the path starts with a scheme of two or more characters that
+     * none of the given file protocols covers, which keeps a local path such as {@code /var/data},
+     * a relative path, and a Windows drive letter such as {@code C:\path} out of the report.
+     *
+     * @param path a path from a file crawling configuration
+     * @param fileProtocols the file protocols in use, each ending with a colon, as
+     *            {@link ProtocolHelper#getFileProtocols()} returns them
+     * @return true if the path carries a protocol that is not in use for file crawling
+     */
+    static boolean isUnsupportedProtocol(final String path, final String[] fileProtocols) {
+        for (final String fileProtocol : fileProtocols) {
+            if (path.startsWith(fileProtocol)) {
+                return false;
+            }
+        }
+        return SCHEME_PATTERN.matcher(path).find();
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/app/web/admin/storage/AdminStorageActionTest.java
+++ b/src/test/java/org/codelibs/fess/app/web/admin/storage/AdminStorageActionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.app.web.admin.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.codelibs.fess.exception.StorageException;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.unit.UnitFessTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+
+public class AdminStorageActionTest extends UnitFessTestCase {
+
+    /**
+     * gcs is served by fess-storage-gcs, so on an installation without that plugin no client is
+     * registered for it. That is the configuration the storage screen used to render as an empty
+     * list.
+     */
+    private void useAStorageTypeNoPluginServes() {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getStorageType() {
+                return "gcs";
+            }
+        });
+    }
+
+    @Test
+    public void test_getFileItems_handsTheFailureToTheCaller() {
+        useAStorageTypeNoPluginServes();
+
+        final List<Exception> failures = new ArrayList<>();
+        final List<Map<String, Object>> items = AdminStorageAction.getFileItems("", failures::add);
+
+        // still an empty list rather than an exception: what changed is that the caller is told why
+        assertTrue(items.isEmpty());
+        assertEquals(1, failures.size());
+        final Exception e = failures.get(0);
+        assertTrue(e instanceof StorageException, "unexpected failure: " + e);
+        // the message the storage screen shows names the component and the plugin to install
+        assertTrue(e.getMessage().contains("gcsStorageClient"), e.getMessage());
+        assertTrue(e.getMessage().contains("fess-storage-gcs"), e.getMessage());
+    }
+
+    @Test
+    public void test_getFileItems_withoutAHandlerStillDiscardsTheFailure() {
+        useAStorageTypeNoPluginServes();
+
+        // the form ApiAdminStorageAction uses: unchanged, an empty list and no exception
+        assertTrue(AdminStorageAction.getFileItems("").isEmpty());
+    }
+}

--- a/src/test/java/org/codelibs/fess/helper/WebFsIndexHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/WebFsIndexHelperTest.java
@@ -468,4 +468,41 @@ public class WebFsIndexHelperTest extends UnitFessTestCase {
             assertTrue(true);
         }
     }
+
+    /**
+     * The file protocols of an installation whose s3 protocol comes from a plugin that is not
+     * installed: crawler.file.protocols minus s3, in the form ProtocolHelper hands out.
+     */
+    private static final String[] FILE_PROTOCOLS_WITHOUT_S3 = { "file:", "smb:", "smb1:", "ftp:" };
+
+    @Test
+    public void test_isUnsupportedProtocol_reportsAProtocolNobodyServes() {
+        // the path is rewritten to file:/s3://bucket/x and crawls nothing, so it has to be reported
+        assertTrue(WebFsIndexHelper.isUnsupportedProtocol("s3://bucket/x", FILE_PROTOCOLS_WITHOUT_S3));
+        assertTrue(WebFsIndexHelper.isUnsupportedProtocol("gcs://bucket/x", FILE_PROTOCOLS_WITHOUT_S3));
+    }
+
+    @Test
+    public void test_isUnsupportedProtocol_keepsQuietForAProtocolInUse() {
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("file:/foo", FILE_PROTOCOLS_WITHOUT_S3));
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("smb://host/share", FILE_PROTOCOLS_WITHOUT_S3));
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("smb1://host/share", FILE_PROTOCOLS_WITHOUT_S3));
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("ftp://host/dir", FILE_PROTOCOLS_WITHOUT_S3));
+        // and the same s3 path once the protocol is configured
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("s3://bucket/x", new String[] { "file:", "s3:" }));
+    }
+
+    @Test
+    public void test_isUnsupportedProtocol_keepsQuietForAPathWithoutAProtocol() {
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("/foo/bar", FILE_PROTOCOLS_WITHOUT_S3));
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("foo/bar", FILE_PROTOCOLS_WITHOUT_S3));
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("\\\\host\\share", FILE_PROTOCOLS_WITHOUT_S3));
+    }
+
+    @Test
+    public void test_isUnsupportedProtocol_doesNotMistakeAWindowsDriveLetterForAProtocol() {
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("C:\\path", FILE_PROTOCOLS_WITHOUT_S3));
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("C:/path", FILE_PROTOCOLS_WITHOUT_S3));
+        assertFalse(WebFsIndexHelper.isUnsupportedProtocol("c:\\Users\\foo\\docs", FILE_PROTOCOLS_WITHOUT_S3));
+    }
 }


### PR DESCRIPTION
Groundwork for moving the S3 storage backend to a plugin, and useful on its own. Four ways a crawl or the storage screen could do nothing while looking fine are now reported. **None of them changes what Fess crawls or stores** — every one only adds a log line, plus one message on the storage screen.

Three of the four become reachable when a storage backend ships as a plugin: an installation that upgrades and does not install it hits them. That is why this goes in first.

## The four

| Where | Before | Now |
| --- | --- | --- |
| File crawl path, protocol not in `crawler.file.protocols` | `s3://bucket/docs` silently became `file:/s3://bucket/docs`; `INFO Target Path:` was the only trace | Warned first, then the same fallback |
| File crawl path, protocol configured but no crawler client | fess-crawler logged `INFO Unsupported URL:` per URL, mid-crawl | Warned once, up front, naming the path |
| Web crawl URL, protocol not in `crawler.web.protocols` | Dropped with **no log at any level** | Still skipped, now warned |
| `AdminStorageAction.getFileItems` failure | `logger.debug` only, so an unreachable endpoint and an uninstalled plugin both rendered as an empty file list | Warned with the exception, and shown on the screen |

The second row is the likeliest of the four in practice, and the first is the rarer companion to it. `CreateForm.paths` carries `@UriType(protocolType = ProtocolType.FILE)`, and `UriTypeValidator` resolves that to `ProtocolHelper.getFileProtocols()`, so on a **fresh** installation the administration screen already refuses to save a path whose protocol is not configured — that case is visible without any change here, and row one catches only a path that arrived some other way: stored before the protocol left, imported, or written through the API.

Row two is the one that is silent for the installation that actually exists. An upgrade keeps its own `fess_config.properties`, so a protocol whose plugin is not installed stays valid in `crawler.file.protocols`: the form accepts the path, row one's warning never fires, and the failure surfaces only as info-level lines from fess-crawler once the crawl is already running.

## The Windows drive letter

The scheme test requires **two or more** characters, so `C:\path` keeps going through the `file:` fallback quietly. `/var/data` and relative paths are unaffected because they carry no scheme at all. The decision is a package-private `isUnsupportedProtocol(path, fileProtocols)` so it can be pinned without a container; six cases are asserted, including `C:\path`, `file:/foo`, `/foo/bar` and `smb://host/share` staying quiet.

## The storage screen message

`getFileItems` gains an overload taking a `Consumer<Exception>`; the existing single-argument form is kept, so `ApiAdminStorageAction` is unchanged apart from the log level. `asListHtml` passes a handler that calls `saveError` with `errors.storage_access_error`, which already exists in all 17 message bundles, and `admin_storage.jsp` already has `<la:errors/>`. No new message key, no JSP change, no regenerated `FessMessages`.

For an uninstalled plugin the text shown is the one `StorageClientFactory` already writes, which names the plugin to install.

`AdminPluginAction.installplugin()` already does `saveError` inside a `renderWith` lambda for an unreachable repository, so the shape is not new here.

## Warning, not error

`ERROR` is a notification trigger in Fess, and a protocol that is not configured is a configuration problem rather than a fault, so all four log at `WARN`.

## Verified

* `mvn test` — **7703 tests, 0 failures** (7696 before this change).
* Not vacuous: each of the three code paths with a test was mutated and the matching test failed. Widening the scheme pattern from `+` to `*` fails the `C:\path` case; dropping the protocol-list loop fails the "protocol in use stays quiet" case; restoring the old debug-only `catch` fails the storage callback case.
* The storage warning was read back out of `target/logs/fess.log` from the test run, carrying the full `StorageException` from `StorageClientFactory` — so the message the screen shows is the one that names the plugin.
* The on-screen rendering itself is traced through LastaFlute and lasta-taglib sources plus the in-repo precedent; it was not exercised against a running Fess.

The fourth path (no registered client) has no unit test: it is a null check on `crawler.getClientFactory().getClient(u)` inside the paths lambda, which needs a crawler. It was verified instead by booting a LastaDi container on a plain JVM with the AWS SDK excluded from the class path, where `clientFactory.getClient("s3://bucket/k")` returns `null` while `file:` still resolves.
