### PR TITLE
feat(setup): install plugins from the snapshot repository and GitHub releases

### DIFF
--- a/src/main/java/org/codelibs/fess/setup/Downloader.java
+++ b/src/main/java/org/codelibs/fess/setup/Downloader.java
@@ -26,7 +26,10 @@ import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.Locale;
 
 /**
  * Downloads an artifact to a local file.
@@ -40,6 +43,10 @@ public final class Downloader {
     private static final int BUFFER_SIZE = 1024 * 1024;
 
     private static final int CONNECT_TIMEOUT_SECONDS = 30;
+
+    private static final int SHA1_HEX_LENGTH = 40;
+
+    private static final int HTTP_NOT_FOUND = 404;
 
     /** Receives download progress. */
     @FunctionalInterface
@@ -57,6 +64,58 @@ public final class Downloader {
     }
 
     /**
+     * Returns the SHA-1 of a file, as lower-case hexadecimal.
+     *
+     * <p>SHA-1 because that is the digest these Maven repositories publish beside an artifact;
+     * it is a transport check against a truncated or swapped file, not a signature.</p>
+     *
+     * @param file the file to hash
+     * @return the digest
+     * @throws SetupException if the file cannot be read
+     */
+    public static String sha1(final Path file) throws SetupException {
+        try (InputStream in = Files.newInputStream(file)) {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            final byte[] buffer = new byte[BUFFER_SIZE];
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                digest.update(buffer, 0, read);
+            }
+            final StringBuilder hex = new StringBuilder();
+            for (final byte b : digest.digest()) {
+                hex.append(Character.forDigit(b >> 4 & 0xf, 16)).append(Character.forDigit(b & 0xf, 16));
+            }
+            return hex.toString();
+        } catch (final IOException e) {
+            throw new SetupException("Failed to read " + file, e);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new SetupException("SHA-1 is not available in this JVM", e);
+        }
+    }
+
+    /**
+     * Checks a downloaded file against a published SHA-1.
+     *
+     * <p>The published form is the bare digest, but a {@code sha1sum} line carries the file name
+     * after it, so only the first token is read.</p>
+     *
+     * @param file the downloaded file
+     * @param published the body of the {@code .sha1} file
+     * @throws SetupException if the digests differ or {@code published} holds no digest
+     */
+    public static void verifySha1(final Path file, final String published) throws SetupException {
+        final String expected = published == null ? "" : published.trim().split("\\s+", 2)[0].toLowerCase(Locale.ROOT);
+        if (expected.length() != SHA1_HEX_LENGTH) {
+            throw new SetupException("The checksum published for " + file.getFileName() + " is not a SHA-1: " + published);
+        }
+        final String actual = sha1(file);
+        if (!expected.equals(actual)) {
+            throw new SetupException(
+                    "Checksum mismatch for " + file.getFileName() + ": expected " + expected + " but the download is " + actual);
+        }
+    }
+
+    /**
      * Reads {@code uri} into a string.
      *
      * <p>For the small documents that describe what to download -- a {@code maven-metadata.xml},
@@ -67,12 +126,35 @@ public final class Downloader {
      * @throws SetupException if the request fails or the server does not answer 200
      */
     public static String readString(final URI uri) throws SetupException {
+        return read(uri, false);
+    }
+
+    /**
+     * Reads {@code uri} into a string, treating a missing document as an answer rather than a
+     * failure.
+     *
+     * <p>For a document whose absence is a normal state -- a checksum a repository does not
+     * publish -- and only that. Every other status still fails, so that a proxy error or a
+     * server fault cannot be mistaken for "there is nothing there".</p>
+     *
+     * @param uri the source
+     * @return the body, or {@code null} when the server answered 404
+     * @throws SetupException if the request fails for any other reason
+     */
+    public static String readStringIfPresent(final URI uri) throws SetupException {
+        return read(uri, true);
+    }
+
+    private static String read(final URI uri, final boolean absentIsNull) throws SetupException {
         try (HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .build()) {
             final HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
             final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            if (absentIsNull && response.statusCode() == HTTP_NOT_FOUND) {
+                return null;
+            }
             if (response.statusCode() != 200) {
                 throw new SetupException("Failed to read " + uri + ": HTTP " + response.statusCode());
             }
@@ -114,6 +196,28 @@ public final class Downloader {
      * @throws SetupException if the download fails
      */
     public static Path download(final URI uri, final Path dest, final Progress progress) throws SetupException {
+        return fetch(uri, dest, progress, false);
+    }
+
+    /**
+     * Downloads {@code uri} to {@code dest}, treating a missing file as an answer rather than a
+     * failure.
+     *
+     * <p>For a source that is tried before another one: a plugin release that is not on GitHub
+     * has to fall through to the Maven repository, and only an error that is not "no such file"
+     * should stop the install.</p>
+     *
+     * @param uri the source
+     * @param dest the destination file
+     * @param progress receives progress updates
+     * @return {@code dest}, or {@code null} when the server answered 404
+     * @throws SetupException if the download fails for any other reason
+     */
+    public static Path downloadIfPresent(final URI uri, final Path dest, final Progress progress) throws SetupException {
+        return fetch(uri, dest, progress, true);
+    }
+
+    private static Path fetch(final URI uri, final Path dest, final Progress progress, final boolean absentIsNull) throws SetupException {
         try (HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
                 .followRedirects(HttpClient.Redirect.NORMAL)
@@ -121,6 +225,9 @@ public final class Downloader {
             final HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
             final HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
             try (InputStream in = response.body()) {
+                if (absentIsNull && response.statusCode() == HTTP_NOT_FOUND) {
+                    return null;
+                }
                 if (response.statusCode() != 200) {
                     throw new SetupException("Failed to download " + uri + ": HTTP " + response.statusCode());
                 }

--- a/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
+++ b/src/main/java/org/codelibs/fess/setup/FessPluginInstaller.java
@@ -16,8 +16,11 @@
 package org.codelibs.fess.setup;
 
 import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -44,7 +47,96 @@ public final class FessPluginInstaller {
 
     private static final String JAR = ".jar";
 
+    /** Suffix of the file a download is written to until its checksum has been checked. */
+    private static final String DOWNLOAD = ".download";
+
     private FessPluginInstaller() {
+    }
+
+    /**
+     * Downloads a plugin jar and checks it against the checksum the repository publishes.
+     *
+     * <p>The URLs are tried in order and the first one that has the file wins, so that a release
+     * comes from its GitHub asset and falls back to the Maven repository. Only the last URL is
+     * allowed to fail the install: a source that answers "no such file" is skipped silently,
+     * because until every plugin publishes its jars on GitHub that is the normal case, and one
+     * that fails for any other reason is reported before the next is tried.</p>
+     *
+     * <p>The checksum is always the Maven repository's, GitHub publishing none. A jar that does
+     * not match it is deleted rather than installed; a checksum that cannot be read leaves the
+     * jar in place with a warning, because a repository that has stopped serving {@code .sha1}
+     * is not a reason to make {@code install plugin} unusable.</p>
+     *
+     * @param urls the candidate jar URLs, most preferred first
+     * @param checksumUrl the URL of the jar's {@code .sha1}
+     * @param jar the file to write
+     * @param out the stream for warnings
+     * @param progress receives download progress
+     * @return the URL the jar came from
+     * @throws SetupException if no source has the jar or the checksum does not match
+     */
+    public static String install(final List<String> urls, final String checksumUrl, final Path jar, final PrintStream out,
+            final Downloader.Progress progress) throws SetupException {
+        final Path download = jar.resolveSibling(jar.getFileName() + DOWNLOAD);
+        try {
+            final String used = fetch(urls, download, out, progress);
+            // The progress line is written with a carriage return and no newline, so anything
+            // printed from here on would land on top of it.
+            out.println();
+            verify(download, jar.getFileName().toString(), checksumUrl, out);
+            move(download, jar);
+            return used;
+        } finally {
+            discard(download);
+            discard(download.resolveSibling(download.getFileName() + ".part"));
+        }
+    }
+
+    private static void move(final Path download, final Path jar) throws SetupException {
+        try {
+            Files.move(download, jar, StandardCopyOption.REPLACE_EXISTING);
+        } catch (final IOException e) {
+            throw new SetupException("Failed to install " + jar, e);
+        }
+    }
+
+    private static void discard(final Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (final IOException e) {
+            // Nothing useful can be done about a leftover temporary file, and reporting it here
+            // would replace the failure that is actually worth reading.
+        }
+    }
+
+    private static String fetch(final List<String> urls, final Path jar, final PrintStream out, final Downloader.Progress progress)
+            throws SetupException {
+        if (urls.isEmpty()) {
+            throw new SetupException("No download source is configured for " + jar.getFileName());
+        }
+        for (int i = 0; i < urls.size() - 1; i++) {
+            final String url = urls.get(i);
+            try {
+                if (Downloader.downloadIfPresent(URI.create(url), jar, progress) != null) {
+                    return url;
+                }
+            } catch (final SetupException e) {
+                out.println("  warning: " + e.getMessage());
+            }
+        }
+        final String last = urls.get(urls.size() - 1);
+        Downloader.download(URI.create(last), jar, progress);
+        return last;
+    }
+
+    private static void verify(final Path download, final String name, final String checksumUrl, final PrintStream out)
+            throws SetupException {
+        final String published = Downloader.readStringIfPresent(URI.create(checksumUrl));
+        if (published == null) {
+            out.println("  warning: no checksum is published at " + checksumUrl + ", so " + name + " was not verified");
+            return;
+        }
+        Downloader.verifySha1(download, published);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/setup/FessSetup.java
+++ b/src/main/java/org/codelibs/fess/setup/FessSetup.java
@@ -66,6 +66,12 @@ public final class FessSetup {
 
               install plugin <name>... [--version <version>] [--repository <url>]
                   Install Fess plugins, for example fess-script-groovy or fess-ds-git.
+                  A release comes from the plugin's GitHub release, or from the Maven
+                  repository when GitHub has no such asset. A development build of Fess
+                  installs the snapshots of its own line as well, and prefers them.
+                  Every jar is checked against the SHA-1 the Maven repository publishes.
+                  --repository takes every version, jar and checksum from one repository,
+                  GitHub included.
 
               remove plugin <name>...
                   Delete installed Fess plugins.
@@ -75,6 +81,7 @@ public final class FessSetup {
 
               list plugins [--repository <url>]
                   Show the Fess plugins published for this version, and which are installed.
+                  A development build lists the snapshot repository too.
 
               list installed
                   Show the installed Fess plugins, without asking the repository.
@@ -186,9 +193,22 @@ public final class FessSetup {
     private static int listPlugins(final Map<String, ComponentDefinition> definitions, final Map<String, String> options,
             final PrintStream out) throws SetupException {
         final ComponentDefinition definition = definitions.get(PLUGIN_COMPONENT);
-        final String repository = options.getOrDefault("repository", definition.get("repository"));
+        final PluginSources sources = pluginSources(definition, options);
         final Path directory = pluginDirectory(definition, options);
-        final List<String> published = PluginRepository.namesFromListing(Downloader.readString(URI.create(repository)));
+        final String release = sources.releaseRepository();
+        List<String> published = PluginRepository.namesFromListing(Downloader.readString(URI.create(release)));
+        final StringBuilder consulted = new StringBuilder(release);
+        if (developmentBuild() && sources.hasSnapshot()) {
+            // A plugin whose line has no release yet is only in the snapshot repository, and
+            // leaving it out would hide exactly the plugins a development build can install.
+            try {
+                published = PluginRepository.mergeNames(published,
+                        PluginRepository.namesFromListing(Downloader.readString(URI.create(sources.snapshot()))));
+                consulted.append(" and ").append(sources.snapshot());
+            } catch (final SetupException e) {
+                out.println("warning: " + e.getMessage());
+            }
+        }
         for (final String name : published) {
             final String versions = installedVersions(directory, name);
             out.println(versions == null ? "  " + name : "  " + name + "  (installed: " + versions + ")");
@@ -204,7 +224,7 @@ public final class FessSetup {
         }
         if (!unlisted.isEmpty()) {
             out.println();
-            out.println("Installed but not published by " + repository + ":");
+            out.println("Installed but not published by " + consulted + ":");
             unlisted.forEach(name -> out.println("  " + name));
         }
         return EXIT_OK;
@@ -281,11 +301,10 @@ public final class FessSetup {
             return EXIT_USAGE;
         }
         final ComponentDefinition definition = definitions.get(PLUGIN_COMPONENT);
-        final String repository = options.getOrDefault("repository", definition.get("repository"));
+        final PluginSources sources = pluginSources(definition, options);
         final Path directory = pluginDirectory(definition, options);
         for (final String artifactId : artifactIds) {
-            final String version = options.containsKey("version") ? options.get("version") : resolveVersion(repository, artifactId);
-            installOne(repository, artifactId, version, directory, out);
+            installOne(sources, artifactId, resolve(sources, artifactId, options.get("version")), directory, out);
         }
         out.println();
         out.println("Restart Fess to load " + (artifactIds.size() == 1 ? "it." : "them."));
@@ -298,21 +317,24 @@ public final class FessSetup {
      * <p>The removal happens after the download on purpose: doing it first would leave an
      * installation with no plugin at all when the download then fails.</p>
      *
-     * @param repository the plugin repository URL
+     * @param sources where plugins are published
      * @param artifactId the plugin name
-     * @param version the version to install
+     * @param resolved the version to install
      * @param directory the plugin directory
      * @param out the stream for normal output
      * @throws SetupException if the download or a file operation fails
      */
-    private static void installOne(final String repository, final String artifactId, final String version, final Path directory,
+    private static void installOne(final PluginSources sources, final String artifactId, final Resolved resolved, final Path directory,
             final PrintStream out) throws SetupException {
-        final Path jar = directory.resolve(FessPluginInstaller.jarName(artifactId, version));
-        final String url = PluginRepository.jarUrl(repository, artifactId, version);
-        out.println("Downloading " + url);
+        final Path jar = directory.resolve(FessPluginInstaller.jarName(artifactId, resolved.fileVersion()));
+        out.println("Downloading " + artifactId + " " + resolved.version());
         final int[] lastPercent = { -1 };
-        Downloader.download(URI.create(url), jar, (bytes, total) -> reportProgress(out, bytes, total, lastPercent));
-        out.println();
+        final String used =
+                FessPluginInstaller.install(PluginRepository.jarUrls(sources, artifactId, resolved.version(), resolved.fileVersion()),
+                        PluginRepository.checksumUrl(
+                                PluginRepository.repositoryJarUrl(sources, artifactId, resolved.version(), resolved.fileVersion())),
+                        jar, out, (bytes, total) -> reportProgress(out, bytes, total, lastPercent));
+        out.println("  from " + used);
         for (final Path previous : FessPluginInstaller.removeOtherVersions(directory, artifactId, jar)) {
             out.println("Removed the previous " + previous.getFileName());
         }
@@ -405,7 +427,7 @@ public final class FessSetup {
         }
         final Map<String, String> options = parseOptions(args, 2);
         final ComponentDefinition definition = definitions.get(PLUGIN_COMPONENT);
-        final String repository = options.getOrDefault("repository", definition.get("repository"));
+        final PluginSources sources = pluginSources(definition, options);
         final Path directory = pluginDirectory(definition, options);
         final List<String> artifactIds = Diagnostics.installedArtifactIds(directory);
         if (artifactIds.isEmpty()) {
@@ -415,13 +437,16 @@ public final class FessSetup {
         int upgraded = 0;
         for (final String artifactId : artifactIds) {
             final String current = installedVersions(directory, artifactId);
-            final String wanted = resolveVersion(repository, artifactId);
-            if (wanted.equals(current)) {
+            final Resolved wanted = resolve(sources, artifactId, null);
+            // The file version, not the version, because a snapshot is on disk under the build
+            // it came from: comparing 15.9.0-SNAPSHOT with the installed timestamp would either
+            // re-download every time or never notice a newer build.
+            if (wanted.fileVersion().equals(current)) {
                 out.println(artifactId + " is already at " + current);
                 continue;
             }
-            out.println(artifactId + " " + current + " -> " + wanted);
-            installOne(repository, artifactId, wanted, directory, out);
+            out.println(artifactId + " " + current + " -> " + wanted.fileVersion());
+            installOne(sources, artifactId, wanted, directory, out);
             upgraded++;
         }
         out.println();
@@ -554,17 +579,134 @@ public final class FessSetup {
     }
 
     /**
+     * A plugin version, in the two forms a Maven repository gives it: the version itself, which
+     * names the directory, and the version the jar's file name carries. They differ for a
+     * snapshot, where {@code 15.9.0-SNAPSHOT} is published as {@code 15.9.0-20260903.015513-6}.
+     *
+     * @param version the version
+     * @param fileVersion the version the file name carries
+     */
+    private record Resolved(String version, String fileVersion) {
+    }
+
+    /**
+     * Reports whether this is a development build of Fess, which is what decides that the
+     * snapshot repository is read at all.
+     *
+     * @return true when this build's version is a snapshot
+     */
+    private static boolean developmentBuild() {
+        return PluginRepository.isSnapshot(fessVersion());
+    }
+
+    /**
+     * Works out which version of a plugin to install, and where its jar is published.
+     *
+     * @param sources where plugins are published
+     * @param artifactId the plugin name
+     * @param named the version the caller asked for, or null to pick one
+     * @return the resolved version
+     * @throws SetupException if the metadata cannot be read or holds no matching version
+     */
+    private static Resolved resolve(final PluginSources sources, final String artifactId, final String named) throws SetupException {
+        final String version = named != null ? named : resolveVersion(sources, artifactId);
+        if (!PluginRepository.isSnapshot(version)) {
+            return new Resolved(version, version);
+        }
+        final String metadata =
+                Downloader.readString(URI.create(PluginRepository.versionMetadataUrl(sources.repositoryOf(version), artifactId, version)));
+        return new Resolved(version, PluginRepository.snapshotFileVersion(metadata, version));
+    }
+
+    /**
      * Picks the plugin version that fits this Fess, reading the artifact's Maven metadata.
      *
-     * @param repository the plugin repository URL
+     * <p>A development build reads the snapshot repository as well as the release one and
+     * prefers a snapshot, so that plugins can be installed on a 15.9.0-SNAPSHOT Fess before the
+     * 15.9 line has released any. A released Fess never reads the snapshot repository, so a
+     * snapshot is neither listed nor installed there.</p>
+     *
+     * @param sources where plugins are published
      * @param artifactId the plugin name
      * @return the version to install
      * @throws SetupException if the metadata cannot be read or holds no matching version
      */
-    private static String resolveVersion(final String repository, final String artifactId) throws SetupException {
-        final String productVersion = FessPluginInstaller.productVersion(fessVersion());
-        final String metadata = Downloader.readString(URI.create(PluginRepository.metadataUrl(repository, artifactId)));
-        return PluginRepository.selectVersion(PluginRepository.versionsFromMetadata(metadata), productVersion);
+    private static String resolveVersion(final PluginSources sources, final String artifactId) throws SetupException {
+        return resolveVersion(sources, artifactId, FessPluginInstaller.productVersion(fessVersion()), developmentBuild());
+    }
+
+    /**
+     * Picks the plugin version that fits a given Fess.
+     *
+     * @param sources where plugins are published
+     * @param artifactId the plugin name
+     * @param productVersion the major.minor that Fess accepts, for example {@code 15.9}
+     * @param development whether this is a snapshot build of Fess
+     * @return the version to install
+     * @throws SetupException if no repository could be read or none holds a matching version
+     */
+    static String resolveVersion(final PluginSources sources, final String artifactId, final String productVersion,
+            final boolean development) throws SetupException {
+        final List<String> problems = new ArrayList<>();
+        final List<String> versions = new ArrayList<>();
+        if (sources.hasRelease()) {
+            versions.addAll(readVersions(sources.release(), artifactId, problems));
+        } else {
+            problems.add("no release repository is configured");
+        }
+        if (development) {
+            if (sources.hasSnapshot()) {
+                versions.addAll(readVersions(sources.snapshot(), artifactId, problems));
+            } else {
+                problems.add("no snapshot repository is configured");
+            }
+        }
+        if (versions.isEmpty()) {
+            throw new SetupException("Failed to read the published versions of " + artifactId + ": " + String.join("; ", problems));
+        }
+        return PluginRepository.selectVersion(versions, productVersion, development);
+    }
+
+    /**
+     * Reads the versions one repository publishes, keeping the reason when it has none.
+     *
+     * <p>A miss is not a failure while another repository is still to be read: a plugin is
+     * routinely absent from the release repository before its line ships, and absent from the
+     * snapshot repository once it stops being built there.</p>
+     *
+     * @param repository the repository URL
+     * @param artifactId the plugin name
+     * @param problems collects the reason a repository returned nothing
+     * @return the versions, empty when the metadata cannot be read
+     */
+    private static List<String> readVersions(final String repository, final String artifactId, final List<String> problems) {
+        try {
+            return PluginRepository
+                    .versionsFromMetadata(Downloader.readString(URI.create(PluginRepository.metadataUrl(repository, artifactId))));
+        } catch (final SetupException e) {
+            problems.add(e.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
+     * Returns where plugins are published.
+     *
+     * <p>{@code --repository} replaces every source rather than only the release one: it names
+     * the repository the caller wants the plugins to come from -- a mirror, or a group
+     * repository that serves both trees -- and honouring it for the version list while still
+     * downloading the jar from github.com would defeat the point of naming it.</p>
+     *
+     * @param definition the plugin definition
+     * @param options the command line options
+     * @return the sources
+     */
+    static PluginSources pluginSources(final ComponentDefinition definition, final Map<String, String> options) {
+        final String named = options.get("repository");
+        if (named != null) {
+            return new PluginSources(named, named, "");
+        }
+        return new PluginSources(definition.get("repository"), definition.get("snapshot.repository"), definition.get("github"));
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/setup/PluginRepository.java
+++ b/src/main/java/org/codelibs/fess/setup/PluginRepository.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,6 +33,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -62,6 +64,8 @@ public final class PluginRepository {
 
     private static final Pattern HREF = Pattern.compile("href=\"[^\"]*?([a-zA-Z0-9\\-]+)/?\"");
 
+    private static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
+
     private PluginRepository() {
     }
 
@@ -79,13 +83,111 @@ public final class PluginRepository {
     /**
      * Returns the jar URL for an artifact version.
      *
+     * <p>The file name is given separately from the version because a Maven repository stores a
+     * snapshot under a directory named for the version and a file named for the build.</p>
+     *
+     * @param repository the group directory URL
+     * @param artifactId the artifact name
+     * @param version the version, which names the directory
+     * @param fileVersion the version the file name carries
+     * @return the jar URL
+     */
+    public static String jarUrl(final String repository, final String artifactId, final String version, final String fileVersion) {
+        return base(repository) + artifactId + "/" + version + "/" + artifactId + "-" + fileVersion + ".jar";
+    }
+
+    /**
+     * Returns the {@code maven-metadata.xml} URL of one version of an artifact, which is where a
+     * snapshot repository records its builds.
+     *
      * @param repository the group directory URL
      * @param artifactId the artifact name
      * @param version the version
-     * @return the jar URL
+     * @return the metadata URL
      */
-    public static String jarUrl(final String repository, final String artifactId, final String version) {
-        return base(repository) + artifactId + "/" + version + "/" + artifactId + "-" + version + ".jar";
+    public static String versionMetadataUrl(final String repository, final String artifactId, final String version) {
+        return base(repository) + artifactId + "/" + version + "/maven-metadata.xml";
+    }
+
+    /**
+     * Returns the GitHub release asset URL for a plugin jar.
+     *
+     * <p>The tag is the one {@code maven-release-plugin} creates, {@code <artifact>-<version>},
+     * and the asset is the jar under its Maven name.</p>
+     *
+     * @param github the GitHub organisation URL, for example {@code https://github.com/codelibs}
+     * @param artifactId the plugin name, which is also its repository name
+     * @param version the release version
+     * @return the asset URL
+     */
+    public static String githubJarUrl(final String github, final String artifactId, final String version) {
+        final String tag = artifactId + "-" + version;
+        return base(github) + artifactId + "/releases/download/" + tag + "/" + tag + ".jar";
+    }
+
+    /**
+     * Returns the Maven repository URL of a plugin jar, which is also where its checksum sits.
+     *
+     * @param sources where plugins are published
+     * @param artifactId the plugin name
+     * @param version the version, which names the directory
+     * @param fileVersion the version the file name carries
+     * @return the jar URL in the Maven repository that publishes that version
+     * @throws SetupException if that repository is not configured
+     */
+    public static String repositoryJarUrl(final PluginSources sources, final String artifactId, final String version,
+            final String fileVersion) throws SetupException {
+        return jarUrl(sources.repositoryOf(version), artifactId, version, fileVersion);
+    }
+
+    /**
+     * Returns the URLs to try for a plugin jar, in order.
+     *
+     * <p>A release is taken from its GitHub release first and from the Maven repository when
+     * that fails, which is the fallback the distribution relies on until every plugin publishes
+     * its jars on GitHub. A snapshot is only ever in the Maven snapshot repository, so there is
+     * nothing to fall back from.</p>
+     *
+     * @param sources where plugins are published
+     * @param artifactId the plugin name
+     * @param version the version, which names the directory
+     * @param fileVersion the version the file name carries
+     * @return the candidate URLs, most preferred first
+     * @throws SetupException if the repository that publishes the version is not configured
+     */
+    public static List<String> jarUrls(final PluginSources sources, final String artifactId, final String version, final String fileVersion)
+            throws SetupException {
+        final String repositoryUrl = repositoryJarUrl(sources, artifactId, version, fileVersion);
+        if (isSnapshot(version) || !sources.hasGithub()) {
+            return List.of(repositoryUrl);
+        }
+        return List.of(githubJarUrl(sources.github(), artifactId, version), repositoryUrl);
+    }
+
+    /**
+     * Returns the URL of the SHA-1 a Maven repository publishes beside an artifact.
+     *
+     * <p>SHA-1 rather than something longer because that, with MD5, is what these repositories
+     * carry: {@code .sha256} and {@code .sha512} answer 404.</p>
+     *
+     * @param jarUrl the artifact URL in a Maven repository
+     * @return the checksum URL
+     */
+    public static String checksumUrl(final String jarUrl) {
+        return jarUrl + ".sha1";
+    }
+
+    /**
+     * Merges two plugin listings into one, without duplicates, in name order.
+     *
+     * @param first the first listing
+     * @param second the second listing
+     * @return the merged names
+     */
+    public static List<String> mergeNames(final List<String> first, final List<String> second) {
+        final Set<String> names = new TreeSet<>(first);
+        names.addAll(second);
+        return new ArrayList<>(names);
     }
 
     private static String base(final String repository) {
@@ -100,6 +202,57 @@ public final class PluginRepository {
      * @throws SetupException if the document cannot be parsed
      */
     public static List<String> versionsFromMetadata(final String xml) throws SetupException {
+        final NodeList nodes = parse(xml).getElementsByTagName("version");
+        final List<String> versions = new ArrayList<>();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            final String v = nodes.item(i).getTextContent().trim();
+            if (!v.isEmpty()) {
+                versions.add(v);
+            }
+        }
+        return versions;
+    }
+
+    /**
+     * Returns the file-name version of a snapshot build, read from the version's
+     * {@code maven-metadata.xml}.
+     *
+     * <p>A deployed snapshot is published under a timestamped file name rather than the
+     * {@code -SNAPSHOT} one, so {@code 15.9.0-SNAPSHOT} is really
+     * {@code 15.9.0-20260903.015513-6} on disk. This reads the {@code <snapshot>} element the
+     * way {@code PluginHelper} does for the admin UI. A repository that instead keeps the
+     * {@code -SNAPSHOT} file -- a locally installed one, whose metadata says
+     * {@code <localCopy>true</localCopy>} and carries no build number -- is reported as having
+     * no build rather than guessed at.</p>
+     *
+     * @param xml the version's metadata document
+     * @param version the snapshot version, for example {@code 15.9.0-SNAPSHOT}
+     * @return the version the jar's file name carries
+     * @throws SetupException if the document cannot be parsed or names no build
+     */
+    public static String snapshotFileVersion(final String xml, final String version) throws SetupException {
+        final NodeList snapshots = parse(xml).getElementsByTagName("snapshot");
+        String timestamp = null;
+        String buildNumber = null;
+        if (snapshots.getLength() > 0) {
+            final NodeList children = snapshots.item(0).getChildNodes();
+            for (int i = 0; i < children.getLength(); i++) {
+                final Node child = children.item(i);
+                if ("timestamp".equalsIgnoreCase(child.getNodeName())) {
+                    timestamp = child.getTextContent().trim();
+                } else if ("buildNumber".equalsIgnoreCase(child.getNodeName())) {
+                    buildNumber = child.getTextContent().trim();
+                }
+            }
+        }
+        if (timestamp == null || timestamp.isEmpty() || buildNumber == null || buildNumber.isEmpty()) {
+            throw new SetupException("No snapshot build is published for " + version
+                    + ". Name a version with --version <version>, or install a release instead.");
+        }
+        return version.replace("SNAPSHOT", timestamp + "-" + buildNumber);
+    }
+
+    private static Document parse(final String xml) throws SetupException {
         try {
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
@@ -108,38 +261,55 @@ public final class PluginRepository {
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             final DocumentBuilder builder = factory.newDocumentBuilder();
-            final Document document = builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
-            final NodeList nodes = document.getElementsByTagName("version");
-            final List<String> versions = new ArrayList<>();
-            for (int i = 0; i < nodes.getLength(); i++) {
-                final String v = nodes.item(i).getTextContent().trim();
-                if (!v.isEmpty()) {
-                    versions.add(v);
-                }
-            }
-            return versions;
+            return builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         } catch (final ParserConfigurationException | SAXException | IOException e) {
             throw new SetupException("Failed to read maven-metadata.xml", e);
         }
     }
 
     /**
+     * Reports whether a version is a Maven snapshot.
+     *
+     * @param version the version
+     * @return true when the version ends with {@code -SNAPSHOT}
+     */
+    public static boolean isSnapshot(final String version) {
+        return version != null && version.endsWith(SNAPSHOT_SUFFIX);
+    }
+
+    /**
      * Picks the highest version matching the product version, comparing numerically so that
      * 15.9.10 sorts above 15.9.9.
      *
+     * <p>Releases and snapshots are ranked separately rather than in one order, because a
+     * development build wants the snapshot of its own line even once that line has a release,
+     * and a released build must never be offered a snapshot that happens to sort higher. A
+     * development build falls back to a release when the plugin has no snapshot yet, which is
+     * what makes {@code install plugin} work on a 15.9.0-SNAPSHOT Fess before any 15.9 snapshot
+     * of that plugin has been deployed. A released build has no fallback: a snapshot is
+     * installed there only when {@code --version} names it.</p>
+     *
      * @param versions the available versions
      * @param productVersion the major.minor this Fess accepts, for example {@code 15.9}
+     * @param preferSnapshot whether a snapshot outranks a release
      * @return the selected version
      * @throws SetupException when no version matches
      */
-    public static String selectVersion(final List<String> versions, final String productVersion) throws SetupException {
+    public static String selectVersion(final List<String> versions, final String productVersion, final boolean preferSnapshot)
+            throws SetupException {
         final String prefix = productVersion + ".";
-        final List<String> matching = new ArrayList<>();
+        final List<String> snapshots = new ArrayList<>();
+        final List<String> releases = new ArrayList<>();
         for (final String v : versions) {
             if (v.equals(productVersion) || v.startsWith(prefix)) {
-                matching.add(v);
+                (isSnapshot(v) ? snapshots : releases).add(v);
             }
         }
+        // Asymmetric on purpose. A development build falls back to a release, because a plugin
+        // whose line has no snapshot yet still has to be installable; a released build has no
+        // fallback at all, because it must never install a snapshot it was not asked for by
+        // name. A --version names one explicitly and does not come through here.
+        final List<String> matching = preferSnapshot && !snapshots.isEmpty() ? snapshots : releases;
         if (matching.isEmpty()) {
             throw new SetupException("No release matches Fess " + productVersion + ". Available versions: " + String.join(", ", versions));
         }

--- a/src/main/java/org/codelibs/fess/setup/PluginSources.java
+++ b/src/main/java/org/codelibs/fess/setup/PluginSources.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+/**
+ * Where Fess plugins are published.
+ *
+ * <p>A release lives in two places: the GitHub release of the plugin's own repository, which is
+ * where a jar is downloaded from, and the Maven repository, which is where the version list and
+ * the checksum come from and which serves the jar when GitHub does not. A snapshot lives only in
+ * the Maven snapshot repository -- GitHub publishes releases, not development builds -- so a
+ * development build of Fess needs both Maven trees.</p>
+ *
+ * @param release the release repository's group directory URL
+ * @param snapshot the snapshot repository's group directory URL
+ * @param github the GitHub organisation URL, blank when jars are not published there
+ */
+public record PluginSources(String release, String snapshot, String github) {
+
+    /**
+     * Returns the Maven repository that publishes a version.
+     *
+     * @param version the version
+     * @return the snapshot repository for a snapshot, the release repository otherwise
+     * @throws SetupException if that repository is not configured
+     */
+    public String repositoryOf(final String version) throws SetupException {
+        return PluginRepository.isSnapshot(version) ? snapshotRepository() : releaseRepository();
+    }
+
+    /**
+     * Returns the release repository.
+     *
+     * @return the release repository URL
+     * @throws SetupException if it is not configured
+     */
+    public String releaseRepository() throws SetupException {
+        return require(release, "release", "component.plugin.repository");
+    }
+
+    /**
+     * Returns the snapshot repository.
+     *
+     * @return the snapshot repository URL
+     * @throws SetupException if it is not configured
+     */
+    public String snapshotRepository() throws SetupException {
+        return require(snapshot, "snapshot", "component.plugin.snapshot.repository");
+    }
+
+    /**
+     * Reports whether a release repository is configured.
+     *
+     * @return true when one is set
+     */
+    public boolean hasRelease() {
+        return release != null && !release.isBlank();
+    }
+
+    /**
+     * Reports whether a snapshot repository is configured.
+     *
+     * @return true when one is set
+     */
+    public boolean hasSnapshot() {
+        return snapshot != null && !snapshot.isBlank();
+    }
+
+    private static String require(final String url, final String kind, final String key) throws SetupException {
+        if (url == null || url.isBlank()) {
+            throw new SetupException("No " + kind + " repository for plugins is configured. Set " + key + " in fess-setup.properties.");
+        }
+        return url;
+    }
+
+    /**
+     * Reports whether GitHub releases are configured as a download source.
+     *
+     * @return true when a GitHub organisation URL is set
+     */
+    public boolean hasGithub() {
+        return github != null && !github.isBlank();
+    }
+}

--- a/src/main/resources/fess-setup.properties
+++ b/src/main/resources/fess-setup.properties
@@ -54,6 +54,20 @@ component.nodejs.env = PLAYWRIGHT_NODEJS_PATH
 # only the components that have one. The version comes from the artifact's maven-metadata.xml,
 # narrowed to the major.minor of this build, so it is not repeated here either.
 #
-# The admin UI reads the same repository through plugin.repositories in fess_config.properties.
+# Three sources, because a plugin is published in more than one place:
+#
+#   repository          the released plugins. It is the list of versions, the checksum, and the
+#                       jar when GitHub does not have it. --repository overrides this one.
+#   snapshot.repository the development builds. A SNAPSHOT build of Fess reads this as well, so
+#                       that plugins can be installed before the line has a release; a released
+#                       Fess never looks at it. A snapshot has no jar of its own name here: the
+#                       version's own maven-metadata.xml names the timestamped file to fetch.
+#   github              the organisation whose repositories publish a release jar as an asset of
+#                       the tag maven-release-plugin creates, <artifact>-<version>. A release is
+#                       taken from there first. Leave it blank to fetch every jar from Maven.
+#
+# The admin UI reads the same repositories through plugin.repositories in fess_config.properties.
 component.plugin.repository = https://maven.codelibs.org/release/org/codelibs/fess/
+component.plugin.snapshot.repository = https://maven.codelibs.org/snapshot/org/codelibs/fess/
+component.plugin.github = https://github.com/codelibs
 component.plugin.dest = ${fess.home}/app/WEB-INF/plugin

--- a/src/test/java/org/codelibs/fess/setup/DownloaderTest.java
+++ b/src/test/java/org/codelibs/fess/setup/DownloaderTest.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.setup;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,6 +44,10 @@ public class DownloaderTest {
 
     private HttpServer server;
 
+    private static final Downloader.Progress NO_PROGRESS = (bytes, total) -> {
+        // progress is not reported
+    };
+
     private static final byte[] BODY = "opensearch-payload".getBytes(StandardCharsets.UTF_8);
 
     @BeforeEach
@@ -53,6 +58,10 @@ public class DownloaderTest {
             try (OutputStream out = exchange.getResponseBody()) {
                 out.write(BODY);
             }
+        });
+        server.createContext("/broken", exchange -> {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
         });
         server.createContext("/missing", exchange -> {
             exchange.sendResponseHeaders(404, -1);
@@ -125,5 +134,80 @@ public class DownloaderTest {
         final Path dest = tempDir.resolve("payload.bin");
         Downloader.download(uri("/ok"), dest);
         assertFalse(Files.exists(tempDir.resolve("payload.bin.part")), "the .part file must be renamed away");
+    }
+
+    @Test
+    public void test_sha1_hashesTheFileContent() throws Exception {
+        final Path file = tempDir.resolve("payload.bin");
+        Files.writeString(file, "abc");
+        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", Downloader.sha1(file));
+    }
+
+    @Test
+    public void test_verifySha1_acceptsTheDigestAsPublished() throws Exception {
+        final Path file = tempDir.resolve("payload.bin");
+        Files.writeString(file, "abc");
+        Downloader.verifySha1(file, "a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    @Test
+    public void test_verifySha1_acceptsADigestFollowedByAFileName() throws Exception {
+        final Path file = tempDir.resolve("payload.bin");
+        Files.writeString(file, "abc");
+        Downloader.verifySha1(file, "A9993E364706816ABA3E25717850C26C9CD0D89D  payload.bin\n");
+    }
+
+    @Test
+    public void test_verifySha1_rejectsAMismatch() throws Exception {
+        final Path file = tempDir.resolve("payload.bin");
+        Files.writeString(file, "abc");
+        final SetupException e =
+                assertThrows(SetupException.class, () -> Downloader.verifySha1(file, "0000000000000000000000000000000000000000"));
+        assertTrue(e.getMessage().contains("a9993e364706816aba3e25717850c26c9cd0d89d"));
+        assertTrue(e.getMessage().contains("0000000000000000000000000000000000000000"));
+    }
+
+    @Test
+    public void test_verifySha1_rejectsAChecksumThatIsNotADigest() throws Exception {
+        final Path file = tempDir.resolve("payload.bin");
+        Files.writeString(file, "abc");
+        assertThrows(SetupException.class, () -> Downloader.verifySha1(file, "  "));
+    }
+
+    @Test
+    public void test_downloadIfPresent_writesTheBody() throws Exception {
+        final Path dest = tempDir.resolve("payload.bin");
+        assertEquals(dest, Downloader.downloadIfPresent(uri("/ok"), dest, NO_PROGRESS));
+        assertArrayEquals(BODY, Files.readAllBytes(dest));
+    }
+
+    @Test
+    public void test_downloadIfPresent_returnsNullWhenTheServerHasNoSuchFile() throws Exception {
+        final Path dest = tempDir.resolve("payload.bin");
+        assertNull(Downloader.downloadIfPresent(uri("/missing"), dest, NO_PROGRESS));
+        assertFalse(Files.exists(dest));
+    }
+
+    @Test
+    public void test_downloadIfPresent_stillFailsOnAnErrorThatIsNotAMissingFile() throws Exception {
+        final Path dest = tempDir.resolve("payload.bin");
+        final SetupException e = assertThrows(SetupException.class, () -> Downloader.downloadIfPresent(uri("/broken"), dest, NO_PROGRESS));
+        assertTrue(e.getMessage().contains("500"), e.getMessage());
+    }
+
+    @Test
+    public void test_readStringIfPresent_readsTheBody() throws Exception {
+        assertEquals("opensearch-payload", Downloader.readStringIfPresent(uri("/ok")));
+    }
+
+    @Test
+    public void test_readStringIfPresent_returnsNullWhenThereIsNoSuchFile() throws Exception {
+        assertNull(Downloader.readStringIfPresent(uri("/missing")));
+    }
+
+    @Test
+    public void test_readStringIfPresent_stillFailsOnAnErrorThatIsNotAMissingFile() throws Exception {
+        final SetupException e = assertThrows(SetupException.class, () -> Downloader.readStringIfPresent(uri("/broken")));
+        assertTrue(e.getMessage().contains("500"), e.getMessage());
     }
 }

--- a/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.setup;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -319,4 +320,38 @@ public class FessSetupTest {
         }
     }
 
+    @Test
+    public void test_loadDefinitions_pluginSnapshotRepository() throws Exception {
+        final ComponentDefinition plugin = FessSetup.loadDefinitions().get("plugin");
+        final String snapshot = plugin.get("snapshot.repository");
+        assertNotNull(snapshot, "a development build installs plugins from the snapshot repository");
+        assertTrue(snapshot.startsWith("https://"), snapshot);
+        assertTrue(snapshot.contains("snapshot"), snapshot);
+    }
+
+    @Test
+    public void test_loadDefinitions_pluginGithub() throws Exception {
+        final ComponentDefinition plugin = FessSetup.loadDefinitions().get("plugin");
+        final String github = plugin.get("github");
+        assertNotNull(github, "a release is downloaded from the plugin's GitHub release");
+        assertTrue(github.startsWith("https://github.com/"), github);
+    }
+
+    @Test
+    public void test_pluginSources_comeFromTheDefinition() throws Exception {
+        final ComponentDefinition plugin = FessSetup.loadDefinitions().get("plugin");
+        final PluginSources sources = FessSetup.pluginSources(plugin, Map.<String, String> of());
+        assertEquals(plugin.get("repository"), sources.release());
+        assertEquals(plugin.get("snapshot.repository"), sources.snapshot());
+        assertEquals(plugin.get("github"), sources.github());
+    }
+
+    @Test
+    public void test_pluginSources_repositoryOptionReplacesEverySource() throws Exception {
+        final ComponentDefinition plugin = FessSetup.loadDefinitions().get("plugin");
+        final PluginSources sources = FessSetup.pluginSources(plugin, Map.of("repository", "https://example.org/m2"));
+        assertEquals("https://example.org/m2", sources.release());
+        assertEquals("https://example.org/m2", sources.snapshot(), "--repository names where every jar comes from");
+        assertFalse(sources.hasGithub(), "--repository must not be quietly ignored in favour of github.com");
+    }
 }

--- a/src/test/java/org/codelibs/fess/setup/PluginJarInstallTest.java
+++ b/src/test/java/org/codelibs/fess/setup/PluginJarInstallTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Covers the download half of installing a plugin jar: which source is used, what happens when
+ * one of them does not have the file, and the checksum.
+ */
+public class PluginJarInstallTest {
+
+    private static final byte[] GITHUB_JAR = "jar-from-github".getBytes(StandardCharsets.UTF_8);
+
+    private static final byte[] MAVEN_JAR = "jar-from-maven".getBytes(StandardCharsets.UTF_8);
+
+    @TempDir
+    Path tempDir;
+
+    private HttpServer server;
+
+    private ByteArrayOutputStream captured;
+
+    private PrintStream out;
+
+    @BeforeEach
+    public void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        serve("/github.jar", GITHUB_JAR);
+        serve("/maven.jar", MAVEN_JAR);
+        // The same jar as the repository's, but publishing no .sha1 of its own -- which is what
+        // a GitHub release asset is.
+        server.createContext("/mirror.jar", exchange -> {
+            exchange.sendResponseHeaders(200, MAVEN_JAR.length);
+            try (OutputStream stream = exchange.getResponseBody()) {
+                stream.write(MAVEN_JAR);
+            }
+        });
+        server.createContext("/missing", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.createContext("/broken", exchange -> {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+        });
+        server.start();
+        captured = new ByteArrayOutputStream();
+        out = new PrintStream(captured, true, StandardCharsets.UTF_8);
+    }
+
+    @AfterEach
+    public void stopServer() {
+        server.stop(0);
+    }
+
+    private void serve(final String path, final byte[] body) {
+        server.createContext(path, exchange -> {
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream stream = exchange.getResponseBody()) {
+                stream.write(body);
+            }
+        });
+        final String sha1 = sha1Of(body);
+        server.createContext(path + ".sha1", exchange -> {
+            final byte[] digest = sha1.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, digest.length);
+            try (OutputStream stream = exchange.getResponseBody()) {
+                stream.write(digest);
+            }
+        });
+    }
+
+    private static String sha1Of(final byte[] body) {
+        try {
+            final Path file = Files.createTempFile("sha1", ".bin");
+            try {
+                Files.write(file, body);
+                return Downloader.sha1(file);
+            } finally {
+                Files.deleteIfExists(file);
+            }
+        } catch (final IOException | SetupException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private String url(final String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    private String out() {
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void test_install_takesTheFirstSourceThatHasTheJarAndChecksItAgainstTheRepository() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        final String used = FessPluginInstaller.install(List.of(url("/mirror.jar"), url("/maven.jar")), url("/maven.jar.sha1"), jar, out,
+                (bytes, total) -> {
+                    // progress is not reported
+                });
+        assertEquals(url("/mirror.jar"), used);
+        assertEquals("jar-from-maven", Files.readString(jar));
+        assertFalse(out().contains("warning"),
+                "the checksum has to be the repository's: the source that served the jar publishes none. " + out());
+    }
+
+    @Test
+    public void test_install_fallsBackWhenTheFirstSourceDoesNotHaveIt() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        final String used = FessPluginInstaller.install(List.of(url("/missing"), url("/maven.jar")), url("/maven.jar.sha1"), jar, out,
+                (bytes, total) -> {
+                    // progress is not reported
+                });
+        assertEquals(url("/maven.jar"), used);
+        assertEquals("jar-from-maven", Files.readString(jar));
+    }
+
+    @Test
+    public void test_install_reportsASourceThatFailedForAnotherReason() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        FessPluginInstaller.install(List.of(url("/broken"), url("/maven.jar")), url("/maven.jar.sha1"), jar, out, (bytes, total) -> {
+            // progress is not reported
+        });
+        assertEquals("jar-from-maven", Files.readString(jar));
+        assertTrue(out().contains("500"), out());
+    }
+
+    @Test
+    public void test_install_failsWhenNoSourceHasTheJar() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        final SetupException e = assertThrows(SetupException.class, () -> FessPluginInstaller
+                .install(List.of(url("/missing/first"), url("/missing/last")), url("/maven.jar.sha1"), jar, out, (bytes, total) -> {
+                    // progress is not reported
+                }));
+        assertTrue(e.getMessage().contains(url("/missing/last")), "the failure has to name the source that was tried last: " + e);
+        assertFalse(Files.exists(jar));
+    }
+
+    @Test
+    public void test_install_rejectsAJarThatDoesNotMatchThePublishedChecksum() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        final SetupException e = assertThrows(SetupException.class,
+                () -> FessPluginInstaller.install(List.of(url("/github.jar")), url("/maven.jar.sha1"), jar, out, (bytes, total) -> {
+                    // progress is not reported
+                }));
+        assertTrue(e.getMessage().contains("Checksum mismatch"), e.getMessage());
+        assertFalse(Files.exists(jar), "a jar that failed its checksum must not stay installed");
+    }
+
+    @Test
+    public void test_install_warnsButKeepsGoingWhenNoChecksumIsPublished() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        FessPluginInstaller.install(List.of(url("/maven.jar")), url("/missing"), jar, out, (bytes, total) -> {
+            // progress is not reported
+        });
+        assertEquals("jar-from-maven", Files.readString(jar));
+        assertTrue(out().contains("was not verified"), out());
+    }
+
+    @Test
+    public void test_install_leavesTheInstalledJarAloneWhenTheDownloadFailsItsChecksum() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        Files.writeString(jar, "the jar that is already installed");
+        assertThrows(SetupException.class,
+                () -> FessPluginInstaller.install(List.of(url("/github.jar")), url("/maven.jar.sha1"), jar, out, (bytes, total) -> {
+                    // progress is not reported
+                }));
+        assertEquals("the jar that is already installed", Files.readString(jar),
+                "a download that fails its checksum must not replace the plugin that was working");
+    }
+
+    @Test
+    public void test_install_leavesNoTemporaryFileBehindWhenTheChecksumFails() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        assertThrows(SetupException.class,
+                () -> FessPluginInstaller.install(List.of(url("/github.jar")), url("/maven.jar.sha1"), jar, out, (bytes, total) -> {
+                    // progress is not reported
+                }));
+        try (Stream<Path> entries = Files.list(tempDir)) {
+            assertEquals(List.of(), entries.map(path -> path.getFileName().toString()).sorted().toList());
+        }
+    }
+
+    @Test
+    public void test_install_failsWhenTheChecksumCannotBeRead() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        final SetupException e = assertThrows(SetupException.class,
+                () -> FessPluginInstaller.install(List.of(url("/maven.jar")), url("/broken"), jar, out, (bytes, total) -> {
+                    // progress is not reported
+                }));
+        assertTrue(e.getMessage().contains("500"), e.getMessage());
+        assertFalse(Files.exists(jar), "only a checksum that is not published may be skipped, not one that failed to load");
+    }
+
+    @Test
+    public void test_install_startsItsWarningsOnALineOfTheirOwn() throws Exception {
+        final Path jar = tempDir.resolve("fess-ds-git-15.9.0.jar");
+        FessPluginInstaller.install(List.of(url("/maven.jar")), url("/missing"), jar, out, (bytes, total) -> {
+            // progress is not reported
+        });
+        assertTrue(out().contains("\n  warning:"), "the progress line has to be terminated first: " + out());
+    }
+}

--- a/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
+++ b/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.setup;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,6 +44,27 @@ public class PluginRepositoryTest {
             </metadata>
             """;
 
+    private static final String SNAPSHOT_METADATA = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <metadata modelVersion="1.1.0">
+              <groupId>org.codelibs.fess</groupId>
+              <artifactId>fess-ds-git</artifactId>
+              <versioning>
+                <lastUpdated>20260903015513</lastUpdated>
+                <snapshot>
+                  <timestamp>20260903.015513</timestamp>
+                  <buildNumber>6</buildNumber>
+                </snapshot>
+                <snapshotVersions>
+                  <snapshotVersion>
+                    <extension>jar</extension>
+                    <value>15.9.0-20260903.015513-6</value>
+                  </snapshotVersion>
+                </snapshotVersions>
+              </versioning>
+            </metadata>
+            """;
+
     @Test
     public void test_versionsFromMetadata() throws Exception {
         final List<String> versions = PluginRepository.versionsFromMetadata(METADATA);
@@ -51,32 +73,32 @@ public class PluginRepositoryTest {
 
     @Test
     public void test_selectVersion_picksTheHighestMatchingTheProductVersion() throws Exception {
-        assertEquals("15.9.1", PluginRepository.selectVersion(PluginRepository.versionsFromMetadata(METADATA), "15.9"));
+        assertEquals("15.9.1", PluginRepository.selectVersion(PluginRepository.versionsFromMetadata(METADATA), "15.9", false));
     }
 
     @Test
     public void test_selectVersion_reportsWhenNothingMatches() {
         final SetupException e =
-                assertThrows(SetupException.class, () -> PluginRepository.selectVersion(List.of("14.19.0", "15.7.0"), "15.9"));
+                assertThrows(SetupException.class, () -> PluginRepository.selectVersion(List.of("14.19.0", "15.7.0"), "15.9", false));
         assertTrue(e.getMessage().contains("15.9"), e.getMessage());
         assertTrue(e.getMessage().contains("14.19.0"), e.getMessage());
     }
 
     @Test
     public void test_selectVersion_ordersNumerically() throws Exception {
-        assertEquals("15.9.10", PluginRepository.selectVersion(List.of("15.9.9", "15.9.10", "15.9.2"), "15.9"));
+        assertEquals("15.9.10", PluginRepository.selectVersion(List.of("15.9.9", "15.9.10", "15.9.2"), "15.9", false));
     }
 
     @Test
     public void test_jarUrl() {
         assertEquals("https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar",
-                PluginRepository.jarUrl("https://maven.codelibs.org/release/org/codelibs/fess/", "fess-ds-git", "15.9.0"));
+                PluginRepository.jarUrl("https://maven.codelibs.org/release/org/codelibs/fess/", "fess-ds-git", "15.9.0", "15.9.0"));
     }
 
     @Test
     public void test_jarUrl_addsTheMissingSlash() {
         assertEquals("https://example.org/m2/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar",
-                PluginRepository.jarUrl("https://example.org/m2", "fess-ds-git", "15.9.0"));
+                PluginRepository.jarUrl("https://example.org/m2", "fess-ds-git", "15.9.0", "15.9.0"));
     }
 
     @Test
@@ -123,5 +145,146 @@ public class PluginRepositoryTest {
         final String html =
                 "<a href=\"fess-crawler-playwright/\">x</a><a href=\"fess-crawler-lasta/\">x</a>" + "<a href=\"fess-ds-git/\">x</a>";
         assertEquals(List.of("fess-ds-git"), PluginRepository.namesFromListing(html));
+    }
+
+    @Test
+    public void test_isSnapshot() throws Exception {
+        assertTrue(PluginRepository.isSnapshot("15.9.0-SNAPSHOT"));
+        assertFalse(PluginRepository.isSnapshot("15.9.0"));
+        assertFalse(PluginRepository.isSnapshot(""));
+    }
+
+    @Test
+    public void test_selectVersion_prefersASnapshotOnASnapshotBuild() throws Exception {
+        final List<String> versions = List.of("15.9.0-SNAPSHOT", "15.9.0", "15.8.0");
+        assertEquals("15.9.0-SNAPSHOT", PluginRepository.selectVersion(versions, "15.9", true));
+    }
+
+    @Test
+    public void test_selectVersion_takesTheHighestSnapshotOnASnapshotBuild() throws Exception {
+        final List<String> versions = List.of("15.9.0-SNAPSHOT", "15.9.2-SNAPSHOT", "15.9.10-SNAPSHOT");
+        assertEquals("15.9.10-SNAPSHOT", PluginRepository.selectVersion(versions, "15.9", true));
+    }
+
+    @Test
+    public void test_selectVersion_fallsBackToAReleaseWhenNoSnapshotIsPublished() throws Exception {
+        final List<String> versions = List.of("15.9.0", "15.9.1");
+        assertEquals("15.9.1", PluginRepository.selectVersion(versions, "15.9", true));
+    }
+
+    @Test
+    public void test_selectVersion_ignoresSnapshotsOnAReleaseBuild() throws Exception {
+        final List<String> versions = List.of("15.9.0", "15.9.1-SNAPSHOT");
+        assertEquals("15.9.0", PluginRepository.selectVersion(versions, "15.9", false));
+    }
+
+    @Test
+    public void test_selectVersion_refusesASnapshotOnAReleaseBuild() throws Exception {
+        final List<String> versions = List.of("15.9.1-SNAPSHOT");
+        final SetupException e = assertThrows(SetupException.class, () -> PluginRepository.selectVersion(versions, "15.9", false));
+        assertTrue(e.getMessage().contains("15.9.1-SNAPSHOT"), e.getMessage());
+    }
+
+    @Test
+    public void test_snapshotFileVersion() throws Exception {
+        assertEquals("15.9.0-20260903.015513-6", PluginRepository.snapshotFileVersion(SNAPSHOT_METADATA, "15.9.0-SNAPSHOT"));
+    }
+
+    @Test
+    public void test_snapshotFileVersion_reportsMetadataWithoutASnapshotBuild() throws Exception {
+        final SetupException e =
+                assertThrows(SetupException.class, () -> PluginRepository.snapshotFileVersion(METADATA, "15.9.0-SNAPSHOT"));
+        assertTrue(e.getMessage().contains("15.9.0-SNAPSHOT"));
+    }
+
+    @Test
+    public void test_versionMetadataUrl() throws Exception {
+        assertEquals("https://example.org/m2/fess-ds-git/15.9.0-SNAPSHOT/maven-metadata.xml",
+                PluginRepository.versionMetadataUrl("https://example.org/m2", "fess-ds-git", "15.9.0-SNAPSHOT"));
+    }
+
+    @Test
+    public void test_jarUrl_namesTheTimestampedFileInsideTheSnapshotDirectory() throws Exception {
+        assertEquals(
+                "https://maven.codelibs.org/snapshot/org/codelibs/fess/fess-ds-git/15.9.0-SNAPSHOT/"
+                        + "fess-ds-git-15.9.0-20260903.015513-6.jar",
+                PluginRepository.jarUrl("https://maven.codelibs.org/snapshot/org/codelibs/fess/", "fess-ds-git", "15.9.0-SNAPSHOT",
+                        "15.9.0-20260903.015513-6"));
+    }
+
+    @Test
+    public void test_githubJarUrl() throws Exception {
+        assertEquals("https://github.com/codelibs/fess-ds-git/releases/download/fess-ds-git-15.9.0/fess-ds-git-15.9.0.jar",
+                PluginRepository.githubJarUrl("https://github.com/codelibs", "fess-ds-git", "15.9.0"));
+    }
+
+    @Test
+    public void test_githubJarUrl_addsTheMissingSlash() throws Exception {
+        assertEquals("https://github.com/codelibs/fess-ds-git/releases/download/fess-ds-git-15.9.0/fess-ds-git-15.9.0.jar",
+                PluginRepository.githubJarUrl("https://github.com/codelibs/", "fess-ds-git", "15.9.0"));
+    }
+
+    @Test
+    public void test_checksumUrl() throws Exception {
+        assertEquals("https://example.org/m2/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar.sha1",
+                PluginRepository.checksumUrl("https://example.org/m2/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar"));
+    }
+
+    @Test
+    public void test_mergeNames_sortsAndDropsDuplicates() throws Exception {
+        assertEquals(List.of("fess-ds-git", "fess-ds-slack", "fess-script-groovy"),
+                PluginRepository.mergeNames(List.of("fess-ds-slack", "fess-ds-git"), List.of("fess-ds-git", "fess-script-groovy")));
+    }
+
+    private static final PluginSources SOURCES = new PluginSources("https://maven.codelibs.org/release/org/codelibs/fess/",
+            "https://maven.codelibs.org/snapshot/org/codelibs/fess/", "https://github.com/codelibs");
+
+    @Test
+    public void test_jarUrls_triesGithubBeforeTheRepositoryForARelease() throws Exception {
+        assertEquals(
+                List.of("https://github.com/codelibs/fess-ds-git/releases/download/fess-ds-git-15.9.0/fess-ds-git-15.9.0.jar",
+                        "https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar"),
+                PluginRepository.jarUrls(SOURCES, "fess-ds-git", "15.9.0", "15.9.0"));
+    }
+
+    @Test
+    public void test_jarUrls_usesOnlyTheSnapshotRepositoryForASnapshot() throws Exception {
+        assertEquals(
+                List.of("https://maven.codelibs.org/snapshot/org/codelibs/fess/fess-ds-git/15.9.0-SNAPSHOT/"
+                        + "fess-ds-git-15.9.0-20260903.015513-6.jar"),
+                PluginRepository.jarUrls(SOURCES, "fess-ds-git", "15.9.0-SNAPSHOT", "15.9.0-20260903.015513-6"));
+    }
+
+    @Test
+    public void test_jarUrls_skipsGithubWhenTheDefinitionNamesNone() throws Exception {
+        final PluginSources sources = new PluginSources("https://example.org/m2", "https://example.org/snapshot", "  ");
+        assertEquals(List.of("https://example.org/m2/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar"),
+                PluginRepository.jarUrls(sources, "fess-ds-git", "15.9.0", "15.9.0"));
+    }
+
+    @Test
+    public void test_repositoryJarUrl_choosesTheRepositoryThatMatchesTheVersion() throws Exception {
+        assertEquals("https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-git/15.9.0/fess-ds-git-15.9.0.jar",
+                PluginRepository.repositoryJarUrl(SOURCES, "fess-ds-git", "15.9.0", "15.9.0"));
+        assertEquals(
+                "https://maven.codelibs.org/snapshot/org/codelibs/fess/fess-ds-git/15.9.0-SNAPSHOT/"
+                        + "fess-ds-git-15.9.0-20260903.015513-6.jar",
+                PluginRepository.repositoryJarUrl(SOURCES, "fess-ds-git", "15.9.0-SNAPSHOT", "15.9.0-20260903.015513-6"));
+    }
+
+    @Test
+    public void test_repositoryJarUrl_reportsASnapshotRepositoryTheDefinitionLeftEmpty() throws Exception {
+        final PluginSources sources = new PluginSources("https://example.org/m2", "", "https://github.com/codelibs");
+        final SetupException e = assertThrows(SetupException.class,
+                () -> PluginRepository.repositoryJarUrl(sources, "fess-ds-git", "15.9.0-SNAPSHOT", "15.9.0-20260903.015513-6"));
+        assertTrue(e.getMessage().contains("snapshot.repository"), e.getMessage());
+    }
+
+    @Test
+    public void test_repositoryJarUrl_reportsAReleaseRepositoryTheDefinitionLeftEmpty() throws Exception {
+        final PluginSources sources = new PluginSources(null, "https://example.org/snapshot", "https://github.com/codelibs");
+        final SetupException e =
+                assertThrows(SetupException.class, () -> PluginRepository.repositoryJarUrl(sources, "fess-ds-git", "15.9.0", "15.9.0"));
+        assertTrue(e.getMessage().contains("plugin.repository"), e.getMessage());
     }
 }

--- a/src/test/java/org/codelibs/fess/setup/PluginVersionResolutionTest.java
+++ b/src/test/java/org/codelibs/fess/setup/PluginVersionResolutionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.setup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Covers which repositories a build of Fess reads, and which version it then picks.
+ *
+ * <p>The repositories are served from a loopback server so that the test can assert on what was
+ * <em>not</em> requested: a released Fess must not so much as ask the snapshot repository.</p>
+ */
+public class PluginVersionResolutionTest {
+
+    private static final String RELEASE_METADATA = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <metadata>
+              <versioning>
+                <versions>
+                  <version>15.8.0</version>
+                  <version>15.9.0</version>
+                </versions>
+              </versioning>
+            </metadata>
+            """;
+
+    private static final String SNAPSHOT_METADATA = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <metadata>
+              <versioning>
+                <versions>
+                  <version>15.9.0-SNAPSHOT</version>
+                  <version>15.9.1-SNAPSHOT</version>
+                </versions>
+              </versioning>
+            </metadata>
+            """;
+
+    private HttpServer server;
+
+    private Set<String> requested;
+
+    @BeforeEach
+    public void startServer() throws IOException {
+        requested = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            final String path = exchange.getRequestURI().getPath();
+            requested.add(path);
+            final String body = switch (path) {
+            case "/release/fess-ds-git/maven-metadata.xml" -> RELEASE_METADATA;
+            case "/snapshot/fess-ds-git/maven-metadata.xml" -> SNAPSHOT_METADATA;
+            default -> null;
+            };
+            if (body == null) {
+                exchange.sendResponseHeaders(404, -1);
+                exchange.close();
+                return;
+            }
+            final byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    public void stopServer() {
+        server.stop(0);
+    }
+
+    private PluginSources sources(final String releasePath, final String snapshotPath) {
+        final String base = "http://127.0.0.1:" + server.getAddress().getPort();
+        return new PluginSources(base + releasePath, base + snapshotPath, "");
+    }
+
+    @Test
+    public void test_aDevelopmentBuildPrefersTheSnapshotOfItsOwnLine() throws Exception {
+        assertEquals("15.9.1-SNAPSHOT", FessSetup.resolveVersion(sources("/release/", "/snapshot/"), "fess-ds-git", "15.9", true));
+        assertTrue(requested.contains("/snapshot/fess-ds-git/maven-metadata.xml"), requested.toString());
+    }
+
+    @Test
+    public void test_aReleasedBuildNeverAsksTheSnapshotRepository() throws Exception {
+        assertEquals("15.9.0", FessSetup.resolveVersion(sources("/release/", "/snapshot/"), "fess-ds-git", "15.9", false));
+        assertTrue(requested.contains("/release/fess-ds-git/maven-metadata.xml"), requested.toString());
+        assertFalse(requested.contains("/snapshot/fess-ds-git/maven-metadata.xml"),
+                "a released Fess must not read the snapshot repository at all: " + requested);
+    }
+
+    @Test
+    public void test_aDevelopmentBuildInstallsAPluginThatOnlyTheSnapshotRepositoryHas() throws Exception {
+        assertEquals("15.9.1-SNAPSHOT", FessSetup.resolveVersion(sources("/empty/", "/snapshot/"), "fess-ds-git", "15.9", true));
+    }
+
+    @Test
+    public void test_aDevelopmentBuildFallsBackToAReleaseWhenThereIsNoSnapshot() throws Exception {
+        assertEquals("15.9.0", FessSetup.resolveVersion(sources("/release/", "/empty/"), "fess-ds-git", "15.9", true));
+    }
+
+    @Test
+    public void test_bothRepositoriesFailing_reportsEachOfThem() throws Exception {
+        final SetupException e = assertThrows(SetupException.class,
+                () -> FessSetup.resolveVersion(sources("/empty/", "/nowhere/"), "fess-ds-git", "15.9", true));
+        assertTrue(e.getMessage().contains("/empty/fess-ds-git/maven-metadata.xml"), e.getMessage());
+        assertTrue(e.getMessage().contains("/nowhere/fess-ds-git/maven-metadata.xml"), e.getMessage());
+    }
+
+    @Test
+    public void test_aRepositoryTheDefinitionLeftEmptyIsSkippedRatherThanRequested() throws Exception {
+        final String base = "http://127.0.0.1:" + server.getAddress().getPort();
+        assertEquals("15.9.0", FessSetup.resolveVersion(new PluginSources(base + "/release/", "", ""), "fess-ds-git", "15.9", true));
+        assertEquals(List.of("/release/fess-ds-git/maven-metadata.xml"), List.copyOf(requested));
+    }
+}


### PR DESCRIPTION
## Why

`fess-setup` resolved every plugin from the release repository alone, so a development build could install nothing of its own line: 15.9 has no plugin releases yet, and `install plugin` ended at `No release matches Fess 15.9`. Pointing it at the snapshot repository by hand would not have worked either, because a snapshot repository holds no jar under the `-SNAPSHOT` name — only the timestamped file the version's own `maven-metadata.xml` names.

## What

A plugin is now resolved from the sources that actually publish it.

|  | SNAPSHOT build (15.9.0-SNAPSHOT) | released build (15.8.0) |
|---|---|---|
| version list | release **and** snapshot `maven-metadata.xml`, merged | release only — the snapshot repository is never requested |
| default choice | the newest snapshot of the line, falling back to a release when the plugin has no snapshot yet | the newest release; a snapshot only when `--version` names one |
| jar | the snapshot repository, under its timestamped file name | the plugin's GitHub release, falling back to the Maven repository |
| checksum | the Maven repository's `.sha1`, always | the Maven repository's `.sha1`, always |

Details worth knowing:

- **Snapshots are installed under their timestamped name** (`fess-ds-slack-15.9.0-20260903.015513-6.jar`), so `upgrade plugins` can tell one build from the next instead of reporting `already at 15.9.0-SNAPSHOT` forever.
- **A source that answers 404 is passed over silently**, which today is every GitHub release; one that fails for another reason is reported before the next is tried.
- **The download is written beside the plugin and moved into place only once its SHA-1 matches**, so a corrupt download cannot take out the version that was already installed. A checksum the repository does not publish warns and continues; one that *fails to load* does not, so that a server error cannot quietly turn verification off. SHA-1 because that, with MD5, is the only checksum these repositories serve — `.sha256` and `.sha512` answer 404.
- **`list plugins` merges the snapshot index on a development build**, which is where seven plugins — `fess-script-groovy` among them — currently live.
- **`--repository` now names every source, GitHub included**, rather than the release repository alone: honouring it for the version list while still downloading the jar from github.com would defeat the point of passing it.

The three source URLs are declared in `fess-setup.properties`, so a mirror remains a matter of editing the file inside `bin/fess-setup.jar`. A repository the definition leaves empty is skipped or reported by name rather than crashing.

## Testing

`mvn test` over the setup package: **159 tests, all passing**, including `SetupPackageDependencyTest` — the package still depends on the JDK alone (`java.security.MessageDigest` is the only new capability). `mvn javadoc:javadoc` is clean for the package.

New coverage:

- `PluginVersionResolutionTest` serves both repositories from a loopback HTTP server and asserts on what was **not** requested: a released Fess must not so much as ask the snapshot repository.
- `PluginJarInstallTest` covers source order, the 404 fallback, a source that fails for another reason, a jar that fails its checksum (and that the previously installed jar survives it), and a checksum that cannot be read.
- Both suites were mutation-checked — reverting the selection asymmetry, always reading the snapshot repository, and deriving the checksum from the source that served the jar each turn tests red.

Verified against the real repositories with jars built at both versions:

- `15.9.0-SNAPSHOT` → installs `fess-ds-slack-15.9.0-20260903.015513-6.jar` from the snapshot repository; the SHA-1 matches the published one; `upgrade plugins` then reports `already at …` and re-downloads nothing.
- `15.8.0` → GitHub answers 404 (no plugin has a GitHub release yet), falls back to the Maven repository with no noise.
- `list plugins` shows 28 plugins on the development build and 21 on the released one.
- `--version 15.9.0-SNAPSHOT` on a released build still installs that snapshot explicitly.

## Note

Plugin repositories publish **no GitHub releases yet**, so the GitHub source is inert until they do. The URL it builds is `…/releases/download/<artifact>-<version>/<artifact>-<version>.jar`, matching the tag `maven-release-plugin` already creates and the convention Fess itself follows (`fess-15.8.0` → `fess-15.8.0.zip`).
