### PR TITLE
build: ship bin/fess-setup in the rpm and the deb, not only the zip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,7 @@
 							<type>files</type>
 							<paths>
 								<path>${project.basedir}/src/main/assemblies/files/fess</path>
+								<path>${project.basedir}/src/main/assemblies/files/fess-setup</path>
 								<path>${project.basedir}/src/main/assemblies/files/fess.in.sh</path>
 								<path>${project.basedir}/src/main/assemblies/files/generate-thumbnail</path>
 							</paths>
@@ -565,6 +566,20 @@
 							<mapper>
 								<type>perm</type>
 								<filemode>755</filemode>
+								<user>${packaging.fess.user}</user>
+								<group>${packaging.fess.group}</group>
+							</mapper>
+						</data>
+						<!-- Unlike the rest of bin this is not a source file: the fess-setup-jar execution
+						     of maven-jar-plugin builds it into target under the build final name. dst
+						     pins the installed name, which bin/fess-setup hardcodes. -->
+						<data>
+							<type>file</type>
+							<src>${project.build.directory}/${project.build.finalName}-setup.jar</src>
+							<dst>${packaging.fess.bin.dir}/fess-setup.jar</dst>
+							<mapper>
+								<type>perm</type>
+								<filemode>644</filemode>
 								<user>${packaging.fess.user}</user>
 								<group>${packaging.fess.group}</group>
 							</mapper>
@@ -789,14 +804,33 @@
 						<mapping>
 							<directory>${packaging.fess.bin.dir}</directory>
 							<filemode>755</filemode>
+							<!-- Once the jar mapping below adds a file this mapping does not own, the plugin
+							     lists bin file by file instead of as one directory entry, and the directory
+							     itself drops out of the package; recurseDirectories keeps it listed. -->
+							<recurseDirectories>true</recurseDirectories>
 							<sources>
 								<source>
 									<location>${project.basedir}/src/main/assemblies/files</location>
 									<includes>
 										<include>fess</include>
+										<include>fess-setup</include>
 										<include>fess.in.sh</include>
 										<include>generate-thumbnail</include>
 									</includes>
+								</source>
+							</sources>
+						</mapping>
+						<!-- Same jar as in the deb bin section: build output rather than a source file,
+						     with destination pinning the installed name that bin/fess-setup hardcodes.
+						     It gets a mapping of its own because filemode is per mapping and only the
+						     launchers have to be executable. -->
+						<mapping>
+							<directory>${packaging.fess.bin.dir}</directory>
+							<directoryIncluded>false</directoryIncluded>
+							<sources>
+								<source>
+									<location>${project.build.directory}/${project.build.finalName}-setup.jar</location>
+									<destination>fess-setup.jar</destination>
 								</source>
 							</sources>
 						</mapping>


### PR DESCRIPTION
`bin/fess-setup` and `bin/fess-setup.jar` reached the **zip only**. The jdeb `bin` data set and the rpm `bin` mapping each listed exactly `fess`, `fess.in.sh` and `generate-thumbnail`, and nothing under `src/packaging/` mentioned fess-setup — confirmed against the built 15.9.0-SNAPSHOT packages, whose `usr/share/fess/bin/` holds those three files and nothing else.

That matters more in 15.9 than in any release before it. fess-setup installs what the distribution no longer bundles: OpenSearch, the Fess plugins, and the Node.js the Playwright crawler needs. An admin who installed the rpm or the deb could not run `bin/fess-setup install plugin` at all, so `fess-script-groovy`, `fess-storage-s3`, `fess-storage-gcs` and the four `fess-sso-*` — which now carry the Groovy script engine, the S3 and GCS storage backends and every `sso.type` — were reachable only through the admin UI.

## `recurseDirectories` is load-bearing, not tidying

The rpm needs the jar in a mapping of its own, because `filemode` is per mapping there and only the launchers should be executable. Adding that second mapping **silently drops `/usr/share/fess/bin` from the package**.

rpm-maven-plugin emits `bin` as one directory entry only while the mapping owns everything under it (`SpecWriter.isEverythingIncluded`). The moment a second mapping contributes a file the first does not own, it switches to per-file entries and the directory itself disappears from `%files`. `_unpackaged_files_terminate_build 0` means rpmbuild says nothing about it.

Confirmed by generating the spec both ways:

```
with     3130: %dir %attr(755,fess,fess)  "/usr/share/fess/bin/"
         3131: %attr(755,fess,fess)  "/usr/share/fess/bin/fess-setup"
         ...
without  3130: %attr(755,fess,fess)  "/usr/share/fess/bin/fess-setup"
         ...            (the %dir line is simply gone; the file entries remain)
```

Putting the jar into the existing mapping as a second `<source>` also preserves the directory entry, but then the jar inherits `filemode` 755.

## The jar is build output, so both formats name it explicitly

`${project.build.finalName}-setup.jar` is what the `fess-setup-jar` execution of maven-jar-plugin writes. jdeb's `dst` and rpm-maven-plugin's `<destination>` pin the installed name to `fess-setup.jar`, which `bin/fess-setup` hardcodes — the same thing `common-bin.xml:103` does with `<destName>` for the zip.

## Verification

| | |
| --- | --- |
| deb, `ar x` + `tar tvzf` | all five files under `./usr/share/fess/bin/`, `fess:fess`; `fess-setup` 755, `fess-setup.jar` 644 |
| rpm, `rpm -qlvp` | the same five, plus `drwxr-xr-x fess fess /usr/share/fess/bin` |
| zip | unchanged — `bin/fess-setup`, `bin/fess-setup.jar`, `bin/fess-setup.bat` still present; `common-bin.xml` was not touched |
| the deb's jar actually runs | extracted and executed: `java -jar` prints the usage and exits 2; manifest carries `Main-Class` and `Implementation-Version: 15.9.0-SNAPSHOT` |
| size | deb +67,266 bytes, rpm +63,983 |

`Implementation-Version` is worth the check rather than assuming: it is where `install plugin` reads which plugin line fits this build, so a jar that lost it would resolve nothing.

The rpm's whole file list was also diffed against a baseline built from the unmodified pom, and it differs by **exactly the two added files** — nothing else moved, and `/usr/share/fess/bin` is present in both.

**Building rpms locally needs `LC_ALL=C LANG=C`.** Under a non-C locale Homebrew's rpmbuild fails with hundreds of `Recognition of file mtype ... regex error 11 for '^[!-?A-~]{1,255}...' (invalid character range)` messages and produces no package. It is libmagic's character-range parsing, unrelated to this change — it fires on kopf's asset files, which nothing here touches, and the unmodified pom fails identically (584 errors, no package). `LC_ALL=C LANG=C mvn rpm:rpm jdeb:jdeb` succeeds with zero such errors. Worth knowing before anyone else builds packages by hand.

## Context

Needed by codelibs/docker-fess#80, which installs those seven plugins at image build time; its `snapshot-noble` and `snapshot-al2023` variants install from the deb and the rpm and cannot call fess-setup until this lands. The Alpine variant installs from the zip and is unaffected.
