### PR TITLE
feat(setup): let install plugin pin a version per plugin

### DIFF
--- a/src/main/java/org/codelibs/fess/setup/FessSetup.java
+++ b/src/main/java/org/codelibs/fess/setup/FessSetup.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Installs the artifacts Fess needs but does not bundle.
@@ -42,6 +43,9 @@ public final class FessSetup {
 
     /** The definition holding where Fess plugins come from and go, rather than a download. */
     private static final String PLUGIN_COMPONENT = "plugin";
+
+    /** What a plugin name and a plugin version may be made of, which is a Maven coordinate. */
+    private static final Pattern COORDINATE = Pattern.compile("[A-Za-z0-9._-]+");
 
     private static final int EXIT_OK = 0;
 
@@ -64,8 +68,12 @@ public final class FessSetup {
               install nodejs [--dest <dir>] [--version <version>]
                   Download Node.js, which the Playwright crawler needs.
 
-              install plugin <name>... [--version <version>] [--repository <url>]
+              install plugin <name>[:<version>]... [--version <version>] [--repository <url>]
                   Install Fess plugins, for example fess-script-groovy or fess-ds-git.
+                  A name with no version is resolved against the repository, which picks
+                  the newest one built for this Fess. Name one instead to pin it, either
+                  per plugin as fess-script-groovy:15.9.0 or, for every plugin that has
+                  no version of its own, with --version.
                   A release comes from the plugin's GitHub release, or from the Maven
                   repository when GitHub has no such asset. A development build of Fess
                   installs the snapshots of its own line as well, and prefers them.
@@ -281,34 +289,94 @@ public final class FessSetup {
      *
      * <p>The version is resolved from the repository unless the caller names one, so that
      * {@code install plugin fess-ds-git} picks the latest release built for this Fess rather
-     * than whatever is newest.</p>
+     * than whatever is newest. A caller that needs a reproducible install -- a Dockerfile,
+     * say -- names the version instead, per plugin, because the plugins of one Fess line are
+     * released separately and need not all be at the same one.</p>
+     *
+     * <p>Every argument is parsed before the first download starts: a typo in the last of
+     * seven plugin names should not leave six of them installed.</p>
      *
      * @param args the command line
      * @param definitions the setup definition
      * @param options the parsed options
      * @param out the stream for normal output
      * @param err the stream for errors
-     * @return 0 on success, 2 when no plugin was named
+     * @return 0 on success, 2 when no plugin was named or one was named badly
      * @throws SetupException if a download or a file operation fails
      */
     private static int installFessPlugins(final String[] args, final Map<String, ComponentDefinition> definitions,
             final Map<String, String> options, final PrintStream out, final PrintStream err) throws SetupException {
-        final List<String> artifactIds = positionals(args, 2);
-        if (artifactIds.isEmpty()) {
+        final List<String> arguments = positionals(args, 2);
+        if (arguments.isEmpty()) {
             err.println("error: install plugin requires at least one plugin name, for example:");
             err.println("  fess-setup install plugin fess-script-groovy");
             err.println("Run `fess-setup list plugins` to see what is published.");
             return EXIT_USAGE;
         }
+        final List<PluginSpec> specs = new ArrayList<>();
+        for (final String argument : arguments) {
+            try {
+                specs.add(parsePluginSpec(argument, options.get("version")));
+            } catch (final SetupException e) {
+                err.println("error: " + e.getMessage());
+                return EXIT_USAGE;
+            }
+        }
         final ComponentDefinition definition = definitions.get(PLUGIN_COMPONENT);
         final PluginSources sources = pluginSources(definition, options);
         final Path directory = pluginDirectory(definition, options);
-        for (final String artifactId : artifactIds) {
-            installOne(sources, artifactId, resolve(sources, artifactId, options.get("version")), directory, out);
+        for (final PluginSpec spec : specs) {
+            installOne(sources, spec.artifactId(), resolve(sources, spec.artifactId(), spec.version()), directory, out);
         }
         out.println();
-        out.println("Restart Fess to load " + (artifactIds.size() == 1 ? "it." : "them."));
+        out.println("Restart Fess to load " + (specs.size() == 1 ? "it." : "them."));
         return EXIT_OK;
+    }
+
+    /**
+     * A plugin named on the command line: which plugin, and which version of it to install.
+     *
+     * @param artifactId the plugin name
+     * @param version the version to install, or {@code null} to let the repository decide
+     */
+    record PluginSpec(String artifactId, String version) {
+    }
+
+    /**
+     * Parses one {@code install plugin} argument, which is a plugin name and may carry a
+     * version after a colon.
+     *
+     * <p>The colon wins over {@code --version}, which is the default for the arguments that
+     * do not carry one, so that a mostly uniform set of plugins can name the odd one out.</p>
+     *
+     * <p>Both parts are checked against the characters a Maven coordinate is made of. This is
+     * not pedantry about version syntax: the name and the version become the jar's file name,
+     * which is resolved against the plugin directory, so a separator in either would write the
+     * jar somewhere else entirely.</p>
+     *
+     * @param argument the argument, either {@code <name>} or {@code <name>:<version>}
+     * @param defaultVersion the version {@code --version} named, or null
+     * @return the plugin and its version
+     * @throws SetupException if the argument or the default version is not in that shape
+     */
+    static PluginSpec parsePluginSpec(final String argument, final String defaultVersion) throws SetupException {
+        final int colon = argument.indexOf(':');
+        if (colon < 0) {
+            if (defaultVersion != null && !COORDINATE.matcher(defaultVersion).matches()) {
+                throw new SetupException("--version " + defaultVersion + " is not a version.");
+            }
+            if (!COORDINATE.matcher(argument).matches()) {
+                throw new SetupException("'" + argument + "' is not a plugin name.");
+            }
+            return new PluginSpec(argument, defaultVersion);
+        }
+        final String artifactId = argument.substring(0, colon);
+        final String version = argument.substring(colon + 1);
+        if (!COORDINATE.matcher(artifactId).matches() || !COORDINATE.matcher(version).matches()) {
+            throw new SetupException("'" + argument + "' is not a plugin, which is written as <name> or <name>:<version>, "
+                    + "for example fess-script-groovy or fess-script-groovy:15.9.0.");
+        }
+        return new PluginSpec(artifactId, version);
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
+++ b/src/test/java/org/codelibs/fess/setup/FessSetupTest.java
@@ -274,6 +274,58 @@ public class FessSetupTest {
     }
 
     @Test
+    public void test_parsePluginSpec_takesTheVersionAfterTheColon() throws Exception {
+        final FessSetup.PluginSpec spec = FessSetup.parsePluginSpec("fess-ds-git:15.9.0", null);
+        assertEquals("fess-ds-git", spec.artifactId());
+        assertEquals("15.9.0", spec.version());
+    }
+
+    @Test
+    public void test_parsePluginSpec_fallsBackToTheOptionVersion() throws Exception {
+        final FessSetup.PluginSpec spec = FessSetup.parsePluginSpec("fess-ds-git", "15.9.0");
+        assertEquals("fess-ds-git", spec.artifactId());
+        assertEquals("15.9.0", spec.version());
+    }
+
+    @Test
+    public void test_parsePluginSpec_leavesTheVersionUnresolvedWhenNoneIsGiven() throws Exception {
+        final FessSetup.PluginSpec spec = FessSetup.parsePluginSpec("fess-ds-git", null);
+        assertEquals("fess-ds-git", spec.artifactId());
+        assertNull(spec.version());
+    }
+
+    @Test
+    public void test_parsePluginSpec_prefersTheColonOverTheOption() throws Exception {
+        assertEquals("15.9.1", FessSetup.parsePluginSpec("fess-ds-git:15.9.1", "15.9.0").version());
+    }
+
+    @Test
+    public void test_parsePluginSpec_rejectsAnEmptyName() {
+        final SetupException e = assertThrows(SetupException.class, () -> FessSetup.parsePluginSpec(":15.9.0", null));
+        assertTrue(e.getMessage().contains(":15.9.0"), e.getMessage());
+    }
+
+    @Test
+    public void test_parsePluginSpec_rejectsAnEmptyVersion() {
+        final SetupException e = assertThrows(SetupException.class, () -> FessSetup.parsePluginSpec("fess-ds-git:", null));
+        assertTrue(e.getMessage().contains("fess-ds-git:"), e.getMessage());
+    }
+
+    @Test
+    public void test_parsePluginSpec_rejectsAVersionThatCouldEscapeThePluginDirectory() {
+        // The version becomes the jar's file name, which is resolved against the plugin
+        // directory, so a separator in it would write outside that directory.
+        assertThrows(SetupException.class, () -> FessSetup.parsePluginSpec("fess-ds-git:../../evil", null));
+        assertThrows(SetupException.class, () -> FessSetup.parsePluginSpec("fess-ds-git", "../../evil"));
+    }
+
+    @Test
+    public void test_installPlugin_reportsAMalformedSpecAsAUsageError() {
+        assertEquals(2, run("install", "plugin", "fess-ds-git:"));
+        assertTrue(err().contains("fess-ds-git:"), err());
+    }
+
+    @Test
     public void test_fessVersion_isEmptyWithoutAManifest() {
         // Under test the class comes from target/classes, which has no manifest. The install
         // path then reports that --version is needed rather than guessing a plugin version.


### PR DESCRIPTION
## Problem

`bin/fess-setup install plugin <name>` asks the repository which version fits
this Fess and takes the newest one. A Dockerfile that installs plugins that way
therefore produces a different image on every build, and there is no way to
reproduce the image a release shipped.

`--version` pins the version, but it applies to every plugin named in the same
command. The plugins of one Fess line are released separately, so they need not
all be at the same version.

## Change

An `install plugin` argument may now carry a version after a colon:

```
bin/fess-setup install plugin \
  fess-script-groovy:15.9.0 \
  fess-storage-s3:15.9.1 \
  fess-sso-saml
```

- `<name>:<version>` wins over `--version`, and `--version` stays the default
  for the names that carry none. A name with neither is resolved as before.
- Both parts are checked against the characters a Maven coordinate is made of.
  This is not syntax pedantry: the name and the version become the jar's file
  name, which is resolved against the plugin directory, so a separator in
  either would write the jar outside it. `--version` is checked the same way,
  which closes the same hole there.
- Every argument is parsed before the first download starts, so a typo in the
  last of seven names does not leave six of them installed.

Nothing else changes: the SNAPSHOT timestamp is still resolved, every jar is
still checked against the published SHA-1, a version that does not exist still
exits 1, and the previously installed version of a plugin is still deleted
*after* the new one has been downloaded.

`remove plugin` and `upgrade plugins` are unchanged and do not take a version.

## Tests

`FessSetupTest` gains eight cases: the colon form, the `--version` fallback,
the precedence between them, no version at all, an empty name, an empty
version, a version that would escape the plugin directory (from both the colon
and `--version`), and the exit code for a malformed argument.

```
mvn test -Dtest='org.codelibs.fess.setup.*Test'
Tests run: 167, Failures: 0, Errors: 0, Skipped: 0
```

## Manual verification

Against a jar built from this branch with an `Implementation-Version` manifest,
installing into a scratch `fess.home` and downloading from the real repository:

| Case | Result |
|---|---|
| `fess-script-groovy:15.9.0-SNAPSHOT` | resolved to the timestamped snapshot jar, SHA-1 verified, exit 0 |
| `fess-ds-git:15.8.0` then `fess-ds-git:15.9.0-SNAPSHOT` | `Removed the previous fess-ds-git-15.8.0.jar` after the download, exit 0 |
| `fess-ds-git:15.8.0 fess-ds-slack --version 15.9.0-SNAPSHOT` | git at 15.8.0, slack at the snapshot, exit 0 |
| `fess-ds-git:` / `:15.9.0` / `fess-ds-git:../../../../evil` | exit 2, nothing downloaded |
| `--version ../evil` | exit 2 |
| `fess-ds-git:15.8.0 fess-ds-slack:` | exit 2, plugin directory left empty |
| `fess-ds-git:99.99.99` | exit 1 (HTTP 404), so a Docker build fails rather than shipping a short image |
| `fess-ds-git` (no version) | unchanged, resolved from the repository |
