### PR TITLE
chore(config): drop four properties whose value has no effect

### DIFF
--- a/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/ChatApiHelper.java
@@ -371,8 +371,12 @@ public class ChatApiHelper {
     }
 
     /**
-     * Resolves {@code rag.chat.message.max.length} from fess_config system properties,
-     * defaulting to {@code 4000} on parse failure.
+     * Resolves {@code rag.chat.message.max.length}, defaulting to {@code 4000} when it is
+     * unset or unparseable.
+     *
+     * <p>This is a system property: it is read from {@code conf/system.properties}, then
+     * {@code -Dfess.system.rag.chat.message.max.length}. It is deliberately not declared in
+     * {@code fess_config.properties}, which this channel never consults.
      *
      * @param fessConfig active Fess config
      * @return max chat message length in characters

--- a/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
+++ b/src/main/java/org/codelibs/fess/mylasta/direction/FessConfig.java
@@ -2077,9 +2077,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     /** The key of the configuration. e.g. title,url,content,doc_id,content_title,content_description */
     String RAG_CHAT_CONTENT_FIELDS = "rag.chat.content.fields";
 
-    /** The key of the configuration. e.g. 4000 */
-    String RAG_CHAT_MESSAGE_MAX_LENGTH = "rag.chat.message.max.length";
-
     /** The key of the configuration. e.g. 500 */
     String RAG_CHAT_HIGHLIGHT_FRAGMENT_SIZE = "rag.chat.highlight.fragment.size";
 
@@ -2157,15 +2154,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
     /** The key of the configuration. e.g. 7 */
     String THEME_UPLOAD_ATTIC_RETENTION_DAYS = "theme.upload.attic.retention.days";
-
-    /** The key of the configuration. e.g. zip */
-    String THEME_ALLOWED_ARCHIVE_EXTENSIONS = "theme.allowed.archive.extensions";
-
-    /** The key of the configuration. e.g. 86400 */
-    String THEME_ASSETS_CACHE_MAX_AGE = "theme.assets.cache.max.age";
-
-    /** The key of the configuration. e.g. true */
-    String THEME_ASSETS_PRECOMPRESSED = "theme.assets.precompressed";
 
     /** The key of the configuration. e.g.  */
     String THEME_API_CSRF_SERVER_ORIGINS = "theme.api.csrf.server.origins";
@@ -9979,21 +9967,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
     String getRagChatContentFields();
 
     /**
-     * Get the value for the key 'rag.chat.message.max.length'. <br>
-     * The value is, e.g. 4000 <br>
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getRagChatMessageMaxLength();
-
-    /**
-     * Get the value for the key 'rag.chat.message.max.length' as {@link Integer}. <br>
-     * The value is, e.g. 4000 <br>
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     * @throws NumberFormatException When the property is not integer.
-     */
-    Integer getRagChatMessageMaxLengthAsInteger();
-
-    /**
      * Get the value for the key 'rag.chat.highlight.fragment.size'. <br>
      * The value is, e.g. 500 <br>
      * comment: Highlight settings for RAG search.
@@ -10384,42 +10357,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
      * @throws NumberFormatException When the property is not integer.
      */
     Integer getThemeUploadAtticRetentionDaysAsInteger();
