### PR TITLE
docs(config): mark the group headings and describe the 24 undocumented properties

### DIFF
--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -52,6 +52,7 @@ app.audit.log.format=
 
 # Script audit log settings.
 script.audit.log.enabled=true
+# Maximum characters of script text kept in a script audit log entry; longer text is truncated.
 script.audit.log.max.length=100
 
 # JVM options for the crawler process.
@@ -94,6 +95,7 @@ jvm.crawler.options=\
 -Dorg.apache.pdfbox.rendering.UsePureJavaCMYKConversion=true\n\
 
 
+# JVM options (newline-separated) passed to the suggest creator child process.
 jvm.suggest.options=\
 -Djava.awt.headless=true\n\
 -Dfile.encoding=UTF-8\n\
@@ -1712,15 +1714,19 @@ rag.chat.context.max.documents=5
 
 # Session settings.
 rag.chat.session.timeout.minutes=30
+# Maximum cached chat sessions; least recently accessed are evicted above it (0 or less means 100).
 rag.chat.session.max.size=10000
+# Maximum messages kept in one chat session; older turns are trimmed on each new message.
 rag.chat.history.max.messages=30
 
 # Enhanced RAG flow settings.
 # Fields to retrieve for full document content.
 rag.chat.content.fields=title,url,content,doc_id,content_title,content_description
+# Maximum characters accepted in a chat API message. Read from conf/system.properties, not this file.
 rag.chat.message.max.length=4000
 # Highlight settings for RAG search.
 rag.chat.highlight.fragment.size=500
+# Number of highlight fragments per document in the RAG chat context search.
 rag.chat.highlight.number.of.fragments=3
 # Large-document handling for answer generation.
 # Documents whose content_length exceeds this value use highlighted passages
@@ -1728,6 +1734,7 @@ rag.chat.highlight.number.of.fragments=3
 rag.chat.content.fulltext.max.length=3000
 # Highlight settings used when extracting passages from large documents for the answer context.
 rag.chat.answer.highlight.fragment.size=1000
+# Number of highlight fragments taken from each oversized document for the answer context.
 rag.chat.answer.highlight.number.of.fragments=5
 # History content mode for assistant messages.
 #   smart_summary           - drop assistant body, keep only past search query + referenced titles per turn (default, recommended)
@@ -1742,8 +1749,11 @@ rag.chat.history.titles.max.count=5
 
 # Index Export
 index.export.path=/var/lib/fess/export
+# Comma-separated document fields omitted from files written by the index export job.
 index.export.exclude.fields=cache
+# Number of documents fetched per scroll request by the index export job.
 index.export.scroll.size=100
+# Output format for exported documents; only html and json are accepted, anything else fails the job.
 index.export.format=html
 
 # Log Notification
@@ -1764,15 +1774,25 @@ log.notification.interval=300
 
 # Static theme system (see docs/superpowers/specs/2026-05-21-fess-static-theme-design.md)
 theme.directory.path=themes
+# Maximum size (bytes) of an uploaded theme archive.
 theme.upload.max.size=52428800
+# Maximum total extracted size (bytes); extraction aborts once it is exceeded.
 theme.upload.max.extracted.size=209715200
+# Maximum number of entries allowed in an uploaded theme archive.
 theme.upload.max.entries=1000
+# Maximum uncompressed/compressed ratio for a single theme archive entry.
 theme.upload.max.compression.ratio=100
+# Maximum cumulative uncompressed/compressed ratio for the whole archive (zip-bomb guard).
 theme.upload.zip.ratio.max=50
+# Compressed bytes read before the cumulative zip ratio check applies; smaller archives skip it.
 theme.upload.zip.ratio.check.threshold.bytes=65536
+# Retention (days) for a replaced theme directory before the cleanup sweep removes it.
 theme.upload.attic.retention.days=7
+# Archive extensions accepted for theme upload. Not read: the upload action accepts only .zip.
 theme.allowed.archive.extensions=zip
+# Cache-Control max-age (seconds) for theme assets. Not read: the responder always sends 86400.
 theme.assets.cache.max.age=86400
+# Whether to serve precompressed theme assets. Not read: no precompressed asset path exists.
 theme.assets.precompressed=true
 # Optional: canonical external origin(s) of this Fess instance (comma/newline separated),
 # e.g. https://fess.example.com. When set, these are treated as same-origin for the v2 CSRF
@@ -1780,9 +1800,13 @@ theme.assets.precompressed=true
 # not listed in rate.limit.trusted.proxies. When empty, the target origin is reconstructed from
 # trusted-proxy X-Forwarded-* headers, then from the servlet request.
 theme.api.csrf.server.origins=
+# Login attempts allowed per client IP each minute; 0 or less disables the gate.
 theme.api.login.rate.limit.per.ip.per.minute=10
+# Login attempts allowed per client IP and user name each minute; also gates password change.
 theme.api.login.rate.limit.per.user.per.minute=5
+# Lockout (seconds) applied once a login rate limit is exceeded; 0 or less disables the lockout.
 theme.api.login.lockout.seconds=900
