### PR TITLE
feat: ship the Playwright crawler as a plugin instead of bundling it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1496,25 +1496,6 @@
 			<version>${crawler.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.codelibs.fess</groupId>
-			<artifactId>fess-crawler-playwright</artifactId>
-			<version>${crawler.playwright.version}</version>
-			<exclusions>
-				<exclusion>
-					<!-- driver-bundle is five Node.js binaries, one per platform, and nothing else:
-					     191 MiB of a 410 MiB distribution, for a crawler that is off by default. The
-					     JS driver itself lives in com.microsoft.playwright:driver, which stays.
-					     Playwright finds Node.js through PLAYWRIGHT_NODEJS_PATH instead, which
-					     bin/fess.in.sh sets from bin/fess-setup install nodejs.
-					     NOTE: this split only exists from Playwright 1.62.0. In 1.60 and earlier
-					     DriverJar itself lived in driver-bundle, so excluding it there would take
-					     the driver away with it. -->
-					<groupId>com.microsoft.playwright</groupId>
-					<artifactId>driver-bundle</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>args4j</groupId>
 			<artifactId>args4j</artifactId>
 			<version>2.33</version>

--- a/src/main/java/org/codelibs/fess/helper/PluginHelper.java
+++ b/src/main/java/org/codelibs/fess/helper/PluginHelper.java
@@ -230,7 +230,6 @@ public class PluginHelper {
                 || "fess-crawler-opensearch".equals(name)//
                 || "fess-crawler-lasta".equals(name)//
                 || "fess-crawler-parent".equals(name)//
-                || "fess-crawler-playwright".equals(name)//
                 || "fess-crawler-webdriver".equals(name)) {
             return true;
         }

--- a/src/main/java/org/codelibs/fess/setup/PluginRepository.java
+++ b/src/main/java/org/codelibs/fess/setup/PluginRepository.java
@@ -59,8 +59,7 @@ public final class PluginRepository {
      * the admin list, and offering them here would let someone install a jar that cannot work.
      */
     private static final Set<String> EXCLUDED = Set.of("fess-crawler", "fess-crawler-db", "fess-crawler-db-h2", "fess-crawler-db-mysql",
-            "fess-crawler-es", "fess-crawler-opensearch", "fess-crawler-lasta", "fess-crawler-parent", "fess-crawler-playwright",
-            "fess-crawler-webdriver");
+            "fess-crawler-es", "fess-crawler-opensearch", "fess-crawler-lasta", "fess-crawler-parent", "fess-crawler-webdriver");
 
     private static final Pattern HREF = Pattern.compile("href=\"[^\"]*?([a-zA-Z0-9\\-]+)/?\"");
 

--- a/src/main/resources/fess-setup.properties
+++ b/src/main/resources/fess-setup.properties
@@ -30,9 +30,12 @@ component.opensearch.plugin.artifacts = org.codelibs.opensearch:opensearch-analy
                                         org.codelibs.opensearch:opensearch-minhash, \
                                         org.codelibs.opensearch:opensearch-configsync
 
-# Node.js, needed only by the Playwright crawler. The distribution no longer bundles the five
-# Node.js binaries Playwright's driver-bundle carries (191 MiB of the zip), so a crawl
-# configured with client.crawlerClients=playwright:... needs one installed here.
+# Node.js, needed only by the Playwright crawler. That crawler is not in the distribution
+# either: a crawl configured with client.crawlerClients=playwright:... needs both
+#     bin/fess-setup install plugin fess-crawler-playwright
+#     bin/fess-setup install nodejs
+# The plugin carries the Playwright API and its JS driver; what it leaves out, and what this
+# component supplies, is the five Node.js binaries driver-bundle carries, one per platform.
 #
 # Playwright 1.62 requires Node.js 20 or later; this is the version its own bundle shipped.
 component.nodejs.version = 24.20.0

--- a/src/test/java/org/codelibs/fess/helper/PluginHelperTest.java
+++ b/src/test/java/org/codelibs/fess/helper/PluginHelperTest.java
@@ -105,13 +105,21 @@ public class PluginHelperTest extends UnitFessTestCase {
     @Test
     public void test_processRepository3() {
         List<Artifact> list = pluginHelper.processRepository(ArtifactType.CRAWLER, "plugin/repo3/");
-        assertEquals(2, list.size());
-        assertEquals("fess-crawler-smbj", list.get(0).getName());
-        assertEquals("14.14.0", list.get(0).getVersion());
-        assertEquals("plugin/repo3/fess-crawler-smbj/14.14.0/fess-crawler-smbj-14.14.0.jar", list.get(0).getUrl());
-        assertEquals("fess-crawler-smbj", list.get(1).getName());
-        assertEquals("14.15.0", list.get(1).getVersion());
-        assertEquals("plugin/repo3/fess-crawler-smbj/14.15.0/fess-crawler-smbj-14.15.0.jar", list.get(1).getUrl());
+        // The listing names nine fess-crawler-* artifacts. Seven are the crawler libraries, which
+        // isExcludedName hides; what is left is the 14 versions of the Playwright crawler, which is
+        // a plugin, and the two of fess-crawler-smbj.
+        assertEquals(16, list.size());
+        assertEquals("fess-crawler-playwright", list.get(0).getName());
+        assertEquals("14.5.0", list.get(0).getVersion());
+        assertEquals("plugin/repo3/fess-crawler-playwright/14.5.0/fess-crawler-playwright-14.5.0.jar", list.get(0).getUrl());
+        assertEquals("fess-crawler-playwright", list.get(13).getName());
+        assertEquals("14.14.0", list.get(13).getVersion());
+        assertEquals("fess-crawler-smbj", list.get(14).getName());
+        assertEquals("14.14.0", list.get(14).getVersion());
+        assertEquals("plugin/repo3/fess-crawler-smbj/14.14.0/fess-crawler-smbj-14.14.0.jar", list.get(14).getUrl());
+        assertEquals("fess-crawler-smbj", list.get(15).getName());
+        assertEquals("14.15.0", list.get(15).getVersion());
+        assertEquals("plugin/repo3/fess-crawler-smbj/14.15.0/fess-crawler-smbj-14.15.0.jar", list.get(15).getUrl());
     }
 
     @Test
@@ -214,9 +222,10 @@ public class PluginHelperTest extends UnitFessTestCase {
         assertTrue(pluginHelper.isExcludedName(ArtifactType.CRAWLER, "fess-crawler-opensearch"));
         assertTrue(pluginHelper.isExcludedName(ArtifactType.CRAWLER, "fess-crawler-lasta"));
         assertTrue(pluginHelper.isExcludedName(ArtifactType.CRAWLER, "fess-crawler-parent"));
-        assertTrue(pluginHelper.isExcludedName(ArtifactType.CRAWLER, "fess-crawler-playwright"));
         assertTrue(pluginHelper.isExcludedName(ArtifactType.CRAWLER, "fess-crawler-webdriver"));
 
+        // The Playwright crawler ships as a plugin, so it has to stay offerable.
+        assertFalse(pluginHelper.isExcludedName(ArtifactType.CRAWLER, "fess-crawler-playwright"));
         assertFalse(pluginHelper.isExcludedName(ArtifactType.CRAWLER, "fess-crawler-smbj"));
         assertFalse(pluginHelper.isExcludedName(ArtifactType.DATA_STORE, "fess-crawler"));
     }

--- a/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
+++ b/src/test/java/org/codelibs/fess/setup/PluginRepositoryTest.java
@@ -124,6 +124,7 @@ public class PluginRepositoryTest {
         assertTrue(names.contains("fess-ds-git"), names.toString());
         assertTrue(names.contains("fess-script-groovy"), names.toString());
         assertTrue(names.contains("fess-theme-classic"), names.toString());
+        assertTrue(names.contains("fess-crawler-playwright"), names.toString());
     }
 
     @Test
@@ -142,9 +143,10 @@ public class PluginRepositoryTest {
     @Test
     public void test_namesFromListing_excludesCrawlerInternals() {
         // PluginHelper hides these from the admin list; fess-setup must not offer them either.
-        final String html =
-                "<a href=\"fess-crawler-playwright/\">x</a><a href=\"fess-crawler-lasta/\">x</a>" + "<a href=\"fess-ds-git/\">x</a>";
-        assertEquals(List.of("fess-ds-git"), PluginRepository.namesFromListing(html));
+        // fess-crawler-playwright is not one of them: it is a plugin, and has to stay offerable.
+        final String html = "<a href=\"fess-crawler-opensearch/\">x</a><a href=\"fess-crawler-lasta/\">x</a>"
+                + "<a href=\"fess-crawler-playwright/\">x</a>" + "<a href=\"fess-ds-git/\">x</a>";
+        assertEquals(List.of("fess-crawler-playwright", "fess-ds-git"), PluginRepository.namesFromListing(html));
     }
 
     @Test


### PR DESCRIPTION
The Playwright crawler leaves the distribution and becomes an installable plugin, like the storage and SSO clients before it.

The Node.js binaries it needs left when `bin/fess-setup` gained `install nodejs`, so a Playwright crawl already required a setup step. The crawler itself can take the same one, instead of costing every installation 3.7 MiB for a client that is off by default.

## What changes

**The dependency.** Nothing in Fess compiles against Playwright. The client registers itself through `crawler/client++.xml` inside the plugin jar, and `WEB-INF/plugin` is already on every class path Fess builds for a child process - crawler, thumbnail, suggest and chunk (`CrawlJob.java:355`). Removing the `<dependency>` is the whole change.

**The two lists of crawler artifacts that are libraries rather than plugins.** `PluginHelper.isExcludedName` and `PluginRepository.EXCLUDED` both stop hiding `fess-crawler-playwright`, so the admin plugin page and `fess-setup install plugin` offer it. The other seven entries stay as they are: those are the crawler libraries, and installing one of them into `WEB-INF/plugin` cannot work.

**`fess-setup.properties`.** The Node.js component's comment said the distribution no longer bundles the Node.js binaries; it now says the crawler is not there either, and names both commands.

## Class path

241 jars / 158.57 MiB -> 237 jars / 154.91 MiB. Removed: `fess-crawler-playwright`, `playwright`, `driver`, and `opentest4j`, which Playwright had been dragging into the runtime scope. `commons-pool2` stays - `fess-crawler` brings it in on its own.

## Requires

codelibs/fess-crawler-playwright#76 must merge and release a shaded jar first. The plain jar this war used to bundle does not stand alone in `WEB-INF/plugin`; installing it would fail with `NoClassDefFoundError` on `com.microsoft.playwright`.

Documentation: codelibs/fess-docs updates the 15.9 upgrade note, which currently says only the Node.js binaries were removed.

Left alone on purpose: `crawler.playwright.version` in codelibs/fess-parent has no consumer after this, but removing a property from the shared parent is its own call.

## Verification

- `mvn clean test` on the full suite: **7,470 tests, 0 failures, 0 errors**.
- `PluginHelperTest`, `PluginRepositoryTest`, `FessPluginInstallerTest`: 85 tests, 0 failures. `test_processRepository3` goes from 2 artifacts to 16 - the same fixture listing, now offering the 14 published Playwright versions alongside the 2 of `fess-crawler-smbj`.
- `FessCrawlerThreadTest` and `ProtocolHelperTest`: 51 tests, 0 failures - `client.crawlerClients=playwright:...` still parses, it is a string rule and never a class reference.