-
-    /**
-     * Get the value for the key 'theme.allowed.archive.extensions'. <br>
-     * The value is, e.g. zip <br>
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getThemeAllowedArchiveExtensions();
-
-    /**
-     * Get the value for the key 'theme.assets.cache.max.age'. <br>
-     * The value is, e.g. 86400 <br>
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getThemeAssetsCacheMaxAge();
-
-    /**
-     * Get the value for the key 'theme.assets.cache.max.age' as {@link Integer}. <br>
-     * The value is, e.g. 86400 <br>
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     * @throws NumberFormatException When the property is not integer.
-     */
-    Integer getThemeAssetsCacheMaxAgeAsInteger();
-
-    /**
-     * Get the value for the key 'theme.assets.precompressed'. <br>
-     * The value is, e.g. true <br>
-     * @return The value of found property. (NotNull: if not found, exception but basically no way)
-     */
-    String getThemeAssetsPrecompressed();
-
-    /**
-     * Is the property for the key 'theme.assets.precompressed' true? <br>
-     * The value is, e.g. true <br>
-     * @return The determination, true or false. (if not found, exception but basically no way)
-     */
-    boolean isThemeAssetsPrecompressed();
 
     /**
      * Get the value for the key 'theme.api.csrf.server.origins'. <br>
@@ -14176,14 +14113,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             return get(FessConfig.RAG_CHAT_CONTENT_FIELDS);
         }
 
-        public String getRagChatMessageMaxLength() {
-            return get(FessConfig.RAG_CHAT_MESSAGE_MAX_LENGTH);
-        }
-
-        public Integer getRagChatMessageMaxLengthAsInteger() {
-            return getAsInteger(FessConfig.RAG_CHAT_MESSAGE_MAX_LENGTH);
-        }
-
         public String getRagChatHighlightFragmentSize() {
             return get(FessConfig.RAG_CHAT_HIGHLIGHT_FRAGMENT_SIZE);
         }
@@ -14370,26 +14299,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
 
         public Integer getThemeUploadAtticRetentionDaysAsInteger() {
             return getAsInteger(FessConfig.THEME_UPLOAD_ATTIC_RETENTION_DAYS);
-        }
-
-        public String getThemeAllowedArchiveExtensions() {
-            return get(FessConfig.THEME_ALLOWED_ARCHIVE_EXTENSIONS);
-        }
-
-        public String getThemeAssetsCacheMaxAge() {
-            return get(FessConfig.THEME_ASSETS_CACHE_MAX_AGE);
-        }
-
-        public Integer getThemeAssetsCacheMaxAgeAsInteger() {
-            return getAsInteger(FessConfig.THEME_ASSETS_CACHE_MAX_AGE);
-        }
-
-        public String getThemeAssetsPrecompressed() {
-            return get(FessConfig.THEME_ASSETS_PRECOMPRESSED);
-        }
-
-        public boolean isThemeAssetsPrecompressed() {
-            return is(FessConfig.THEME_ASSETS_PRECOMPRESSED);
         }
 
         public String getThemeApiCsrfServerOrigins() {
@@ -15060,7 +14969,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.RAG_CHAT_SESSION_MAX_SIZE, "10000");
             defaultMap.put(FessConfig.RAG_CHAT_HISTORY_MAX_MESSAGES, "30");
             defaultMap.put(FessConfig.RAG_CHAT_CONTENT_FIELDS, "title,url,content,doc_id,content_title,content_description");
-            defaultMap.put(FessConfig.RAG_CHAT_MESSAGE_MAX_LENGTH, "4000");
             defaultMap.put(FessConfig.RAG_CHAT_HIGHLIGHT_FRAGMENT_SIZE, "500");
             defaultMap.put(FessConfig.RAG_CHAT_HIGHLIGHT_NUMBER_OF_FRAGMENTS, "3");
             defaultMap.put(FessConfig.RAG_CHAT_CONTENT_FULLTEXT_MAX_LENGTH, "3000");
@@ -15087,9 +14995,6 @@ public interface FessConfig extends FessEnv, org.codelibs.fess.mylasta.direction
             defaultMap.put(FessConfig.THEME_UPLOAD_ZIP_RATIO_MAX, "50");
             defaultMap.put(FessConfig.THEME_UPLOAD_ZIP_RATIO_CHECK_THRESHOLD_BYTES, "65536");
             defaultMap.put(FessConfig.THEME_UPLOAD_ATTIC_RETENTION_DAYS, "7");
-            defaultMap.put(FessConfig.THEME_ALLOWED_ARCHIVE_EXTENSIONS, "zip");
-            defaultMap.put(FessConfig.THEME_ASSETS_CACHE_MAX_AGE, "86400");
-            defaultMap.put(FessConfig.THEME_ASSETS_PRECOMPRESSED, "true");
             defaultMap.put(FessConfig.THEME_API_CSRF_SERVER_ORIGINS, "");
             defaultMap.put(FessConfig.THEME_API_LOGIN_RATE_LIMIT_PER_IP_PER_MINUTE, "10");
             defaultMap.put(FessConfig.THEME_API_LOGIN_RATE_LIMIT_PER_USER_PER_MINUTE, "5");

--- a/src/main/resources/fess_config.properties
+++ b/src/main/resources/fess_config.properties
@@ -1722,8 +1722,6 @@ rag.chat.history.max.messages=30
 # Enhanced RAG flow settings.
 # Fields to retrieve for full document content.
 rag.chat.content.fields=title,url,content,doc_id,content_title,content_description
-# Maximum characters accepted in a chat API message. Read from conf/system.properties, not this file.
-rag.chat.message.max.length=4000
 # Highlight settings for RAG search.
 rag.chat.highlight.fragment.size=500
 # Number of highlight fragments per document in the RAG chat context search.
@@ -1788,12 +1786,6 @@ theme.upload.zip.ratio.max=50
 theme.upload.zip.ratio.check.threshold.bytes=65536
 # Retention (days) for a replaced theme directory before the cleanup sweep removes it.
 theme.upload.attic.retention.days=7
-# Archive extensions accepted for theme upload. Not read: the upload action accepts only .zip.
-theme.allowed.archive.extensions=zip
-# Cache-Control max-age (seconds) for theme assets. Not read: the responder always sends 86400.
-theme.assets.cache.max.age=86400
-# Whether to serve precompressed theme assets. Not read: no precompressed asset path exists.
-theme.assets.precompressed=true
 # Optional: canonical external origin(s) of this Fess instance (comma/newline separated),
 # e.g. https://fess.example.com. When set, these are treated as same-origin for the v2 CSRF
 # Origin check WITHOUT trusting forwarded headers. Recommended behind reverse proxies that are


### PR DESCRIPTION
Stacked on #3434 — review that one first; this PR's diff against it is 3 files.

#3434 documented these four keys with a "Not read: …" caveat. This removes them instead,
which is what the caveat was really saying.

## The four

| key | why it does nothing |
| --- | --- |
| `theme.allowed.archive.extensions` | `getThemeAllowedArchiveExtensions()` has no caller. `AdminThemeAction.hasZipExtension` hardcodes `endsWith(".zip")`. |
| `theme.assets.cache.max.age` | `getThemeAssetsCacheMaxAgeAsInteger()` has no caller. `StaticThemeResponder` sends a literal `public, max-age=86400` — equal to the default, so setting the key looks harmless and changes nothing. |
| `theme.assets.precompressed` | `isThemeAssetsPrecompressed()` has no caller and there is no precompressed asset path; the responder sets `Vary: Accept-Encoding` but negotiates nothing. |
| `rag.chat.message.max.length` | `ChatApiHelper` reads it through `FessProp#getSystemProperty`, which consults `conf/system.properties`, then `-Dfess.system.<key>`, then a literal `"4000"`. It never reads `fess_config.properties`. |

The first three are dead outright. The fourth is a **live setting declared in the wrong
file** — it keeps working exactly as before through `conf/system.properties`; only the
inert declaration goes.

That last one is not a judgement call. **44 keys are read via `getSystemProperty`, and
this was the only one also declared in `fess_config.properties`.** The other 43 —
`saml.*`, `spnego.*`, `oic.*`, `entraid.*`, `thumbnail.command.*`, `rag.llm.name`,
`api.chat.rate.limit.per.user.per.minute` — are not. Removing it makes it consistent
rather than exceptional.

## Nothing referenced them

A sweep of every repository in the workspace (`*.java`, `*.jsp`, `*.xml`, `*.properties`,
`*.js`, `*.ts`, `*.rst`, `*.md`, `*.yaml`) found the three theme keys **only** in
`fess_config.properties` and the generated `FessConfig.java`. No plugin, no JSP, no test,
no documentation page.

`rag.chat.message.max.length` keeps its documentation: fess-docs `config/rag-chat.rst` and
`api/api-chat.rst` already describe it in all seven languages, and already say "This value
is read as a System Property; the entry in `fess_config.properties` is not used." After
this, that sentence can lose its second half — a small fess-docs follow-up, not a gap.

## What removal touched

Removing a key also removes what freegen generates from it, so `FessConfig` still matches
what a regeneration would emit:

| | before | after |
| --- | --- | --- |
| keys in `fess_config.properties` | 639 | 635 |
| `String X = "…"` constants | 581 | 577 |
| `defaultMap.put` entries | 584 | 580 |

Exactly −4 in each, plus the 7 accessor declarations and 7 `SimpleImpl` bodies those keys
generated. `keys-without-constant` is 58 before and after — a pre-existing property of the
file, untouched here.

Also corrects `ChatApiHelper#getMaxMessageLength`'s javadoc, which said the value came
"from fess_config system properties" and named the channel that does not apply.

## Verification

- `mvn compile` — BUILD SUCCESS.
- `mvn test` for `ChatApiHelperTest`, `ChatHandlerTest`, `FessConfigTest` and the theme
  suites — **307 tests, 0 failures, 0 errors**. The chat tests exercise the surviving
  `getSystemProperty` path, so the message-length limit is covered as still working.
- `mvn formatter:format && mvn license:format` — no further changes.
- Grep for each key and each generated constant across `src/` — the only survivors are the
  live `rag.chat.message.max.length` consumer, its tests, and doc comments naming it.