+# Maximum login rate-limit buckets held in memory; idle buckets are evicted at the cap.
 theme.api.login.rate.limit.max.entries=100000
 
 # Interval between SSE keep-alive pings emitted by /api/v2/chat/stream. The

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -8,7 +8,7 @@
 # The title of the domain for logging and display.
 domain.title = Fess
 
-# Search Engine
+#> Search Engine
 
 # The type of search engine backend (e.g., default, opensearch).
 search_engine.type=default
@@ -214,7 +214,7 @@ jvm.thumbnail.options=\
 #-Xdebug\n\
 #-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=127.0.0.1:8000\n\
 
-# job
+#> Job
 
 # System job IDs for scheduled jobs.
 job.system.job.ids=default_crawler
@@ -344,7 +344,7 @@ http.fileupload.max.file.count=10
 #                                                                                   Index
 #                                                                                     ====
 
-# common
+#> Crawler Common
 
 # Number of threads for HTTP crawling.
 crawler.http.thread_pool.size=0
@@ -410,7 +410,7 @@ title=title:string\n\
 Title=title:string\n\
 dc:title=title:string\n\
 
-# html
+#> Crawler HTML
 
 # XPath to extract main content from HTML documents.
 crawler.document.html.content.xpath=//BODY
@@ -435,7 +435,7 @@ crawler.document.html.default.include.search.patterns=
 # Patterns to exclude for HTML search processing.
 crawler.document.html.default.exclude.search.patterns=
 
-# file
+#> Crawler File
 
 # Encoding for file names in documents.
 crawler.document.file.name.encoding=
@@ -462,7 +462,7 @@ crawler.document.file.default.include.search.patterns=
 # Patterns to exclude for file search processing.
 crawler.document.file.default.exclude.search.patterns=
 
-# cache
+#> Crawler Cache
 
 # Whether document cache is enabled.
 crawler.document.cache.enabled=true
@@ -476,7 +476,7 @@ crawler.document.cache.html.mimetypes=text/html
 # Extension-to-MIME-type override mappings for MIME type detection (one per line: .ext=mime/type).
 crawler.document.mimetype.extension.overrides=
 
-# indexer
+#> Indexer
 
 # Whether to enable thread dump for the indexer.
 indexer.thread.dump.enabled=true
@@ -513,7 +513,7 @@ indexer.max.result.window.size=10000
 # Maximum number of search documents for the indexer.
 indexer.max.search.doc.size=50000
 
-# index setting
+#> Index Settings
 
 # Codec type for the index.
 index.codec=default
@@ -526,7 +526,7 @@ index.id.digest.algorithm=SHA-512
 # Initial password for the index user.
 index.user.initial_password=admin
 
-# field names
+#> Field Names
 
 # Field name for favorite count in the index.
 index.field.favorite_count=favorite_count
@@ -621,7 +621,7 @@ text/html=Content-Security-Policy: reflected-xss block\n\
 text/html=X-Frame-Options: SAMEORIGIN\n\
 
 
-# document index
+#> Document Index
 
 # Index name for search documents.
 index.document.search.index=fess.search
@@ -652,7 +652,7 @@ index.log.index=fess_log
 # Prefix for dictionary index names.
 index.dictionary.prefix=
 
-# doc management
+#> Document Management
 
 # Array-type fields for admin in the index.
 index.admin.array.fields=lang,role,label,anchor,virtual_host
@@ -669,7 +669,7 @@ index.admin.double.fields=
 # Required fields for admin in the index.
 index.admin.required.fields=url,title,role,boost
 
-# timeout
+#> Timeouts
 
 # Timeout for index search operations.
 index.search.timeout=3m
@@ -686,7 +686,7 @@ index.health.timeout=10m
 # Timeout for index indices operations.
 index.indices.timeout=1m
 
-# filetype
+#> File Types
 
 # Mapping of MIME types to filetype labels for indexing.
 index.filetype=\
@@ -757,7 +757,7 @@ index.reindex.scroll=5m
 # Maximum number of documents for reindex operations.
 index.reindex.max_docs=
 
-# query
+#> Query
 
 # Maximum length of search queries.
 query.max.length=1000
@@ -936,7 +936,7 @@ zh-tw=zh-tw\n\
 zh_TW=zh-tw\n\
 zh=zh\n\
 
-# boost
+#> Boost
 
 # Boost value for title field in queries.
 query.boost.title=0.5
@@ -991,7 +991,7 @@ query.fuzzy.expansions=50
 # Whether to allow transpositions in fuzzy queries.
 query.fuzzy.transpositions=true
 
-# facet
+#> Facet
 
 # Fields for facet queries.
 query.facet.fields=label
@@ -1032,7 +1032,7 @@ labels.facet_filetype_pdf=filetype:pdf\t\
 labels.facet_filetype_txt=filetype:txt\t\
 labels.facet_filetype_others=filetype:others\n\
 
-# ranking
+#> Ranking
 
 # Window size for rank fusion.
 rank.fusion.window_size=200
@@ -1057,7 +1057,7 @@ rank.fusion.combination.weights=
 # how deep a client can page and the set of documents the engine ranks.
 rank.fusion.pagination_depth=200
 
-# acl
+#> ACL
 
 # Whether to get SMB roles from a file.
 smb.role.from.file=true
@@ -1068,7 +1068,7 @@ file.role.from.file=true
 # Whether to get FTP roles from a file.
 ftp.role.from.file=true
 
-# backup
+#> Backup
 
 # Target files for index backup.
 index.backup.targets=fess_basic_config.bulk,fess_config.bulk,fess_user.bulk,system.properties,fess.json,doc.json
@@ -1077,7 +1077,7 @@ index.backup.log.targets=click_log.ndjson,favorite_log.ndjson,search_log.ndjson,
 # Timeout for loading index backup logs.
 index.backup.log.load.timeout=60000
 
-# logging
+#> Logging
 
 # Application packages for logging.
 logging.app.packages=org.codelibs,org.dbflute,org.lastaflute
@@ -1200,7 +1200,7 @@ paging.page.range.size = 5
 # The option 'fillLimit' of page range for paging
 paging.page.range.fill.limit = true
 
-# fetch page size
+#> Fetch Page Size
 
 # Maximum number of docboost records to fetch per page.
 page.docboost.max.fetch.size=1000
@@ -1266,7 +1266,7 @@ page.searchlist.track.total.hits=true
 # Maximum content length (in characters) rendered on the search list edit page.
 page.searchlist.content.max.length=100000
 
-# search page
+#> Search Page
 
 # Default start page for search results.
 paging.search.page.start=0
@@ -1313,7 +1313,7 @@ thumbnail.crawler.enabled=true
 # Interval for system monitor in thumbnail processing.
 thumbnail.system.monitor.interval=60
 
-# user
+#> User
 
 # User code settings
 user.code.request.parameter=userCode


### PR DESCRIPTION
Groundwork for codelibs/fess-docs, which is about to generate its configuration
reference page from this file instead of maintaining it by hand. Comments only — no key,
default or ordering changes.

## Why the page is being generated

`en/<version>/config/properties.rst` lists every configuration property with its
description and default. Kept by hand it rotted: measured against this file it is **120
keys short**, and it documents **10 keys that no longer exist**, several under a
misspelling — `app.cipher.algorism`, `app.digest.algorism`, `domain.tile`,
`http.proxy.Host`. `domain.tile` even acquired an invented description, "The domain name
of the tile server". It also carried jcifs property names no supported jcifs version
reads, until codelibs/fess-docs#532.

Generating it makes this file the single source for the keys, the defaults, the
descriptions, the headings and the order.

## What changes here

**Group headings get a marker.** The file already groups its properties: a bare comment
followed by a blank line introduces a run of related keys, and 23 do. That convention
cannot be read reliably, because a commented-out configuration example has exactly the
same shape — two are picked up as headings by that rule today, a continuation line of the
commented-out remote-debug JVM options and a commented-out `plugin.repositories` value.
`#> ` is a marker commented-out configuration never starts with. The terse lowercase
labels also become display titles, since they turn into the documentation's section
headings: `# job` to `#> Job`, `# html` to `#> Crawler HTML`, `# acl` to `#> ACL`.

The four top-level DBFlute banners — Core, Rate Limiting, Index, Web — are read as they
are and are untouched.

**The 24 keys with no comment get one.** Each was written from the code that reads the
key rather than from the key's name, so it records what the value actually controls: that
a login rate limit of 0 or less disables the gate, that `index.export.format` accepts only
`html` and `json` and fails the job on anything else, that the per-user login bucket is
keyed by client IP *and* user name rather than by user alone.

## Four of those keys turned out to have no effect

Worth stating where an operator will read it, rather than leaving them to discover it:

| key | what happens |
| --- | --- |
| `theme.allowed.archive.extensions` | `getThemeAllowedArchiveExtensions()` has no caller. `AdminThemeAction.hasZipExtension` hardcodes `endsWith(".zip")`. |
| `theme.assets.cache.max.age` | `getThemeAssetsCacheMaxAgeAsInteger()` has no caller. `StaticThemeResponder` sends a literal `max-age=86400` — which equals the default, so changing the key looks harmless and does nothing. |
| `theme.assets.precompressed` | `isThemeAssetsPrecompressed()` has no caller, and no precompressed asset path exists; the responder sets `Vary: Accept-Encoding` but negotiates nothing. |
| `rag.chat.message.max.length` | Read through `FessProp#getSystemProperty`, which consults `conf/system.properties` then `-Dfess.<key>` then a literal `"4000"`. It never reads `fess_config.properties`, so the value here is documentation only. |

Each is described as what it is for, followed by the caveat. Wiring them up or removing
them is a separate call — this PR only stops the file from claiming they work.

## Verification

- `git diff -U0 | grep -cE '^[-+][^-+#]'` is 0 across both commits: every changed line is
  a comment.
- Parsing the file with the new fess-docs generator yields 4 sections, 26 groups and
  **639 keys, none without a description** (before: 24 without).
- The two commented-out examples that the old heuristic misread are still commented-out
  configuration and are no longer mistaken for headings.
